### PR TITLE
ci(release): rename release binary assets to friendly CPU-arch names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,10 +66,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target:
-          - x86_64-unknown-linux-musl
-          - aarch64-unknown-linux-musl
-          - armv7-unknown-linux-musleabihf
+        # `target` is the internal cargo/cross BUILD triple (unchanged); `asset` is the published,
+        # human-friendly binary name. The released binary drops the `unknown`-vendored triple for an
+        # obvious CPU-arch name; the triple stays the build target only. The `.deb` packages keep the
+        # cargo-deb Debian-arch naming (set in package-deb), so they are unaffected by this mapping.
+        include:
+          - target: x86_64-unknown-linux-musl
+            asset: ironbus-linux-amd64
+          - target: aarch64-unknown-linux-musl
+            asset: ironbus-linux-arm64
+          - target: armv7-unknown-linux-musleabihf
+            asset: ironbus-linux-armv7
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -115,14 +122,16 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p dist
-          out="dist/ironbus-${{ matrix.target }}"
+          # Stage the binary under its FRIENDLY published name (the `unknown`-vendored triple is only
+          # the internal cargo/cross target); the per-binary .sha256 is named with that same bare
+          # asset name so `sha256sum -c` works from the download dir. The consolidated SHA256SUMS is
+          # built once in the publish job.
+          out="dist/${{ matrix.asset }}"
           cp "target/${{ matrix.target }}/release/ironbus" "$out"
-          # The per-binary .sha256 is named with the bare asset name so `sha256sum -c` works from
-          # the download dir; the consolidated SHA256SUMS is built once in the publish job.
-          ( cd dist && sha256sum "ironbus-${{ matrix.target }}" > "ironbus-${{ matrix.target }}.sha256" )
+          ( cd dist && sha256sum "${{ matrix.asset }}" > "${{ matrix.asset }}.sha256" )
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: ironbus-${{ matrix.target }}
+          name: ${{ matrix.asset }}
           path: dist/*
           if-no-files-found: error
 
@@ -134,12 +143,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # `target` is the cargo BUILD triple; `asset` is the friendly binary name produced by the
+        # `build` job (what package-deb downloads + stages); `deb_arch` is the Debian architecture.
+        # The `.deb` itself keeps the existing `ironbus-<target>.deb` name (a build-target-derived
+        # name, not the binary asset name), so the rename does not touch the .deb filenames.
         include:
           - target: x86_64-unknown-linux-musl
+            asset: ironbus-linux-amd64
             deb_arch: amd64
           - target: aarch64-unknown-linux-musl
+            asset: ironbus-linux-arm64
             deb_arch: arm64
           - target: armv7-unknown-linux-musleabihf
+            asset: ironbus-linux-armv7
             deb_arch: armhf
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -151,11 +167,12 @@ jobs:
           tool: cargo-deb
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
-          name: ironbus-${{ matrix.target }}
+          name: ${{ matrix.asset }}
           path: dist
       - name: build the .deb from the verified static binary (no recompile)
         env:
           TARGET: ${{ matrix.target }}
+          ASSET: ${{ matrix.asset }}
           DEB_ARCH: ${{ matrix.deb_arch }}
         run: |
           set -euo pipefail
@@ -165,11 +182,11 @@ jobs:
           # `Architecture` from the `--target` triple (amd64/arm64/armhf), NOT from the host. Without
           # `--target` every leg would label `amd64` (the ubuntu-latest host), so the aarch64/armv7
           # .debs would declare amd64 and `dpkg -i` would refuse them on an arm node. We pass the
-          # per-triple binary and `--target`, matching docs/DISTRIBUTION.md. --no-build skips the
+          # friendly-named binary and `--target`, matching docs/DISTRIBUTION.md. --no-build skips the
           # compile (ships the exact reproducible release bytes, not a fresh glibc rebuild);
           # --no-strip preserves the embedded SBOM and the reproducible bytes.
           mkdir -p "target/${TARGET}/release"
-          install -m 0755 "dist/ironbus-${TARGET}" "target/${TARGET}/release/ironbus"
+          install -m 0755 "dist/${ASSET}" "target/${TARGET}/release/ironbus"
           cargo deb -p ironbus-cli --target "${TARGET}" --no-build --no-strip \
             --output "dist/ironbus-${TARGET}.deb"
           ls -l dist/*.deb
@@ -205,7 +222,7 @@ jobs:
           ref: ${{ github.event.inputs.tag || github.ref }}
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
-          name: ironbus-x86_64-unknown-linux-musl
+          name: ironbus-linux-amd64
           path: dist
       - name: build the distroless image from the verified static binary
         run: |
@@ -217,9 +234,9 @@ jobs:
           # it), so restore it before the build. Dockerfile.release also does `COPY --chmod=0755`, so
           # the image entrypoint is executable even if a future build path drops this; together the
           # `docker run ... --version` smoke below can never fail permission-denied on the binary.
-          chmod 0755 "dist/ironbus-x86_64-unknown-linux-musl"
+          chmod 0755 "dist/ironbus-linux-amd64"
           docker build -f Dockerfile.release \
-            --build-arg IRONBUS_BIN=dist/ironbus-x86_64-unknown-linux-musl \
+            --build-arg IRONBUS_BIN=dist/ironbus-linux-amd64 \
             -t "ironbus:${{ github.event.inputs.tag || github.ref_name }}" .
           # Smoke: the non-root entrypoint runs (--version is a pure stdout-and-exit, no data dir).
           docker run --rm "ironbus:${{ github.event.inputs.tag || github.ref_name }}" --version
@@ -301,18 +318,26 @@ jobs:
           # as the installer's source of truth), and the per-target .deb (built by package-deb from
           # the same verified binary), then build one SHA256SUMS over all three binaries AND the
           # three .deb packages so the checksummed-release channel covers the .deb too.
-          for t in x86_64-unknown-linux-musl aarch64-unknown-linux-musl armv7-unknown-linux-musleabihf; do
-            cp "artifacts/ironbus-${t}/ironbus-${t}" "dist/ironbus-${t}"
-            cp "artifacts/ironbus-${t}/ironbus-${t}.sha256" "dist/ironbus-${t}.sha256"
+          # Map each build triple to its friendly binary asset name and its per-triple .deb name.
+          # The binary ships under the friendly name; the .deb keeps its existing
+          # `ironbus-<triple>.deb` name (a build-target-derived name, left as-is by this rename).
+          for pair in \
+            "x86_64-unknown-linux-musl:ironbus-linux-amd64" \
+            "aarch64-unknown-linux-musl:ironbus-linux-arm64" \
+            "armv7-unknown-linux-musleabihf:ironbus-linux-armv7"; do
+            t="${pair%%:*}"
+            a="${pair##*:}"
+            cp "artifacts/${a}/${a}" "dist/${a}"
+            cp "artifacts/${a}/${a}.sha256" "dist/${a}.sha256"
             cp "artifacts/ironbus-deb-${t}/ironbus-${t}.deb" "dist/ironbus-${t}.deb"
           done
           # The syft CycloneDX SBOM (dist/ironbus.cyclonedx.json) was written in this same job; fold
           # it into SHA256SUMS so the scannable manifest is checksummed alongside the binaries and
           # .deb packages (#367).
           ( cd dist && sha256sum \
-              ironbus-x86_64-unknown-linux-musl \
-              ironbus-aarch64-unknown-linux-musl \
-              ironbus-armv7-unknown-linux-musleabihf \
+              ironbus-linux-amd64 \
+              ironbus-linux-arm64 \
+              ironbus-linux-armv7 \
               ironbus-x86_64-unknown-linux-musl.deb \
               ironbus-aarch64-unknown-linux-musl.deb \
               ironbus-armv7-unknown-linux-musleabihf.deb \
@@ -327,9 +352,9 @@ jobs:
           # Keyless Sigstore build-provenance over every shipped artifact, per SECURITY.md. The
           # SHA256SUMS is attested too, so a verifier can anchor the whole set to one provenance.
           subject-path: |
-            dist/ironbus-x86_64-unknown-linux-musl
-            dist/ironbus-aarch64-unknown-linux-musl
-            dist/ironbus-armv7-unknown-linux-musleabihf
+            dist/ironbus-linux-amd64
+            dist/ironbus-linux-arm64
+            dist/ironbus-linux-armv7
             dist/ironbus-x86_64-unknown-linux-musl.deb
             dist/ironbus-aarch64-unknown-linux-musl.deb
             dist/ironbus-armv7-unknown-linux-musleabihf.deb
@@ -367,12 +392,12 @@ jobs:
             --verify-tag \
             $prerelease_flag \
             --notes "Static musl binaries for the three edge triples (x86_64, aarch64, armv7) and a .deb package per triple, each with a SHA256 checksum, a consolidated SHA256SUMS (over the binaries, the .deb packages, and the CycloneDX SBOM), a cargo-auditable SBOM (ironbus.sbom.json), a syft CycloneDX SBOM (ironbus.cyclonedx.json, scannable with syft/grype), and a keyless Sigstore build-provenance attestation over every artifact. Verify integrity with: sha256sum -c SHA256SUMS, and provenance with: gh attestation verify <artifact> --repo $REPO. The fail-closed installer (scripts/install.sh) verifies the checksum before installing; the distroless container image is built and (opt-in) published by the release workflow. See docs/DISTRIBUTION.md for all four channels and CHANGELOG.md for changes." \
-            dist/ironbus-x86_64-unknown-linux-musl \
-            dist/ironbus-x86_64-unknown-linux-musl.sha256 \
-            dist/ironbus-aarch64-unknown-linux-musl \
-            dist/ironbus-aarch64-unknown-linux-musl.sha256 \
-            dist/ironbus-armv7-unknown-linux-musleabihf \
-            dist/ironbus-armv7-unknown-linux-musleabihf.sha256 \
+            dist/ironbus-linux-amd64 \
+            dist/ironbus-linux-amd64.sha256 \
+            dist/ironbus-linux-arm64 \
+            dist/ironbus-linux-arm64.sha256 \
+            dist/ironbus-linux-armv7 \
+            dist/ironbus-linux-armv7.sha256 \
             dist/ironbus-x86_64-unknown-linux-musl.deb \
             dist/ironbus-aarch64-unknown-linux-musl.deb \
             dist/ironbus-armv7-unknown-linux-musleabihf.deb \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,8 +68,9 @@ jobs:
       matrix:
         # `target` is the internal cargo/cross BUILD triple (unchanged); `asset` is the published,
         # human-friendly binary name. The released binary drops the `unknown`-vendored triple for an
-        # obvious CPU-arch name; the triple stays the build target only. The `.deb` packages keep the
-        # cargo-deb Debian-arch naming (set in package-deb), so they are unaffected by this mapping.
+        # obvious CPU-arch name; the triple stays the build target only. The `.deb` packages now use
+        # the friendly `ironbus-linux-<arch>.deb` name too (set in package-deb), mirroring the binary
+        # asset name, so they carry no `unknown` triple either.
         include:
           - target: x86_64-unknown-linux-musl
             asset: ironbus-linux-amd64
@@ -145,8 +146,8 @@ jobs:
       matrix:
         # `target` is the cargo BUILD triple; `asset` is the friendly binary name produced by the
         # `build` job (what package-deb downloads + stages); `deb_arch` is the Debian architecture.
-        # The `.deb` itself keeps the existing `ironbus-<target>.deb` name (a build-target-derived
-        # name, not the binary asset name), so the rename does not touch the .deb filenames.
+        # The `.deb` itself now uses the friendly `ironbus-linux-<arch>.deb` name (mirroring `asset`,
+        # via `--output dist/${ASSET}.deb`), so the .deb filenames carry no `unknown` triple either.
         include:
           - target: x86_64-unknown-linux-musl
             asset: ironbus-linux-amd64
@@ -188,24 +189,24 @@ jobs:
           mkdir -p "target/${TARGET}/release"
           install -m 0755 "dist/${ASSET}" "target/${TARGET}/release/ironbus"
           cargo deb -p ironbus-cli --target "${TARGET}" --no-build --no-strip \
-            --output "dist/ironbus-${TARGET}.deb"
+            --output "dist/${ASSET}.deb"
           ls -l dist/*.deb
           # A self-check: dpkg-deb can parse the package and it lists the binary, the unit, and the
           # conffile, so a broken metadata change is caught at the tag, not on a device.
-          dpkg-deb -I "dist/ironbus-${TARGET}.deb"
-          dpkg-deb -c "dist/ironbus-${TARGET}.deb" | grep -E 'usr/bin/ironbus|ironbus.service|etc/ironbus/ironbus.env'
+          dpkg-deb -I "dist/${ASSET}.deb"
+          dpkg-deb -c "dist/${ASSET}.deb" | grep -E 'usr/bin/ironbus|ironbus.service|etc/ironbus/ironbus.env'
           # ASSERT the Debian Architecture matches this leg's triple. A mislabeled .deb (the amd64-for-
           # everything bug) now FAILS the job instead of shipping a package an arm `dpkg -i` rejects.
-          actual_arch="$(dpkg-deb -f "dist/ironbus-${TARGET}.deb" Architecture)"
+          actual_arch="$(dpkg-deb -f "dist/${ASSET}.deb" Architecture)"
           if [ "${actual_arch}" != "${DEB_ARCH}" ]; then
-            echo "::error::ironbus-${TARGET}.deb declares Architecture '${actual_arch}', expected '${DEB_ARCH}'"
+            echo "::error::${ASSET}.deb declares Architecture '${actual_arch}', expected '${DEB_ARCH}'"
             exit 1
           fi
-          echo "ironbus-${TARGET}.deb Architecture = ${actual_arch} (matches ${DEB_ARCH})"
+          echo "${ASSET}.deb Architecture = ${actual_arch} (matches ${DEB_ARCH})"
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ironbus-deb-${{ matrix.target }}
-          path: dist/ironbus-${{ matrix.target }}.deb
+          path: dist/${{ matrix.asset }}.deb
           if-no-files-found: error
 
   container:
@@ -318,9 +319,9 @@ jobs:
           # as the installer's source of truth), and the per-target .deb (built by package-deb from
           # the same verified binary), then build one SHA256SUMS over all three binaries AND the
           # three .deb packages so the checksummed-release channel covers the .deb too.
-          # Map each build triple to its friendly binary asset name and its per-triple .deb name.
-          # The binary ships under the friendly name; the .deb keeps its existing
-          # `ironbus-<triple>.deb` name (a build-target-derived name, left as-is by this rename).
+          # Map each build triple to its friendly asset name. The binary AND the .deb both ship under
+          # that friendly name (`ironbus-linux-<arch>` / `ironbus-linux-<arch>.deb`), so neither
+          # carries the `unknown`-vendored triple; only the build-target triple `t` keeps it.
           for pair in \
             "x86_64-unknown-linux-musl:ironbus-linux-amd64" \
             "aarch64-unknown-linux-musl:ironbus-linux-arm64" \
@@ -329,7 +330,7 @@ jobs:
             a="${pair##*:}"
             cp "artifacts/${a}/${a}" "dist/${a}"
             cp "artifacts/${a}/${a}.sha256" "dist/${a}.sha256"
-            cp "artifacts/ironbus-deb-${t}/ironbus-${t}.deb" "dist/ironbus-${t}.deb"
+            cp "artifacts/ironbus-deb-${t}/${a}.deb" "dist/${a}.deb"
           done
           # The syft CycloneDX SBOM (dist/ironbus.cyclonedx.json) was written in this same job; fold
           # it into SHA256SUMS so the scannable manifest is checksummed alongside the binaries and
@@ -338,9 +339,9 @@ jobs:
               ironbus-linux-amd64 \
               ironbus-linux-arm64 \
               ironbus-linux-armv7 \
-              ironbus-x86_64-unknown-linux-musl.deb \
-              ironbus-aarch64-unknown-linux-musl.deb \
-              ironbus-armv7-unknown-linux-musleabihf.deb \
+              ironbus-linux-amd64.deb \
+              ironbus-linux-arm64.deb \
+              ironbus-linux-armv7.deb \
               ironbus.cyclonedx.json \
               > SHA256SUMS )
           # Self-check: the consolidated file must verify before it ships, so a bad upload can
@@ -355,9 +356,9 @@ jobs:
             dist/ironbus-linux-amd64
             dist/ironbus-linux-arm64
             dist/ironbus-linux-armv7
-            dist/ironbus-x86_64-unknown-linux-musl.deb
-            dist/ironbus-aarch64-unknown-linux-musl.deb
-            dist/ironbus-armv7-unknown-linux-musleabihf.deb
+            dist/ironbus-linux-amd64.deb
+            dist/ironbus-linux-arm64.deb
+            dist/ironbus-linux-armv7.deb
             dist/SHA256SUMS
             dist/ironbus.sbom.json
             dist/ironbus.cyclonedx.json
@@ -398,9 +399,9 @@ jobs:
             dist/ironbus-linux-arm64.sha256 \
             dist/ironbus-linux-armv7 \
             dist/ironbus-linux-armv7.sha256 \
-            dist/ironbus-x86_64-unknown-linux-musl.deb \
-            dist/ironbus-aarch64-unknown-linux-musl.deb \
-            dist/ironbus-armv7-unknown-linux-musleabihf.deb \
+            dist/ironbus-linux-amd64.deb \
+            dist/ironbus-linux-arm64.deb \
+            dist/ironbus-linux-armv7.deb \
             dist/SHA256SUMS \
             dist/ironbus.sbom.json \
             dist/ironbus.cyclonedx.json

--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -78,10 +78,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target:
-          - x86_64-unknown-linux-musl
-          - aarch64-unknown-linux-musl
-          - armv7-unknown-linux-musleabihf
+        # `target` is the internal cargo/cross BUILD triple (unchanged); `asset` is the published,
+        # human-friendly binary name. The `unknown` vendor field in a Linux triple confuses non-Rust
+        # edge operators, so the released asset drops the triple for an obvious CPU-arch name. The
+        # mapping is pinned here so the build step stages the friendly name and every consumer
+        # (SHA256SUMS, attestation, the release assets, the installer, the docs) agrees.
+        include:
+          - target: x86_64-unknown-linux-musl
+            asset: ironbus-linux-amd64
+          - target: aarch64-unknown-linux-musl
+            asset: ironbus-linux-arm64
+          - target: armv7-unknown-linux-musleabihf
+            asset: ironbus-linux-armv7
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -130,14 +138,16 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p dist
-          out="dist/ironbus-${{ matrix.target }}"
+          # Stage the binary under its FRIENDLY published name (the `unknown`-vendored triple is only
+          # the internal cargo/cross target); the per-binary .sha256 is named with that same bare
+          # asset name so `sha256sum -c` works from the download dir. The consolidated SHA256SUMS is
+          # built once in the publish job.
+          out="dist/${{ matrix.asset }}"
           cp "target/${{ matrix.target }}/release/ironbus" "$out"
-          # The per-binary .sha256 is named with the bare asset name so `sha256sum -c` works from
-          # the download dir; the consolidated SHA256SUMS is built once in the publish job.
-          ( cd dist && sha256sum "ironbus-${{ matrix.target }}" > "ironbus-${{ matrix.target }}.sha256" )
+          ( cd dist && sha256sum "${{ matrix.asset }}" > "${{ matrix.asset }}.sha256" )
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: ironbus-${{ matrix.target }}
+          name: ${{ matrix.asset }}
           path: dist/*
           if-no-files-found: error
 
@@ -159,16 +169,18 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p dist
-          # Copy the three binaries and their per-binary .sha256 out of the per-target artifacts,
-          # then build one SHA256SUMS over the three binaries (the installer's source of truth).
-          for t in x86_64-unknown-linux-musl aarch64-unknown-linux-musl armv7-unknown-linux-musleabihf; do
-            cp "artifacts/ironbus-${t}/ironbus-${t}" "dist/ironbus-${t}"
-            cp "artifacts/ironbus-${t}/ironbus-${t}.sha256" "dist/ironbus-${t}.sha256"
+          # Copy the three FRIENDLY-named binaries and their per-binary .sha256 out of the per-asset
+          # artifacts, then build one SHA256SUMS over the three binaries (the installer's source of
+          # truth). The asset names are the published, human-friendly names; the triple stays the
+          # internal build target only.
+          for a in ironbus-linux-amd64 ironbus-linux-arm64 ironbus-linux-armv7; do
+            cp "artifacts/${a}/${a}" "dist/${a}"
+            cp "artifacts/${a}/${a}.sha256" "dist/${a}.sha256"
           done
           ( cd dist && sha256sum \
-              ironbus-x86_64-unknown-linux-musl \
-              ironbus-aarch64-unknown-linux-musl \
-              ironbus-armv7-unknown-linux-musleabihf \
+              ironbus-linux-amd64 \
+              ironbus-linux-arm64 \
+              ironbus-linux-armv7 \
               > SHA256SUMS )
           # Self-check: the consolidated file must verify before it ships, so a bad upload can
           # never produce a release whose SHA256SUMS does not match its own binaries.
@@ -179,9 +191,9 @@ jobs:
           # Keyless Sigstore build-provenance over the binaries + SHA256SUMS, so a verifier can
           # anchor the whole set to one provenance (verify with `gh attestation verify`).
           subject-path: |
-            dist/ironbus-x86_64-unknown-linux-musl
-            dist/ironbus-aarch64-unknown-linux-musl
-            dist/ironbus-armv7-unknown-linux-musleabihf
+            dist/ironbus-linux-amd64
+            dist/ironbus-linux-arm64
+            dist/ironbus-linux-armv7
             dist/SHA256SUMS
       - name: create the rolling GitHub Release
         env:
@@ -205,13 +217,14 @@ jobs:
           curl -fsSL https://raw.githubusercontent.com/ELares/IronBus/main/scripts/install.sh | sh
           \`\`\`
 
-          Or grab the static \`musl\` binary for your CPU from this release, \`chmod +x\`, and run:
+          Each binary is a static \`musl\` build (no runtime dependency, not even a libc). Grab the
+          one for your CPU from this release, \`chmod +x\`, and run:
 
           | Edge CPU | Asset |
           | --- | --- |
-          | Raspberry Pi 4 / 5 (64-bit) and other arm64 | \`ironbus-aarch64-unknown-linux-musl\` |
-          | Raspberry Pi 32-bit / armv7 | \`ironbus-armv7-unknown-linux-musleabihf\` |
-          | x86_64 / amd64 | \`ironbus-x86_64-unknown-linux-musl\` |
+          | Raspberry Pi 4 / 5 (64-bit) and other arm64 | \`ironbus-linux-arm64\` |
+          | Raspberry Pi 32-bit / armv7 | \`ironbus-linux-armv7\` |
+          | x86_64 / amd64 | \`ironbus-linux-amd64\` |
 
           Verify integrity with \`sha256sum -c SHA256SUMS\`, and provenance with \`gh attestation verify <asset> --repo ${REPO}\`. See docs/DISTRIBUTION.md for all channels.
           EOF
@@ -221,10 +234,10 @@ jobs:
             --title "$VERSION" \
             --target "$SHA" \
             --notes "$notes" \
-            dist/ironbus-x86_64-unknown-linux-musl \
-            dist/ironbus-x86_64-unknown-linux-musl.sha256 \
-            dist/ironbus-aarch64-unknown-linux-musl \
-            dist/ironbus-aarch64-unknown-linux-musl.sha256 \
-            dist/ironbus-armv7-unknown-linux-musleabihf \
-            dist/ironbus-armv7-unknown-linux-musleabihf.sha256 \
+            dist/ironbus-linux-amd64 \
+            dist/ironbus-linux-amd64.sha256 \
+            dist/ironbus-linux-arm64 \
+            dist/ironbus-linux-arm64.sha256 \
+            dist/ironbus-linux-armv7 \
+            dist/ironbus-linux-armv7.sha256 \
             dist/SHA256SUMS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ to follow Semantic Versioning once it reaches a tagged release.
 ## [Unreleased]
 
 ### Changed
-- Renamed the published release binary assets to friendly CPU-arch names: `ironbus-linux-amd64`, `ironbus-linux-arm64`, `ironbus-linux-armv7` (dropping the `unknown`-vendored `musl` triple, which stays the internal cargo/cross build target). The installer (`detect_target` + download URL), its tests, both release workflows (staging, `SHA256SUMS`, attestation, release assets, notes table), and the install docs (README, DISTRIBUTION, RELEASING) are updated to match. The binaries are still static `musl` with no runtime dependency; the `.deb` package names are unchanged.
+- Renamed the published release binary assets to friendly CPU-arch names: `ironbus-linux-amd64`, `ironbus-linux-arm64`, `ironbus-linux-armv7` (dropping the `unknown`-vendored `musl` triple, which stays the internal cargo/cross build target). The installer (`detect_target` + download URL), its tests, both release workflows (staging, `SHA256SUMS`, attestation, release assets, notes table), and the install docs (README, DISTRIBUTION, RELEASING) are updated to match. The `.deb` packages were renamed to match (`ironbus-linux-amd64.deb`, `ironbus-linux-arm64.deb`, `ironbus-linux-armv7.deb`), so no published asset carries the `unknown` triple; it stays the cargo `--target` only. The binaries are still static `musl` with no runtime dependency.
 
 ### Fixed
 - Hardened the upgrade rollback against the two-rename re-entry window (Closes #348).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ to follow Semantic Versioning once it reaches a tagged release.
 
 ## [Unreleased]
 
+### Changed
+- Renamed the published release binary assets to friendly CPU-arch names: `ironbus-linux-amd64`, `ironbus-linux-arm64`, `ironbus-linux-armv7` (dropping the `unknown`-vendored `musl` triple, which stays the internal cargo/cross build target). The installer (`detect_target` + download URL), its tests, both release workflows (staging, `SHA256SUMS`, attestation, release assets, notes table), and the install docs (README, DISTRIBUTION, RELEASING) are updated to match. The binaries are still static `musl` with no runtime dependency; the `.deb` package names are unchanged.
+
 ### Fixed
 - Hardened the upgrade rollback against the two-rename re-entry window (Closes #348).
   - `ironbus rollback` now restores `ironbus.prev` over the destination WITHOUT first moving the destination onto `.prev`, so a power cut between the renames preserves the last known-good bytes and a re-entry converges to the good binary.

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@
 #   docker build -t ironbus:dev .
 #
 # Or build from a release artifact without recompiling (CI path; see .github/workflows/release.yml):
-#   docker build --build-arg IRONBUS_BIN=dist/ironbus-x86_64-unknown-linux-musl \
+#   docker build --build-arg IRONBUS_BIN=dist/ironbus-linux-amd64 \
 #     -f Dockerfile.release .
 
 ARG RUST_VERSION=1.78

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,15 +1,15 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
 #
 # IronBus distroless image built from an ALREADY-VERIFIED release binary (#104), with no compile
-# step. The release workflow downloads the static musl `ironbus-<triple>` artifact, verifies it
-# against the signed SHA256SUMS (the same fail-closed check scripts/install.sh enforces), and only
-# then passes it here as IRONBUS_BIN. This keeps the container on the exact reproducible bytes the
-# release ships, and the verify-before-package property holds: the image is never built over an
-# unverified binary.
+# step. The release workflow downloads the friendly-named static musl `ironbus-linux-<arch>` artifact
+# (e.g. `ironbus-linux-amd64`), verifies it against the signed SHA256SUMS (the same fail-closed check
+# scripts/install.sh enforces), and only then passes it here as IRONBUS_BIN. This keeps the container
+# on the exact reproducible bytes the release ships, and the verify-before-package property holds: the
+# image is never built over an unverified binary.
 #
 # Build (from the repo root, with a verified binary staged under dist/):
 #   docker build -f Dockerfile.release \
-#     --build-arg IRONBUS_BIN=dist/ironbus-x86_64-unknown-linux-musl \
+#     --build-arg IRONBUS_BIN=dist/ironbus-linux-amd64 \
 #     -t ghcr.io/elares/ironbus:latest .
 #
 # The runtime stage and its non-root user, CA certs, tzdata, required writable volume, and reserved

--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ Prefer to grab the binary yourself? Download the static `musl` binary for your C
 
 | Edge CPU | Asset |
 | --- | --- |
-| arm64 / Raspberry Pi 4 / 5 (64-bit) | `ironbus-aarch64-unknown-linux-musl` |
-| armv7 / Raspberry Pi (32-bit) | `ironbus-armv7-unknown-linux-musleabihf` |
-| x86_64 / amd64 | `ironbus-x86_64-unknown-linux-musl` |
+| arm64 / Raspberry Pi 4 / 5 (64-bit) | `ironbus-linux-arm64` |
+| armv7 / Raspberry Pi (32-bit) | `ironbus-linux-armv7` |
+| x86_64 / amd64 | `ironbus-linux-amd64` |
 
 Every push to main publishes a fresh `YYYY.MMDD.N` build (calendar-versioned, the three static binaries plus a consolidated `SHA256SUMS` and a Sigstore provenance attestation), so `releases/latest` and the installer always resolve to the newest build. See [docs/DISTRIBUTION.md](docs/DISTRIBUTION.md) for every channel.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -55,9 +55,10 @@ For each of the three build targets `x86_64-unknown-linux-musl`, `aarch64-unknow
 - `ironbus-linux-<arch>`: the static `musl` binary (no `PT_INTERP`, no `NEEDED` libs; asserted in the
   job). It has no runtime dependency even though the friendly name drops `musl`.
 - `ironbus-linux-<arch>.sha256`: its SHA256 checksum.
-- `ironbus-<triple>.deb`: the Debian package built from that verified binary (no recompile),
-  self-checked with `dpkg-deb -c` in the `package-deb` job. The `.deb` keeps the Debian-arch-derived
-  `ironbus-<triple>.deb` name, unaffected by the binary asset rename.
+- `ironbus-linux-<arch>.deb`: the Debian package built from that verified binary (no recompile),
+  self-checked with `dpkg-deb -c` in the `package-deb` job. The `.deb` now mirrors the friendly
+  binary asset name (`ironbus-linux-amd64.deb`, `ironbus-linux-arm64.deb`, `ironbus-linux-armv7.deb`),
+  so it carries no `unknown`-vendored triple either; the triple stays the cargo `--target` only.
 
 Plus, once per release:
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -47,13 +47,17 @@ never ship without an audit-trail entry. Tag a release only after the entries ar
 
 ## What the release produces
 
-For each of `x86_64-unknown-linux-musl`, `aarch64-unknown-linux-musl`, and
-`armv7-unknown-linux-musleabihf`:
+For each of the three build targets `x86_64-unknown-linux-musl`, `aarch64-unknown-linux-musl`, and
+`armv7-unknown-linux-musleabihf`, the published binary asset carries a friendly CPU-arch name
+(`ironbus-linux-amd64`, `ironbus-linux-arm64`, `ironbus-linux-armv7` respectively); the
+`unknown`-vendored triple stays the internal cargo/cross build target only:
 
-- `ironbus-<triple>`: the static binary (no `PT_INTERP`, no `NEEDED` libs; asserted in the job).
-- `ironbus-<triple>.sha256`: its SHA256 checksum.
+- `ironbus-linux-<arch>`: the static `musl` binary (no `PT_INTERP`, no `NEEDED` libs; asserted in the
+  job). It has no runtime dependency even though the friendly name drops `musl`.
+- `ironbus-linux-<arch>.sha256`: its SHA256 checksum.
 - `ironbus-<triple>.deb`: the Debian package built from that verified binary (no recompile),
-  self-checked with `dpkg-deb -c` in the `package-deb` job.
+  self-checked with `dpkg-deb -c` in the `package-deb` job. The `.deb` keeps the Debian-arch-derived
+  `ironbus-<triple>.deb` name, unaffected by the binary asset rename.
 
 Plus, once per release:
 
@@ -81,8 +85,9 @@ and not yet a stability promise (see SECURITY.md); a `v1+` tag publishes a full 
 ## Install (the fail-closed installer)
 
 `scripts/install.sh` is a `curl | sh`-style installer that detects the host architecture, maps it
-to a musl triple, downloads the matching `ironbus-<triple>` binary AND the release `SHA256SUMS`,
-and verifies the binary's SHA256 against `SHA256SUMS` BEFORE installing. It is **fail-closed**: any
+to a friendly asset suffix, downloads the matching `ironbus-linux-<arch>` binary (e.g.
+`ironbus-linux-arm64`) AND the release `SHA256SUMS`, and verifies the binary's SHA256 against
+`SHA256SUMS` BEFORE installing. It is **fail-closed**: any
 download error, a missing or mismatched checksum, a malformed `SHA256SUMS`, or an unsupported
 platform aborts with a non-zero exit and installs nothing. It never `eval`s or `sh`-pipes any
 downloaded content. There is no insecure / skip-verification override.
@@ -129,10 +134,10 @@ failed starts, and the explicit `migrate` format gate) is also in
 ```sh
 # Integrity (one file for all three binaries, or the per-binary .sha256):
 sha256sum -c SHA256SUMS                              # checks every listed asset present locally
-sha256sum -c ironbus-x86_64-unknown-linux-musl.sha256
+sha256sum -c ironbus-linux-amd64.sha256
 
 # Provenance (it was built by this repo's Release workflow, signed via Sigstore, no key needed):
-gh attestation verify ironbus-x86_64-unknown-linux-musl --repo ELares/IronBus
+gh attestation verify ironbus-linux-amd64 --repo ELares/IronBus
 
 # Dependency manifest (the embedded or attached SBOM):
 rust-audit-info ironbus.sbom.json
@@ -152,7 +157,7 @@ syft convert ironbus.cyclonedx.json -o cyclonedx-json    # or spdx-json, syft-ta
 grype sbom:ironbus.cyclonedx.json
 
 # Equivalently, scan the downloaded binary directly (syft/grype generate the SBOM on the fly):
-grype ./ironbus-x86_64-unknown-linux-musl
+grype ./ironbus-linux-amd64
 ```
 
 The CycloneDX SBOM and the embedded `cargo-auditable` SBOM (`ironbus.sbom.json`) describe the SAME

--- a/crates/ironbus-cli/tests/acceptance.rs
+++ b/crates/ironbus-cli/tests/acceptance.rs
@@ -553,7 +553,7 @@ fn golden_path_acceptance_install_to_recovery_to_upgrade() {
         //     REJECTED. This runs the ACTUAL installer `verify_checksum`.
         let fx = scratch.join("fixture");
         std::fs::create_dir_all(&fx).expect("create the installer fixture dir");
-        let asset = "ironbus-x86_64-unknown-linux-musl";
+        let asset = "ironbus-linux-amd64";
         let genuine = b"the genuine ironbus binary bytes".as_slice();
         std::fs::write(fx.join(asset), genuine).expect("write the genuine fixture asset");
         let digest = sha256_hex(&fx.join(asset));

--- a/crates/ironbus-cli/tests/installer_verify.rs
+++ b/crates/ironbus-cli/tests/installer_verify.rs
@@ -126,18 +126,20 @@ impl Fixture {
     }
 }
 
-/// Build a fixture: write `ironbus-<target>` with `payload`, and a `SHA256SUMS` over it (plus a
-/// second, unrelated asset entry so the "select the right line" path is exercised).
+/// Build a fixture: write the friendly-named asset (`ironbus-linux-amd64`) with `payload`, and a
+/// `SHA256SUMS` over it (plus a second, unrelated asset entry so the "select the right line" path is
+/// exercised). The asset names match the published, human-friendly release assets, not the internal
+/// build triple.
 fn fixture(payload: &[u8]) -> Fixture {
     let dir = tempdir::TempDir::new("ib-installer");
-    let asset = "ironbus-x86_64-unknown-linux-musl".to_string();
+    let asset = "ironbus-linux-amd64".to_string();
     std::fs::write(dir.path().join(&asset), payload).unwrap();
 
     let other = b"a different architecture's bytes";
-    std::fs::write(dir.path().join("ironbus-aarch64-unknown-linux-musl"), other).unwrap();
+    std::fs::write(dir.path().join("ironbus-linux-arm64"), other).unwrap();
 
     let mut sums = String::new();
-    sums.push_str(&sums_line(other, "ironbus-aarch64-unknown-linux-musl"));
+    sums.push_str(&sums_line(other, "ironbus-linux-arm64"));
     sums.push_str(&sums_line(payload, &asset));
     std::fs::write(dir.path().join("SHA256SUMS"), sums).unwrap();
 
@@ -179,15 +181,11 @@ fn an_asset_absent_from_sha256sums_is_rejected() {
     let fx = fixture(payload);
     // Ask to verify an asset name that has no entry in SHA256SUMS; a missing checksum is a
     // failure, never a pass.
-    std::fs::write(
-        fx.dir().join("ironbus-armv7-unknown-linux-musleabihf"),
-        payload,
-    )
-    .unwrap();
+    std::fs::write(fx.dir().join("ironbus-linux-armv7"), payload).unwrap();
     let code = run_verify(
         fx.dir(),
-        "ironbus-armv7-unknown-linux-musleabihf",
-        "ironbus-armv7-unknown-linux-musleabihf",
+        "ironbus-linux-armv7",
+        "ironbus-linux-armv7",
         "SHA256SUMS",
     );
     assert_ne!(

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -34,8 +34,11 @@ bump is never silent.
 
 ## 1. The fail-closed installer
 
-`scripts/install.sh` detects the host architecture, maps it to a musl triple, downloads the matching
-`ironbus-<triple>` binary AND the release `SHA256SUMS`, and verifies the SHA256 BEFORE installing. It
+`scripts/install.sh` detects the host architecture, maps it to a friendly asset suffix, downloads the
+matching `ironbus-linux-<arch>` binary (e.g. `ironbus-linux-arm64`) AND the release `SHA256SUMS`, and
+verifies the SHA256 BEFORE installing. The asset is a static `musl` binary with no runtime dependency
+even though the friendly name drops `musl`; the `unknown`-vendored triple stays the internal build
+target only. It
 is fail-closed: any download error, a missing or mismatched checksum, a malformed `SHA256SUMS`, or an
 unsupported platform aborts with a non-zero exit and installs nothing. It never `eval`s or `sh`-pipes
 downloaded content, and there is no skip-verification override. On an upgrade it retains the prior
@@ -140,7 +143,7 @@ behind an explicit opt-in, and the documented push command is:
 
 ```sh
 docker build -f Dockerfile.release \
-  --build-arg IRONBUS_BIN=dist/ironbus-x86_64-unknown-linux-musl \
+  --build-arg IRONBUS_BIN=dist/ironbus-linux-amd64 \
   -t ghcr.io/elares/ironbus:<tag> .
 docker push ghcr.io/elares/ironbus:<tag>
 ```
@@ -150,11 +153,15 @@ the build and the verified-artifact wiring land now without blocking on org-leve
 
 ## 4. Checksummed GitHub Releases
 
-Each release publishes, for `x86_64`, `aarch64`, and `armv7` musl triples: the static binary, a
-per-binary `.sha256`, one consolidated `SHA256SUMS`, and a keyless Sigstore build-provenance
-attestation over the binaries and `SHA256SUMS`. This is the source of truth the installer, the
-`.deb`, and the container all consume. Verify integrity with `sha256sum -c SHA256SUMS` and provenance
-with `gh attestation verify <binary> --repo ELares/IronBus`.
+Each release publishes, for the three edge CPUs, a friendly-named static binary
+(`ironbus-linux-amd64` for x86_64/amd64, `ironbus-linux-arm64` for arm64 / Raspberry Pi 4-5 64-bit,
+`ironbus-linux-armv7` for armv7 / 32-bit Pi), a per-binary `.sha256`, one consolidated `SHA256SUMS`,
+and a keyless Sigstore build-provenance attestation over the binaries and `SHA256SUMS`. Each binary is
+a static `musl` build with no runtime dependency (the friendly name drops `musl`; the
+`unknown`-vendored triple is only the internal cargo build target). This is the source of truth the
+installer, the `.deb`, and the container all consume. The installer auto-detects the host arch and
+picks the matching asset. Verify integrity with `sha256sum -c SHA256SUMS` and provenance with
+`gh attestation verify <binary> --repo ELares/IronBus`.
 
 These releases come from the two channels above: the **rolling** channel (automatic on every main
 push, `YYYY.MMDD.N`, the three binaries + `SHA256SUMS` + provenance) and the **formal** `v*` channel

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -63,10 +63,14 @@ The package installs:
   `ironbus` system user (created by the postinst) against `/var/lib/ironbus`.
 - `/etc/ironbus/ironbus.env`, the default config (a dpkg conffile, so local edits survive upgrades).
 
-The unit is installed but NOT enabled or started automatically; enable it deliberately:
+The published `.deb` asset carries the same friendly CPU-arch name as the binary,
+`ironbus-linux-<arch>.deb` (`ironbus-linux-amd64.deb`, `ironbus-linux-arm64.deb`,
+`ironbus-linux-armv7.deb`), so it too drops the `unknown`-vendored triple; the triple stays the cargo
+`--target` only. The unit is installed but NOT enabled or started automatically; enable it
+deliberately:
 
 ```sh
-sudo dpkg -i ironbus_<version>_<arch>.deb
+sudo dpkg -i ironbus-linux-<arch>.deb
 sudo systemctl enable --now ironbus
 ```
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,8 +3,10 @@
 #
 # IronBus fail-closed installer (#103).
 #
-# Downloads the static musl `ironbus` binary that matches this host's architecture from a GitHub
-# Release, verifies its SHA256 against the release's signed `SHA256SUMS`, and installs it. It is
+# Downloads the static `ironbus` binary that matches this host's architecture from a GitHub Release,
+# verifies its SHA256 against the release's signed `SHA256SUMS`, and installs it. The release assets
+# carry friendly CPU-arch names (`ironbus-linux-amd64` / `-arm64` / `-armv7`); they are static musl
+# builds with no runtime dependency (not even a libc). It is
 # FAIL-CLOSED: it NEVER places a binary it has not verified. Any download failure, a missing or
 # mismatched checksum, or an unsupported platform aborts with a non-zero exit and installs nothing.
 # It does not `eval` or `sh`-pipe any downloaded content; the only thing fetched is the binary and
@@ -19,7 +21,8 @@
 #   --version <tag>        Release tag to install (default: latest). Pin this for reproducibility.
 #   --bin-dir <dir>        Install directory (default: /usr/local/bin, or $HOME/.local/bin if the
 #                          default is not writable).
-#   --target <triple>      Force the musl target instead of auto-detecting from `uname -m`.
+#   --target <arch>        Force the asset arch suffix (linux-amd64 / linux-arm64 / linux-armv7)
+#                          instead of auto-detecting from `uname -m`.
 #   --verify-provenance    Additionally verify the keyless Sigstore build-provenance attestation
 #                          with `gh attestation verify`. FAIL-CLOSED: if requested and `gh` is
 #                          absent or verification fails, the install aborts. (Without this flag the
@@ -42,13 +45,16 @@ REPO="ELares/IronBus"
 log() { printf 'ironbus-install: %s\n' "$*" >&2; }
 die() { printf 'ironbus-install: error: %s\n' "$*" >&2; exit 1; }
 
-# Map `uname -m` to the musl release target. Unknown -> empty (caller treats it as unsupported).
+# Map `uname -m` to the FRIENDLY release asset suffix (the published asset is `ironbus-<suffix>`,
+# e.g. `ironbus-linux-arm64`). These static binaries are the `unknown`-vendored musl build targets
+# internally, but ship under obvious CPU-arch names. Unknown -> empty (caller treats it as
+# unsupported).
 detect_target() {
     arch="${1:-$(uname -m)}"
     case "$arch" in
-        x86_64 | amd64) printf '%s' "x86_64-unknown-linux-musl" ;;
-        aarch64 | arm64) printf '%s' "aarch64-unknown-linux-musl" ;;
-        armv7l | armv7 | armhf) printf '%s' "armv7-unknown-linux-musleabihf" ;;
+        x86_64 | amd64) printf '%s' "linux-amd64" ;;
+        aarch64 | arm64) printf '%s' "linux-arm64" ;;
+        armv7l | armv7 | armhf) printf '%s' "linux-armv7" ;;
         *) printf '' ;;
     esac
 }


### PR DESCRIPTION
## What and why

The published release binary **assets** were named with the full Rust target triple, e.g. `ironbus-aarch64-unknown-linux-musl`. The `unknown` field is the triple's VENDOR (normal for Linux targets) but it confuses non-Rust edge operators and undercuts the "grab the right CPU arch" install goal.

This renames the **published assets** to obvious, human-friendly names and keeps the triple ONLY as the internal `cargo`/`cross` BUILD target. The binaries are still static `musl` builds with no runtime dependency; only the published name drops `musl` (the docs still say they are static).

## Mapping (build target triple to published asset name)

| Build target (internal, unchanged) | Published asset (new) |
| --- | --- |
| `x86_64-unknown-linux-musl` | `ironbus-linux-amd64` |
| `aarch64-unknown-linux-musl` | `ironbus-linux-arm64` |
| `armv7-unknown-linux-musleabihf` | `ironbus-linux-armv7` |

The `.sha256` sidecars and `SHA256SUMS` use the same friendly names (e.g. `ironbus-linux-arm64.sha256`).

## The single hard invariant (held)

The asset name the workflows PRODUCE == the name `install.sh` DOWNLOADS == the name in `SHA256SUMS` == the name in README/docs/release-notes == the test fixtures.

## What changed, per consumer

- **`.github/workflows/rolling-release.yml`**: build matrix now pairs each `target` (cargo build triple, unchanged) with a friendly `asset` via `include`. Staging (`dist/ironbus-linux-<arch>` + `.sha256`), the upload/download-artifact handoff (`name: ${{ matrix.asset }}`), the consolidated `SHA256SUMS` (over the 3 friendly names, self-check kept), the `attest-build-provenance` subject-path, the `gh release create` asset list, and the per-arch release-notes table all use the friendly names.
- **`.github/workflows/release.yml`** (formal `v*` channel, still dormant): same asset rename for the 3 binaries across staging, `SHA256SUMS`, attestation subject, the `gh release` asset list, and the container `IRONBUS_BIN=dist/ironbus-linux-amd64` build-arg. The `.deb` filenames are LEFT as cargo produces them (Debian-arch derived), so the formal release ships `ironbus-linux-{amd64,arm64,armv7}` + the `.deb`s + `SHA256SUMS` + SBOMs as before.
- **`scripts/install.sh`**: `detect_target` now returns the friendly suffix (`linux-amd64` / `linux-arm64` / `linux-armv7`) from `uname -m`, so the downloaded asset is `ironbus-linux-arm64` etc. `--target` now forces the friendly suffix; help text and the top-of-file comments updated. The fail-closed verification logic is unchanged.
- **`crates/ironbus-cli/tests/installer_verify.rs`** (and the `acceptance.rs` fixture): fixtures + assertions use the friendly asset names. The fail-closed tamper/absent/empty/malformed/missing tests still pass.
- **Docs**: `README.md` install table, `docs/DISTRIBUTION.md`, `RELEASING.md`, and the `Dockerfile`/`Dockerfile.release` build-arg examples now list the friendly assets; they still state the binaries are static `musl` with no runtime deps. `CHANGELOG.md` gets a terse `### Changed` bullet.

## Gates (all green locally)

- `actionlint .github/workflows/*.yml`: clean (SHA-pins untouched)
- `shellcheck scripts/install.sh`: clean
- `cargo fmt --all -- --check`: OK
- `cargo clippy --workspace --all-targets -- -D warnings -W clippy::pedantic`: no warnings
- `cargo test --workspace`: all pass (incl. `installer_verify` 8/8 and the golden-path acceptance run)
- `sh scripts/ci/relative-link-check.sh`: 0 problems
- No em-dash / en-dash anywhere in the diff
- Consistency grep over README/docs/`install.sh`/workflows/installer-test: no triple **asset** names remain; the triple survives only as the cargo build target (`--target <triple>`, `target/<triple>/release/...`, matrix `target:` values, CI build references) and in the intentionally-preserved `.deb` filenames.

## Note

The fail-closed installer verification is unchanged (not weakened). No tag is pushed by this PR. Merging will trigger a new rolling release carrying the friendly-named assets, which is the end-to-end test of the rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
