### PR TITLE
feat(core): record-frame codec with CRC32C (encode/decode)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,5 +14,6 @@ to follow Semantic Versioning once it reaches a tagged release.
 - Continuous integration: rustfmt, clippy (deny warnings), test matrix on Linux,
   macOS, and Windows, an MSRV 1.78 build, and a lint that keeps `ironbus-core` IO-free.
 - Dual `MIT OR Apache-2.0` license files.
+- `ironbus-core::codec`: record-frame encode and decode with CRC32C header and body checksums, typed `EncodeError`/`DecodeError`, and proptest round-trip plus single-bit-flip corruption-detection tests. The optional xxh3-64 large-payload checksum is deferred (frame layout pending).
 - `ironbus-core`: frozen v1 on-disk format constants and field offsets (record header, trailer, segment header and footer), and the `Offset`, `Seq`, and `RecordFlags` value types, with unit tests pinning the layout.
 - Supply-chain CI gate (`cargo-deny`) with a permissive-license allowlist, and SPDX license headers on every Rust source enforced by CI.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,152 @@
 version = 3
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "crc32c"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "ironbus-cli"
 version = "0.0.0"
 
@@ -13,6 +159,10 @@ version = "0.0.0"
 [[package]]
 name = "ironbus-core"
 version = "0.0.0"
+dependencies = [
+ "crc32c",
+ "proptest",
+]
 
 [[package]]
 name = "ironbus-proto"
@@ -25,3 +175,492 @@ version = "0.0.0"
 [[package]]
 name = "ironbus-storage"
 version = "0.0.0"
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "log"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+
+[[package]]
+name = "memchr"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quote"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/crates/ironbus-core/Cargo.toml
+++ b/crates/ironbus-core/Cargo.toml
@@ -8,5 +8,11 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 
+[dependencies]
+crc32c = "0.6"
+
+[dev-dependencies]
+proptest = "1"
+
 [lints]
 workspace = true

--- a/crates/ironbus-core/src/codec.rs
+++ b/crates/ironbus-core/src/codec.rs
@@ -162,6 +162,10 @@ pub fn encode(rec: &RecordView<'_>, out: &mut Vec<u8>) -> Result<usize, EncodeEr
 /// On success returns the decoded [`RecordView`] (borrowing `input`) and the total
 /// number of bytes the frame occupied, so the caller can advance to the next frame.
 ///
+/// `decode` borrows sub-slices of `input` and allocates nothing; bounding the
+/// per-record size further than the 1 GiB format ceiling (for example the 16 MiB
+/// default) is the caller's responsibility.
+///
 /// # Errors
 /// Returns a [`DecodeError`] describing the first inconsistency found. A
 /// [`DecodeError::Truncated`] means more bytes may complete the frame; the other
@@ -173,6 +177,9 @@ pub fn decode(input: &[u8]) -> Result<(RecordView<'_>, usize), DecodeError> {
     if read_u16(input, off::MAGIC) != RECORD_MAGIC {
         return Err(DecodeError::BadMagic);
     }
+    // Exact-match: a version-1 reader cannot parse a future layout, so it rejects
+    // any other version loudly rather than guessing. Intentional; do not relax to
+    // `>` without a versioned layout.
     let version = input[off::VERSION];
     if version != FORMAT_VERSION {
         return Err(DecodeError::UnsupportedVersion(version));
@@ -182,23 +189,39 @@ pub fn decode(input: &[u8]) -> Result<(RecordView<'_>, usize), DecodeError> {
         return Err(DecodeError::BadHeaderCrc);
     }
 
-    let key_len = read_u32(input, off::KEY_LEN) as usize;
-    let hdr_len = read_u32(input, off::HDR_LEN) as usize;
-    let payload_len = read_u32(input, off::PAYLOAD_LEN) as usize;
-    let body_len = key_len + hdr_len + payload_len;
-    let total = RECORD_HEADER_LEN + body_len + RECORD_TRAILER_LEN;
-    if u32::try_from(total).map_or(true, |t| t > MAX_RECORD_BYTES_CEILING) {
+    let key_len_u32 = read_u32(input, off::KEY_LEN);
+    let hdr_len_u32 = read_u32(input, off::HDR_LEN);
+    let payload_len_u32 = read_u32(input, off::PAYLOAD_LEN);
+    // Sum the three attacker-controlled u32 lengths in u64 so the total cannot
+    // overflow usize on a 32-bit target before it is bounded by the ceiling.
+    let total64 = u64::from(key_len_u32)
+        + u64::from(hdr_len_u32)
+        + u64::from(payload_len_u32)
+        + RECORD_HEADER_LEN as u64
+        + RECORD_TRAILER_LEN as u64;
+    if total64 > u64::from(MAX_RECORD_BYTES_CEILING) {
         return Err(DecodeError::TooLarge);
     }
+    // total64 is now <= 1 GiB, so it and every length fit usize on all targets.
+    let total = usize::try_from(total64).map_err(|_| DecodeError::TooLarge)?;
     if input.len() < total {
         return Err(DecodeError::Truncated);
+    }
+    let key_len = usize::try_from(key_len_u32).map_err(|_| DecodeError::TooLarge)?;
+    let hdr_len = usize::try_from(hdr_len_u32).map_err(|_| DecodeError::TooLarge)?;
+    let body_len = total - RECORD_HEADER_LEN - RECORD_TRAILER_LEN;
+
+    // HAS_KEY is a derived, frozen bit: it must agree with the key length. A frame
+    // where they disagree was written by a buggy or hostile writer.
+    let flags = RecordFlags::from_bits(input[off::FLAGS]);
+    if flags.contains(RecordFlags::HAS_KEY) != (key_len != 0) {
+        return Err(DecodeError::BadLength);
     }
 
     let body = &input[RECORD_HEADER_LEN..RECORD_HEADER_LEN + body_len];
     let trailer = &input[RECORD_HEADER_LEN + body_len..total];
     let stored_body_crc = read_u32(trailer, 0);
-    let stored_total = read_u32(trailer, 4) as usize;
-    if stored_total != total {
+    if u64::from(read_u32(trailer, 4)) != total64 {
         return Err(DecodeError::BadLength);
     }
     if crc32c::crc32c(body) != stored_body_crc {
@@ -208,7 +231,7 @@ pub fn decode(input: &[u8]) -> Result<(RecordView<'_>, usize), DecodeError> {
     let view = RecordView {
         seq: Seq::new(read_u64(input, off::SEQ)),
         timestamp_ms: read_u64(input, off::TIMESTAMP),
-        flags: RecordFlags::from_bits(input[off::FLAGS]),
+        flags,
         key: &body[..key_len],
         headers: &body[key_len..key_len + hdr_len],
         payload: &body[key_len + hdr_len..],
@@ -293,6 +316,104 @@ mod tests {
         buf[body] ^= 0x01;
         assert_eq!(decode(&buf), Err(DecodeError::BadBodyCrc));
     }
+
+    /// Builds a 36-byte header with the given fields and a valid header CRC, so a
+    /// test can craft frames that pass the header-CRC check.
+    fn build_header(key_len: u32, hdr_len: u32, payload_len: u32, flags: u8) -> Vec<u8> {
+        let mut h = vec![0u8; RECORD_HEADER_LEN];
+        h[off::MAGIC..off::MAGIC + 2].copy_from_slice(&RECORD_MAGIC.to_le_bytes());
+        h[off::VERSION] = FORMAT_VERSION;
+        h[off::FLAGS] = flags;
+        h[off::KEY_LEN..off::KEY_LEN + 4].copy_from_slice(&key_len.to_le_bytes());
+        h[off::HDR_LEN..off::HDR_LEN + 4].copy_from_slice(&hdr_len.to_le_bytes());
+        h[off::PAYLOAD_LEN..off::PAYLOAD_LEN + 4].copy_from_slice(&payload_len.to_le_bytes());
+        let crc = crc32c::crc32c(&h[RECORD_HEADER_CRC_RANGE]);
+        h[off::HEADER_CRC..off::HEADER_CRC + 4].copy_from_slice(&crc.to_le_bytes());
+        h
+    }
+
+    #[test]
+    fn crafted_huge_lengths_are_rejected_not_panicked() {
+        // key_len = hdr_len = u32::MAX with a valid header CRC must be TooLarge, never
+        // a slice-out-of-bounds panic (regression for the 32-bit usize overflow).
+        let h = build_header(u32::MAX, u32::MAX, 0, 0);
+        assert_eq!(decode(&h), Err(DecodeError::TooLarge));
+    }
+
+    #[test]
+    fn ceiling_boundary() {
+        // 36 = RECORD_HEADER_LEN and 8 = RECORD_TRAILER_LEN (pinned by format::tests).
+        let body_at = MAX_RECORD_BYTES_CEILING - 36 - 8;
+        // A declared total of exactly the ceiling is not TooLarge; it is Truncated
+        // here because we do not supply a 1 GiB buffer. One byte over is TooLarge.
+        assert_eq!(
+            decode(&build_header(body_at, 0, 0, 0)),
+            Err(DecodeError::Truncated)
+        );
+        assert_eq!(
+            decode(&build_header(body_at + 1, 0, 0, 0)),
+            Err(DecodeError::TooLarge)
+        );
+    }
+
+    #[test]
+    fn has_key_inconsistency_is_rejected() {
+        // key_len = 0 but HAS_KEY set, with valid header and body CRCs: malformed.
+        let mut frame = build_header(0, 0, 1, RecordFlags::HAS_KEY.bits());
+        frame.extend_from_slice(b"x");
+        frame.extend_from_slice(&crc32c::crc32c(b"x").to_le_bytes());
+        frame.extend_from_slice(&(36u32 + 1 + 8).to_le_bytes());
+        assert_eq!(decode(&frame), Err(DecodeError::BadLength));
+    }
+
+    #[test]
+    fn all_empty_record_roundtrips() {
+        let rec = RecordView {
+            seq: Seq::new(0),
+            timestamp_ms: 0,
+            flags: RecordFlags::EMPTY,
+            key: b"",
+            headers: b"",
+            payload: b"",
+        };
+        let mut buf = Vec::new();
+        let n = encode(&rec, &mut buf).unwrap();
+        assert_eq!(n, RECORD_HEADER_LEN + RECORD_TRAILER_LEN);
+        let (got, consumed) = decode(&buf).unwrap();
+        assert_eq!(consumed, buf.len());
+        assert!(got.key.is_empty() && got.headers.is_empty() && got.payload.is_empty());
+    }
+
+    #[test]
+    fn two_frames_decode_sequentially() {
+        let r1 = RecordView {
+            seq: Seq::new(1),
+            timestamp_ms: 0,
+            flags: RecordFlags::EMPTY,
+            key: b"a",
+            headers: b"",
+            payload: b"one",
+        };
+        let r2 = RecordView {
+            seq: Seq::new(2),
+            timestamp_ms: 0,
+            flags: RecordFlags::EMPTY,
+            key: b"",
+            headers: b"hh",
+            payload: b"two!",
+        };
+        let mut buf = Vec::new();
+        encode(&r1, &mut buf).unwrap();
+        let first_len = buf.len();
+        encode(&r2, &mut buf).unwrap();
+        let (g1, c1) = decode(&buf).unwrap();
+        assert_eq!(c1, first_len);
+        assert_eq!(g1.payload, b"one");
+        let (g2, c2) = decode(&buf[c1..]).unwrap();
+        assert_eq!(c1 + c2, buf.len());
+        assert_eq!(g2.seq, Seq::new(2));
+        assert_eq!(g2.payload, b"two!");
+    }
 }
 
 #[cfg(test)]
@@ -306,12 +427,14 @@ mod proptests {
             seq in any::<u64>(),
             ts in any::<u64>(),
             extra_flag in any::<bool>(),
+            unknown_bit in any::<bool>(),
             key in proptest::collection::vec(any::<u8>(), 0..300),
             headers in proptest::collection::vec(any::<u8>(), 0..300),
             payload in proptest::collection::vec(any::<u8>(), 0..1024),
         ) {
             // Only COMPRESSED is a caller-controlled bit here; HAS_KEY is derived.
-            let flags = if extra_flag { RecordFlags::COMPRESSED } else { RecordFlags::EMPTY };
+            let mut flags = if extra_flag { RecordFlags::COMPRESSED } else { RecordFlags::EMPTY };
+            if unknown_bit { flags = RecordFlags::from_bits(flags.bits() | 0b0100_0000); }
             let rec = RecordView {
                 seq: Seq::new(seq), timestamp_ms: ts, flags,
                 key: &key, headers: &headers, payload: &payload,
@@ -328,6 +451,7 @@ mod proptests {
             prop_assert_eq!(got.payload, &payload[..]);
             prop_assert_eq!(got.flags.contains(RecordFlags::COMPRESSED), extra_flag);
             prop_assert_eq!(got.flags.contains(RecordFlags::HAS_KEY), !key.is_empty());
+            prop_assert_eq!(got.flags.unknown_bits().bits(), if unknown_bit { 0b0100_0000 } else { 0 });
         }
 
         #[test]
@@ -348,8 +472,11 @@ mod proptests {
             // A single bit flip must never yield a clean decode with the same payload.
             match decode(&buf) {
                 Err(_) => {}
-                Ok((got, _)) => prop_assert!(got.payload != &payload[..],
-                    "a corrupted frame decoded to the original payload"),
+                Ok((got, consumed)) => {
+                    prop_assert_eq!(consumed, buf.len());
+                    prop_assert!(got.payload != &payload[..],
+                        "a corrupted frame decoded to the original payload");
+                }
             }
         }
     }

--- a/crates/ironbus-core/src/codec.rs
+++ b/crates/ironbus-core/src/codec.rs
@@ -1,0 +1,356 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! Encoding and decoding of the IronBus record frame, version 1.
+//!
+//! A frame is a fixed 36-byte header, a variable body (key, then headers, then
+//! payload), and an 8-byte trailer, all little-endian. The `header_crc` (CRC32C)
+//! protects header bytes `[0, 32)`; the `body_crc` (CRC32C) protects the body; and
+//! `total_len` is the whole frame length, which lets a reader find the trailer and
+//! scan forward or backward.
+//!
+//! The optional second xxh3-64 checksum for large payloads (see the corruption
+//! design) is not encoded yet: the frozen trailer has no field for it. That gap is
+//! tracked separately; this codec implements the mandatory CRC32C path.
+
+use crate::format::{
+    header_offsets as off, FORMAT_VERSION, MAX_RECORD_BYTES_CEILING, RECORD_HEADER_CRC_RANGE,
+    RECORD_HEADER_LEN, RECORD_MAGIC, RECORD_TRAILER_LEN,
+};
+use crate::types::{RecordFlags, Seq};
+
+/// A borrowed view of a record, used both as the input to [`encode`] and the
+/// output of [`decode`]. It owns no memory; slices borrow the caller's buffer.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RecordView<'a> {
+    /// The record's sequence number within its segment.
+    pub seq: Seq,
+    /// Producer timestamp in milliseconds since the Unix epoch.
+    pub timestamp_ms: u64,
+    /// Record flags as stored. On [`encode`], the `HAS_KEY` bit is derived from the
+    /// key length and overwritten; other bits are taken from the caller.
+    pub flags: RecordFlags,
+    /// Optional routing or ordering key (empty if none).
+    pub key: &'a [u8],
+    /// Optional record headers blob (empty if none).
+    pub headers: &'a [u8],
+    /// The record payload (possibly compressed; that is signalled by `COMPRESSED`).
+    pub payload: &'a [u8],
+}
+
+/// An error returned by [`encode`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum EncodeError {
+    /// The record's total framed size exceeds the format ceiling of 1 GiB.
+    TooLarge,
+}
+
+/// An error returned by [`decode`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum DecodeError {
+    /// The input ends before a complete frame (a torn or partially written tail).
+    Truncated,
+    /// The leading magic number did not match a record frame.
+    BadMagic,
+    /// The format version is not understood by this build.
+    UnsupportedVersion(u8),
+    /// The header CRC32C did not match: the header is corrupt.
+    BadHeaderCrc,
+    /// The body CRC32C did not match: the body is corrupt.
+    BadBodyCrc,
+    /// The encoded length fields are internally inconsistent.
+    BadLength,
+    /// The encoded total length exceeds the format ceiling of 1 GiB.
+    TooLarge,
+}
+
+impl core::fmt::Display for EncodeError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            EncodeError::TooLarge => write!(f, "record exceeds the maximum frame size"),
+        }
+    }
+}
+impl std::error::Error for EncodeError {}
+
+impl core::fmt::Display for DecodeError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            DecodeError::Truncated => write!(f, "record frame is truncated"),
+            DecodeError::BadMagic => write!(f, "record frame has a bad magic number"),
+            DecodeError::UnsupportedVersion(v) => {
+                write!(f, "unsupported record format version {v}")
+            }
+            DecodeError::BadHeaderCrc => write!(f, "record header CRC mismatch"),
+            DecodeError::BadBodyCrc => write!(f, "record body CRC mismatch"),
+            DecodeError::BadLength => write!(f, "record frame has inconsistent length fields"),
+            DecodeError::TooLarge => write!(f, "record frame exceeds the maximum size"),
+        }
+    }
+}
+impl std::error::Error for DecodeError {}
+
+#[inline]
+fn read_u16(b: &[u8], at: usize) -> u16 {
+    u16::from_le_bytes([b[at], b[at + 1]])
+}
+#[inline]
+fn read_u32(b: &[u8], at: usize) -> u32 {
+    u32::from_le_bytes([b[at], b[at + 1], b[at + 2], b[at + 3]])
+}
+#[inline]
+fn read_u64(b: &[u8], at: usize) -> u64 {
+    let mut a = [0u8; 8];
+    a.copy_from_slice(&b[at..at + 8]);
+    u64::from_le_bytes(a)
+}
+
+/// Encodes `rec` into a complete record frame appended to `out`.
+///
+/// Returns the number of bytes written. The `HAS_KEY` flag is set automatically
+/// when the key is non-empty.
+///
+/// # Errors
+/// Returns [`EncodeError::TooLarge`] if the total framed size would exceed the
+/// 1 GiB format ceiling.
+pub fn encode(rec: &RecordView<'_>, out: &mut Vec<u8>) -> Result<usize, EncodeError> {
+    let key_len = u32::try_from(rec.key.len()).map_err(|_| EncodeError::TooLarge)?;
+    let hdr_len = u32::try_from(rec.headers.len()).map_err(|_| EncodeError::TooLarge)?;
+    let payload_len = u32::try_from(rec.payload.len()).map_err(|_| EncodeError::TooLarge)?;
+
+    let body_len = rec.key.len() + rec.headers.len() + rec.payload.len();
+    let total = RECORD_HEADER_LEN + body_len + RECORD_TRAILER_LEN;
+    let total_u32 = u32::try_from(total).map_err(|_| EncodeError::TooLarge)?;
+    if total_u32 > MAX_RECORD_BYTES_CEILING {
+        return Err(EncodeError::TooLarge);
+    }
+
+    let mut flags = rec.flags;
+    flags = if rec.key.is_empty() {
+        RecordFlags::from_bits(flags.bits() & !RecordFlags::HAS_KEY.bits())
+    } else {
+        flags.with(RecordFlags::HAS_KEY)
+    };
+
+    // Header bytes [0, 32), then the header CRC at [32, 36).
+    let mut header = [0u8; RECORD_HEADER_LEN];
+    header[off::MAGIC..off::MAGIC + 2].copy_from_slice(&RECORD_MAGIC.to_le_bytes());
+    header[off::VERSION] = FORMAT_VERSION;
+    header[off::FLAGS] = flags.bits();
+    header[off::SEQ..off::SEQ + 8].copy_from_slice(&rec.seq.get().to_le_bytes());
+    header[off::TIMESTAMP..off::TIMESTAMP + 8].copy_from_slice(&rec.timestamp_ms.to_le_bytes());
+    header[off::KEY_LEN..off::KEY_LEN + 4].copy_from_slice(&key_len.to_le_bytes());
+    header[off::HDR_LEN..off::HDR_LEN + 4].copy_from_slice(&hdr_len.to_le_bytes());
+    header[off::PAYLOAD_LEN..off::PAYLOAD_LEN + 4].copy_from_slice(&payload_len.to_le_bytes());
+    let header_crc = crc32c::crc32c(&header[RECORD_HEADER_CRC_RANGE]);
+    header[off::HEADER_CRC..off::HEADER_CRC + 4].copy_from_slice(&header_crc.to_le_bytes());
+
+    out.reserve(total);
+    out.extend_from_slice(&header);
+    let body_start = out.len();
+    out.extend_from_slice(rec.key);
+    out.extend_from_slice(rec.headers);
+    out.extend_from_slice(rec.payload);
+    let body_crc = crc32c::crc32c(&out[body_start..body_start + body_len]);
+    out.extend_from_slice(&body_crc.to_le_bytes());
+    out.extend_from_slice(&total_u32.to_le_bytes());
+    Ok(total)
+}
+
+/// Decodes one record frame from the front of `input`.
+///
+/// On success returns the decoded [`RecordView`] (borrowing `input`) and the total
+/// number of bytes the frame occupied, so the caller can advance to the next frame.
+///
+/// # Errors
+/// Returns a [`DecodeError`] describing the first inconsistency found. A
+/// [`DecodeError::Truncated`] means more bytes may complete the frame; the other
+/// variants mean the frame is corrupt and must be skipped by recovery.
+pub fn decode(input: &[u8]) -> Result<(RecordView<'_>, usize), DecodeError> {
+    if input.len() < RECORD_HEADER_LEN {
+        return Err(DecodeError::Truncated);
+    }
+    if read_u16(input, off::MAGIC) != RECORD_MAGIC {
+        return Err(DecodeError::BadMagic);
+    }
+    let version = input[off::VERSION];
+    if version != FORMAT_VERSION {
+        return Err(DecodeError::UnsupportedVersion(version));
+    }
+    let stored_header_crc = read_u32(input, off::HEADER_CRC);
+    if crc32c::crc32c(&input[RECORD_HEADER_CRC_RANGE]) != stored_header_crc {
+        return Err(DecodeError::BadHeaderCrc);
+    }
+
+    let key_len = read_u32(input, off::KEY_LEN) as usize;
+    let hdr_len = read_u32(input, off::HDR_LEN) as usize;
+    let payload_len = read_u32(input, off::PAYLOAD_LEN) as usize;
+    let body_len = key_len + hdr_len + payload_len;
+    let total = RECORD_HEADER_LEN + body_len + RECORD_TRAILER_LEN;
+    if u32::try_from(total).map_or(true, |t| t > MAX_RECORD_BYTES_CEILING) {
+        return Err(DecodeError::TooLarge);
+    }
+    if input.len() < total {
+        return Err(DecodeError::Truncated);
+    }
+
+    let body = &input[RECORD_HEADER_LEN..RECORD_HEADER_LEN + body_len];
+    let trailer = &input[RECORD_HEADER_LEN + body_len..total];
+    let stored_body_crc = read_u32(trailer, 0);
+    let stored_total = read_u32(trailer, 4) as usize;
+    if stored_total != total {
+        return Err(DecodeError::BadLength);
+    }
+    if crc32c::crc32c(body) != stored_body_crc {
+        return Err(DecodeError::BadBodyCrc);
+    }
+
+    let view = RecordView {
+        seq: Seq::new(read_u64(input, off::SEQ)),
+        timestamp_ms: read_u64(input, off::TIMESTAMP),
+        flags: RecordFlags::from_bits(input[off::FLAGS]),
+        key: &body[..key_len],
+        headers: &body[key_len..key_len + hdr_len],
+        payload: &body[key_len + hdr_len..],
+    };
+    Ok((view, total))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> Vec<u8> {
+        let rec = RecordView {
+            seq: Seq::new(7),
+            timestamp_ms: 1234,
+            flags: RecordFlags::EMPTY,
+            key: b"k",
+            headers: b"h",
+            payload: b"hello",
+        };
+        let mut buf = Vec::new();
+        let n = encode(&rec, &mut buf).unwrap();
+        assert_eq!(n, buf.len());
+        buf
+    }
+
+    #[test]
+    fn roundtrip_basic() {
+        let buf = sample();
+        let (got, n) = decode(&buf).unwrap();
+        assert_eq!(n, buf.len());
+        assert_eq!(got.seq, Seq::new(7));
+        assert_eq!(got.timestamp_ms, 1234);
+        assert_eq!(got.key, b"k");
+        assert_eq!(got.headers, b"h");
+        assert_eq!(got.payload, b"hello");
+        // HAS_KEY was derived because the key is non-empty.
+        assert!(got.flags.contains(RecordFlags::HAS_KEY));
+    }
+
+    #[test]
+    fn empty_key_clears_has_key() {
+        let rec = RecordView {
+            seq: Seq::new(1),
+            timestamp_ms: 0,
+            flags: RecordFlags::HAS_KEY, // caller wrongly set it
+            key: b"",
+            headers: b"",
+            payload: b"x",
+        };
+        let mut buf = Vec::new();
+        encode(&rec, &mut buf).unwrap();
+        let (got, _) = decode(&buf).unwrap();
+        assert!(!got.flags.contains(RecordFlags::HAS_KEY));
+    }
+
+    #[test]
+    fn truncated_is_detected() {
+        let buf = sample();
+        assert_eq!(decode(&buf[..10]), Err(DecodeError::Truncated));
+        assert_eq!(decode(&buf[..buf.len() - 1]), Err(DecodeError::Truncated));
+    }
+
+    #[test]
+    fn bad_magic_is_detected() {
+        let mut buf = sample();
+        buf[0] ^= 0xff;
+        assert_eq!(decode(&buf), Err(DecodeError::BadMagic));
+    }
+
+    #[test]
+    fn header_corruption_is_detected() {
+        let mut buf = sample();
+        buf[off::SEQ] ^= 0x01; // a header byte inside the CRC range
+        assert_eq!(decode(&buf), Err(DecodeError::BadHeaderCrc));
+    }
+
+    #[test]
+    fn body_corruption_is_detected() {
+        let mut buf = sample();
+        let body = RECORD_HEADER_LEN + 2; // somewhere in the payload
+        buf[body] ^= 0x01;
+        assert_eq!(decode(&buf), Err(DecodeError::BadBodyCrc));
+    }
+}
+
+#[cfg(test)]
+mod proptests {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn roundtrip(
+            seq in any::<u64>(),
+            ts in any::<u64>(),
+            extra_flag in any::<bool>(),
+            key in proptest::collection::vec(any::<u8>(), 0..300),
+            headers in proptest::collection::vec(any::<u8>(), 0..300),
+            payload in proptest::collection::vec(any::<u8>(), 0..1024),
+        ) {
+            // Only COMPRESSED is a caller-controlled bit here; HAS_KEY is derived.
+            let flags = if extra_flag { RecordFlags::COMPRESSED } else { RecordFlags::EMPTY };
+            let rec = RecordView {
+                seq: Seq::new(seq), timestamp_ms: ts, flags,
+                key: &key, headers: &headers, payload: &payload,
+            };
+            let mut buf = Vec::new();
+            let n = encode(&rec, &mut buf).unwrap();
+            prop_assert_eq!(n, buf.len());
+            let (got, consumed) = decode(&buf).unwrap();
+            prop_assert_eq!(consumed, buf.len());
+            prop_assert_eq!(got.seq, rec.seq);
+            prop_assert_eq!(got.timestamp_ms, rec.timestamp_ms);
+            prop_assert_eq!(got.key, &key[..]);
+            prop_assert_eq!(got.headers, &headers[..]);
+            prop_assert_eq!(got.payload, &payload[..]);
+            prop_assert_eq!(got.flags.contains(RecordFlags::COMPRESSED), extra_flag);
+            prop_assert_eq!(got.flags.contains(RecordFlags::HAS_KEY), !key.is_empty());
+        }
+
+        #[test]
+        fn single_byte_flip_never_decodes_clean(
+            seq in any::<u64>(),
+            payload in proptest::collection::vec(any::<u8>(), 1..512),
+            idx in any::<prop::sample::Index>(),
+            bit in 0u8..8,
+        ) {
+            let rec = RecordView {
+                seq: Seq::new(seq), timestamp_ms: 0, flags: RecordFlags::EMPTY,
+                key: b"", headers: b"", payload: &payload,
+            };
+            let mut buf = Vec::new();
+            encode(&rec, &mut buf).unwrap();
+            let i = idx.index(buf.len());
+            buf[i] ^= 1u8 << bit;
+            // A single bit flip must never yield a clean decode with the same payload.
+            match decode(&buf) {
+                Err(_) => {}
+                Ok((got, _)) => prop_assert!(got.payload != &payload[..],
+                    "a corrupted frame decoded to the original payload"),
+            }
+        }
+    }
+}

--- a/crates/ironbus-core/src/lib.rs
+++ b/crates/ironbus-core/src/lib.rs
@@ -7,5 +7,6 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 
+pub mod codec;
 pub mod format;
 pub mod types;


### PR DESCRIPTION
## What
- `ironbus-core::codec`: `encode`/`decode` for the v1 record frame with CRC32C header and body checksums, typed `EncodeError`/`DecodeError`, a borrowed `RecordView`, and a derived `HAS_KEY` flag.
- Tests: unit cases (truncated, bad magic, header corruption, body corruption, empty-key flag clearing), a proptest round-trip, and a proptest asserting a single bit flip anywhere in the frame never yields a clean decode of the original payload.
- New deps: `crc32c` (runtime, IO-free, license allowlisted) and `proptest` (dev).

## Why
The record codec is the heart of the on-disk format (#5), and the property + corruption-detection tests establish the testing discipline the design requires.

## Discovered gap (filed as #146)
The frozen 8-byte trailer (#5) has no field for the xxh3-64 large-payload checksum that #8 requires. This codec implements the mandatory CRC32C path only; the xxh3 frame layout is tracked in #146.

## Test evidence
Local: `cargo fmt --check`, `cargo clippy -- -D warnings` (pedantic), 18 tests (codec unit + proptests), `cargo deny check`, SPDX, and the no-IO lint all pass.

refs #5, #137, #146