### PR TITLE
feat(storage): file IO seam (RandomAccessFile trait + InMemoryFile)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ to follow Semantic Versioning once it reaches a tagged release.
 - Continuous integration: rustfmt, clippy (deny warnings), test matrix on Linux,
   macOS, and Windows, an MSRV 1.78 build, and a lint that keeps `ironbus-core` IO-free.
 - Dual `MIT OR Apache-2.0` license files.
+- `ironbus-storage::io`: the `RandomAccessFile` trait (positioned reads/writes, `sync_data`, `len`, `set_len`) and an `InMemoryFile` (sync-counting, snapshot-able) so storage goes through a seam the deterministic simulation can substitute.
 - `ironbus-core::clock`: the `Clock` trait (wall and monotonic time) and a deterministic `ManualClock`, so engine logic never reads the host clock directly and the simulation controls time.
 - `ironbus-core::codec`: record-frame encode and decode with CRC32C header and body checksums, typed `EncodeError`/`DecodeError`, and proptest round-trip plus single-bit-flip corruption-detection tests. The optional xxh3-64 large-payload checksum is deferred (frame layout pending).
 - `ironbus-core`: frozen v1 on-disk format constants and field offsets (record header, trailer, segment header and footer), and the `Offset`, `Seq`, and `RecordFlags` value types, with unit tests pinning the layout.

--- a/crates/ironbus-storage/src/io.rs
+++ b/crates/ironbus-storage/src/io.rs
@@ -10,12 +10,13 @@ use std::io;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Mutex, PoisonError};
 
-/// A file supporting positioned (offset-addressed) reads and writes plus an explicit
-/// data sync.
+/// A file supporting positioned (offset-addressed) reads and writes plus explicit
+/// data and metadata syncs.
 ///
 /// All methods take `&self`. The single-logical-writer rule is enforced by the
 /// layers above, not the borrow checker, so a file can be shared with lock-free
-/// readers.
+/// readers. The production implementation relies on that upper-layer invariant: it
+/// does not itself guard against two concurrent `&self` writers.
 pub trait RandomAccessFile: Send + Sync {
     /// Reads into `buf` starting at `offset`, returning the number of bytes read.
     ///
@@ -26,6 +27,30 @@ pub trait RandomAccessFile: Send + Sync {
     /// Propagates the underlying IO error.
     fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<usize>;
 
+    /// Fills `buf` exactly from `offset`, erroring with [`io::ErrorKind::UnexpectedEof`]
+    /// if the file ends first. This is the primitive sealed-segment readers use to
+    /// read fixed-size headers and footers.
+    ///
+    /// # Errors
+    /// Propagates the underlying IO error, or `UnexpectedEof` on a short file.
+    fn read_exact_at(&self, mut buf: &mut [u8], mut offset: u64) -> io::Result<()> {
+        while !buf.is_empty() {
+            match self.read_at(buf, offset)? {
+                0 => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        "read past end of file",
+                    ))
+                }
+                n => {
+                    buf = &mut buf[n..];
+                    offset += n as u64;
+                }
+            }
+        }
+        Ok(())
+    }
+
     /// Writes all of `buf` starting at `offset`, extending the file with zero bytes
     /// if `offset` lies beyond the current end.
     ///
@@ -33,12 +58,23 @@ pub trait RandomAccessFile: Send + Sync {
     /// Propagates the underlying IO error.
     fn write_all_at(&self, buf: &[u8], offset: u64) -> io::Result<()>;
 
-    /// Flushes file data (not necessarily metadata) to durable storage, like
-    /// `fdatasync`.
+    /// Flushes file data to durable storage, like `fdatasync`. Does not guarantee
+    /// that metadata such as the file length is persisted; use [`sync_all`] after a
+    /// [`set_len`] that must survive a crash.
+    ///
+    /// [`sync_all`]: RandomAccessFile::sync_all
+    /// [`set_len`]: RandomAccessFile::set_len
     ///
     /// # Errors
     /// Propagates the underlying IO error.
     fn sync_data(&self) -> io::Result<()>;
+
+    /// Flushes file data and metadata (including length) to durable storage, like
+    /// `fsync`.
+    ///
+    /// # Errors
+    /// Propagates the underlying IO error.
+    fn sync_all(&self) -> io::Result<()>;
 
     /// Returns the current file length in bytes.
     ///
@@ -46,7 +82,10 @@ pub trait RandomAccessFile: Send + Sync {
     /// Propagates the underlying IO error.
     fn len(&self) -> io::Result<u64>;
 
-    /// Truncates or extends the file to `len` bytes; extension zero-fills.
+    /// Truncates or extends the file to `len` bytes; extension zero-fills. The new
+    /// length is metadata, so it is only crash-durable after [`sync_all`].
+    ///
+    /// [`sync_all`]: RandomAccessFile::sync_all
     ///
     /// # Errors
     /// Propagates the underlying IO error.
@@ -65,14 +104,23 @@ fn invalid_input(msg: &'static str) -> io::Error {
     io::Error::new(io::ErrorKind::InvalidInput, msg)
 }
 
+#[derive(Debug, Default)]
+struct State {
+    /// The current (possibly-unsynced) bytes.
+    live: Vec<u8>,
+    /// The bytes as of the last sync: the only bytes that survive a power loss.
+    durable: Vec<u8>,
+}
+
 /// An in-memory [`RandomAccessFile`] for tests and the deterministic simulation.
 ///
-/// It counts calls to [`sync_data`](RandomAccessFile::sync_data) and can
-/// [`snapshot`](InMemoryFile::snapshot) its bytes, so a simulation can model power
-/// loss by treating only the bytes present at the last sync as durable.
+/// It tracks two images: the `live` bytes and the `durable` bytes (a copy taken at
+/// each sync). [`simulate_power_loss`](InMemoryFile::simulate_power_loss) discards
+/// every write made since the last sync, so a simulation can verify that no
+/// acknowledged-and-synced data is ever lost and that unsynced writes may vanish.
 #[derive(Debug, Default)]
 pub struct InMemoryFile {
-    data: Mutex<Vec<u8>>,
+    state: Mutex<State>,
     syncs: AtomicU64,
 }
 
@@ -83,40 +131,63 @@ impl InMemoryFile {
         InMemoryFile::default()
     }
 
-    /// Creates an in-memory file pre-populated with `bytes`.
+    /// Creates an in-memory file whose `bytes` are already durable (as if loaded
+    /// from disk).
     #[must_use]
     pub fn from_bytes(bytes: Vec<u8>) -> InMemoryFile {
         InMemoryFile {
-            data: Mutex::new(bytes),
+            state: Mutex::new(State {
+                live: bytes.clone(),
+                durable: bytes,
+            }),
             syncs: AtomicU64::new(0),
         }
     }
 
-    /// Returns how many times `sync_data` has been called.
+    // A panic mid-method cannot leave `State` torn: the only mutations are
+    // `copy_from_slice`/`resize`/`clone`, none of which unwind partway through a
+    // structurally invalid state, so recovering the guard from poison is safe and
+    // keeps the test or simulation process alive.
+    fn lock(&self) -> std::sync::MutexGuard<'_, State> {
+        self.state.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    /// Returns how many times `sync_data` or `sync_all` has been called.
     #[must_use]
     pub fn sync_count(&self) -> u64 {
         self.syncs.load(Ordering::SeqCst)
     }
 
-    /// Returns a copy of the file's current bytes.
+    /// Returns a copy of the current (live) bytes.
     #[must_use]
     pub fn snapshot(&self) -> Vec<u8> {
-        self.data
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner)
-            .clone()
+        self.lock().live.clone()
+    }
+
+    /// Returns a copy of the durable bytes: the file as of the last sync.
+    #[must_use]
+    pub fn durable_snapshot(&self) -> Vec<u8> {
+        self.lock().durable.clone()
+    }
+
+    /// Discards every write made since the last sync, modelling a power loss: the
+    /// live bytes revert to the durable image.
+    pub fn simulate_power_loss(&self) {
+        let mut guard = self.lock();
+        let s = &mut *guard;
+        s.live.clone_from(&s.durable);
     }
 }
 
 impl RandomAccessFile for InMemoryFile {
     fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<usize> {
         let off = usize::try_from(offset).map_err(|_| invalid_input("offset out of range"))?;
-        let data = self.data.lock().unwrap_or_else(PoisonError::into_inner);
-        if off >= data.len() {
+        let s = self.lock();
+        if off >= s.live.len() {
             return Ok(0);
         }
-        let n = (data.len() - off).min(buf.len());
-        buf[..n].copy_from_slice(&data[off..off + n]);
+        let n = (s.live.len() - off).min(buf.len());
+        buf[..n].copy_from_slice(&s.live[off..off + n]);
         Ok(n)
     }
 
@@ -125,33 +196,34 @@ impl RandomAccessFile for InMemoryFile {
         let end = off
             .checked_add(buf.len())
             .ok_or_else(|| invalid_input("write extends past the addressable range"))?;
-        let mut data = self.data.lock().unwrap_or_else(PoisonError::into_inner);
-        if data.len() < end {
-            data.resize(end, 0);
+        let mut s = self.lock();
+        if s.live.len() < end {
+            s.live.resize(end, 0);
         }
-        data[off..end].copy_from_slice(buf);
+        s.live[off..end].copy_from_slice(buf);
         Ok(())
     }
 
     fn sync_data(&self) -> io::Result<()> {
+        // In-memory has no separate metadata, so data and metadata sync are identical.
+        let mut guard = self.lock();
+        let s = &mut *guard;
+        s.durable.clone_from(&s.live);
         self.syncs.fetch_add(1, Ordering::SeqCst);
         Ok(())
     }
 
+    fn sync_all(&self) -> io::Result<()> {
+        self.sync_data()
+    }
+
     fn len(&self) -> io::Result<u64> {
-        Ok(self
-            .data
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner)
-            .len() as u64)
+        Ok(self.lock().live.len() as u64)
     }
 
     fn set_len(&self, len: u64) -> io::Result<()> {
         let len = usize::try_from(len).map_err(|_| invalid_input("length out of range"))?;
-        self.data
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner)
-            .resize(len, 0);
+        self.lock().live.resize(len, 0);
         Ok(())
     }
 }
@@ -184,11 +256,22 @@ mod tests {
     fn read_past_end_returns_zero_and_partial_near_end() {
         let f = InMemoryFile::from_bytes(b"abcd".to_vec());
         let mut buf = [0u8; 8];
-        assert_eq!(f.read_at(&mut buf, 4).unwrap(), 0); // at end
-        assert_eq!(f.read_at(&mut buf, 100).unwrap(), 0); // past end
-        let n = f.read_at(&mut buf, 2).unwrap(); // partial: only 2 bytes left
+        assert_eq!(f.read_at(&mut buf, 4).unwrap(), 0);
+        assert_eq!(f.read_at(&mut buf, 100).unwrap(), 0);
+        let n = f.read_at(&mut buf, 2).unwrap();
         assert_eq!(n, 2);
         assert_eq!(&buf[..2], b"cd");
+    }
+
+    #[test]
+    fn read_exact_at_fills_or_errors() {
+        let f = InMemoryFile::from_bytes(b"abcdef".to_vec());
+        let mut buf = [0u8; 4];
+        f.read_exact_at(&mut buf, 2).unwrap();
+        assert_eq!(&buf, b"cdef");
+        // Not enough bytes left: UnexpectedEof.
+        let err = f.read_exact_at(&mut buf, 4).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
     }
 
     #[test]
@@ -201,13 +284,41 @@ mod tests {
     }
 
     #[test]
-    fn sync_is_counted() {
+    fn sync_captures_durable_image_and_is_counted() {
         let f = InMemoryFile::new();
         assert_eq!(f.sync_count(), 0);
-        f.write_all_at(b"x", 0).unwrap();
+        f.write_all_at(b"one", 0).unwrap();
         f.sync_data().unwrap();
-        f.sync_data().unwrap();
+        assert_eq!(f.sync_count(), 1);
+        assert_eq!(f.durable_snapshot(), b"one");
+        // A write after the sync is live but not yet durable.
+        f.write_all_at(b"two", 3).unwrap();
+        assert_eq!(f.snapshot(), b"onetwo");
+        assert_eq!(f.durable_snapshot(), b"one");
+        f.sync_all().unwrap();
         assert_eq!(f.sync_count(), 2);
+        assert_eq!(f.durable_snapshot(), b"onetwo");
+    }
+
+    #[test]
+    fn power_loss_discards_unsynced_writes_only() {
+        let f = InMemoryFile::new();
+        f.write_all_at(b"durable", 0).unwrap();
+        f.sync_data().unwrap();
+        f.write_all_at(b"!!!", 7).unwrap(); // unsynced
+        assert_eq!(f.snapshot(), b"durable!!!");
+        f.simulate_power_loss();
+        // Only the synced prefix survives.
+        assert_eq!(f.snapshot(), b"durable");
+        assert_eq!(f.durable_snapshot(), b"durable");
+    }
+
+    #[test]
+    fn from_bytes_is_already_durable() {
+        let f = InMemoryFile::from_bytes(b"loaded".to_vec());
+        f.write_all_at(b"X", 0).unwrap();
+        f.simulate_power_loss();
+        assert_eq!(f.snapshot(), b"loaded");
     }
 
     #[test]

--- a/crates/ironbus-storage/src/io.rs
+++ b/crates/ironbus-storage/src/io.rs
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! The file IO seam for IronBus storage.
+//!
+//! Storage code reads and writes through [`RandomAccessFile`] rather than calling
+//! the filesystem directly, so the deterministic simulation can substitute an
+//! in-memory disk it fully controls. Production wires a real file (added later);
+//! tests and the simulation wire [`InMemoryFile`].
+
+use std::io;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, PoisonError};
+
+/// A file supporting positioned (offset-addressed) reads and writes plus an explicit
+/// data sync.
+///
+/// All methods take `&self`. The single-logical-writer rule is enforced by the
+/// layers above, not the borrow checker, so a file can be shared with lock-free
+/// readers.
+pub trait RandomAccessFile: Send + Sync {
+    /// Reads into `buf` starting at `offset`, returning the number of bytes read.
+    ///
+    /// Like `pread`: it may read fewer bytes than requested (for example near the
+    /// end of the file) and returns `0` at or past the end.
+    ///
+    /// # Errors
+    /// Propagates the underlying IO error.
+    fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<usize>;
+
+    /// Writes all of `buf` starting at `offset`, extending the file with zero bytes
+    /// if `offset` lies beyond the current end.
+    ///
+    /// # Errors
+    /// Propagates the underlying IO error.
+    fn write_all_at(&self, buf: &[u8], offset: u64) -> io::Result<()>;
+
+    /// Flushes file data (not necessarily metadata) to durable storage, like
+    /// `fdatasync`.
+    ///
+    /// # Errors
+    /// Propagates the underlying IO error.
+    fn sync_data(&self) -> io::Result<()>;
+
+    /// Returns the current file length in bytes.
+    ///
+    /// # Errors
+    /// Propagates the underlying IO error.
+    fn len(&self) -> io::Result<u64>;
+
+    /// Truncates or extends the file to `len` bytes; extension zero-fills.
+    ///
+    /// # Errors
+    /// Propagates the underlying IO error.
+    fn set_len(&self, len: u64) -> io::Result<()>;
+
+    /// Returns `true` if the file is empty.
+    ///
+    /// # Errors
+    /// Propagates the underlying IO error.
+    fn is_empty(&self) -> io::Result<bool> {
+        Ok(self.len()? == 0)
+    }
+}
+
+fn invalid_input(msg: &'static str) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidInput, msg)
+}
+
+/// An in-memory [`RandomAccessFile`] for tests and the deterministic simulation.
+///
+/// It counts calls to [`sync_data`](RandomAccessFile::sync_data) and can
+/// [`snapshot`](InMemoryFile::snapshot) its bytes, so a simulation can model power
+/// loss by treating only the bytes present at the last sync as durable.
+#[derive(Debug, Default)]
+pub struct InMemoryFile {
+    data: Mutex<Vec<u8>>,
+    syncs: AtomicU64,
+}
+
+impl InMemoryFile {
+    /// Creates an empty in-memory file.
+    #[must_use]
+    pub fn new() -> InMemoryFile {
+        InMemoryFile::default()
+    }
+
+    /// Creates an in-memory file pre-populated with `bytes`.
+    #[must_use]
+    pub fn from_bytes(bytes: Vec<u8>) -> InMemoryFile {
+        InMemoryFile {
+            data: Mutex::new(bytes),
+            syncs: AtomicU64::new(0),
+        }
+    }
+
+    /// Returns how many times `sync_data` has been called.
+    #[must_use]
+    pub fn sync_count(&self) -> u64 {
+        self.syncs.load(Ordering::SeqCst)
+    }
+
+    /// Returns a copy of the file's current bytes.
+    #[must_use]
+    pub fn snapshot(&self) -> Vec<u8> {
+        self.data
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .clone()
+    }
+}
+
+impl RandomAccessFile for InMemoryFile {
+    fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<usize> {
+        let off = usize::try_from(offset).map_err(|_| invalid_input("offset out of range"))?;
+        let data = self.data.lock().unwrap_or_else(PoisonError::into_inner);
+        if off >= data.len() {
+            return Ok(0);
+        }
+        let n = (data.len() - off).min(buf.len());
+        buf[..n].copy_from_slice(&data[off..off + n]);
+        Ok(n)
+    }
+
+    fn write_all_at(&self, buf: &[u8], offset: u64) -> io::Result<()> {
+        let off = usize::try_from(offset).map_err(|_| invalid_input("offset out of range"))?;
+        let end = off
+            .checked_add(buf.len())
+            .ok_or_else(|| invalid_input("write extends past the addressable range"))?;
+        let mut data = self.data.lock().unwrap_or_else(PoisonError::into_inner);
+        if data.len() < end {
+            data.resize(end, 0);
+        }
+        data[off..end].copy_from_slice(buf);
+        Ok(())
+    }
+
+    fn sync_data(&self) -> io::Result<()> {
+        self.syncs.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+
+    fn len(&self) -> io::Result<u64> {
+        Ok(self
+            .data
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .len() as u64)
+    }
+
+    fn set_len(&self, len: u64) -> io::Result<()> {
+        let len = usize::try_from(len).map_err(|_| invalid_input("length out of range"))?;
+        self.data
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .resize(len, 0);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    #[test]
+    fn write_then_read_roundtrip() {
+        let f = InMemoryFile::new();
+        f.write_all_at(b"hello", 0).unwrap();
+        let mut buf = [0u8; 5];
+        assert_eq!(f.read_at(&mut buf, 0).unwrap(), 5);
+        assert_eq!(&buf, b"hello");
+        assert_eq!(f.len().unwrap(), 5);
+        assert!(!f.is_empty().unwrap());
+    }
+
+    #[test]
+    fn write_past_end_zero_fills_the_gap() {
+        let f = InMemoryFile::new();
+        f.write_all_at(b"ab", 4).unwrap();
+        assert_eq!(f.len().unwrap(), 6);
+        assert_eq!(f.snapshot(), vec![0, 0, 0, 0, b'a', b'b']);
+    }
+
+    #[test]
+    fn read_past_end_returns_zero_and_partial_near_end() {
+        let f = InMemoryFile::from_bytes(b"abcd".to_vec());
+        let mut buf = [0u8; 8];
+        assert_eq!(f.read_at(&mut buf, 4).unwrap(), 0); // at end
+        assert_eq!(f.read_at(&mut buf, 100).unwrap(), 0); // past end
+        let n = f.read_at(&mut buf, 2).unwrap(); // partial: only 2 bytes left
+        assert_eq!(n, 2);
+        assert_eq!(&buf[..2], b"cd");
+    }
+
+    #[test]
+    fn set_len_truncates_and_extends() {
+        let f = InMemoryFile::from_bytes(b"abcdef".to_vec());
+        f.set_len(3).unwrap();
+        assert_eq!(f.snapshot(), b"abc");
+        f.set_len(5).unwrap();
+        assert_eq!(f.snapshot(), vec![b'a', b'b', b'c', 0, 0]);
+    }
+
+    #[test]
+    fn sync_is_counted() {
+        let f = InMemoryFile::new();
+        assert_eq!(f.sync_count(), 0);
+        f.write_all_at(b"x", 0).unwrap();
+        f.sync_data().unwrap();
+        f.sync_data().unwrap();
+        assert_eq!(f.sync_count(), 2);
+    }
+
+    #[test]
+    fn empty_file_reports_empty() {
+        let f = InMemoryFile::new();
+        assert!(f.is_empty().unwrap());
+        assert_eq!(f.len().unwrap(), 0);
+        let mut buf = [0u8; 4];
+        assert_eq!(f.read_at(&mut buf, 0).unwrap(), 0);
+    }
+
+    #[test]
+    fn shared_across_threads_as_trait_object() {
+        let f: Arc<dyn RandomAccessFile> = Arc::new(InMemoryFile::new());
+        let f2 = Arc::clone(&f);
+        std::thread::scope(|s| {
+            s.spawn(move || f2.write_all_at(b"data", 0).unwrap());
+        });
+        let mut buf = [0u8; 4];
+        assert_eq!(f.read_at(&mut buf, 0).unwrap(), 4);
+        assert_eq!(&buf, b"data");
+    }
+}

--- a/crates/ironbus-storage/src/lib.rs
+++ b/crates/ironbus-storage/src/lib.rs
@@ -1,2 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 //! Storage engine for IronBus: segmented log, durability, recovery.
+#![warn(missing_docs)]
+
+pub mod io;


### PR DESCRIPTION
## What
- `ironbus-storage::io::RandomAccessFile`: positioned `read_at`/`write_all_at` (pread/pwrite semantics, zero-fill on write past end), `sync_data` (fdatasync), `len`, `set_len`, `is_empty`. All `&self` so a file can be shared with lock-free readers.
- `InMemoryFile`: a `Vec`-backed deterministic implementation that counts `sync_data` calls and can `snapshot()` its bytes, so the simulation can model power loss (only bytes present at the last sync are durable). Poisoned-lock recovery avoids panics.

## Why
The determinism seam (#21): storage must not call the filesystem directly, so the simulation can drive a disk it controls. This is the file half of the IO seam (the clock half landed in #149). The production `std::fs` impl and directory fsync come with the segment store.

## Test evidence
Local: fmt, clippy pedantic `-D warnings`, 7 tests (round-trip, zero-fill gap, partial/past-end reads, truncate/extend, sync counting, cross-thread `Arc<dyn RandomAccessFile>`), cargo-deny, SPDX all pass.

refs #21, #4