### PR TITLE
feat(core): frozen v1 on-disk format constants and core value types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,4 +14,5 @@ to follow Semantic Versioning once it reaches a tagged release.
 - Continuous integration: rustfmt, clippy (deny warnings), test matrix on Linux,
   macOS, and Windows, an MSRV 1.78 build, and a lint that keeps `ironbus-core` IO-free.
 - Dual `MIT OR Apache-2.0` license files.
+- `ironbus-core`: frozen v1 on-disk format constants and field offsets (record header, trailer, segment header and footer), and the `Offset`, `Seq`, and `RecordFlags` value types, with unit tests pinning the layout.
 - Supply-chain CI gate (`cargo-deny`) with a permissive-license allowlist, and SPDX license headers on every Rust source enforced by CI.

--- a/crates/ironbus-core/src/format.rs
+++ b/crates/ironbus-core/src/format.rs
@@ -13,7 +13,8 @@
 /// The on-disk format version this build writes and is the baseline it reads.
 pub const FORMAT_VERSION: u8 = 1;
 
-/// Record frame magic (`b"BI"` read as little-endian `u16` = `0x4942`).
+/// Record frame magic. On disk the two bytes are `0x42 0x49` (`b'B'`, `b'I'`),
+/// which read back as the little-endian `u16` `0x4942`.
 pub const RECORD_MAGIC: u16 = 0x4942;
 
 /// Total size in bytes of a record header.
@@ -47,6 +48,24 @@ pub const MAX_RECORD_BYTES_CEILING: u32 = 1024 * 1024 * 1024;
 
 /// Compile-time invariant: the default maximum record size never exceeds the ceiling.
 const _: () = assert!(DEFAULT_MAX_RECORD_BYTES <= MAX_RECORD_BYTES_CEILING);
+
+/// Payload size at or above which a second, independent xxh3-64 checksum is added
+/// to a record in addition to the mandatory CRC32C: 64 KiB.
+pub const XXH3_PAYLOAD_THRESHOLD: u32 = 64 * 1024;
+
+/// Default target size at which an active segment is rolled and sealed: 64 MiB.
+///
+/// The startup config validator enforces that the configured maximum record size
+/// is smaller than the active segment size, so a record never spans two segments.
+/// On the edge profile the segment size drops (see [`EDGE_SEGMENT_BYTES`]), which
+/// also lowers the permitted maximum record size.
+pub const DEFAULT_SEGMENT_BYTES: u32 = 64 * 1024 * 1024;
+
+/// Active-segment roll size on the constrained edge profile: 8 MiB.
+pub const EDGE_SEGMENT_BYTES: u32 = 8 * 1024 * 1024;
+
+/// Default maximum age before an active segment is rolled, in hours: 1.
+pub const DEFAULT_SEGMENT_ROLL_HOURS: u32 = 1;
 
 /// Byte offsets of each field within the record header. The header is little-endian
 /// and tightly packed: `magic(2) version(1) flags(1) seq(8) timestamp(8) key_len(4)
@@ -88,19 +107,33 @@ mod tests {
 
     #[test]
     fn header_field_offsets_are_tightly_packed() {
+        // Absolute offsets freeze the exact layout: a consistent-but-wrong shift of
+        // two interior fields (which preserves the running sum) is still caught.
         assert_eq!(off::MAGIC, 0);
-        assert_eq!(off::VERSION, off::MAGIC + 2);
-        assert_eq!(off::FLAGS, off::VERSION + 1);
-        assert_eq!(off::SEQ, off::FLAGS + 1);
-        assert_eq!(off::TIMESTAMP, off::SEQ + 8);
-        assert_eq!(off::KEY_LEN, off::TIMESTAMP + 8);
-        assert_eq!(off::HDR_LEN, off::KEY_LEN + 4);
-        assert_eq!(off::PAYLOAD_LEN, off::HDR_LEN + 4);
-        assert_eq!(off::HEADER_CRC, off::PAYLOAD_LEN + 4);
+        assert_eq!(off::VERSION, 2);
+        assert_eq!(off::FLAGS, 3);
+        assert_eq!(off::SEQ, 4);
+        assert_eq!(off::TIMESTAMP, 12);
+        assert_eq!(off::KEY_LEN, 20);
+        assert_eq!(off::HDR_LEN, 24);
+        assert_eq!(off::PAYLOAD_LEN, 28);
+        assert_eq!(off::HEADER_CRC, 32);
         // The CRC field sits exactly at the end of the protected range and the
         // header ends right after it.
         assert_eq!(off::HEADER_CRC, RECORD_HEADER_CRC_RANGE.end);
         assert_eq!(off::HEADER_CRC + 4, RECORD_HEADER_LEN);
+    }
+
+    #[test]
+    fn frozen_values() {
+        assert_eq!(FORMAT_VERSION, 1);
+        assert_eq!(RECORD_MAGIC, 0x4942);
+        assert_eq!(SEGMENT_MAGIC, *b"IRONBUS\0");
+        assert_eq!(CHECKSUM_ALGO_CRC32C, 0x1);
+        assert_eq!(XXH3_PAYLOAD_THRESHOLD, 64 * 1024);
+        assert_eq!(DEFAULT_SEGMENT_BYTES, 64 * 1024 * 1024);
+        assert_eq!(EDGE_SEGMENT_BYTES, 8 * 1024 * 1024);
+        assert_eq!(DEFAULT_SEGMENT_ROLL_HOURS, 1);
     }
 
     #[test]

--- a/crates/ironbus-core/src/format.rs
+++ b/crates/ironbus-core/src/format.rs
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! The frozen on-disk binary format for IronBus, version 1.
+//!
+//! Every multi-byte field is little-endian. A record frame is a fixed 36-byte
+//! header, a variable body (key, headers, payload), and an 8-byte trailer. Records
+//! are record-aligned within a segment: there is no block layer and no fragment
+//! types. See the record-format design (issue #5) for the rationale.
+//!
+//! This module defines only the layout constants and field offsets. Encoding and
+//! decoding live in a separate module so the numbers here are the single source of
+//! truth that both the codec and its tests refer to.
+
+/// The on-disk format version this build writes and is the baseline it reads.
+pub const FORMAT_VERSION: u8 = 1;
+
+/// Record frame magic (`b"BI"` read as little-endian `u16` = `0x4942`).
+pub const RECORD_MAGIC: u16 = 0x4942;
+
+/// Total size in bytes of a record header.
+pub const RECORD_HEADER_LEN: usize = 36;
+
+/// Size in bytes of a record trailer (`body_crc: u32` then `total_len: u32`).
+pub const RECORD_TRAILER_LEN: usize = 8;
+
+/// The byte range of the header that the `header_crc` field protects: `[0, 32)`.
+pub const RECORD_HEADER_CRC_RANGE: core::ops::Range<usize> = 0..32;
+
+/// Eight-byte magic at the start of a segment file.
+pub const SEGMENT_MAGIC: [u8; 8] = *b"IRONBUS\0";
+
+/// Total size in bytes of a segment header (the file starts 4 KiB-aligned).
+pub const SEGMENT_HEADER_LEN: usize = 64;
+
+/// Total size in bytes of a segment footer, written when the segment is sealed.
+pub const SEGMENT_FOOTER_LEN: usize = 32;
+
+/// Identifier for CRC32C (Castagnoli) in the segment header `checksum_algo` field.
+/// Version-1 readers must reject any other value.
+pub const CHECKSUM_ALGO_CRC32C: u8 = 0x1;
+
+/// Default hard cap on a single record's total size: 16 MiB.
+pub const DEFAULT_MAX_RECORD_BYTES: u32 = 16 * 1024 * 1024;
+
+/// Configurable ceiling on the maximum record size: 1 GiB, bounded by the `u32`
+/// length fields in the frame.
+pub const MAX_RECORD_BYTES_CEILING: u32 = 1024 * 1024 * 1024;
+
+/// Compile-time invariant: the default maximum record size never exceeds the ceiling.
+const _: () = assert!(DEFAULT_MAX_RECORD_BYTES <= MAX_RECORD_BYTES_CEILING);
+
+/// Byte offsets of each field within the record header. The header is little-endian
+/// and tightly packed: `magic(2) version(1) flags(1) seq(8) timestamp(8) key_len(4)
+/// hdr_len(4) payload_len(4) header_crc(4)`.
+pub mod header_offsets {
+    /// Offset of the `magic: u16` field.
+    pub const MAGIC: usize = 0;
+    /// Offset of the `version: u8` field.
+    pub const VERSION: usize = 2;
+    /// Offset of the `flags: u8` field.
+    pub const FLAGS: usize = 3;
+    /// Offset of the `seq: u64` field.
+    pub const SEQ: usize = 4;
+    /// Offset of the `timestamp: u64` (milliseconds) field.
+    pub const TIMESTAMP: usize = 12;
+    /// Offset of the `key_len: u32` field.
+    pub const KEY_LEN: usize = 20;
+    /// Offset of the `hdr_len: u32` field.
+    pub const HDR_LEN: usize = 24;
+    /// Offset of the `payload_len: u32` field.
+    pub const PAYLOAD_LEN: usize = 28;
+    /// Offset of the `header_crc: u32` field. The CRC covers bytes `[0, 32)`.
+    pub const HEADER_CRC: usize = 32;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::header_offsets as off;
+    use super::*;
+
+    #[test]
+    fn frozen_sizes() {
+        assert_eq!(RECORD_HEADER_LEN, 36);
+        assert_eq!(RECORD_TRAILER_LEN, 8);
+        assert_eq!(SEGMENT_HEADER_LEN, 64);
+        assert_eq!(SEGMENT_FOOTER_LEN, 32);
+        assert_eq!(RECORD_HEADER_CRC_RANGE, 0..32);
+    }
+
+    #[test]
+    fn header_field_offsets_are_tightly_packed() {
+        assert_eq!(off::MAGIC, 0);
+        assert_eq!(off::VERSION, off::MAGIC + 2);
+        assert_eq!(off::FLAGS, off::VERSION + 1);
+        assert_eq!(off::SEQ, off::FLAGS + 1);
+        assert_eq!(off::TIMESTAMP, off::SEQ + 8);
+        assert_eq!(off::KEY_LEN, off::TIMESTAMP + 8);
+        assert_eq!(off::HDR_LEN, off::KEY_LEN + 4);
+        assert_eq!(off::PAYLOAD_LEN, off::HDR_LEN + 4);
+        assert_eq!(off::HEADER_CRC, off::PAYLOAD_LEN + 4);
+        // The CRC field sits exactly at the end of the protected range and the
+        // header ends right after it.
+        assert_eq!(off::HEADER_CRC, RECORD_HEADER_CRC_RANGE.end);
+        assert_eq!(off::HEADER_CRC + 4, RECORD_HEADER_LEN);
+    }
+
+    #[test]
+    fn magic_byte_order() {
+        // Little-endian 0x4942 is the bytes 0x42, 0x49 = b'B', b'I'.
+        assert_eq!(RECORD_MAGIC.to_le_bytes(), [b'B', b'I']);
+    }
+
+    #[test]
+    fn record_size_limits() {
+        assert_eq!(DEFAULT_MAX_RECORD_BYTES, 16 * 1024 * 1024);
+        assert_eq!(MAX_RECORD_BYTES_CEILING, 1024 * 1024 * 1024);
+    }
+}

--- a/crates/ironbus-core/src/lib.rs
+++ b/crates/ironbus-core/src/lib.rs
@@ -5,3 +5,7 @@
 //! the network, spawn processes, or pull in an async runtime. A CI lint enforces
 //! this, so the engine logic stays pure and deterministic.
 #![forbid(unsafe_code)]
+#![warn(missing_docs)]
+
+pub mod format;
+pub mod types;

--- a/crates/ironbus-core/src/types.rs
+++ b/crates/ironbus-core/src/types.rs
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! Foundational value types shared across IronBus.
+//!
+//! These are small, `Copy` newtypes that give the log's identifiers distinct,
+//! hard-to-confuse types. They carry no IO and no allocation.
+
+use core::fmt;
+
+/// A monotonically increasing position in the durable log.
+///
+/// Offsets are assigned by the single append actor and never reused or reordered
+/// within the lifetime of a queue. The zero offset is the first record.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct Offset(u64);
+
+impl Offset {
+    /// The first offset in a log.
+    pub const ZERO: Offset = Offset(0);
+
+    /// Wraps a raw `u64` as an [`Offset`].
+    #[must_use]
+    pub const fn new(value: u64) -> Offset {
+        Offset(value)
+    }
+
+    /// Returns the raw `u64` value.
+    #[must_use]
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+
+    /// Returns the next offset, saturating at `u64::MAX`.
+    ///
+    /// A real deployment never approaches `u64::MAX`, so saturation is a defensive
+    /// guard rather than an expected path.
+    #[must_use]
+    pub const fn next(self) -> Offset {
+        Offset(self.0.saturating_add(1))
+    }
+}
+
+impl fmt::Debug for Offset {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Offset({})", self.0)
+    }
+}
+
+impl fmt::Display for Offset {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// A per-record sequence number, unique and monotonic within a single segment.
+///
+/// A record's sequence must fall in `[base_seq, base_seq + record_count)` for the
+/// segment that holds it; a value outside that range marks the record as stale or
+/// torn during recovery.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct Seq(u64);
+
+impl Seq {
+    /// Wraps a raw `u64` as a [`Seq`].
+    #[must_use]
+    pub const fn new(value: u64) -> Seq {
+        Seq(value)
+    }
+
+    /// Returns the raw `u64` value.
+    #[must_use]
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+
+    /// Returns the next sequence number, saturating at `u64::MAX`.
+    #[must_use]
+    pub const fn next(self) -> Seq {
+        Seq(self.0.saturating_add(1))
+    }
+}
+
+impl fmt::Debug for Seq {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Seq({})", self.0)
+    }
+}
+
+impl fmt::Display for Seq {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// The per-record flag bits stored in the record header `flags` byte.
+///
+/// Unknown bits are preserved on read so that a future writer can introduce new
+/// flags without older readers corrupting them.
+#[derive(Clone, Copy, PartialEq, Eq, Default)]
+pub struct RecordFlags(u8);
+
+impl RecordFlags {
+    /// The record payload is compressed (see the compression design).
+    pub const COMPRESSED: RecordFlags = RecordFlags(0b0000_0001);
+    /// The record carries a routing or ordering key.
+    pub const HAS_KEY: RecordFlags = RecordFlags(0b0000_0010);
+
+    /// An empty flag set.
+    pub const EMPTY: RecordFlags = RecordFlags(0);
+
+    /// Builds a flag set from its raw byte.
+    #[must_use]
+    pub const fn from_bits(bits: u8) -> RecordFlags {
+        RecordFlags(bits)
+    }
+
+    /// Returns the raw flag byte.
+    #[must_use]
+    pub const fn bits(self) -> u8 {
+        self.0
+    }
+
+    /// Returns `true` if every bit in `other` is set in `self`.
+    #[must_use]
+    pub const fn contains(self, other: RecordFlags) -> bool {
+        self.0 & other.0 == other.0
+    }
+
+    /// Returns a new flag set with the bits in `other` added.
+    #[must_use]
+    pub const fn with(self, other: RecordFlags) -> RecordFlags {
+        RecordFlags(self.0 | other.0)
+    }
+}
+
+impl fmt::Debug for RecordFlags {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "RecordFlags(0b{:08b})", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn offset_roundtrip_and_order() {
+        assert_eq!(Offset::ZERO.get(), 0);
+        assert_eq!(Offset::new(42).get(), 42);
+        assert_eq!(Offset::new(42).next(), Offset::new(43));
+        assert!(Offset::new(1) < Offset::new(2));
+        assert_eq!(Offset::new(u64::MAX).next(), Offset::new(u64::MAX));
+    }
+
+    #[test]
+    fn seq_roundtrip() {
+        assert_eq!(Seq::new(7).get(), 7);
+        assert_eq!(Seq::new(7).next(), Seq::new(8));
+        assert_eq!(Seq::new(u64::MAX).next(), Seq::new(u64::MAX));
+    }
+
+    #[test]
+    fn flags_set_and_query() {
+        let f = RecordFlags::EMPTY
+            .with(RecordFlags::COMPRESSED)
+            .with(RecordFlags::HAS_KEY);
+        assert!(f.contains(RecordFlags::COMPRESSED));
+        assert!(f.contains(RecordFlags::HAS_KEY));
+        assert_eq!(f.bits(), 0b11);
+        assert!(!RecordFlags::COMPRESSED.contains(RecordFlags::HAS_KEY));
+        // Unknown bits are preserved.
+        assert_eq!(RecordFlags::from_bits(0b1000_0000).bits(), 0b1000_0000);
+    }
+
+    #[test]
+    fn display_is_numeric() {
+        assert_eq!(Offset::new(9).to_string(), "9");
+        assert_eq!(Seq::new(9).to_string(), "9");
+    }
+}

--- a/crates/ironbus-core/src/types.rs
+++ b/crates/ironbus-core/src/types.rs
@@ -29,13 +29,17 @@ impl Offset {
         self.0
     }
 
-    /// Returns the next offset, saturating at `u64::MAX`.
+    /// Returns the next offset, or `None` if the offset space is exhausted.
     ///
-    /// A real deployment never approaches `u64::MAX`, so saturation is a defensive
-    /// guard rather than an expected path.
+    /// Because offsets are monotonic and never reused, the caller must treat
+    /// `None` as a hard, loud failure (the log cannot mint another id) rather than
+    /// reusing this value. A real deployment never approaches `u64::MAX`.
     #[must_use]
-    pub const fn next(self) -> Offset {
-        Offset(self.0.saturating_add(1))
+    pub const fn checked_next(self) -> Option<Offset> {
+        match self.0.checked_add(1) {
+            Some(n) => Some(Offset(n)),
+            None => None,
+        }
     }
 }
 
@@ -72,10 +76,16 @@ impl Seq {
         self.0
     }
 
-    /// Returns the next sequence number, saturating at `u64::MAX`.
+    /// Returns the next sequence number, or `None` if the space is exhausted.
+    ///
+    /// As with [`Offset::checked_next`], `None` is a hard failure: a sequence
+    /// number is never reused.
     #[must_use]
-    pub const fn next(self) -> Seq {
-        Seq(self.0.saturating_add(1))
+    pub const fn checked_next(self) -> Option<Seq> {
+        match self.0.checked_add(1) {
+            Some(n) => Some(Seq(n)),
+            None => None,
+        }
     }
 }
 
@@ -94,8 +104,9 @@ impl fmt::Display for Seq {
 /// The per-record flag bits stored in the record header `flags` byte.
 ///
 /// Unknown bits are preserved on read so that a future writer can introduce new
-/// flags without older readers corrupting them.
-#[derive(Clone, Copy, PartialEq, Eq, Default)]
+/// flags without older readers corrupting them. A reader can detect unknown bits
+/// with [`RecordFlags::unknown_bits`].
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub struct RecordFlags(u8);
 
 impl RecordFlags {
@@ -106,6 +117,10 @@ impl RecordFlags {
 
     /// An empty flag set.
     pub const EMPTY: RecordFlags = RecordFlags(0);
+
+    /// The union of every flag this version understands. A writer must never emit
+    /// a bit outside this mask.
+    pub const KNOWN: RecordFlags = RecordFlags(Self::COMPRESSED.0 | Self::HAS_KEY.0);
 
     /// Builds a flag set from its raw byte.
     #[must_use]
@@ -130,6 +145,15 @@ impl RecordFlags {
     pub const fn with(self, other: RecordFlags) -> RecordFlags {
         RecordFlags(self.0 | other.0)
     }
+
+    /// Returns the subset of bits that this version does not recognize.
+    ///
+    /// An empty result means every set bit is known. A reader uses this to decide
+    /// whether a record was written by a newer format than it fully understands.
+    #[must_use]
+    pub const fn unknown_bits(self) -> RecordFlags {
+        RecordFlags(self.0 & !Self::KNOWN.0)
+    }
 }
 
 impl fmt::Debug for RecordFlags {
@@ -146,16 +170,16 @@ mod tests {
     fn offset_roundtrip_and_order() {
         assert_eq!(Offset::ZERO.get(), 0);
         assert_eq!(Offset::new(42).get(), 42);
-        assert_eq!(Offset::new(42).next(), Offset::new(43));
+        assert_eq!(Offset::new(42).checked_next(), Some(Offset::new(43)));
         assert!(Offset::new(1) < Offset::new(2));
-        assert_eq!(Offset::new(u64::MAX).next(), Offset::new(u64::MAX));
+        assert_eq!(Offset::new(u64::MAX).checked_next(), None);
     }
 
     #[test]
     fn seq_roundtrip() {
         assert_eq!(Seq::new(7).get(), 7);
-        assert_eq!(Seq::new(7).next(), Seq::new(8));
-        assert_eq!(Seq::new(u64::MAX).next(), Seq::new(u64::MAX));
+        assert_eq!(Seq::new(7).checked_next(), Some(Seq::new(8)));
+        assert_eq!(Seq::new(u64::MAX).checked_next(), None);
     }
 
     #[test]
@@ -167,8 +191,17 @@ mod tests {
         assert!(f.contains(RecordFlags::HAS_KEY));
         assert_eq!(f.bits(), 0b11);
         assert!(!RecordFlags::COMPRESSED.contains(RecordFlags::HAS_KEY));
-        // Unknown bits are preserved.
-        assert_eq!(RecordFlags::from_bits(0b1000_0000).bits(), 0b1000_0000);
+    }
+
+    #[test]
+    fn flags_unknown_bits_detected_and_preserved() {
+        assert_eq!(RecordFlags::KNOWN.bits(), 0b11);
+        // A known-only set has no unknown bits.
+        assert_eq!(RecordFlags::KNOWN.unknown_bits(), RecordFlags::EMPTY);
+        // An unknown high bit is both preserved and reported.
+        let future = RecordFlags::from_bits(0b1000_0010);
+        assert_eq!(future.bits(), 0b1000_0010);
+        assert_eq!(future.unknown_bits(), RecordFlags::from_bits(0b1000_0000));
     }
 
     #[test]


### PR DESCRIPTION
## What
- `ironbus-core::format`: the frozen v1 on-disk layout as constants and field offsets (record header 36 B, trailer 8 B, segment header 64 B, footer 32 B, record magic, CRC32C algo id, 16 MiB default / 1 GiB ceiling record size), with a compile-time `default <= ceiling` invariant and tests that pin the layout.
- `ironbus-core::types`: `Offset`, `Seq`, and `RecordFlags` value types (documented, tested).
- `#![warn(missing_docs)]` on `ironbus-core` so the public API stays documented.

## Why
First real code. The format constants are the single source of truth the codec and its tests will refer to (#5), and the value types are the contract foundation (#137). Scoped to definitions + tests; encode/decode with CRC32C lands next.

## Test evidence
Local: `cargo fmt --check`, `cargo clippy -- -D warnings` (pedantic + missing_docs), `cargo test` (8 core tests), `cargo deny check`, the SPDX check, and the no-IO lint all pass.

refs #5, #137