### PR TITLE
perf: 64 KiB connection read chunk + opt-in --commit-gather-us group-commit window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ to follow Semantic Versioning once it reaches a tagged release.
 ## [Unreleased]
 
 ### Changed
+- The per-connection read chunk grew from a 4 KiB stack array to a 64 KiB zero-page heap buffer (#454). The pipelined produce window (#450) is pass-scoped, and a pass sees at most one read chunk, so 4 KiB silently capped the publisher pipeline at ~13 records per group commit on 256 B payloads (~40 fsyncs per 512-record window on the reference edge box). Untouched pages cost no resident memory, so idle connections are unaffected.
+
+### Added
+- `serve --commit-gather-us <us>` / `IRONBUS_COMMIT_GATHER_US` (#454): an opt-in bounded group-commit gather window. When a drain pass already holds at least two produces (evidence of a pipelining publisher; an unpipelined producer never pays the window), the append actor keeps collecting commands for up to the window before committing, so a pipelined publisher's whole in-flight window lands under one covering fsync instead of arrival-rate-sized slivers (measured on the reference edge box: a 512-record client window was committing as ~12 records per fsync). Default `0` keeps the actor byte-identical; acks keep their fsynced-durable meaning at any setting; validation caps the window at 1 second. The materialized-config line gains a `commit_gather_us=` field.
+
+### Changed
 - Renamed the published release binary assets to friendly CPU-arch names: `ironbus-linux-amd64`, `ironbus-linux-arm64`, `ironbus-linux-armv7` (dropping the `unknown`-vendored `musl` triple, which stays the internal cargo/cross build target). The installer (`detect_target` + download URL), its tests, both release workflows (staging, `SHA256SUMS`, attestation, release assets, notes table), and the install docs (README, DISTRIBUTION, RELEASING) are updated to match. The `.deb` packages were renamed to match (`ironbus-linux-amd64.deb`, `ironbus-linux-arm64.deb`, `ironbus-linux-armv7.deb`), so no published asset carries the `unknown` triple; it stays the cargo `--target` only. The binaries are still static `musl` with no runtime dependency.
 
 ### Fixed

--- a/crates/ironbus-cli/src/main.rs
+++ b/crates/ironbus-cli/src/main.rs
@@ -110,7 +110,7 @@ use ironbus_core::lease::LeaseConfig;
 #[cfg(unix)]
 use ironbus_core::types::RecordFlags;
 #[cfg(unix)]
-use ironbus_server::actor::{spawn_actor, DEFAULT_CHANNEL_BOUND};
+use ironbus_server::actor::{spawn_actor_with_gather, DEFAULT_CHANNEL_BOUND};
 #[cfg(unix)]
 use ironbus_server::engine::{DiskFullPolicy, DurabilityLevel, Engine, EngineConfig};
 #[cfg(unix)]
@@ -1679,6 +1679,9 @@ struct ServeFlags {
     compression: Option<String>,
     /// The `interval` level's TIME window in ms (#341); `None` falls back to the default.
     flush_interval_ms: Option<u64>,
+    /// The opt-in GROUP-COMMIT GATHER window in MICROSECONDS (#454); `None` resolves to 0 (off,
+    /// byte-identical actor behavior). See the `ServeConfig` field for the contract.
+    commit_gather_us: Option<u64>,
     /// The `interval` level's unsynced-byte budget (#341); `None` falls back to the default.
     flush_max_bytes: Option<u64>,
     /// The explicit data-loss acknowledgement for `async`/`none` (#49, #379): the `--async-loss-ack`
@@ -1823,6 +1826,9 @@ fn collect_serve_flags(args: &[String]) -> Result<ServeFlags, CliError> {
             }
             "--flush-interval-ms" => {
                 f.flush_interval_ms = Some(take_number("--flush-interval-ms", args, &mut i)?);
+            }
+            "--commit-gather-us" => {
+                f.commit_gather_us = Some(take_number("--commit-gather-us", args, &mut i)?);
             }
             "--flush-max-bytes" => {
                 f.flush_max_bytes = Some(take_number("--flush-max-bytes", args, &mut i)?);
@@ -2243,6 +2249,8 @@ fn parse_serve_flags_with_env_and_reader(
                 env,
                 DEFAULT_FLUSH_MAX_BYTES,
             )?,
+            // The group-commit gather (#454): default 0 = off, the byte-identical historical actor.
+            commit_gather_us: resolve_number("--commit-gather-us", f.commit_gather_us, env, 0)?,
             async_loss_ack: resolve_bool("--async-loss-ack", f.async_loss_ack, env)?,
             // The storage backend (#443), resolved above (flag > env > default `disk`); the
             // ephemeral consent resolves like the other bare safety flags. `memory` without the
@@ -2559,6 +2567,14 @@ fn finish_serve(
 
 /// Rejects an out-of-range `serve` tuning value with a usage error before the broker opens.
 fn validate_serve_config(config: &ServeConfig) -> Result<(), CliError> {
+    if config.commit_gather_us > 1_000_000 {
+        // The gather window delays every produce ack by up to its full length under load; a
+        // fat-fingered value (ms pasted as us, or an extra zero) must not silently turn into a
+        // multi-second ack stall. One second is already far past any useful group-commit window.
+        return Err(CliError::Usage(
+            "`--commit-gather-us` must be at most 1000000 (1 second)".to_string(),
+        ));
+    }
     if config.max_connections == 0 {
         // A zero cap binds and looks healthy but refuses every connection: reject it.
         return Err(CliError::Usage(
@@ -2994,6 +3010,16 @@ struct ServeConfig {
     /// (`DEFAULT_FLUSH_MAX_BYTES`); `0` disables the byte trigger (the time window alone forces the
     /// sync). The EFFECTIVE worst-case loss bound is the smaller of the time and byte triggers.
     flush_max_bytes: u64,
+    /// The opt-in GROUP-COMMIT GATHER window in MICROSECONDS (#454): when a drain pass already
+    /// holds at least TWO produces (evidence of a pipelining publisher; a single-produce pass
+    /// never gathers, so an unpipelined producer pays no window), the append actor keeps
+    /// collecting commands for up to this long before committing, so the publisher's whole
+    /// in-flight window lands under ONE covering fsync instead of arrival-rate-sized slivers. `0` (the default) disables the gather and the
+    /// actor is byte-identical to the historical drain. Durability is UNTOUCHED: acks still mean
+    /// fsynced-durable; the knob trades up to this much added commit latency under produce bursts
+    /// for fewer, larger sync barriers (the `MySQL` `binlog_group_commit_sync_delay` precedent).
+    /// Bounded at 1 second by validation so a typo cannot stall acks indefinitely.
+    commit_gather_us: u64,
     /// The explicit DATA-LOSS ACKNOWLEDGEMENT for the unbounded-loss levels (#49, #379): the
     /// `--async-loss-ack` (a.k.a. `i-accept-acknowledged-data-loss`) bare flag. `async` and `none`
     /// WAIVE I2 with an unbounded loss window, so they REFUSE TO BOOT unless this is set (the
@@ -3106,6 +3132,7 @@ impl ServeConfig {
             compression: CompressionArg::Lz4,
             flush_interval_ms: DEFAULT_FLUSH_INTERVAL_MS,
             flush_max_bytes: DEFAULT_FLUSH_MAX_BYTES,
+            commit_gather_us: 0,
             async_loss_ack: false,
             // The default storage backend (#443): the durable on-disk store, no ephemeral consent.
             storage: StorageArg::Disk,
@@ -3278,7 +3305,8 @@ fn materialized_config_line(config: &ServeConfig, addr: &str, data_dir: Option<&
          max_retained_bytes={} max_age_ms={} max_messages={} health_liveness_window_ms={} \
          enable_admin={} ram_ceiling_bytes={} durability_level={durability_level} \
          power_loss_safe={power_loss_safe} compression={compression} flush_interval_ms={} \
-         flush_max_bytes={} async_loss_ack={} wal_fsync_headroom_bytes={} storage={storage}",
+         flush_max_bytes={} async_loss_ack={} wal_fsync_headroom_bytes={} storage={storage} \
+         commit_gather_us={}",
         config.profile.name(),
         config.profile_schema_version,
         config.max_connections,
@@ -3303,6 +3331,7 @@ fn materialized_config_line(config: &ServeConfig, addr: &str, data_dir: Option<&
         config.flush_max_bytes,
         config.async_loss_ack,
         config.wal_fsync_headroom_bytes,
+        config.commit_gather_us,
         data_dir = data_dir.map_or_else(|| "none".to_string(), |d| d.display().to_string()),
     )
 }
@@ -3479,7 +3508,8 @@ fn run_broker<F: Filesystem + 'static>(
     // it only through the bounded-channel handle, so no handler holds a lock across an fsync. The
     // actor's join handle yields the engine back on its clean exit (a Shutdown drain), which is how
     // the graceful-shutdown cursor flush (#195) completes before the process exits 0.
-    let (shared, actor) = spawn_actor(engine, DEFAULT_CHANNEL_BOUND);
+    let (shared, actor) =
+        spawn_actor_with_gather(engine, DEFAULT_CHANNEL_BOUND, config.commit_gather_us);
     let listener = TcpListener::bind(addr)
         .map_err(|e| CliError::Internal(format!("cannot bind {addr}: {e}")))?;
     let local = listener
@@ -6171,6 +6201,7 @@ mod tests {
             compression: CompressionArg::Lz4,
             flush_interval_ms: DEFAULT_FLUSH_INTERVAL_MS,
             flush_max_bytes: DEFAULT_FLUSH_MAX_BYTES,
+            commit_gather_us: 0,
             async_loss_ack: false,
             // The default storage backend (#443): the durable on-disk store, no ephemeral consent.
             storage: StorageArg::Disk,
@@ -8294,6 +8325,7 @@ mod tests {
             compression: CompressionArg::Lz4,
             flush_interval_ms: DEFAULT_FLUSH_INTERVAL_MS,
             flush_max_bytes: DEFAULT_FLUSH_MAX_BYTES,
+            commit_gather_us: 0,
             async_loss_ack: false,
             // The default storage backend (#443): the durable on-disk store, no ephemeral consent.
             storage: StorageArg::Disk,
@@ -8711,6 +8743,44 @@ mod tests {
             validate_serve_config(&ok).is_ok(),
             "interval with a positive trigger and no ack must boot"
         );
+    }
+
+    #[test]
+    fn the_commit_gather_flag_parses_defaults_off_echoes_and_caps_at_one_second() {
+        // The group-commit gather knob (#454). Default OFF: an untouched serve resolves to 0 and
+        // the actor stays byte-identical. The flag parses WITHOUT swallowing the next flag (the
+        // `--pubwindow` parse-cursor regression class), the materialized-config line echoes the
+        // resolved value, and validation refuses a window past one second (an ms-pasted-as-us typo
+        // must not become a silent multi-second ack stall).
+        let off = parse_serve_flags(&serve_args(&[])).unwrap().config;
+        assert_eq!(off.commit_gather_us, 0, "gather defaults off");
+        let on = parse_serve_flags(&serve_args(&[
+            "--commit-gather-us",
+            "3000",
+            "--max-connections",
+            "7",
+        ]))
+        .unwrap()
+        .config;
+        assert_eq!(on.commit_gather_us, 3000);
+        assert_eq!(
+            on.max_connections, 7,
+            "the flag after --commit-gather-us still parses (cursor not swallowed)"
+        );
+        assert!(validate_serve_config(&on).is_ok());
+        let line =
+            materialized_config_line(&on, "127.0.0.1:7777", Some(Path::new("/var/lib/ironbus")));
+        assert!(line.contains("commit_gather_us=3000"), "{line}");
+        let over = parse_serve_flags(&serve_args(&["--commit-gather-us", "1000001"]))
+            .unwrap()
+            .config;
+        match validate_serve_config(&over) {
+            Err(CliError::Usage(m)) => {
+                assert!(m.contains("--commit-gather-us"), "{m}");
+                assert!(m.contains("1000000"), "{m}");
+            }
+            other => panic!("an over-cap gather window must be a usage error, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/ironbus-server/src/actor.rs
+++ b/crates/ironbus-server/src/actor.rs
@@ -645,6 +645,33 @@ where
     F: Filesystem + 'static,
     C: Clock + Clone + 'static,
 {
+    spawn_actor_with_gather(engine, channel_bound, 0)
+}
+
+/// Like [`spawn_actor`] with an opt-in bounded GROUP-COMMIT GATHER (#454). With `gather_micros`
+/// of 0 (the default everywhere except an operator's explicit `--commit-gather-us`) the actor is
+/// byte-identical to the historical drain. With a window set, a drain pass that already holds at
+/// least TWO produces (evidence of a pipelining publisher; a single-produce pass never gathers,
+/// so an unpipelined producer pays no window) keeps collecting commands for up to the window
+/// before committing, so a pipelined publisher's whole in-flight window lands under ONE covering
+/// fsync instead of self-sizing slivers (measured on the reference edge box: a 512-record client window committed as ~12
+/// records per fsync, because the drain only sees what arrived during the PREVIOUS batch's
+/// fsync). Acks keep their fsynced-durable meaning; the knob trades up to the window in added
+/// commit latency under produce bursts for fewer, larger barriers (the `MySQL`
+/// `binlog_group_commit_sync_delay` / `PostgreSQL` `commit_delay` precedent).
+///
+/// # Panics
+/// Panics if the OS refuses to spawn the actor thread, exactly as [`spawn_actor`]: a STARTUP step,
+/// not a request path, so the no-panic bar for the library hot paths is untouched.
+pub fn spawn_actor_with_gather<F, C>(
+    engine: Engine<F, C>,
+    channel_bound: usize,
+    gather_micros: u64,
+) -> (EngineHandle<F, C>, std::thread::JoinHandle<Engine<F, C>>)
+where
+    F: Filesystem + 'static,
+    C: Clock + Clone + 'static,
+{
     let (tx, rx) = sync_channel::<Command<F, C>>(channel_bound.max(1));
     // Clone the engine's clock seam BEFORE the engine moves into the actor thread, so the handle can
     // stamp a produce's enqueue instant (the CoDel sojourn measurement, #68) with the SAME clock the
@@ -655,7 +682,7 @@ where
     let consumer_credit_caps = (engine.consumer_credit(), engine.consumer_credit_bytes());
     let join = std::thread::Builder::new()
         .name("ironbus-append-actor".to_string())
-        .spawn(move || run_actor(engine, &rx))
+        .spawn(move || run_actor(engine, &rx, gather_micros))
         // A thread-spawn failure at startup is unrecoverable for the server, but the no-panic bar is
         // for the LIBRARY hot paths; spawning the single actor at boot is a startup step. Surface it
         // by propagating the panic only here (boot), never on a request path.
@@ -670,12 +697,59 @@ where
     )
 }
 
+/// The bounded group-commit gather (#454): keeps collecting commands into `commands` for up to
+/// `gather_micros`, so the caller's batch covers a pipelined publisher's whole in-flight window
+/// under ONE fsync. Wall-clock (`std::time::Instant`) is correct here: the gather is a real-time
+/// IO batching decision on the actor thread, outside the engine's deterministic clock seam (the
+/// sim drives the `Engine` directly and never runs this loop). A `Shutdown` gathered mid-window is
+/// processed in order after the batch, exactly as if it had arrived in the same burst. A
+/// disconnect ends the gather early; the caller's batch then processes and the next outer `recv`
+/// observes the disconnect.
+///
+/// A pass holding FEWER THAN TWO produces never gathers: an unpipelined producer (one in-flight
+/// produce, awaiting each ack) would otherwise stall the full window on every send and gain
+/// nothing, since its next produce cannot arrive until this one is acked; and a produce-less
+/// control pass (acks, polls, subscribes) has no fsync to amortize.
+fn gather_commands<F, C>(
+    commands: &mut Vec<Command<F, C>>,
+    rx: &Receiver<Command<F, C>>,
+    gather_micros: u64,
+) where
+    F: Filesystem,
+    C: Clock + Clone,
+{
+    let produces = commands
+        .iter()
+        .filter(|c| matches!(c, Command::Produce { .. }))
+        .count();
+    if produces < 2 {
+        return;
+    }
+    let deadline = std::time::Instant::now() + std::time::Duration::from_micros(gather_micros);
+    while let Some(left) = deadline.checked_duration_since(std::time::Instant::now()) {
+        if left.is_zero() {
+            return;
+        }
+        let Ok(cmd) = rx.recv_timeout(left) else {
+            return;
+        };
+        commands.push(cmd);
+        while let Ok(c) = rx.try_recv() {
+            commands.push(c);
+        }
+    }
+}
+
 /// The actor's run loop. It blocks for one command, then DRAINS every command already queued
 /// (`try_recv`) into the same pass so a burst of produces group-commits together. Produces are
 /// appended (no sync) and their replies parked; a non-produce job or the end of the drain triggers
 /// the ONE `commit_batch` that covers the parked produces, after which their replies are released.
 /// Returns the engine on exit so a caller can recover it.
-fn run_actor<F, C>(mut engine: Engine<F, C>, rx: &Receiver<Command<F, C>>) -> Engine<F, C>
+fn run_actor<F, C>(
+    mut engine: Engine<F, C>,
+    rx: &Receiver<Command<F, C>>,
+    gather_micros: u64,
+) -> Engine<F, C>
 where
     F: Filesystem,
     C: Clock + Clone,
@@ -694,6 +768,11 @@ where
         // Drain everything immediately available so a concurrent burst of produces forms one group.
         while let Ok(cmd) = rx.try_recv() {
             commands.push(cmd);
+        }
+        // The opt-in bounded gather (#454); a no-op unless configured AND this pass already
+        // shows a pipelining publisher (two or more produces).
+        if gather_micros > 0 {
+            gather_commands(&mut commands, rx, gather_micros);
         }
         for cmd in commands {
             match cmd {
@@ -1311,6 +1390,81 @@ mod tests {
             1,
             "the record stayed durable"
         );
+    }
+
+    #[test]
+    fn a_commit_gather_window_collects_a_spaced_produce_into_the_pipelined_batch() {
+        // The opt-in group-commit gather (#454): a drain pass holding TWO OR MORE produces (a
+        // pipelining publisher) keeps gathering, so a produce that arrives WHILE the actor is
+        // gathering joins the in-progress batch instead of paying its own fsync. The sync gate
+        // gives a deterministic setup: a primer produce parks the actor on its covering fsync,
+        // TWO produces queue behind it (so the next drain pass proves pipelining), the gate
+        // opens, and a fourth produce sent mid-gather must land in the SAME batch: exactly TWO
+        // syncs total (the primer's, then ONE covering the gathered three).
+        let (fs, control) = FaultFs::new(InMemoryFs::new());
+        let engine = Engine::open(fs, ManualClock::new(), config()).unwrap();
+        let (handle, actor) = spawn_actor_with_gather(engine, DEFAULT_CHANNEL_BOUND, 800_000);
+        control.close_sync_gate();
+        let primer = handle.produce_async(append(b"primer")).unwrap();
+        control.wait_for_sync_gate_entered(1);
+        let queued_a = handle.produce_async(append(b"queued-a")).unwrap();
+        let queued_b = handle.produce_async(append(b"queued-b")).unwrap();
+        let before = control.sync_count();
+        control.open_sync_gate();
+        match primer.recv().unwrap() {
+            ProduceOutcome::Appended(o) => assert_eq!(o.get(), 0),
+            other => panic!("expected Appended primer, got {other:?}"),
+        }
+        // The primer is acked, so the actor is in its next pass: it drained the two queued
+        // produces (>= 2, the gather engages) and is now collecting. Real-time spacing is the
+        // point under test (the gather is a wall-clock IO batching decision, outside the
+        // ManualClock seam), with a 16x margin between the spacing and the window so a slow CI
+        // runner cannot expire the gather before the late produce lands.
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        let late = handle.produce_async(append(b"gathered-late")).unwrap();
+        let mut offsets = Vec::new();
+        for reply in [queued_a, queued_b, late] {
+            match reply.recv().unwrap() {
+                ProduceOutcome::Appended(o) => offsets.push(o.get()),
+                other => panic!("expected Appended, got {other:?}"),
+            }
+        }
+        assert_eq!(offsets, vec![1, 2, 3], "all three appended in send order");
+        // `sync_count` ticks when a sync ENTERS the gate, so the primer's (parked) sync is
+        // already inside `before`; the gathered batch of three adds exactly ONE more.
+        assert_eq!(
+            control.sync_count() - before,
+            1,
+            "ONE covering fsync for the gathered batch of three, none for the late produce"
+        );
+        drop(handle);
+        actor.join().unwrap();
+    }
+
+    #[test]
+    fn a_single_inflight_produce_never_pays_the_gather_window() {
+        // The no-tax rule (#454): a drain pass holding ONE produce never gathers, so an
+        // unpipelined producer (send, await ack, send) on a gather-enabled broker keeps the
+        // historical ack latency. With an 800 ms window, a gathered single produce could not ack
+        // in under 800 ms; the bound asserts the ack came back far sooner.
+        let (fs, control) = FaultFs::new(InMemoryFs::new());
+        let engine = Engine::open(fs, ManualClock::new(), config()).unwrap();
+        let (handle, actor) = spawn_actor_with_gather(engine, DEFAULT_CHANNEL_BOUND, 800_000);
+        let before = control.sync_count();
+        let started = std::time::Instant::now();
+        let reply = handle.produce_async(append(b"solo")).unwrap();
+        match reply.recv().unwrap() {
+            ProduceOutcome::Appended(o) => assert_eq!(o.get(), 0),
+            other => panic!("expected Appended, got {other:?}"),
+        }
+        assert!(
+            started.elapsed() < std::time::Duration::from_millis(400),
+            "a single produce must ack without waiting out the 800 ms gather window, took {:?}",
+            started.elapsed()
+        );
+        assert_eq!(control.sync_count() - before, 1, "one produce, one fsync");
+        drop(handle);
+        actor.join().unwrap();
     }
 
     #[test]

--- a/crates/ironbus-server/src/server.rs
+++ b/crates/ironbus-server/src/server.rs
@@ -173,13 +173,20 @@ where
     C: Clock + Clone + 'static,
 {
     let mut inbuf: Vec<u8> = Vec::new();
-    let mut chunk = [0u8; 4096];
+    // The read chunk BOUNDS the pipelined-window pass (#450, #454): a `process` pass sees at most
+    // one chunk of new frames, and every pass ends by awaiting its parked produce acks, so the
+    // effective publisher pipeline depth is (chunk bytes / wire frame bytes). The old 4 KiB stack
+    // chunk capped a 512-produce window at ~13 records per group commit on 256 B payloads (hive
+    // measured), paying ~40 fsyncs per window. 64 KiB lets a pass carry hundreds of small frames.
+    // Heap-allocated and zero-initialized: `alloc_zeroed` pages stay untouched (no RSS) until the
+    // kernel actually fills them, so an idle or ping-only connection still costs about a page.
+    let mut chunk = vec![0u8; 64 * 1024];
     // The minimum buffer length before re-running `process` is worth it: `0` means run on any new
     // byte; a larger value is the trailing partial frame's `needed` hint, so a near-cap frame
     // trickled byte-by-byte is decoded once it is whole, not once per byte (#176).
     let mut needed: usize = 0;
     loop {
-        let n = stream.read(&mut chunk)?;
+        let n = stream.read(&mut chunk[..])?;
         if n == 0 {
             return Ok(()); // the client closed the connection
         }

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -238,6 +238,7 @@ field and flag are the #4/#87 implementation residual.
 | `durability_level` | `--durability-level` / `IRONBUS_DURABILITY_LEVEL` | enum | `sync` (`DEFAULT_DURABILITY_LEVEL`) | -- | `sync \| interval \| async \| none` | COLD (coupled with the flush knobs and `async_loss_ack`) |
 | `flush_interval_ms` | `--flush-interval-ms` / `IRONBUS_FLUSH_INTERVAL_MS` | u64 | `1000` (`DEFAULT_FLUSH_INTERVAL_MS`) | ms | `>= 0` (`0` disables the time trigger) | COLD (coupled with `durability_level`) |
 | `flush_max_bytes` | `--flush-max-bytes` / `IRONBUS_FLUSH_MAX_BYTES` | size | `1048576` (1 MiB, `DEFAULT_FLUSH_MAX_BYTES`) | bytes | `>= 0` (`0` disables the byte trigger) | COLD (coupled with `durability_level`) |
+| (no file key: flag/env ONLY) | `--commit-gather-us` / `IRONBUS_COMMIT_GATHER_US` | u64 | `0` (off) | us | `0..=1000000` (`0` disables the gather) | COLD (an actor-spawn decision) (#454) |
 | `async_loss_ack` | `--async-loss-ack` / `IRONBUS_ASYNC_LOSS_ACK` | bool | `false` | -- | `true` to enable `async` / `none` | COLD (coupled with `durability_level`) |
 
 The durability `durability_level` enum is now IMPLEMENTED (#341, #379). The DEFAULT

--- a/docs/PERF_LEDGER.md
+++ b/docs/PERF_LEDGER.md
@@ -102,3 +102,60 @@ times fsync latency; if the steady-state drain is far below the client window, e
 several fsyncs). If confirmed, add a bounded group-commit gather delay or min-batch (the MySQL
 binlog_group_commit_sync_delay precedent; PostgreSQL commit_delay) so a pipelined window commits
 in one or two batches. Leg 2 stands at median ~1,951/s vs the 2,030 target (9.6x of NATS's 203).
+
+## Round 3 (#454): the 4 KiB read chunk was the pipeline cap; 64 KiB chunk = 7,200-10,300/s durable
+
+Sources: MySQL binlog_group_commit_sync_delay and PostgreSQL commit_delay (bounded group-commit
+gather); DeWitt et al. 1984 (group commit); the round-2 ledger entry (batch-size hypothesis).
+
+### Hypothesis and what the instrumentation actually showed
+
+Hypothesis: the actor drain self-sizes to arrival rate x fsync latency, so a 512-record client
+window commits in many small batches; a bounded gather window would merge them. The zero-code
+measurement (delta ironbus_produced_total / delta fsync_duration_seconds_count on the hive)
+confirmed tiny batches: mean 12-13 records per fsync against a 512 window, ~40 fsyncs per window.
+
+The gather knob alone then DISPROVED the mechanism: with gather windows of 1/3/5/13 ms the batch
+stayed at 13-15 and throughput fell monotonically (2,384 -> 645/s at 13 ms). The batch was not
+arrival-sized; it was CAPPED. The session's pipelined window (#450) is pass-scoped, a pass sees
+at most one connection-loop read chunk, and the chunk was a 4 KiB stack array: ~13 frames of
+256 B realistic payloads, after which the session blocks awaiting its parked acks while the
+actor waits out the gather. The two waits compound; nothing feeds.
+
+### Fix shipped
+
+1. Read chunk 4 KiB -> 64 KiB zero-page heap buffer (the actual win). A pass now carries
+   hundreds of frames, so the pass-scoped window group-commits in a few fsyncs, not ~40.
+   Untouched pages cost no RSS; idle/ping-only connections still touch about a page.
+2. serve --commit-gather-us (default 0 = off, validation-capped at 1 s) kept as the OPT-IN
+   multi-producer lever: many connections each trickling singles can amortize one fsync. It
+   only engages when a drain pass already holds >= 2 produces (a single-produce pass never
+   gathers, so an unpipelined producer pays no window; the MySQL no-delay-count analogue).
+
+### Measured (hive, 256B realistic, 15s runs, pre-merge cross-compiled, scratch broker)
+
+| leg | round 2 | round 3 (64 KiB chunk) |
+| --- | --- | --- |
+| disk w=1 | 201/s | 198/s (fsync physics, unchanged) |
+| disk w=64 | 1,502/s | 5,215/s |
+| disk w=512 | ~1,951/s | 7,193/s (batch 90 rec/fsync) |
+| disk w=1024 | 1,956/s | 9,197-10,294/s (batch 104) |
+| memory w=1 | 980/s | 1,364/s |
+| memory w=512 | 4,882/s | 8,023/s |
+| memory w=1024 | -- | 11,171/s |
+
+Gather on a single pipelined connection now HURTS (6,839 vs 7,193 at w=512): default 0 stays.
+Guardrails: binary 1.53 MB (<= 3 MB), peak RSS under w=1024 load 2.1 MB (<= 8 MB), ack-after-
+fdatasync default untouched, all suites green.
+
+Verdict: KEEP. Win-condition leg 2 (durable pipelined >= 2,030/s = 10x NATS sync-always) is
+cleared at 35-50x (7,193-10,294 vs 203). Leg 1 holds (198-205 vs NATS 191-203). Legs 3 and 4
+(memory per-ack >= 2,491; memory pipelined >= 27,250) remain open: both are now CPU-floor bound
+(~125 us/op at w=512), not batching bound.
+
+### Round 4 hypothesis (queued)
+
+Profile the per-op CPU floor on the wire/session/engine path (memory w=1 is 733 us round-trip;
+NATS does 401 us). Candidates: per-record allocations in decode/dispatch (arena or reuse), the
+per-frame reply flush (vectored writes), checkpoint cadence in the hot loop. Target: memory
+w=1 >= 2,491/s (leg 3) and memory pipelined toward 27,250/s (leg 4).


### PR DESCRIPTION
Closes #454.

## What the instrumentation showed (and disproved)

Round 3 started with the round-2 hypothesis: the actor drain self-sizes its group-commit batch to arrival rate x fsync latency, so a 512-record pipelined window pays ~40 fsyncs. The zero-code measurement (delta produced_total / delta fsync_count on the reference edge box) confirmed mean batches of 12-13 records against a 512 window.

The gather knob alone then DISPROVED the mechanism: with gather windows of 1/3/5/13 ms the batch stayed at 13-15 records and throughput fell monotonically (2,384 -> 645 msg/s). The batch was not arrival-sized; it was CAPPED. The pipelined window (#450) is pass-scoped, a `process` pass sees at most one connection-loop read chunk, and the chunk was a 4 KiB stack array: ~13 frames of 256 B realistic payloads, after which the session blocks awaiting its parked acks while the actor waits out its gather. The two waits compound; nothing feeds.

## Changes

1. **Connection read chunk 4 KiB -> 64 KiB zero-page heap buffer** (the actual win). A pass now carries hundreds of frames, so a pipelined window group-commits in a few fsyncs instead of ~40. `vec![0u8; 64*1024]` is `alloc_zeroed`-backed: untouched pages cost no resident memory, so idle or ping-only connections still touch about a page.
2. **`serve --commit-gather-us <us>` / `IRONBUS_COMMIT_GATHER_US`** (default 0 = off, validation-capped at 1 s): an opt-in bounded group-commit gather for multi-producer fan-in (the MySQL `binlog_group_commit_sync_delay` / PostgreSQL `commit_delay` precedent). It engages only when a drain pass already holds TWO OR MORE produces, so an unpipelined producer (one in-flight produce, awaiting each ack) never pays the window. Acks keep their fsynced-durable meaning at any setting; `0` is byte-identical to the historical actor.

## Hive A/B (pre-merge cross-compiled armv7 musl, 256 B realistic, 15 s runs)

| leg | before (merged main) | after |
| --- | --- | --- |
| disk w=1 | 201/s | 198/s (fsync physics, unchanged) |
| disk w=64 | 1,502/s | 5,215/s |
| disk w=512 | ~1,951/s | **7,193/s** (batch 90 rec/fsync) |
| disk w=1024 | 1,956/s | **9,197-10,294/s** (batch 104) |
| memory w=1 | 980/s | 1,364/s |
| memory w=512 | 4,882/s | 8,023/s |
| memory w=1024 | -- | 11,171/s |

Gather on a single pipelined connection now measurably hurts (6,839 vs 7,193 at w=512), which is why the default stays 0. Guardrails verified on the hive: binary 1.53 MB (<= 3 MB), peak RSS under w=1024 load 2.1 MB (<= 8 MB), ack-after-fdatasync default untouched.

## Tests

- `a_commit_gather_window_collects_a_spaced_produce_into_the_pipelined_batch`: sync-gate-deterministic proof that a produce arriving mid-gather joins the in-progress batch under ONE covering fsync.
- `a_single_inflight_produce_never_pays_the_gather_window`: the no-tax rule; a solo produce acks far inside the window with exactly one sync.
- `the_commit_gather_flag_parses_defaults_off_echoes_and_caps_at_one_second`: default-off, parse-cursor regression guard (the `--pubwindow` bug class), materialized-config echo, 1 s cap as a usage error.
- Full workspace suite green locally; every existing actor/session/crash-recovery contract passes unchanged (gather 0 is the delegating default everywhere).

Review-of-record: panel capacity is unavailable until Jun 13; this PR carries the inline adversarial pass (the gather-only sweep that falsified the original mechanism is documented above and in `docs/PERF_LEDGER.md`).