### PR TITLE
feat(storage): production StdFile (cursor-free positioned IO) + sync_dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ to follow Semantic Versioning once it reaches a tagged release.
   macOS, and Windows, an MSRV 1.78 build, and a lint that keeps `ironbus-core` IO-free.
 - Dual `MIT OR Apache-2.0` license files.
 - `ironbus-storage::io`: the `RandomAccessFile` trait (positioned reads/writes, `sync_data`, `len`, `set_len`) and an `InMemoryFile` (sync-counting, snapshot-able) so storage goes through a seam the deterministic simulation can substitute.
+- `ironbus-storage::io::StdFile`: production `RandomAccessFile` over an OS file using cursor-free positioned IO (pread/pwrite), plus `sync_dir` for crash-durable segment creation (Unix targets; Windows is a v1 non-goal).
 - `ironbus-core::clock`: the `Clock` trait (wall and monotonic time) and a deterministic `ManualClock`, so engine logic never reads the host clock directly and the simulation controls time.
 - `ironbus-core::codec`: record-frame encode and decode with CRC32C header and body checksums, typed `EncodeError`/`DecodeError`, and proptest round-trip plus single-bit-flip corruption-detection tests. The optional xxh3-64 large-payload checksum is deferred (frame layout pending).
 - `ironbus-core`: frozen v1 on-disk format constants and field offsets (record header, trailer, segment header and footer), and the `Offset`, `Seq`, and `RecordFlags` value types, with unit tests pinning the layout.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,6 +175,9 @@ version = "0.0.0"
 [[package]]
 name = "ironbus-storage"
 version = "0.0.0"
+dependencies = [
+ "tempfile",
+]
 
 [[package]]
 name = "itoa"

--- a/crates/ironbus-storage/Cargo.toml
+++ b/crates/ironbus-storage/Cargo.toml
@@ -8,5 +8,8 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 
+[dev-dependencies]
+tempfile = "3"
+
 [lints]
 workspace = true

--- a/crates/ironbus-storage/src/io.rs
+++ b/crates/ironbus-storage/src/io.rs
@@ -342,3 +342,139 @@ mod tests {
         assert_eq!(&buf, b"data");
     }
 }
+
+/// A production [`RandomAccessFile`] backed by an OS file, using cursor-free
+/// positioned IO (`pread`/`pwrite`) so concurrent readers never contend on a shared
+/// file cursor. Available on Unix targets (the v1 production targets are Linux musl
+/// and macOS); Windows is a v1 non-goal and gets only the trait and [`InMemoryFile`].
+#[cfg(unix)]
+#[derive(Debug)]
+pub struct StdFile {
+    file: std::fs::File,
+}
+
+#[cfg(unix)]
+impl StdFile {
+    /// Opens an existing file for reading and writing.
+    ///
+    /// # Errors
+    /// Propagates the underlying IO error.
+    pub fn open(path: &std::path::Path) -> io::Result<StdFile> {
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(path)?;
+        Ok(StdFile { file })
+    }
+
+    /// Creates a new file (truncating any existing one) for reading and writing.
+    ///
+    /// # Errors
+    /// Propagates the underlying IO error.
+    pub fn create(path: &std::path::Path) -> io::Result<StdFile> {
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(path)?;
+        Ok(StdFile { file })
+    }
+
+    /// Wraps an already-open file.
+    #[must_use]
+    pub fn from_file(file: std::fs::File) -> StdFile {
+        StdFile { file }
+    }
+}
+
+#[cfg(unix)]
+impl RandomAccessFile for StdFile {
+    fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<usize> {
+        std::os::unix::fs::FileExt::read_at(&self.file, buf, offset)
+    }
+
+    fn write_all_at(&self, buf: &[u8], offset: u64) -> io::Result<()> {
+        std::os::unix::fs::FileExt::write_all_at(&self.file, buf, offset)
+    }
+
+    fn sync_data(&self) -> io::Result<()> {
+        self.file.sync_data()
+    }
+
+    fn sync_all(&self) -> io::Result<()> {
+        self.file.sync_all()
+    }
+
+    fn len(&self) -> io::Result<u64> {
+        Ok(self.file.metadata()?.len())
+    }
+
+    fn set_len(&self, len: u64) -> io::Result<()> {
+        self.file.set_len(len)
+    }
+}
+
+/// Fsyncs the directory at `path` so a newly created, renamed, or removed entry in
+/// it is crash-durable. Without this, a power loss after creating a segment file but
+/// before syncing its directory can leave the file absent on restart.
+///
+/// # Errors
+/// Propagates the underlying IO error.
+#[cfg(unix)]
+pub fn sync_dir(path: &std::path::Path) -> io::Result<()> {
+    std::fs::File::open(path)?.sync_all()
+}
+
+#[cfg(all(test, unix))]
+mod std_file_tests {
+    use super::*;
+
+    #[test]
+    fn stdfile_roundtrip_and_persists() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("seg.log");
+        let f = StdFile::create(&path).unwrap();
+        f.write_all_at(b"hello world", 0).unwrap();
+        f.sync_data().unwrap();
+        let mut buf = [0u8; 11];
+        f.read_exact_at(&mut buf, 0).unwrap();
+        assert_eq!(&buf, b"hello world");
+        assert_eq!(f.len().unwrap(), 11);
+        drop(f);
+        // Reopen and verify the bytes persisted.
+        let g = StdFile::open(&path).unwrap();
+        let mut b2 = [0u8; 5];
+        assert_eq!(g.read_at(&mut b2, 6).unwrap(), 5);
+        assert_eq!(&b2, b"world");
+    }
+
+    #[test]
+    fn stdfile_set_len_truncate_and_extend() {
+        let dir = tempfile::tempdir().unwrap();
+        let f = StdFile::create(&dir.path().join("x")).unwrap();
+        f.write_all_at(b"abcdef", 0).unwrap();
+        f.set_len(3).unwrap();
+        assert_eq!(f.len().unwrap(), 3);
+        f.set_len(5).unwrap();
+        let mut buf = [9u8; 5];
+        f.read_exact_at(&mut buf, 0).unwrap();
+        assert_eq!(&buf, &[b'a', b'b', b'c', 0, 0]);
+    }
+
+    #[test]
+    fn stdfile_read_past_end_is_zero() {
+        let dir = tempfile::tempdir().unwrap();
+        let f = StdFile::create(&dir.path().join("e")).unwrap();
+        let mut buf = [0u8; 4];
+        assert_eq!(f.read_at(&mut buf, 0).unwrap(), 0);
+    }
+
+    #[test]
+    fn sync_dir_succeeds() {
+        let dir = tempfile::tempdir().unwrap();
+        let f = StdFile::create(&dir.path().join("f")).unwrap();
+        f.sync_all().unwrap();
+        sync_dir(dir.path()).unwrap();
+    }
+}

--- a/crates/ironbus-storage/src/io.rs
+++ b/crates/ironbus-storage/src/io.rs
@@ -367,7 +367,9 @@ impl StdFile {
         Ok(StdFile { file })
     }
 
-    /// Creates a new file (truncating any existing one) for reading and writing.
+    /// Creates a file for reading and writing, TRUNCATING any existing file at the
+    /// path. This is destructive: for a durable segment that must never clobber an
+    /// existing one, use [`StdFile::create_new`]. Intended for scratch and tests.
     ///
     /// # Errors
     /// Propagates the underlying IO error.
@@ -381,7 +383,24 @@ impl StdFile {
         Ok(StdFile { file })
     }
 
-    /// Wraps an already-open file.
+    /// Creates a new file for reading and writing, failing with
+    /// [`io::ErrorKind::AlreadyExists`] if the path already exists (`O_EXCL`). This is
+    /// the safe primitive for creating a durable segment: it can never clobber an
+    /// existing one.
+    ///
+    /// # Errors
+    /// Returns `AlreadyExists` if the path exists, or propagates the underlying IO error.
+    pub fn create_new(path: &std::path::Path) -> io::Result<StdFile> {
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create_new(true)
+            .open(path)?;
+        Ok(StdFile { file })
+    }
+
+    /// Wraps an already-open file, for a preallocated or handed-off descriptor. The
+    /// caller is responsible for opening it read and write.
     #[must_use]
     pub fn from_file(file: std::fs::File) -> StdFile {
         StdFile { file }
@@ -418,6 +437,9 @@ impl RandomAccessFile for StdFile {
 /// Fsyncs the directory at `path` so a newly created, renamed, or removed entry in
 /// it is crash-durable. Without this, a power loss after creating a segment file but
 /// before syncing its directory can leave the file absent on restart.
+///
+/// Ordering: call this AFTER the new file's own `sync_all`, so the create path is
+/// fsync-the-file, then full-fsync-the-parent-directory, then ack.
 ///
 /// # Errors
 /// Propagates the underlying IO error.
@@ -468,6 +490,38 @@ mod std_file_tests {
         let f = StdFile::create(&dir.path().join("e")).unwrap();
         let mut buf = [0u8; 4];
         assert_eq!(f.read_at(&mut buf, 0).unwrap(), 0);
+    }
+
+    #[test]
+    fn create_new_refuses_existing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("seg");
+        let _f = StdFile::create_new(&path).unwrap();
+        let err = StdFile::create_new(&path).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::AlreadyExists);
+    }
+
+    #[test]
+    fn concurrent_positioned_reads_are_race_free() {
+        let dir = tempfile::tempdir().unwrap();
+        let f = StdFile::create(&dir.path().join("seg")).unwrap();
+        f.write_all_at(b"0123456789", 0).unwrap();
+        f.sync_data().unwrap();
+        let f = std::sync::Arc::new(f);
+        std::thread::scope(|sc| {
+            for k in 0u64..8 {
+                let f = std::sync::Arc::clone(&f);
+                sc.spawn(move || {
+                    let off = k % 7;
+                    let start = usize::try_from(off).unwrap();
+                    for _ in 0..200 {
+                        let mut buf = [0u8; 3];
+                        f.read_exact_at(&mut buf, off).unwrap();
+                        assert_eq!(&buf, &b"0123456789"[start..start + 3]);
+                    }
+                });
+            }
+        });
     }
 
     #[test]


### PR DESCRIPTION
## What
- `ironbus-storage::io::StdFile`: a production `RandomAccessFile` backed by `std::fs::File`, using cursor-free positioned IO (`FileExt::read_at`/`write_all_at` = `pread`/`pwrite`) so lock-free concurrent readers never contend on a shared file cursor. `open`/`create`/`from_file` constructors; `sync_data`/`sync_all` map to `fdatasync`/`fsync`.
- `sync_dir(path)`: fsyncs a directory so a newly created, renamed, or removed entry is crash-durable (needed before acking a segment roll).

## Scope
Scoped to `cfg(unix)`. The v1 first-class targets are Linux musl (aarch64/x86_64/armv7) and macOS, all Unix. Windows is a committed v1 non-goal, so it compiles and tests the trait + `InMemoryFile` only. Note: macOS `fsync` does not flush to the platter without `F_FULLFSYNC`; that durability nuance belongs to the durability model (#6).

## Test evidence
Local (macOS): fmt, clippy pedantic `-D warnings`, 14 storage tests (4 new `StdFile`: round-trip + reopen persistence, truncate/extend, read-past-end, `sync_dir`), cargo-deny (tempfile licenses allowlisted), SPDX, no-IO lint all pass. `ironbus-core` dep tree stays runtime-free.

refs #4, #6, #17