### PR TITLE
test(core): make the dead-letter proptest robust under a deep sweep (#21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ to follow Semantic Versioning once it reaches a tagged release.
 
 ## [Unreleased]
 
+### Fixed
+- The `dead_letter_iff_a_finite_cap_is_exceeded` delivery proptest no longer relies on a `prop_assume!` that rejected ~2.5% of inputs: under a deep (nightly) sweep that exhausted proptest's global-reject budget and aborted the test. The strategy now generates only valid configs (max == 0 forces the unlimited opt-in), so it rejects nothing and is robust at any case count (refs #21).
+
 ### Added
 - `ironbus serve --visibility-timeout-ms <n>` (#91): tune how long a delivered message stays in flight before it may redeliver (default 30000 ms), instead of the hardcoded lease default. Must be at least 1 (a zero window is a hot redelivery loop). The lease hard cap is derived as the larger of 5 minutes and the visibility window, so it is never below one redelivery window.
 - Determinism meta-test (refs #119): a storage gate asserting that two runs of the same fixed produce/sync workload, under a fresh manual clock, produce a byte-identical disk image. This pins the deterministic-simulation foundation, the on-disk format must be a pure function of its inputs, and fails the moment a `SystemTime`, `Instant::now`, or ambient RNG leaks into a header, record, or footer (the design routes IO and the clock through seams).

--- a/crates/ironbus-core/src/delivery.rs
+++ b/crates/ironbus-core/src/delivery.rs
@@ -254,11 +254,14 @@ mod tests {
         /// A message is dead-lettered exactly when a finite cap is exceeded.
         #[test]
         fn dead_letter_iff_a_finite_cap_is_exceeded(
-            max in 0u32..20,
-            allow in any::<bool>(),
+            // Generate only VALID configs directly: max == 0 (unlimited) requires the opt-in,
+            // so force `allow` true there. The earlier `prop_assume!(max != 0 || allow)`
+            // rejected ~2.5% of inputs, which exhausts proptest's global-reject budget under a
+            // deep (nightly) sweep; constraining the strategy rejects nothing.
+            (max, allow) in (0u32..20, any::<bool>())
+                .prop_map(|(max, allow)| (max, allow || max == 0)),
             deliveries in 1u32..40,
         ) {
-            prop_assume!(max != 0 || allow);
             let c = DeliveryConfig::new(max, allow, vec![]).unwrap();
             let expected = if max != 0 && deliveries > max {
                 Disposition::DeadLetter


### PR DESCRIPTION
## What

A deep proptest sweep (toward the nightly crash-gate lane, #21/#123) surfaced this fragile test. `dead_letter_iff_a_finite_cap_is_exceeded` used `prop_assume!(max != 0 || allow)`, which rejects the `max==0 && !allow` inputs (the invalid "unlimited delivery without opt-in" config that `DeliveryConfig::new` refuses). That is ~2.5% of generated inputs (`max in 0..20` -> P(max==0)=1/20, times P(!allow)=1/2). Past proptest's default 1024 global-reject budget the run **aborts** with "Too many global rejects", so the test passed at the default 256 cases but **failed at 50000+**.

Fix: constrain the strategy to generate only **valid** configs, forcing `allow=true` when `max==0` (the only valid unlimited config), so it rejects nothing:
```rust
(max, allow) in (0u32..20, any::<bool>()).prop_map(|(max, allow)| (max, allow || max == 0))
```

No product behavior change. Coverage of valid configs is unchanged: `max==0` is always the unlimited config (never dead-letters), and `max>0` keeps `allow` free (a finite cap regardless). The invalid `(0, false)` combination is correctly never tested here (the constructor's rejection of it is covered by the `DeliveryConfig::new` unit tests).

## Testing

`dead_letter_iff_a_finite_cap_is_exceeded` now passes at **100000** cases; the full `ironbus-core` suite passes at 60000. `cargo fmt --check`, `clippy -D warnings -W clippy::pedantic`, `cargo test --workspace` all green.

refs #21
