### PR TITLE
perf: incremental dirty-range sync_data for InMemoryFile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ to follow Semantic Versioning once it reaches a tagged release.
 ## [Unreleased]
 
 ### Changed
+- `InMemoryFile::sync_data` now copies only the byte ranges written since the last sync into the durable image instead of cloning the whole file (#456). An in-memory group commit costs O(bytes appended) like a real fdatasync, not O(file): under `--storage memory` this removes a whole-segment memcpy per commit (82 percent of append-actor CPU in a profiled pipelined publish run) and a quadratic per-message copy at window 1. The durable image is byte-for-byte unchanged (unsynced-truncation tail retention, zero-fill growth, power-loss reverts all preserved; the determinism, crash-recovery, and power-loss suites pass unchanged).
+
+### Changed
 - The per-connection read chunk grew from a 4 KiB stack array to a 64 KiB zero-page heap buffer (#454). The pipelined produce window (#450) is pass-scoped, and a pass sees at most one read chunk, so 4 KiB silently capped the publisher pipeline at ~13 records per group commit on 256 B payloads (~40 fsyncs per 512-record window on the reference edge box). Untouched pages cost no resident memory, so idle connections are unaffected.
 
 ### Added

--- a/crates/ironbus-storage/src/io.rs
+++ b/crates/ironbus-storage/src/io.rs
@@ -150,6 +150,52 @@ struct State {
     /// truncation (length is metadata): only `sync_all` (fsync) makes a truncation
     /// durable. See the sync methods below and [`InMemoryFile`] for the contract.
     durable: Vec<u8>,
+    /// The byte ranges of `live` written since the last sync: sorted, disjoint, half-open.
+    /// `sync_data` copies ONLY these into the durable image (#456) instead of cloning the whole
+    /// file, so an in-memory group commit costs O(bytes appended since the last sync) like a real
+    /// fdatasync, not O(file). Soundness invariant: every byte of `live` that differs from the
+    /// corresponding `durable` byte is inside a dirty range (every `live` mutation marks its
+    /// range, including a zero-fill growth gap; the power-loss models rewrite `live` from the
+    /// durable image and clear the list). For the append-only log writer this is almost always a
+    /// single coalesced range.
+    dirty: Vec<(usize, usize)>,
+}
+
+/// Records `[a, b)` as written-since-last-sync, keeping `dirty` sorted, disjoint, and coalesced.
+/// The fast path is the log writer's append pattern (the new range starts at or inside the last
+/// one); an arbitrary overlap falls back to a sort-and-merge pass.
+fn mark_dirty(dirty: &mut Vec<(usize, usize)>, a: usize, b: usize) {
+    if a >= b {
+        return;
+    }
+    match dirty.last_mut() {
+        None => dirty.push((a, b)),
+        // At or after the last range's start: earlier ranges all end before it, so the new range
+        // either merges with the last one or goes after it. O(1), the append fast path.
+        Some(last) if a >= last.0 => {
+            if a <= last.1 {
+                last.1 = last.1.max(b);
+            } else {
+                dirty.push((a, b));
+            }
+        }
+        // A write behind the frontier (a header patch, a compaction rewrite): general coalesce.
+        Some(_) => {
+            dirty.push((a, b));
+            dirty.sort_unstable();
+            let mut merged: Vec<(usize, usize)> = Vec::with_capacity(dirty.len());
+            for &(x, y) in dirty.iter() {
+                if let Some(m) = merged.last_mut() {
+                    if x <= m.1 {
+                        m.1 = m.1.max(y);
+                        continue;
+                    }
+                }
+                merged.push((x, y));
+            }
+            *dirty = merged;
+        }
+    }
 }
 
 /// An in-memory [`RandomAccessFile`] for tests and the deterministic simulation.
@@ -198,6 +244,7 @@ impl InMemoryFile {
             state: Mutex::new(State {
                 live: bytes.clone(),
                 durable: bytes,
+                dirty: Vec::new(),
             }),
             syncs: AtomicU64::new(0),
             preallocated_to: AtomicU64::new(0),
@@ -246,6 +293,8 @@ impl InMemoryFile {
         let mut guard = self.lock();
         let s = &mut *guard;
         s.live.clone_from(&s.durable);
+        // The unsynced writes are gone with the live image: live == durable again.
+        s.dirty.clear();
     }
 
     /// Models a power loss with page-cache reorder/drop of the UNSYNCED tail (#164, #55).
@@ -300,6 +349,7 @@ impl InMemoryFile {
         // post-cut live image: a later `simulate_power_loss` then resurrects nothing, and the kept
         // unsynced prefix is now itself durable (the cut is the new ground truth).
         s.durable.clone_from(&s.live);
+        s.dirty.clear();
         kept as u64
     }
 }
@@ -321,11 +371,16 @@ impl RandomAccessFile for InMemoryFile {
         let end = off
             .checked_add(buf.len())
             .ok_or_else(|| invalid_input("write extends past the addressable range"))?;
-        let mut s = self.lock();
-        if s.live.len() < end {
+        let mut guard = self.lock();
+        let s = &mut *guard;
+        let old_len = s.live.len();
+        if old_len < end {
             s.live.resize(end, 0);
         }
         s.live[off..end].copy_from_slice(buf);
+        // The zero-fill gap of a past-EOF write is new data too: a real fdatasync persists the
+        // allocated zeros, so the dirty range starts at the old length when the write grew the file.
+        mark_dirty(&mut s.dirty, off.min(old_len), end);
         Ok(())
     }
 
@@ -337,14 +392,24 @@ impl RandomAccessFile for InMemoryFile {
         // writes that extend the file are data, so they DO become durable here.
         let mut guard = self.lock();
         let s = &mut *guard;
-        if s.live.len() >= s.durable.len() {
-            s.durable.clone_from(&s.live);
-        } else {
-            // An unsynced truncation: flush the surviving data in place, keep the old
-            // durable length, and retain the un-truncated tail so a power loss can still
-            // expose it (exactly until a `sync_all` persists the shorter length).
-            s.durable[..s.live.len()].copy_from_slice(&s.live);
+        if s.live.len() > s.durable.len() {
+            // Data grew the file: the durable length advances with it (the grown range is in a
+            // dirty range, so the zeros materialized here are overwritten just below).
+            s.durable.resize(s.live.len(), 0);
         }
+        // Copy ONLY the bytes written since the last sync (#456). Outside the dirty ranges, live
+        // and durable already agree (the soundness invariant on `State::dirty`), so this is
+        // byte-for-byte the old clone-the-whole-file image at O(written) cost. Under an unsynced
+        // truncation the ranges were clamped by `set_len`, the durable image keeps its old length,
+        // and the un-truncated durable tail survives so a power loss can still expose it (exactly
+        // until a `sync_all` persists the shorter length).
+        for &(a, b) in &s.dirty {
+            debug_assert!(b <= s.live.len(), "dirty range past live length");
+            let b = b.min(s.live.len());
+            let a = a.min(b);
+            s.durable[a..b].copy_from_slice(&s.live[a..b]);
+        }
+        s.dirty.clear();
         self.syncs.fetch_add(1, Ordering::SeqCst);
         Ok(())
     }
@@ -355,6 +420,7 @@ impl RandomAccessFile for InMemoryFile {
         let mut guard = self.lock();
         let s = &mut *guard;
         s.durable.clone_from(&s.live);
+        s.dirty.clear();
         self.syncs.fetch_add(1, Ordering::SeqCst);
         Ok(())
     }
@@ -365,7 +431,25 @@ impl RandomAccessFile for InMemoryFile {
 
     fn set_len(&self, len: u64) -> io::Result<()> {
         let len = usize::try_from(len).map_err(|_| invalid_input("length out of range"))?;
-        self.lock().live.resize(len, 0);
+        let mut guard = self.lock();
+        let s = &mut *guard;
+        let old_len = s.live.len();
+        s.live.resize(len, 0);
+        if len > old_len {
+            // Growth zero-fills: new live bytes that must reach the durable image at the next sync
+            // (matching the old clone-everything image, which carried the grown zeros and length).
+            mark_dirty(&mut s.dirty, old_len, len);
+        } else {
+            // Truncation: the dropped bytes no longer exist in `live`, so no range may reach past
+            // the new length (the durable image keeps its own longer tail until `sync_all`).
+            s.dirty.retain_mut(|r| {
+                if r.0 >= len {
+                    return false;
+                }
+                r.1 = r.1.min(len);
+                r.0 < r.1
+            });
+        }
         Ok(())
     }
 
@@ -383,6 +467,53 @@ impl RandomAccessFile for InMemoryFile {
 mod tests {
     use super::*;
     use std::sync::Arc;
+
+    #[test]
+    fn dirty_range_sync_matches_the_clone_everything_durable_image() {
+        // The incremental sync (#456) must be observationally identical to the old
+        // clone-the-whole-file `sync_data`. Each step mutates the live image, syncs, and asserts
+        // the durable snapshot is exactly what the old semantics produced, through the tricky
+        // cases: an in-place edit inside the synced prefix, an append, a past-EOF write with a
+        // zero-fill gap, an unsynced truncation (durable keeps its longer tail), a write after
+        // the truncation, the power-loss revert clearing pending writes, and the sync_all length
+        // barrier.
+        let f = InMemoryFile::new();
+        f.write_all_at(b"AAAAAAAAAA", 0).unwrap();
+        f.sync_data().unwrap();
+        assert_eq!(f.durable_snapshot(), b"AAAAAAAAAA");
+        // An in-place edit inside the already-synced prefix.
+        f.write_all_at(b"B", 2).unwrap();
+        f.sync_data().unwrap();
+        assert_eq!(f.durable_snapshot(), b"AABAAAAAAA");
+        // A past-EOF write: the zero-fill gap (10..12) is data and becomes durable with it.
+        f.write_all_at(b"CC", 12).unwrap();
+        f.sync_data().unwrap();
+        assert_eq!(f.durable_snapshot(), b"AABAAAAAAA\x00\x00CC");
+        // An unsynced truncation + fdatasync: durable keeps its OLD length and un-truncated tail
+        // (a shrink is metadata; only sync_all persists it), exactly the old prefix-copy image.
+        f.set_len(4).unwrap();
+        f.sync_data().unwrap();
+        assert_eq!(f.durable_snapshot(), b"AABAAAAAAA\x00\x00CC");
+        // A write after the truncation flushes in place under the longer durable tail.
+        f.write_all_at(b"D", 1).unwrap();
+        f.sync_data().unwrap();
+        assert_eq!(f.durable_snapshot(), b"ADBAAAAAAA\x00\x00CC");
+        assert_eq!(f.snapshot(), b"ADBA");
+        // sync_all is the full barrier: the truncation becomes durable.
+        f.sync_all().unwrap();
+        assert_eq!(f.durable_snapshot(), b"ADBA");
+        // Unsynced writes vanish at a power loss and must NOT resurface at the next sync.
+        f.write_all_at(b"EEEE", 4).unwrap();
+        f.simulate_power_loss();
+        assert_eq!(f.snapshot(), b"ADBA");
+        f.sync_data().unwrap();
+        assert_eq!(f.durable_snapshot(), b"ADBA");
+        // A behind-the-frontier write coalesces with an append (the slow merge path).
+        f.write_all_at(b"FF", 6).unwrap();
+        f.write_all_at(b"G", 0).unwrap();
+        f.sync_data().unwrap();
+        assert_eq!(f.durable_snapshot(), b"GDBA\x00\x00FF");
+    }
 
     #[test]
     fn write_then_read_roundtrip() {

--- a/docs/PERF_LEDGER.md
+++ b/docs/PERF_LEDGER.md
@@ -159,3 +159,62 @@ Profile the per-op CPU floor on the wire/session/engine path (memory w=1 is 733 
 NATS does 401 us). Candidates: per-record allocations in decode/dispatch (arena or reuse), the
 per-frame reply flush (vectored writes), checkpoint cadence in the hot loop. Target: memory
 w=1 >= 2,491/s (leg 3) and memory pipelined toward 27,250/s (leg 4).
+
+## Round 4 (#456): InMemoryFile::sync_data cloned the whole segment per commit; dirty ranges = leg 3 cleared
+
+Sources: the round-3 ledger entry (CPU-floor hypothesis); LMAX Disruptor (Thompson et al. 2011,
+mechanical sympathy: the hot path should never copy what it does not have to); the incremental
+checkpoint/shadow-paging tradition (copy only what changed since the last barrier).
+
+### What the profile showed
+
+Round 3 left legs 3 and 4 "CPU-floor bound". A symbolized macOS `sample` of the broker under a
+memory-mode w=512 publish run located the floor precisely: 82 percent of the append-actor
+thread was `actor::flush_pending -> Log::sync -> SegmentWriter::sync -> Vec::clone_from ->
+memmove`. `InMemoryFile::sync_data` maintained the power-loss-simulation durable image by
+CLONING THE ENTIRE LIVE FILE on every sync: every group commit memcpy'd the whole accumulated
+segment (64 MiB profile segments), and window-1 publishing re-copied everything per MESSAGE
+(quadratic in segment fill). Strace corroborated: mmap/munmap churn from the repeated large
+clones. The hive's earlier "memory barely beats disk" oddity (8,023 vs 7,193) was this copy.
+
+Also measured and parked for later rounds: clock_gettime64 is a REAL syscall on the 32-bit ARM
+musl static build (~3/msg pipelined, 6/msg at w=1; no time64 vDSO) ~ a few us/op; futex 4/msg at
+w=1 from the per-produce sync_channel rendezvous; TCP_NODELAY is never set. All second-order
+next to the clone.
+
+### Fix shipped
+
+`State` tracks the byte ranges written since the last sync (sorted, disjoint, coalesced; the
+append pattern is the O(1) fast path). `sync_data` copies only those ranges into the durable
+image and clears the list. Byte-for-byte identical durable semantics: zero-fill growth gaps are
+dirty, an unsynced truncation clamps ranges while the durable image keeps its longer tail until
+`sync_all`, and both power-loss models clear the list when they rewrite the live image. The
+determinism, crash-recovery, torn-write, and power-loss suites pass unchanged, plus a focused
+equivalence test walks the tricky interleavings against the old clone-everything image.
+
+### Measured (hive, 256B realistic, 15s runs, pre-merge cross-compiled, scratch broker)
+
+| leg | round 3 | round 4 (dirty ranges) |
+| --- | --- | --- |
+| memory w=1 | 1,364/s | 7,045/s (5.2x; the quadratic clone is gone) |
+| memory w=512 | 8,023/s | 9,012/s |
+| memory w=1024 | 11,171/s | 16,461-16,753/s |
+| disk w=512 | 7,193/s | 6,791/s (run noise; disk never cloned) |
+| disk w=1024 | 9,197-10,294/s | 9,346/s |
+
+Guardrails: binary 1.54 MB (<= 3 MB); bounded-cap memory RSS 6.2 MB peak under w=1024 load with
+a 2 MiB store cap (the #443 model, <= 8 MB); the big-cap RSS scales with STORED MESSAGES by
+memory-mode design (45 MB at a 512 MiB cap, the queue itself, not overhead).
+
+Verdict: KEEP. Win-condition leg 3 (memory per-ack >= 2,491 = NATS memory sync) CLEARED at
+7,045 = 2.8x NATS. Standing: leg 1 held (198-205 vs 191-203), leg 2 cleared (46x), leg 3
+cleared (2.8x), leg 5 cleared (two legs led by >= 2x). OPEN: leg 4 only (memory pipelined
+16,461 vs 27,250 = 60 percent).
+
+### Round 5 hypothesis (queued)
+
+Leg 4 is now genuinely wire/session/engine CPU. Candidates in measured order: per-record
+allocations on the produce path (OwnedAppend payload Vec + per-produce reply sync_channel:
+reuse/arena them), the parked-ack reply encode path, clock_gettime64 batching (stamp once per
+drain batch), TCP_NODELAY + vectored reply writes. Re-profile AFTER the clone is gone; the 82
+percent memmove was masking everything downstream.


### PR DESCRIPTION
Closes #456. Round 4 of the NATS-parity ledger (docs/PERF_LEDGER.md).

## The find

A symbolized profile of the broker under a memory-mode pipelined publish put **82% of the append-actor thread** in `actor::flush_pending -> Log::sync -> SegmentWriter::sync -> Vec::clone_from -> memmove`: `InMemoryFile::sync_data` maintained the power-loss-simulation durable image by cloning the ENTIRE live file on every sync. Every group commit memcpy'd the whole accumulated segment, and window-1 publishing re-copied everything per MESSAGE (quadratic in segment fill). It also explained round 3's oddity of memory mode barely beating disk on the hive.

## The fix

`State` gains a sorted, disjoint, coalesced list of byte ranges written since the last sync (the log writer's append pattern is the O(1) fast path). `sync_data` copies only those ranges into the durable image and clears the list, so an in-memory commit costs O(bytes appended since last sync), exactly like a real fdatasync.

Durable-image semantics are byte-for-byte unchanged:
- a past-EOF write marks its zero-fill gap dirty (allocated zeros become durable with the data);
- `set_len` growth marks the grown range; truncation clamps ranges while the durable image keeps its longer length and un-truncated tail until `sync_all` (the #158 fdatasync-vs-fsync rule);
- both power-loss models clear the list when they rewrite the live image, so reverted writes can never resurface at the next sync;
- `sync_all` stays a full clone + length barrier (per segment lifecycle, not per batch).

## Proof

- The determinism, crash-recovery, torn-write, and power-loss simulation suites pass unchanged (they pin the durable image bytes).
- New `dirty_range_sync_matches_the_clone_everything_durable_image` walks the tricky interleavings (in-place edit, append, gap write, unsynced truncation + in-place flush under the longer durable tail, sync_all barrier, power-loss revert, behind-the-frontier coalesce) against the old semantics.
- Full workspace suite green locally (24 suites).

## Hive A/B (pre-merge cross-compiled armv7, 256 B realistic, 15 s runs)

| leg | before | after |
| --- | --- | --- |
| memory w=1 | 1,364/s | **7,045/s** (5.2x; quadratic clone gone; clears the NATS memory per-ack 2,491 target at 2.8x) |
| memory w=512 | 8,023/s | 9,012/s |
| memory w=1024 | 11,171/s | **16,461-16,753/s** |
| disk w=512 / w=1024 | 7,193 / 9,2-10,3k | 6,791 / 9,346 (run noise; disk never cloned) |

Guardrails: binary 1.54 MB; bounded-cap memory RSS 6.2 MB peak under w=1024 load with a 2 MiB store cap (the #443 model); ack-after-fdatasync default untouched (disk path unmodified).

Review-of-record (inline adversarial pass; panel capacity returns Jun 13):
1. *Can a live byte differ from durable outside a dirty range?* Every `live` mutation marks its range (`write_all_at` incl. growth gap, `set_len` growth) or clears the list after re-deriving `live` from `durable` (both power-loss models); reads and `preallocate` do not mutate. Induction holds from the empty file and `from_bytes` (live == durable, list empty).
2. *Truncate-then-regrow aliasing?* `set_len` shrink clamps ranges to the new length; a later regrow marks the re-zero-filled range, so stale durable tail bytes inside the regrown region are overwritten at the next sync, matching the old prefix-copy image (covered in the new test).
3. *Does `debug_assert` hide a release-mode bug?* The copy clamps defensively (`b.min(live.len())`) after the assert, so a violated invariant degrades to the old prefix behavior, never a panic or OOB.
4. *Capacity blowup?* `durable.resize` grows amortized like the old `clone_from` reserve; no shrink behavior change.