### PR TITLE
feat(core): segment header/footer codec; share raw read helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ to follow Semantic Versioning once it reaches a tagged release.
 - Dual `MIT OR Apache-2.0` license files.
 - `ironbus-storage::io`: the `RandomAccessFile` trait (positioned reads/writes, `sync_data`, `len`, `set_len`) and an `InMemoryFile` (sync-counting, snapshot-able) so storage goes through a seam the deterministic simulation can substitute.
 - `ironbus-storage::io::StdFile`: production `RandomAccessFile` over an OS file using cursor-free positioned IO (pread/pwrite), plus `sync_dir` for crash-durable segment creation (Unix targets; Windows is a v1 non-goal).
+- `ironbus-core::segment`: encode and decode of the frozen 64-byte segment header and 32-byte sealed footer, both CRC32C-protected, with a typed `SegmentError` and proptest round-trip plus corruption tests. Shared little-endian read helpers factored into `crate::raw`.
 - `ironbus-core::clock`: the `Clock` trait (wall and monotonic time) and a deterministic `ManualClock`, so engine logic never reads the host clock directly and the simulation controls time.
 - `ironbus-core::codec`: record-frame encode and decode with CRC32C header and body checksums, typed `EncodeError`/`DecodeError`, and proptest round-trip plus single-bit-flip corruption-detection tests. The optional xxh3-64 large-payload checksum is deferred (frame layout pending).
 - `ironbus-core`: frozen v1 on-disk format constants and field offsets (record header, trailer, segment header and footer), and the `Offset`, `Seq`, and `RecordFlags` value types, with unit tests pinning the layout.

--- a/crates/ironbus-core/src/codec.rs
+++ b/crates/ironbus-core/src/codec.rs
@@ -15,6 +15,7 @@ use crate::format::{
     header_offsets as off, FORMAT_VERSION, MAX_RECORD_BYTES_CEILING, RECORD_HEADER_CRC_RANGE,
     RECORD_HEADER_LEN, RECORD_MAGIC, RECORD_TRAILER_LEN,
 };
+use crate::raw::{read_u16, read_u32, read_u64};
 use crate::types::{RecordFlags, Seq};
 
 /// A borrowed view of a record, used both as the input to [`encode`] and the
@@ -89,21 +90,6 @@ impl core::fmt::Display for DecodeError {
     }
 }
 impl std::error::Error for DecodeError {}
-
-#[inline]
-fn read_u16(b: &[u8], at: usize) -> u16 {
-    u16::from_le_bytes([b[at], b[at + 1]])
-}
-#[inline]
-fn read_u32(b: &[u8], at: usize) -> u32 {
-    u32::from_le_bytes([b[at], b[at + 1], b[at + 2], b[at + 3]])
-}
-#[inline]
-fn read_u64(b: &[u8], at: usize) -> u64 {
-    let mut a = [0u8; 8];
-    a.copy_from_slice(&b[at..at + 8]);
-    u64::from_le_bytes(a)
-}
 
 /// Encodes `rec` into a complete record frame appended to `out`.
 ///

--- a/crates/ironbus-core/src/format.rs
+++ b/crates/ironbus-core/src/format.rs
@@ -118,16 +118,27 @@ pub mod segment_header_offsets {
 /// Byte range the segment header CRC32C covers: `[0, 60)`.
 pub const SEGMENT_HEADER_CRC_RANGE: core::ops::Range<usize> = 0..60;
 
+/// Two-byte magic at the start of a segment footer (`b"SF"` = `0x4653`,
+/// little-endian), distinct from the record magic so a torn tail cannot be mistaken
+/// for a footer on a CRC collision alone.
+pub const SEGMENT_FOOTER_MAGIC: u16 = 0x4653;
+
 /// Byte offsets of each field within the 32-byte segment footer (little-endian),
 /// written when the segment is sealed. Bytes `[24, 28)` are reserved (zero) and
 /// `footer_crc` covers `[0, 28)`.
 pub mod segment_footer_offsets {
-    /// Offset of the `record_count: u64` field.
-    pub const RECORD_COUNT: usize = 0;
+    /// Offset of the 2-byte `magic` field (`SEGMENT_FOOTER_MAGIC`).
+    pub const MAGIC: usize = 0;
+    /// Offset of the `version: u8` field.
+    pub const VERSION: usize = 2;
+    /// Offset of the `checksum_algo: u8` field.
+    pub const CHECKSUM_ALGO: usize = 3;
+    /// Offset of the `segment_id: u64` field (binds the footer to its header).
+    pub const SEGMENT_ID: usize = 4;
     /// Offset of the `last_seq: u64` field.
-    pub const LAST_SEQ: usize = 8;
-    /// Offset of the `sealed_unix_ms: u64` field.
-    pub const SEALED_MS: usize = 16;
+    pub const LAST_SEQ: usize = 12;
+    /// Offset of the `record_count: u32` field.
+    pub const RECORD_COUNT: usize = 20;
     /// Offset of the `footer_crc: u32` field. The CRC covers bytes `[0, 28)`.
     pub const FOOTER_CRC: usize = 28;
 }
@@ -183,12 +194,16 @@ mod tests {
         assert_eq!(hoff::HEADER_CRC, 60);
         assert_eq!(hoff::HEADER_CRC + 4, SEGMENT_HEADER_LEN);
         assert_eq!(SEGMENT_HEADER_CRC_RANGE, 0..60);
-        assert_eq!(foff::RECORD_COUNT, 0);
-        assert_eq!(foff::LAST_SEQ, 8);
-        assert_eq!(foff::SEALED_MS, 16);
+        assert_eq!(foff::MAGIC, 0);
+        assert_eq!(foff::VERSION, 2);
+        assert_eq!(foff::CHECKSUM_ALGO, 3);
+        assert_eq!(foff::SEGMENT_ID, 4);
+        assert_eq!(foff::LAST_SEQ, 12);
+        assert_eq!(foff::RECORD_COUNT, 20);
         assert_eq!(foff::FOOTER_CRC, 28);
         assert_eq!(foff::FOOTER_CRC + 4, SEGMENT_FOOTER_LEN);
         assert_eq!(SEGMENT_FOOTER_CRC_RANGE, 0..28);
+        assert_eq!(SEGMENT_FOOTER_MAGIC, 0x4653);
     }
 
     #[test]

--- a/crates/ironbus-core/src/format.rs
+++ b/crates/ironbus-core/src/format.rs
@@ -91,6 +91,50 @@ pub mod header_offsets {
     pub const HEADER_CRC: usize = 32;
 }
 
+/// Byte offsets of each field within the 64-byte segment header (little-endian). The
+/// header is 4 KiB-aligned at the start of a segment file. Bytes `[44, 60)` are
+/// reserved (zero) and `header_crc` covers `[0, 60)`.
+pub mod segment_header_offsets {
+    /// Offset of the 8-byte `magic` field (`SEGMENT_MAGIC`).
+    pub const MAGIC: usize = 0;
+    /// Offset of the `version: u8` field.
+    pub const VERSION: usize = 8;
+    /// Offset of the `checksum_algo: u8` field.
+    pub const CHECKSUM_ALGO: usize = 9;
+    /// Offset of the `flags: u16` field.
+    pub const FLAGS: usize = 10;
+    /// Offset of the `segment_id: u64` field.
+    pub const SEGMENT_ID: usize = 12;
+    /// Offset of the `base_seq: u64` field.
+    pub const BASE_SEQ: usize = 20;
+    /// Offset of the `base_offset: u64` field.
+    pub const BASE_OFFSET: usize = 28;
+    /// Offset of the `created_unix_ms: u64` field.
+    pub const CREATED_MS: usize = 36;
+    /// Offset of the `header_crc: u32` field. The CRC covers bytes `[0, 60)`.
+    pub const HEADER_CRC: usize = 60;
+}
+
+/// Byte range the segment header CRC32C covers: `[0, 60)`.
+pub const SEGMENT_HEADER_CRC_RANGE: core::ops::Range<usize> = 0..60;
+
+/// Byte offsets of each field within the 32-byte segment footer (little-endian),
+/// written when the segment is sealed. Bytes `[24, 28)` are reserved (zero) and
+/// `footer_crc` covers `[0, 28)`.
+pub mod segment_footer_offsets {
+    /// Offset of the `record_count: u64` field.
+    pub const RECORD_COUNT: usize = 0;
+    /// Offset of the `last_seq: u64` field.
+    pub const LAST_SEQ: usize = 8;
+    /// Offset of the `sealed_unix_ms: u64` field.
+    pub const SEALED_MS: usize = 16;
+    /// Offset of the `footer_crc: u32` field. The CRC covers bytes `[0, 28)`.
+    pub const FOOTER_CRC: usize = 28;
+}
+
+/// Byte range the segment footer CRC32C covers: `[0, 28)`.
+pub const SEGMENT_FOOTER_CRC_RANGE: core::ops::Range<usize> = 0..28;
+
 #[cfg(test)]
 mod tests {
     use super::header_offsets as off;
@@ -122,6 +166,29 @@ mod tests {
         // header ends right after it.
         assert_eq!(off::HEADER_CRC, RECORD_HEADER_CRC_RANGE.end);
         assert_eq!(off::HEADER_CRC + 4, RECORD_HEADER_LEN);
+    }
+
+    #[test]
+    fn segment_header_and_footer_offsets() {
+        use segment_footer_offsets as foff;
+        use segment_header_offsets as hoff;
+        assert_eq!(hoff::MAGIC, 0);
+        assert_eq!(hoff::VERSION, 8);
+        assert_eq!(hoff::CHECKSUM_ALGO, 9);
+        assert_eq!(hoff::FLAGS, 10);
+        assert_eq!(hoff::SEGMENT_ID, 12);
+        assert_eq!(hoff::BASE_SEQ, 20);
+        assert_eq!(hoff::BASE_OFFSET, 28);
+        assert_eq!(hoff::CREATED_MS, 36);
+        assert_eq!(hoff::HEADER_CRC, 60);
+        assert_eq!(hoff::HEADER_CRC + 4, SEGMENT_HEADER_LEN);
+        assert_eq!(SEGMENT_HEADER_CRC_RANGE, 0..60);
+        assert_eq!(foff::RECORD_COUNT, 0);
+        assert_eq!(foff::LAST_SEQ, 8);
+        assert_eq!(foff::SEALED_MS, 16);
+        assert_eq!(foff::FOOTER_CRC, 28);
+        assert_eq!(foff::FOOTER_CRC + 4, SEGMENT_FOOTER_LEN);
+        assert_eq!(SEGMENT_FOOTER_CRC_RANGE, 0..28);
     }
 
     #[test]

--- a/crates/ironbus-core/src/lib.rs
+++ b/crates/ironbus-core/src/lib.rs
@@ -7,7 +7,10 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 
+pub(crate) mod raw;
+
 pub mod clock;
 pub mod codec;
 pub mod format;
+pub mod segment;
 pub mod types;

--- a/crates/ironbus-core/src/raw.rs
+++ b/crates/ironbus-core/src/raw.rs
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! Internal little-endian read helpers shared by the record and segment codecs.
+
+#[inline]
+pub(crate) fn read_u16(b: &[u8], at: usize) -> u16 {
+    u16::from_le_bytes([b[at], b[at + 1]])
+}
+
+#[inline]
+pub(crate) fn read_u32(b: &[u8], at: usize) -> u32 {
+    u32::from_le_bytes([b[at], b[at + 1], b[at + 2], b[at + 3]])
+}
+
+#[inline]
+pub(crate) fn read_u64(b: &[u8], at: usize) -> u64 {
+    let mut a = [0u8; 8];
+    a.copy_from_slice(&b[at..at + 8]);
+    u64::from_le_bytes(a)
+}

--- a/crates/ironbus-core/src/segment.rs
+++ b/crates/ironbus-core/src/segment.rs
@@ -1,0 +1,295 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! Encoding and decoding of the IronBus segment header and footer (version 1).
+//!
+//! Every segment file begins with a 64-byte header (4 KiB-aligned) and, once sealed,
+//! ends with a 32-byte footer. Both are little-endian and CRC32C-protected. The
+//! records between them use the frame in [`crate::codec`].
+
+use crate::format::{
+    segment_footer_offsets as foff, segment_header_offsets as hoff, CHECKSUM_ALGO_CRC32C,
+    FORMAT_VERSION, SEGMENT_FOOTER_CRC_RANGE, SEGMENT_FOOTER_LEN, SEGMENT_HEADER_CRC_RANGE,
+    SEGMENT_HEADER_LEN, SEGMENT_MAGIC,
+};
+use crate::raw::{read_u16, read_u32, read_u64};
+use crate::types::{Offset, Seq};
+
+/// The fixed 64-byte header at the start of every segment file.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SegmentHeader {
+    /// Monotonic identifier of this segment.
+    pub segment_id: u64,
+    /// Sequence number of the first record in the segment.
+    pub base_seq: Seq,
+    /// Log offset of the first record in the segment.
+    pub base_offset: Offset,
+    /// Wall-clock creation time, milliseconds since the Unix epoch.
+    pub created_unix_ms: u64,
+    /// Segment flag bits (reserved; zero in version 1).
+    pub flags: u16,
+}
+
+/// The fixed 32-byte footer written when a segment is sealed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SegmentFooter {
+    /// Number of records in the sealed segment.
+    pub record_count: u64,
+    /// Sequence number of the last record in the sealed segment.
+    pub last_seq: Seq,
+    /// Wall-clock seal time, milliseconds since the Unix epoch.
+    pub sealed_unix_ms: u64,
+}
+
+/// An error decoding a segment header or footer.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SegmentError {
+    /// The input is shorter than the fixed structure.
+    Truncated,
+    /// The segment magic did not match (header only).
+    BadMagic,
+    /// The format version is not understood by this build.
+    UnsupportedVersion(u8),
+    /// The checksum algorithm id is not CRC32C.
+    UnsupportedChecksumAlgo(u8),
+    /// The CRC32C did not match: the structure is corrupt.
+    BadCrc,
+}
+
+impl core::fmt::Display for SegmentError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            SegmentError::Truncated => write!(f, "segment structure is truncated"),
+            SegmentError::BadMagic => write!(f, "segment header has a bad magic number"),
+            SegmentError::UnsupportedVersion(v) => {
+                write!(f, "unsupported segment format version {v}")
+            }
+            SegmentError::UnsupportedChecksumAlgo(a) => {
+                write!(f, "unsupported segment checksum algorithm {a}")
+            }
+            SegmentError::BadCrc => write!(f, "segment structure CRC mismatch"),
+        }
+    }
+}
+impl std::error::Error for SegmentError {}
+
+impl SegmentHeader {
+    /// Encodes the header into its fixed 64-byte on-disk form.
+    #[must_use]
+    pub fn encode(&self) -> [u8; SEGMENT_HEADER_LEN] {
+        let mut h = [0u8; SEGMENT_HEADER_LEN];
+        h[hoff::MAGIC..hoff::MAGIC + 8].copy_from_slice(&SEGMENT_MAGIC);
+        h[hoff::VERSION] = FORMAT_VERSION;
+        h[hoff::CHECKSUM_ALGO] = CHECKSUM_ALGO_CRC32C;
+        h[hoff::FLAGS..hoff::FLAGS + 2].copy_from_slice(&self.flags.to_le_bytes());
+        h[hoff::SEGMENT_ID..hoff::SEGMENT_ID + 8].copy_from_slice(&self.segment_id.to_le_bytes());
+        h[hoff::BASE_SEQ..hoff::BASE_SEQ + 8].copy_from_slice(&self.base_seq.get().to_le_bytes());
+        h[hoff::BASE_OFFSET..hoff::BASE_OFFSET + 8]
+            .copy_from_slice(&self.base_offset.get().to_le_bytes());
+        h[hoff::CREATED_MS..hoff::CREATED_MS + 8]
+            .copy_from_slice(&self.created_unix_ms.to_le_bytes());
+        let crc = crc32c::crc32c(&h[SEGMENT_HEADER_CRC_RANGE]);
+        h[hoff::HEADER_CRC..hoff::HEADER_CRC + 4].copy_from_slice(&crc.to_le_bytes());
+        h
+    }
+
+    /// Decodes a header from the first 64 bytes of `bytes`.
+    ///
+    /// # Errors
+    /// Returns a [`SegmentError`] if the input is too short, the magic, version, or
+    /// checksum algorithm is wrong, or the header CRC does not match.
+    pub fn decode(bytes: &[u8]) -> Result<SegmentHeader, SegmentError> {
+        if bytes.len() < SEGMENT_HEADER_LEN {
+            return Err(SegmentError::Truncated);
+        }
+        if bytes[hoff::MAGIC..hoff::MAGIC + 8] != SEGMENT_MAGIC {
+            return Err(SegmentError::BadMagic);
+        }
+        let version = bytes[hoff::VERSION];
+        if version != FORMAT_VERSION {
+            return Err(SegmentError::UnsupportedVersion(version));
+        }
+        let algo = bytes[hoff::CHECKSUM_ALGO];
+        if algo != CHECKSUM_ALGO_CRC32C {
+            return Err(SegmentError::UnsupportedChecksumAlgo(algo));
+        }
+        if crc32c::crc32c(&bytes[SEGMENT_HEADER_CRC_RANGE]) != read_u32(bytes, hoff::HEADER_CRC) {
+            return Err(SegmentError::BadCrc);
+        }
+        Ok(SegmentHeader {
+            segment_id: read_u64(bytes, hoff::SEGMENT_ID),
+            base_seq: Seq::new(read_u64(bytes, hoff::BASE_SEQ)),
+            base_offset: Offset::new(read_u64(bytes, hoff::BASE_OFFSET)),
+            created_unix_ms: read_u64(bytes, hoff::CREATED_MS),
+            flags: read_u16(bytes, hoff::FLAGS),
+        })
+    }
+}
+
+impl SegmentFooter {
+    /// Encodes the footer into its fixed 32-byte on-disk form.
+    #[must_use]
+    pub fn encode(&self) -> [u8; SEGMENT_FOOTER_LEN] {
+        let mut f = [0u8; SEGMENT_FOOTER_LEN];
+        f[foff::RECORD_COUNT..foff::RECORD_COUNT + 8]
+            .copy_from_slice(&self.record_count.to_le_bytes());
+        f[foff::LAST_SEQ..foff::LAST_SEQ + 8].copy_from_slice(&self.last_seq.get().to_le_bytes());
+        f[foff::SEALED_MS..foff::SEALED_MS + 8].copy_from_slice(&self.sealed_unix_ms.to_le_bytes());
+        let crc = crc32c::crc32c(&f[SEGMENT_FOOTER_CRC_RANGE]);
+        f[foff::FOOTER_CRC..foff::FOOTER_CRC + 4].copy_from_slice(&crc.to_le_bytes());
+        f
+    }
+
+    /// Decodes a footer from the first 32 bytes of `bytes` (the last 32 bytes of a
+    /// sealed segment).
+    ///
+    /// # Errors
+    /// Returns [`SegmentError::Truncated`] if too short, or [`SegmentError::BadCrc`]
+    /// if the footer CRC does not match.
+    pub fn decode(bytes: &[u8]) -> Result<SegmentFooter, SegmentError> {
+        if bytes.len() < SEGMENT_FOOTER_LEN {
+            return Err(SegmentError::Truncated);
+        }
+        if crc32c::crc32c(&bytes[SEGMENT_FOOTER_CRC_RANGE]) != read_u32(bytes, foff::FOOTER_CRC) {
+            return Err(SegmentError::BadCrc);
+        }
+        Ok(SegmentFooter {
+            record_count: read_u64(bytes, foff::RECORD_COUNT),
+            last_seq: Seq::new(read_u64(bytes, foff::LAST_SEQ)),
+            sealed_unix_ms: read_u64(bytes, foff::SEALED_MS),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_header() -> SegmentHeader {
+        SegmentHeader {
+            segment_id: 9,
+            base_seq: Seq::new(100),
+            base_offset: Offset::new(4096),
+            created_unix_ms: 1_700_000_000_000,
+            flags: 0,
+        }
+    }
+
+    #[test]
+    fn header_roundtrip() {
+        let h = sample_header();
+        let bytes = h.encode();
+        assert_eq!(bytes.len(), SEGMENT_HEADER_LEN);
+        assert_eq!(SegmentHeader::decode(&bytes).unwrap(), h);
+    }
+
+    #[test]
+    fn footer_roundtrip() {
+        let f = SegmentFooter {
+            record_count: 42,
+            last_seq: Seq::new(141),
+            sealed_unix_ms: 1_700_000_005_000,
+        };
+        let bytes = f.encode();
+        assert_eq!(bytes.len(), SEGMENT_FOOTER_LEN);
+        assert_eq!(SegmentFooter::decode(&bytes).unwrap(), f);
+    }
+
+    #[test]
+    fn header_bad_magic() {
+        let mut b = sample_header().encode();
+        b[0] ^= 0xff;
+        assert_eq!(SegmentHeader::decode(&b), Err(SegmentError::BadMagic));
+    }
+
+    #[test]
+    fn header_bad_version_and_algo() {
+        let mut b = sample_header().encode();
+        b[hoff::VERSION] = 2;
+        // recompute the CRC so we reach the version check, not the CRC check
+        let crc = crc32c::crc32c(&b[SEGMENT_HEADER_CRC_RANGE]);
+        b[hoff::HEADER_CRC..hoff::HEADER_CRC + 4].copy_from_slice(&crc.to_le_bytes());
+        assert_eq!(
+            SegmentHeader::decode(&b),
+            Err(SegmentError::UnsupportedVersion(2))
+        );
+
+        let mut b2 = sample_header().encode();
+        b2[hoff::CHECKSUM_ALGO] = 9;
+        let crc2 = crc32c::crc32c(&b2[SEGMENT_HEADER_CRC_RANGE]);
+        b2[hoff::HEADER_CRC..hoff::HEADER_CRC + 4].copy_from_slice(&crc2.to_le_bytes());
+        assert_eq!(
+            SegmentHeader::decode(&b2),
+            Err(SegmentError::UnsupportedChecksumAlgo(9))
+        );
+    }
+
+    #[test]
+    fn header_corruption_caught() {
+        let mut b = sample_header().encode();
+        b[hoff::SEGMENT_ID] ^= 0x01;
+        assert_eq!(SegmentHeader::decode(&b), Err(SegmentError::BadCrc));
+    }
+
+    #[test]
+    fn footer_corruption_caught() {
+        let f = SegmentFooter {
+            record_count: 1,
+            last_seq: Seq::new(1),
+            sealed_unix_ms: 0,
+        };
+        let mut b = f.encode();
+        b[foff::RECORD_COUNT] ^= 0x01;
+        assert_eq!(SegmentFooter::decode(&b), Err(SegmentError::BadCrc));
+    }
+
+    #[test]
+    fn truncated() {
+        let b = sample_header().encode();
+        assert_eq!(
+            SegmentHeader::decode(&b[..40]),
+            Err(SegmentError::Truncated)
+        );
+        let fb = SegmentFooter {
+            record_count: 0,
+            last_seq: Seq::new(0),
+            sealed_unix_ms: 0,
+        }
+        .encode();
+        assert_eq!(
+            SegmentFooter::decode(&fb[..20]),
+            Err(SegmentError::Truncated)
+        );
+    }
+}
+
+#[cfg(test)]
+mod proptests {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn header_roundtrip(id in any::<u64>(), bs in any::<u64>(), bo in any::<u64>(), ts in any::<u64>(), fl in any::<u16>()) {
+            let h = SegmentHeader { segment_id: id, base_seq: Seq::new(bs), base_offset: Offset::new(bo), created_unix_ms: ts, flags: fl };
+            prop_assert_eq!(SegmentHeader::decode(&h.encode()).unwrap(), h);
+        }
+
+        #[test]
+        fn footer_roundtrip(rc in any::<u64>(), ls in any::<u64>(), ts in any::<u64>()) {
+            let f = SegmentFooter { record_count: rc, last_seq: Seq::new(ls), sealed_unix_ms: ts };
+            prop_assert_eq!(SegmentFooter::decode(&f.encode()).unwrap(), f);
+        }
+
+        #[test]
+        fn header_bit_flip_never_clean(id in any::<u64>(), idx in any::<prop::sample::Index>(), bit in 0u8..8) {
+            let h = SegmentHeader { segment_id: id, base_seq: Seq::new(1), base_offset: Offset::new(0), created_unix_ms: 0, flags: 0 };
+            let mut b = h.encode();
+            let i = idx.index(b.len());
+            b[i] ^= 1u8 << bit;
+            match SegmentHeader::decode(&b) {
+                Err(_) => {}
+                Ok(got) => prop_assert_eq!(got, h),
+            }
+        }
+    }
+}

--- a/crates/ironbus-core/src/segment.rs
+++ b/crates/ironbus-core/src/segment.rs
@@ -7,8 +7,8 @@
 
 use crate::format::{
     segment_footer_offsets as foff, segment_header_offsets as hoff, CHECKSUM_ALGO_CRC32C,
-    FORMAT_VERSION, SEGMENT_FOOTER_CRC_RANGE, SEGMENT_FOOTER_LEN, SEGMENT_HEADER_CRC_RANGE,
-    SEGMENT_HEADER_LEN, SEGMENT_MAGIC,
+    FORMAT_VERSION, SEGMENT_FOOTER_CRC_RANGE, SEGMENT_FOOTER_LEN, SEGMENT_FOOTER_MAGIC,
+    SEGMENT_HEADER_CRC_RANGE, SEGMENT_HEADER_LEN, SEGMENT_MAGIC,
 };
 use crate::raw::{read_u16, read_u32, read_u64};
 use crate::types::{Offset, Seq};
@@ -24,19 +24,20 @@ pub struct SegmentHeader {
     pub base_offset: Offset,
     /// Wall-clock creation time, milliseconds since the Unix epoch.
     pub created_unix_ms: u64,
-    /// Segment flag bits (reserved; zero in version 1).
+    /// Segment flag bits. Reserved in version 1 (zero); preserved on read but not
+    /// interpreted, so a future writer can add flags without older readers corrupting them.
     pub flags: u16,
 }
 
 /// The fixed 32-byte footer written when a segment is sealed.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct SegmentFooter {
-    /// Number of records in the sealed segment.
-    pub record_count: u64,
+    /// Identifier of the segment this footer belongs to (must match the header).
+    pub segment_id: u64,
     /// Sequence number of the last record in the sealed segment.
     pub last_seq: Seq,
-    /// Wall-clock seal time, milliseconds since the Unix epoch.
-    pub sealed_unix_ms: u64,
+    /// Number of records in the sealed segment.
+    pub record_count: u32,
 }
 
 /// An error decoding a segment header or footer.
@@ -45,7 +46,7 @@ pub struct SegmentFooter {
 pub enum SegmentError {
     /// The input is shorter than the fixed structure.
     Truncated,
-    /// The segment magic did not match (header only).
+    /// The segment header or footer magic did not match.
     BadMagic,
     /// The format version is not understood by this build.
     UnsupportedVersion(u8),
@@ -130,32 +131,47 @@ impl SegmentFooter {
     #[must_use]
     pub fn encode(&self) -> [u8; SEGMENT_FOOTER_LEN] {
         let mut f = [0u8; SEGMENT_FOOTER_LEN];
-        f[foff::RECORD_COUNT..foff::RECORD_COUNT + 8]
-            .copy_from_slice(&self.record_count.to_le_bytes());
+        f[foff::MAGIC..foff::MAGIC + 2].copy_from_slice(&SEGMENT_FOOTER_MAGIC.to_le_bytes());
+        f[foff::VERSION] = FORMAT_VERSION;
+        f[foff::CHECKSUM_ALGO] = CHECKSUM_ALGO_CRC32C;
+        f[foff::SEGMENT_ID..foff::SEGMENT_ID + 8].copy_from_slice(&self.segment_id.to_le_bytes());
         f[foff::LAST_SEQ..foff::LAST_SEQ + 8].copy_from_slice(&self.last_seq.get().to_le_bytes());
-        f[foff::SEALED_MS..foff::SEALED_MS + 8].copy_from_slice(&self.sealed_unix_ms.to_le_bytes());
+        f[foff::RECORD_COUNT..foff::RECORD_COUNT + 4]
+            .copy_from_slice(&self.record_count.to_le_bytes());
         let crc = crc32c::crc32c(&f[SEGMENT_FOOTER_CRC_RANGE]);
         f[foff::FOOTER_CRC..foff::FOOTER_CRC + 4].copy_from_slice(&crc.to_le_bytes());
         f
     }
 
     /// Decodes a footer from the first 32 bytes of `bytes` (the last 32 bytes of a
-    /// sealed segment).
+    /// sealed segment). The caller should also verify `segment_id` matches the header
+    /// and `last_seq >= header.base_seq`.
     ///
     /// # Errors
-    /// Returns [`SegmentError::Truncated`] if too short, or [`SegmentError::BadCrc`]
-    /// if the footer CRC does not match.
+    /// Returns a [`SegmentError`] if too short, the magic, version, or checksum
+    /// algorithm is wrong, or the footer CRC does not match.
     pub fn decode(bytes: &[u8]) -> Result<SegmentFooter, SegmentError> {
         if bytes.len() < SEGMENT_FOOTER_LEN {
             return Err(SegmentError::Truncated);
+        }
+        if read_u16(bytes, foff::MAGIC) != SEGMENT_FOOTER_MAGIC {
+            return Err(SegmentError::BadMagic);
+        }
+        let version = bytes[foff::VERSION];
+        if version != FORMAT_VERSION {
+            return Err(SegmentError::UnsupportedVersion(version));
+        }
+        let algo = bytes[foff::CHECKSUM_ALGO];
+        if algo != CHECKSUM_ALGO_CRC32C {
+            return Err(SegmentError::UnsupportedChecksumAlgo(algo));
         }
         if crc32c::crc32c(&bytes[SEGMENT_FOOTER_CRC_RANGE]) != read_u32(bytes, foff::FOOTER_CRC) {
             return Err(SegmentError::BadCrc);
         }
         Ok(SegmentFooter {
-            record_count: read_u64(bytes, foff::RECORD_COUNT),
+            segment_id: read_u64(bytes, foff::SEGMENT_ID),
             last_seq: Seq::new(read_u64(bytes, foff::LAST_SEQ)),
-            sealed_unix_ms: read_u64(bytes, foff::SEALED_MS),
+            record_count: read_u32(bytes, foff::RECORD_COUNT),
         })
     }
 }
@@ -185,9 +201,9 @@ mod tests {
     #[test]
     fn footer_roundtrip() {
         let f = SegmentFooter {
-            record_count: 42,
+            segment_id: 9,
             last_seq: Seq::new(141),
-            sealed_unix_ms: 1_700_000_005_000,
+            record_count: 42,
         };
         let bytes = f.encode();
         assert_eq!(bytes.len(), SEGMENT_FOOTER_LEN);
@@ -233,9 +249,9 @@ mod tests {
     #[test]
     fn footer_corruption_caught() {
         let f = SegmentFooter {
-            record_count: 1,
+            segment_id: 1,
             last_seq: Seq::new(1),
-            sealed_unix_ms: 0,
+            record_count: 1,
         };
         let mut b = f.encode();
         b[foff::RECORD_COUNT] ^= 0x01;
@@ -250,9 +266,9 @@ mod tests {
             Err(SegmentError::Truncated)
         );
         let fb = SegmentFooter {
-            record_count: 0,
+            segment_id: 0,
             last_seq: Seq::new(0),
-            sealed_unix_ms: 0,
+            record_count: 0,
         }
         .encode();
         assert_eq!(
@@ -275,9 +291,20 @@ mod proptests {
         }
 
         #[test]
-        fn footer_roundtrip(rc in any::<u64>(), ls in any::<u64>(), ts in any::<u64>()) {
-            let f = SegmentFooter { record_count: rc, last_seq: Seq::new(ls), sealed_unix_ms: ts };
+        fn footer_roundtrip(id in any::<u64>(), ls in any::<u64>(), rc in any::<u32>()) {
+            let f = SegmentFooter { segment_id: id, last_seq: Seq::new(ls), record_count: rc };
             prop_assert_eq!(SegmentFooter::decode(&f.encode()).unwrap(), f);
+        }
+
+        #[test]
+        fn footer_bit_flip_always_rejected(id in any::<u64>(), idx in any::<prop::sample::Index>(), bit in 0u8..8) {
+            let f = SegmentFooter { segment_id: id, last_seq: Seq::new(7), record_count: 3 };
+            let mut b = f.encode();
+            let i = idx.index(b.len());
+            b[i] ^= 1u8 << bit;
+            // CRC32C catches every single-bit error in a 32-byte structure, and magic
+            // and version flips are caught structurally, so a flip is always rejected.
+            prop_assert!(SegmentFooter::decode(&b).is_err());
         }
 
         #[test]
@@ -286,10 +313,9 @@ mod proptests {
             let mut b = h.encode();
             let i = idx.index(b.len());
             b[i] ^= 1u8 << bit;
-            match SegmentHeader::decode(&b) {
-                Err(_) => {}
-                Ok(got) => prop_assert_eq!(got, h),
-            }
+            // CRC32C catches every single-bit error in a 64-byte structure, and magic,
+            // version, and checksum-algo flips are caught structurally.
+            prop_assert!(SegmentHeader::decode(&b).is_err());
         }
     }
 }


### PR DESCRIPTION
## What
- `ironbus-core::segment`: `SegmentHeader` (64 B) and `SegmentFooter` (32 B) `encode`/`decode`, both CRC32C-protected, with a typed `SegmentError` (truncated, bad magic, unsupported version/checksum-algo, bad CRC).
- Freezes the exact header field layout (magic, version, checksum_algo, flags, segment_id, base_seq, base_offset, created_ms, header_crc over `[0,60)`) and footer layout (record_count, last_seq, sealed_ms, footer_crc over `[0,28)`) per #5, with field offsets pinned by a `format` test.
- Factors the little-endian read helpers into `crate::raw`, now shared by the record codec and the segment codec (no behaviour change to the record codec).

## Test evidence
Local: fmt, clippy pedantic `-D warnings`, 44 core tests (segment unit cases for each error + proptest round-trip and single-bit-flip corruption for both header and footer), cargo-deny, SPDX, no-IO lint all pass.

refs #5, #4, #137