### PR TITLE
fix(bench): allow the unix-only fsync_is_measured on non-unix builds

### DIFF
--- a/crates/ironbus-cli/src/bench.rs
+++ b/crates/ironbus-cli/src/bench.rs
@@ -200,6 +200,10 @@ impl BenchConfig {
     /// (the in-memory engine issues NO fsync at all, so there is no durable-write cost to
     /// attribute; reporting one would be dishonest) and only outside the `--no-fsync` dry run
     /// (which batches the cursor checkpoints, so the per-ack durable path is not exercised).
+    /// The callers live in `bench_run.rs` behind `cfg(unix)` (the bench broker is the real
+    /// `serve` path, Unix-only in v1), so on a non-unix build this method is otherwise dead
+    /// code and `-D warnings` refuses the build (the Windows CI lane caught exactly that).
+    #[cfg_attr(not(unix), allow(dead_code))]
     #[must_use]
     pub fn fsync_is_measured(&self) -> bool {
         !self.no_fsync && self.storage == StorageArg::Disk


### PR DESCRIPTION
## Problem

The #448 squash broke the `test (windows-latest)` lane on main: `BenchConfig::fsync_is_measured` is called only from `bench_run.rs`, whose callers sit behind `cfg(unix)` (the bench broker is the real `serve` path, Unix-only in v1). On a non-unix build the method is dead code, and the CI wall (`RUSTFLAGS=-D warnings`) refuses the compile:

```
error: method `fsync_is_measured` is never used
```

The branch CI showed the failure but the merge was gated on checks settling rather than all-green; that process gap is mine, recorded here for honesty.

## Fix

One attribute with the explanation: `#[cfg_attr(not(unix), allow(dead_code))]` on the method. The unit tests that call it compile on every platform (tests are not cfg-gated), the unix builds keep the full warning wall, and the method stays available for a future Windows-enabled serve.

Verified: unix clippy pedantic clean, ironbus-cli unit tests green. The Windows lane on this PR is the authoritative check (the local cross-target stdlib is not installed).
