### PR TITLE
feat: Client::produce_stream full-duplex sliding-window publish + bench --stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ to follow Semantic Versioning once it reaches a tagged release.
 
 ## [Unreleased]
 
+### Added
+- `Client::produce_stream(messages, window)` (#458): a FULL-DUPLEX sliding-window publish. The caller's thread keeps writing coalesced PUB batches while a scoped reader thread drains the FIFO acks concurrently from a cloned read half, with at most `window` produces un-acked; termination rides the wire's frame-order guarantee (a trailing Ping whose Pong proves the drain is complete). Reply semantics follow `produce_window` except that server Err replies are COUNTED in the returned summary (first one kept verbatim) instead of failing the call, since the stream has fully drained by then and the tally is the product (a shed under `drop-new` no longer discards the run's counts); `fire_and_forget` is forced clear; on success the connection stays fully usable. `bench --mode publish` gains `--stream` (requires `--pubwindow >= 2`) to drive it, with a `"stream"` field in the JSON object; per-produce fsync cost is not attributed in stream mode. No broker or wire-protocol changes.
+
 ### Changed
 - `InMemoryFile::sync_data` now copies only the byte ranges written since the last sync into the durable image instead of cloning the whole file (#456). An in-memory group commit costs O(bytes appended) like a real fdatasync, not O(file): under `--storage memory` this removes a whole-segment memcpy per commit (82 percent of append-actor CPU in a profiled pipelined publish run) and a quadratic per-message copy at window 1. The durable image is byte-for-byte unchanged (unsynced-truncation tail retention, zero-fill growth, power-loss reverts all preserved; the determinism, crash-recovery, and power-loss suites pass unchanged).
 

--- a/crates/ironbus-cli/src/bench.rs
+++ b/crates/ironbus-cli/src/bench.rs
@@ -184,6 +184,13 @@ pub struct BenchConfig {
     /// covers the window with one fdatasync instead of N. Acks keep their unchanged
     /// fsynced-durable meaning; only WHEN the publisher awaits changes.
     pub pub_window: usize,
+    /// FULL-DUPLEX streaming publish (#458): with `--stream`, the publisher uses
+    /// [`ironbus_client::Client::produce_stream`] (a writer that never stops for acks while a
+    /// reader thread drains them concurrently, in-flight capped at `pub_window`) instead of the
+    /// half-duplex write-window-then-drain `produce_window` round-trips. Requires
+    /// `--pubwindow >= 2`. Per-produce fsync cost is NOT attributed in this mode (the overlap
+    /// makes a per-message share dishonest), so the fsync histogram stays empty.
+    pub stream: bool,
     /// The storage BACKEND of bench's own ISOLATED synthetic broker (#445, refs #443): `disk` (the
     /// default, the historical bench broker over an auto-deleted synthetic data dir) or `memory`
     /// (the same engine over the in-memory filesystem, for honest RAM-path numbers next to the
@@ -273,6 +280,7 @@ pub fn parse_bench(args: &[String], random_suffix: &str) -> Result<BenchConfig, 
     let mut live_addr: Option<String> = None;
     let mut live_ack = false;
     let mut no_fsync = false;
+    let mut stream = false;
     let mut pub_window: usize = 1;
     let mut storage: Option<StorageArg> = None;
     let mut json = false;
@@ -356,6 +364,10 @@ pub fn parse_bench(args: &[String], random_suffix: &str) -> Result<BenchConfig, 
             }
             "--no-fsync" => {
                 no_fsync = true;
+                i += 1;
+            }
+            "--stream" => {
+                stream = true;
                 i += 1;
             }
             // The pipelined publish window (#450): 0 is meaningless (nothing would ever be
@@ -466,6 +478,14 @@ pub fn parse_bench(args: &[String], random_suffix: &str) -> Result<BenchConfig, 
         None => format!("{BENCH_NAMESPACE_PREFIX}{random_suffix}"),
     };
 
+    if stream && pub_window < 2 {
+        return Err(CliError::Usage(
+            "`--stream` needs `--pubwindow` of at least 2 (the full-duplex slide is the point; \
+             window 1 is the plain awaited-ack path)"
+                .into(),
+        ));
+    }
+
     Ok(BenchConfig {
         mode,
         bound,
@@ -476,6 +496,7 @@ pub fn parse_bench(args: &[String], random_suffix: &str) -> Result<BenchConfig, 
         group,
         live_addr,
         no_fsync,
+        stream,
         pub_window,
         storage,
         json,
@@ -646,7 +667,7 @@ pub fn bench_json(cfg: &BenchConfig, report: &BenchReport) -> String {
         s,
         "{{\"schema_version\":{},\"mode\":\"{}\",\"isolated\":{},\"group\":\"{}\",\
          \"bound\":{{{}}},\"target_rate_hz\":{},\"payload_bytes\":{},\"payload_shape\":\"{}\",\
-         \"fetch_batch\":{},\"no_fsync\":{},\"pubwindow\":{},\"storage\":\"{}\",\"results\":{{\
+         \"fetch_batch\":{},\"no_fsync\":{},\"pubwindow\":{},\"stream\":{},\"storage\":\"{}\",\"results\":{{\
          \"produced\":{},\"recorded\":{},\"elapsed_secs\":{},\"msgs_per_sec\":{},\
          \"mb_per_sec\":{},\"bytes_per_op\":{},\
          \"latency_p50_us\":{},\"latency_p99_us\":{},\"latency_p999_us\":{},\"latency_max_us\":{},\
@@ -662,6 +683,7 @@ pub fn bench_json(cfg: &BenchConfig, report: &BenchReport) -> String {
         cfg.fetch_batch,
         cfg.no_fsync,
         cfg.pub_window,
+        cfg.stream,
         cfg.storage.as_str(),
         report.produced,
         report.recorded,
@@ -1099,6 +1121,36 @@ mod tests {
             "json: {json}"
         );
         assert!(json.contains("\"storage\":\"memory\""), "json: {json}");
+    }
+
+    #[test]
+    fn the_stream_flag_parses_requires_a_window_and_lands_in_the_json() {
+        // The full-duplex publish flag (#458): default off; bare flag does not swallow the next
+        // flag; refused without a pipelining window (>= 2); echoed in the JSON object.
+        let off = parse(&["--count", "5", "--pubwindow", "64"]).unwrap();
+        assert!(!off.stream, "stream defaults off");
+        let on = parse(&[
+            "--count",
+            "5",
+            "--stream",
+            "--pubwindow",
+            "64",
+            "--no-fsync",
+        ])
+        .unwrap();
+        assert!(on.stream);
+        assert!(on.no_fsync, "the flag after --stream must still parse");
+        assert_eq!(on.pub_window, 64);
+        match parse(&["--count", "5", "--stream"]) {
+            Err(CliError::Usage(msg)) => assert!(msg.contains("--pubwindow"), "{msg}"),
+            other => panic!("--stream without a window must be a usage error, got {other:?}"),
+        }
+        match parse(&["--count", "5", "--stream", "--pubwindow", "1"]) {
+            Err(CliError::Usage(msg)) => assert!(msg.contains("at least 2"), "{msg}"),
+            other => panic!("--stream with window 1 must be a usage error, got {other:?}"),
+        }
+        let json = bench_json(&on, &BenchReport::default());
+        assert!(json.contains("\"stream\":true"), "{json}");
     }
 
     #[test]

--- a/crates/ironbus-cli/src/bench_run.rs
+++ b/crates/ironbus-cli/src/bench_run.rs
@@ -352,6 +352,62 @@ fn pace(rate_hz: Option<f64>, seq: u64, started: Instant) {
     }
 }
 
+/// The FULL-DUPLEX publish leg (#458), split from [`run_publish`]: one `produce_stream` call
+/// pumps the whole run, writer and ack-reader overlapped, in-flight capped at the window.
+fn run_publish_stream(
+    cfg: &BenchConfig,
+    pub_client: &mut Client,
+    addr: &str,
+    started: Instant,
+) -> Result<BenchReport, CliError> {
+    // The FULL-DUPLEX sliding window (#458): one produce_stream call pumps the whole run,
+    // writer and ack-reader overlapped, in-flight capped at the window. Payloads come from a
+    // pool of `window` DISTINCT pre-filled buffers cycled by sequence: the pool slots cannot
+    // be re-stamped per message (they may still be borrowed by the in-flight encoder), and
+    // publish mode never reads payloads back, so the seq/send-time stamps the half-duplex
+    // path embeds would be dead bytes here anyway. Entropy honesty matches the windowed
+    // path's working set: `window` distinct realistic payloads in rotation.
+    let mut pool: Vec<Vec<u8>> = vec![vec![0u8; cfg.payload_bytes]; cfg.pub_window];
+    for (i, buf) in pool.iter_mut().enumerate() {
+        fill_payload(buf, cfg.payload_shape, i as u64, ROUND_TRIP_TOKEN_LEN);
+    }
+    let pool = &pool;
+    let bound = &cfg.bound;
+    let mut seq: u64 = 0;
+    let messages = std::iter::from_fn(move || {
+        if should_stop(bound, seq, started) {
+            return None;
+        }
+        let body = PubBody {
+            flags: 0,
+            timestamp_ms: 0,
+            key: b"",
+            headers: b"",
+            dedup: None,
+            fire_and_forget: false,
+            payload: &pool[usize::try_from(seq).unwrap_or(0) % pool.len()],
+        };
+        seq += 1;
+        Some(body)
+    });
+    let summary = pub_client
+        .produce_stream(messages, cfg.pub_window)
+        .map_err(|e| classify(addr, "streaming produces to", &e))?;
+    let produced = summary.acked;
+    let elapsed = started.elapsed();
+    // No per-produce fsync attribution: the overlap makes a per-message share dishonest, so
+    // the histogram stays empty and the report's fsync_measured flag is forced off.
+    Ok(finish_report(
+        cfg,
+        produced,
+        produced,
+        &[],
+        &[],
+        elapsed,
+        false,
+    ))
+}
+
 /// PUBLISH mode: append at the bound/rate, measuring produce-side throughput and bytes/op. Latency
 /// is not measured (no read-back), so the latency fields stay `None`.
 fn run_publish(cfg: &BenchConfig, addr: &str) -> Result<BenchReport, CliError> {
@@ -360,6 +416,9 @@ fn run_publish(cfg: &BenchConfig, addr: &str) -> Result<BenchReport, CliError> {
     let mut produced: u64 = 0;
     let mut fsync_samples: Vec<u64> = Vec::new();
     let started = Instant::now();
+    if cfg.stream && cfg.pub_window > 1 {
+        return run_publish_stream(cfg, &mut pub_client, addr, started);
+    }
     if cfg.pub_window > 1 {
         // The PIPELINED window (#450): fill W distinct payload buffers, write all W PUB frames
         // before awaiting any ack (Client::produce_window), and attribute the window's elapsed

--- a/crates/ironbus-cli/src/main.rs
+++ b/crates/ironbus-cli/src/main.rs
@@ -743,7 +743,7 @@ USAGE:
                   [--interval <secs>] [--once] [--json] [--no-color]
     ironbus bench (--duration <secs> | --count <n>) [--mode <publish|subscribe|round-trip>]
                   [--rate <msg/s>] [--payload-bytes <n>] [--payload-shape <realistic|random>]
-                  [--fetch-batch <n>] [--group <name>] [--no-fsync] [--pubwindow <n>] [--json]
+                  [--fetch-batch <n>] [--group <name>] [--no-fsync] [--pubwindow <n>] [--stream] [--json]
                   [--storage <disk|memory>]
                   [--addr <host:port> --i-understand-this-is-live]
     ironbus upgrade --new-binary <path> --dest <path> [--max-failed-starts <n>]
@@ -927,6 +927,9 @@ Notes:
     latency_p999_us, latency_max_us) and an additive storage field naming the backend.
     Every serve setting can also be supplied via an environment variable IRONBUS_<FLAG>, the flag
     name uppercased with dashes as underscores (--max-total-bytes -> IRONBUS_MAX_TOTAL_BYTES,
+    --stream (publish mode, needs --pubwindow >= 2) makes the publisher FULL-DUPLEX: writes
+        never stop for acks; a reader thread drains them concurrently with at most the
+        window un-acked. Per-produce fsync cost is not attributed in this mode.
     --data-dir -> IRONBUS_DATA_DIR, --addr -> IRONBUS_ADDR). Precedence is flag > env > default: an
     explicit flag overrides the env var, which overrides the compiled default. A bad env value (e.g.
     non-numeric where a number is expected) is a usage error naming the env var. See docs/CLI.md.

--- a/crates/ironbus-client/src/lib.rs
+++ b/crates/ironbus-client/src/lib.rs
@@ -288,6 +288,168 @@ pub enum ProgressOutcome {
     Fenced,
 }
 
+/// One produce reply, classified: the single decode point shared by the half-duplex
+/// [`Client::produce_window`] drain and the [`Client::produce_stream`] reader thread (#458), so
+/// the two paths can never drift on the reply contract.
+enum PubReply {
+    Acked(u64),
+    Duplicate(u64),
+    ServerErr(String),
+    Pong,
+}
+
+/// One coalesced write's byte budget for [`Client::produce_stream`] (#458): large enough to
+/// amortize the syscall, small enough that the first acks stream back while later frames are
+/// still being written.
+const STREAM_FLUSH_BYTES: usize = 32 * 1024;
+
+/// The shared tally between [`Client::produce_stream`]'s writer (the caller thread) and its
+/// reader thread, guarded by a mutex with a condvar the reader signals as window room opens.
+#[derive(Default)]
+struct StreamFlow {
+    /// Reply slots consumed so far (acks + duplicates + server errors).
+    done: u64,
+    acked: u64,
+    duplicates: u64,
+    server_errors: u64,
+    last_offset: Option<u64>,
+    first_server_err: Option<String>,
+    /// The reader hit a fatal error and exited; the writer must stop waiting on it.
+    reader_dead: bool,
+}
+
+/// The reader half of [`Client::produce_stream`] (#458): drains produce replies into `flow`
+/// (notifying `room` as slots free) until the terminal `Pong` or a fatal error. Runs on the
+/// scoped reader thread over the cloned read half.
+fn drain_stream_replies(
+    stream: &mut TcpStream,
+    buf: &mut Vec<u8>,
+    flow: &std::sync::Mutex<StreamFlow>,
+    room: &std::sync::Condvar,
+) -> Result<(), ClientError> {
+    let outcome: Result<(), ClientError> = loop {
+        let (ty, body) = match read_frame_from(stream, buf) {
+            Ok(f) => f,
+            Err(e) => break Err(e),
+        };
+        let reply = match classify_pub_reply(ty, &body) {
+            Ok(r) => r,
+            Err(e) => break Err(e),
+        };
+        let mut f = flow
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        match reply {
+            PubReply::Acked(offset) => {
+                f.done += 1;
+                f.acked += 1;
+                f.last_offset = Some(offset);
+            }
+            PubReply::Duplicate(offset) => {
+                f.done += 1;
+                f.acked += 1;
+                f.duplicates += 1;
+                f.last_offset = Some(offset);
+            }
+            PubReply::ServerErr(msg) => {
+                f.done += 1;
+                f.server_errors += 1;
+                if f.first_server_err.is_none() {
+                    f.first_server_err = Some(msg);
+                }
+            }
+            // The terminal marker: the server's FIFO frame order guarantees every prior
+            // produce's reply has already been consumed.
+            PubReply::Pong => break Ok(()),
+        }
+        room.notify_all();
+        drop(f);
+    };
+    if outcome.is_err() {
+        let mut f = flow
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        f.reader_dead = true;
+        room.notify_all();
+    }
+    outcome
+}
+
+fn classify_pub_reply(ty: FrameType, body: &[u8]) -> Result<PubReply, ClientError> {
+    match ty {
+        FrameType::PubAck => {
+            let ack = decode_pub_ack(body).map_err(|_| {
+                ClientError::BadResponse("produce reply was not an eight-byte offset")
+            })?;
+            Ok(PubReply::Acked(ack.offset))
+        }
+        FrameType::PubAckDuplicate => {
+            let ack = decode_pub_ack(body).map_err(|_| {
+                ClientError::BadResponse("dedup-hit reply was not an eight-byte offset")
+            })?;
+            Ok(PubReply::Duplicate(ack.offset))
+        }
+        FrameType::Err => Ok(PubReply::ServerErr(String::from_utf8_lossy(body).into())),
+        FrameType::Pong => Ok(PubReply::Pong),
+        other => Err(ClientError::Unexpected(other)),
+    }
+}
+
+/// Reads one whole frame from `stream`, buffering partial bytes in `buf`. The free-function
+/// form of [`Client::read_frame`] so [`Client::produce_stream`]'s reader thread can drain a
+/// cloned read half with its own buffer (#458).
+fn read_frame_from(
+    stream: &mut TcpStream,
+    buf: &mut Vec<u8>,
+) -> Result<(FrameType, Vec<u8>), ClientError> {
+    let mut chunk = [0u8; 4096];
+    loop {
+        match decode_frame(buf).map_err(ClientError::Frame)? {
+            FrameDecode::Frame {
+                type_tag,
+                body,
+                consumed,
+            } => {
+                // An unknown tag (e.g. from a newer server) has no client handler; name
+                // the raw tag rather than pretending it was some known frame.
+                let ty =
+                    FrameType::from_u8(type_tag).ok_or(ClientError::UnknownFrameType(type_tag))?;
+                let body = body.to_vec();
+                buf.drain(..consumed);
+                return Ok((ty, body));
+            }
+            FrameDecode::Incomplete { .. } => {}
+        }
+        let n = stream.read(&mut chunk)?;
+        if n == 0 {
+            return Err(ClientError::Closed);
+        }
+        buf.extend_from_slice(&chunk[..n]);
+    }
+}
+
+/// The tally a fully-drained [`Client::produce_stream`] returns (#458). A stream is a TALLY,
+/// not a transcript: by the time a server `Err` could be surfaced the stream has already fully
+/// drained, and failing the call would discard the whole run's counts, so server-side rejections
+/// (a shed under `drop-new`, a malformed produce) are COUNTED here instead of returned as
+/// `Err` (the documented divergence from [`Client::produce_window`], which fails on the first
+/// server error). The call still fails for transport-level problems: IO errors, decode errors,
+/// an unexpected frame, or a reply-count mismatch.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StreamSummary {
+    /// Messages acknowledged (including dedup hits).
+    pub acked: u64,
+    /// How many of `acked` were `PubAckDuplicate` dedup hits.
+    pub duplicates: u64,
+    /// Produces the server rejected with an `Err` reply (each consumed its FIFO slot).
+    pub server_errors: u64,
+    /// The first server `Err` body, kept verbatim so a caller can distinguish a benign shed
+    /// (`at capacity` under `drop-new`) from a real rejection.
+    pub first_server_error: Option<String>,
+    /// The offset carried by the last ack observed, if any message was acked.
+    pub last_offset: Option<u64>,
+}
+
 /// A connected IronBus client over one TCP connection.
 #[derive(Debug)]
 pub struct Client {
@@ -541,38 +703,151 @@ impl Client {
         let mut acks = Vec::with_capacity(messages.len());
         let mut first_err: Option<ClientError> = None;
         for _ in 0..messages.len() {
-            match self.read_frame()? {
-                (FrameType::PubAck, body) => {
-                    let ack = decode_pub_ack(&body).map_err(|_| {
-                        ClientError::BadResponse("produce reply was not an eight-byte offset")
-                    })?;
-                    acks.push(ProduceAck {
-                        offset: ack.offset,
-                        duplicate: false,
-                    });
-                }
-                (FrameType::PubAckDuplicate, body) => {
-                    let ack = decode_pub_ack(&body).map_err(|_| {
-                        ClientError::BadResponse("dedup-hit reply was not an eight-byte offset")
-                    })?;
-                    acks.push(ProduceAck {
-                        offset: ack.offset,
-                        duplicate: true,
-                    });
-                }
-                (FrameType::Err, body) => {
+            let (ty, body) = self.read_frame()?;
+            match classify_pub_reply(ty, &body)? {
+                PubReply::Acked(offset) => acks.push(ProduceAck {
+                    offset,
+                    duplicate: false,
+                }),
+                PubReply::Duplicate(offset) => acks.push(ProduceAck {
+                    offset,
+                    duplicate: true,
+                }),
+                PubReply::ServerErr(msg) => {
                     if first_err.is_none() {
-                        first_err =
-                            Some(ClientError::Server(String::from_utf8_lossy(&body).into()));
+                        first_err = Some(ClientError::Server(msg));
                     }
                 }
-                (other, _) => return Err(ClientError::Unexpected(other)),
+                PubReply::Pong => return Err(ClientError::Unexpected(FrameType::Pong)),
             }
         }
         match first_err {
             Some(e) => Err(e),
             None => Ok(acks),
         }
+    }
+
+    /// Produces a stream of messages FULL-DUPLEX with a sliding in-flight window (#458): the
+    /// caller's thread keeps encoding and writing PUB frames (coalesced into batched writes)
+    /// while a scoped reader thread drains the FIFO acks concurrently from a cloned read half,
+    /// so neither side ever idles waiting for the other the way the half-duplex
+    /// [`produce_window`](Client::produce_window) round-trips do. At most `window` produces are
+    /// unacknowledged at any moment (a full window blocks the WRITER only, never the reader).
+    ///
+    /// The reply contract is `produce_window`'s, applied as a running tally instead of a
+    /// returned `Vec`: one reply per message FIFO, `PubAckDuplicate` counts as acked-and-
+    /// duplicate, a server `Err` consumes its slot and is COUNTED in the summary (the first
+    /// one kept verbatim) rather than failing the call, and `fire_and_forget` is forced
+    /// CLEAR on every message. See [`StreamSummary`] for why server errors tally instead of
+    /// erroring: the stream has fully drained by then, and the counts are the product. Termination uses the wire's frame-order guarantee: after the
+    /// last produce the writer sends a `Ping`, and the `Pong` (which the server emits only
+    /// after every prior reply) tells the reader the drain is complete, with no read timeout
+    /// and no protocol change.
+    ///
+    /// On success the connection is fully reusable (the reader's leftover bytes are restored
+    /// to this client's buffer). On any error the connection state is undefined, exactly like
+    /// an errored `produce_window`: drop the client.
+    ///
+    /// # Errors
+    /// Returns a [`ClientError`] on an IO/encode error, an unexpected frame, or a reply-count
+    /// mismatch. Server `Err` replies do NOT fail the call; they are counted in the summary.
+    pub fn produce_stream<'a, I>(
+        &mut self,
+        messages: I,
+        window: usize,
+    ) -> Result<StreamSummary, ClientError>
+    where
+        I: IntoIterator<Item = PubBody<'a>>,
+    {
+        let window = window.max(1) as u64;
+        let mut reader_stream = self.stream.try_clone()?;
+        let mut reader_buf = std::mem::take(&mut self.buf);
+        let flow = std::sync::Mutex::new(StreamFlow::default());
+        let room = std::sync::Condvar::new();
+
+        let (writer_result, reader_outcome) = std::thread::scope(|s| {
+            let reader =
+                s.spawn(|| drain_stream_replies(&mut reader_stream, &mut reader_buf, &flow, &room));
+
+            let mut body = Vec::new();
+            let mut wire: Vec<u8> = Vec::with_capacity(STREAM_FLUSH_BYTES + 1024);
+            let mut sent: u64 = 0;
+            let mut buffered: u64 = 0;
+            let writer_result: Result<u64, ClientError> = (|| {
+                for message in messages {
+                    body.clear();
+                    let at_least_once = PubBody {
+                        fire_and_forget: false,
+                        ..message
+                    };
+                    encode_pub(&at_least_once, &mut body).map_err(ClientError::Body)?;
+                    encode_frame(FrameType::Pub, &body, &mut wire).map_err(ClientError::Frame)?;
+                    buffered += 1;
+                    if wire.len() >= STREAM_FLUSH_BYTES || buffered >= window {
+                        // Wait for window room for the WHOLE buffered batch, then one write.
+                        let mut f = flow
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner);
+                        while !f.reader_dead && sent + buffered - f.done > window {
+                            f = room
+                                .wait(f)
+                                .unwrap_or_else(std::sync::PoisonError::into_inner);
+                        }
+                        let dead = f.reader_dead;
+                        drop(f);
+                        if dead {
+                            // The reader's own error is the root cause; surface it after join.
+                            return Ok(sent);
+                        }
+                        self.stream.write_all(&wire)?;
+                        sent += buffered;
+                        buffered = 0;
+                        wire.clear();
+                    }
+                }
+                if buffered > 0 {
+                    self.stream.write_all(&wire)?;
+                    sent += buffered;
+                }
+                // The terminal Ping: its Pong arrives after every produce reply (FIFO), which
+                // is what releases the reader without a read timeout.
+                let mut ping = Vec::new();
+                encode_frame(FrameType::Ping, &[], &mut ping).map_err(ClientError::Frame)?;
+                self.stream.write_all(&ping)?;
+                Ok(sent)
+            })();
+            if writer_result.is_err() {
+                // The writer failed mid-stream (encode or write): the connection is undefined,
+                // so unblock a reader parked in read() by shutting the socket's read half.
+                let _ = self.stream.shutdown(std::net::Shutdown::Both);
+            }
+            (writer_result, reader.join())
+        });
+
+        let reader_result = match reader_outcome {
+            Ok(r) => r,
+            Err(panic) => std::panic::resume_unwind(panic),
+        };
+        let sent = writer_result?;
+        reader_result?;
+        // The reader exited cleanly on the Pong: restore its leftover bytes so this client
+        // stays usable, then settle the tallies.
+        self.buf = reader_buf;
+        let f = flow
+            .into_inner()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if f.done != sent {
+            return Err(ClientError::BadResponse(
+                "the produce stream's reply count did not match the messages sent",
+            ));
+        }
+        Ok(StreamSummary {
+            acked: f.acked,
+            duplicates: f.duplicates,
+            server_errors: f.server_errors,
+            first_server_error: f.first_server_err,
+            last_offset: f.last_offset,
+        })
     }
 
     /// Produces a message on the FIRE-AND-FORGET (QoS-0, #11, #402) fast path: it sets the additive
@@ -1006,30 +1281,7 @@ impl Client {
 
     /// Reads one complete frame, buffering leftover bytes for the next call.
     fn read_frame(&mut self) -> Result<(FrameType, Vec<u8>), ClientError> {
-        let mut chunk = [0u8; 4096];
-        loop {
-            match decode_frame(&self.buf).map_err(ClientError::Frame)? {
-                FrameDecode::Frame {
-                    type_tag,
-                    body,
-                    consumed,
-                } => {
-                    // An unknown tag (e.g. from a newer server) has no client handler; name
-                    // the raw tag rather than pretending it was some known frame.
-                    let ty = FrameType::from_u8(type_tag)
-                        .ok_or(ClientError::UnknownFrameType(type_tag))?;
-                    let body = body.to_vec();
-                    self.buf.drain(..consumed);
-                    return Ok((ty, body));
-                }
-                FrameDecode::Incomplete { .. } => {}
-            }
-            let n = self.stream.read(&mut chunk)?;
-            if n == 0 {
-                return Err(ClientError::Closed);
-            }
-            self.buf.extend_from_slice(&chunk[..n]);
-        }
+        read_frame_from(&mut self.stream, &mut self.buf)
     }
 }
 
@@ -1200,6 +1452,60 @@ mod tests {
             }
         });
         (addr, handle)
+    }
+
+    #[test]
+    fn a_produce_stream_slides_its_window_full_duplex_against_a_real_server() {
+        // The #458 full-duplex sliding window over the real wire: far more messages than the
+        // window, so the writer must interleave with the reader's ack drain; every message acked
+        // exactly once, the last offset is the final message's, and the connection is fully
+        // usable afterwards (the reader's leftover buffer is restored).
+        let (addr, shutdown, handle) = start_server();
+        let mut c = Client::connect(addr).unwrap();
+
+        let payloads: Vec<Vec<u8>> = (0..100u8).map(|i| vec![b's', i]).collect();
+        let summary = c
+            .produce_stream(
+                payloads.iter().map(|p| PubBody {
+                    flags: 0,
+                    timestamp_ms: 0,
+                    key: b"k",
+                    headers: b"",
+                    dedup: None,
+                    fire_and_forget: false,
+                    payload: p,
+                }),
+                8,
+            )
+            .unwrap();
+        assert_eq!(summary.acked, 100, "every streamed message acked");
+        assert_eq!(summary.duplicates, 0);
+        assert_eq!(summary.server_errors, 0);
+        assert_eq!(summary.first_server_error, None);
+        assert_eq!(
+            summary.last_offset,
+            Some(99),
+            "offsets assigned in send order"
+        );
+        // An empty stream is a clean no-op round trip (just the terminal ping/pong).
+        let empty = c.produce_stream(std::iter::empty(), 8).unwrap();
+        assert_eq!((empty.acked, empty.last_offset), (0, None));
+        // The connection stays healthy: a plain produce gets the next offset.
+        let next = c
+            .produce(&PubBody {
+                flags: 0,
+                timestamp_ms: 0,
+                key: b"k",
+                headers: b"",
+                dedup: None,
+                fire_and_forget: false,
+                payload: b"after-stream",
+            })
+            .unwrap();
+        assert_eq!(next, 100);
+        shutdown.store(true, Ordering::Relaxed);
+        drop(c);
+        let _ = handle.join();
     }
 
     #[test]

--- a/docs/PERF_LEDGER.md
+++ b/docs/PERF_LEDGER.md
@@ -218,3 +218,61 @@ allocations on the produce path (OwnedAppend payload Vec + per-produce reply syn
 reuse/arena them), the parked-ack reply encode path, clock_gettime64 batching (stamp once per
 drain batch), TCP_NODELAY + vectored reply writes. Re-profile AFTER the clone is gone; the 82
 percent memmove was masking everything downstream.
+
+## Round 5 (#458): the half-duplex window was the leg-4 gap; full-duplex produce_stream = 92.8k/s, ALL FIVE LEGS CLEARED
+
+Sources: the NATS bench tool's async JetStream publisher (the leg-4 baseline itself: a writer
+that never stops for acks); classic sliding-window pipelining (TCP, HTTP/2 streams); the round-4
+ledger's queued candidates (all parked: see below).
+
+### What the measurement showed
+
+Per-thread CPU on the hive during a memory w=1024 publish run at 16.2k msg/s: append-actor 25.4
+percent of one core, session 20.5, bench client 16.1, on a 4-core box. NOTHING saturated; the
+same code does 1.02M msg/s on an M-series laptop. Leg 4 was not CPU and not the engine: it was
+SYNCHRONIZATION BUBBLES. Client::produce_window writes a window then blocks draining all W acks
+(feeding nothing); the session's pass-scoped parked-ack drain serializes read -> actor round
+trip -> write. The two half-duplex loops interlock so every stage idles most of the time. The
+NATS async baseline never had this handicap. (Also measured and parked again as second-order:
+broker-side lz4 ~5 percent at this shape; clock_gettime64 syscalls; per-produce futex pair;
+TCP_NODELAY unset.)
+
+### Fix shipped
+
+Client::produce_stream(messages, window) (#458): FULL-DUPLEX sliding window. The caller's
+thread keeps encoding and writing coalesced PUB batches (32 KiB flush budget, never more than
+`window` unacked) while a scoped reader thread drains the FIFO acks concurrently from a
+try_clone'd read half; termination rides the wire's frame-order guarantee (a trailing Ping
+whose Pong proves every prior reply was consumed). Server Err replies COUNT in the returned
+tally instead of failing the call (the stream has fully drained by then; a drop-new shed no
+longer discards the run's counts). The reply classifier is shared with produce_window so the
+two paths cannot drift. `bench --stream` (requires --pubwindow >= 2) drives it. NO broker, wire,
+or engine changes: the server side already handled a saturated socket; no client could present
+one until now.
+
+### Measured (hive, 256B realistic, 15s runs, pre-merge cross-compiled, scratch broker)
+
+| leg | half-duplex window | full-duplex --stream |
+| --- | --- | --- |
+| memory w=512 | 9,012/s | 87,368/s |
+| memory w=1024 | 16,165/s | 92,801-93,097/s |
+| memory w=4096 | -- | 88,877/s (saturates ~90k) |
+| disk w=1024 (full fsync) | 9,346/s | 16,172/s |
+
+NATS fairness rerun SAME DAY, same box, matched batch 1024: JS memory async 28,337/s (28,337 vs
+yesterday's 27,250: consistent); JS memory sync 2,555/s. IronBus memory stream = 3.3x NATS
+async. Guardrails: binary 1.55 MB; bounded-cap RSS 6.1 MB peak under stream load at a 2 MiB
+store cap, with drop-new shedding exercised end to end (the bench reports acked-only goodput).
+
+### Win condition: ALL FIVE LEGS CLEARED
+
+1. Durable single-ack within 10 percent of NATS: 198-205 vs 191-203 (fsync physics parity).
+2. Durable pipelined >= 10x NATS sync-always (2,030): 16,172 = 80x.
+3. Memory per-ack >= NATS (2,491): 7,045 = 2.8x.
+4. Memory pipelined >= NATS (27,250; rerun 28,337): 92,801 = 3.3x.
+5. At least 2 legs led by >= 2x: legs 2 (80x), 3 (2.8x), 4 (3.3x).
+
+Verdict: KEEP. The goal's standing follow-ups: a final full NATS matrix rerun is recorded above
+for the contested legs; the consume-side legs (NATS ordered consume 43,877/s) were never part
+of the win condition and remain the natural next frontier, along with the parked second-order
+CPU items (clocks, futex pairs, NODELAY) if a future round needs them.


### PR DESCRIPTION
Closes #458. Round 5 of the NATS-parity ledger (docs/PERF_LEDGER.md). **All five win-condition legs now cleared.**

## The find

Per-thread CPU on the reference edge box at the half-duplex ceiling (memory w=1024, 16.2k msg/s): append-actor 25.4% of one core, session 20.5%, bench client 16.1%, on 4 cores. Nothing saturated; the same code does 1.02M msg/s on an M-series laptop. Leg 4 was synchronization bubbles, not CPU: `produce_window` writes a window then blocks draining all W acks (feeding nothing meanwhile), and the session's pass-scoped drain serializes read -> actor round trip -> write. The NATS async-pub baseline that set the 27,250 leg-4 bar streams full-duplex and never had this handicap.

## Changes (client + bench only; NO broker, wire, or engine changes)

- **`Client::produce_stream(messages, window)`**: the caller's thread keeps encoding and writing coalesced PUB batches (32 KiB flush budget) while a scoped reader thread drains the FIFO acks concurrently from a `try_clone`'d read half, with at most `window` produces un-acked (Mutex+Condvar flow control; the reader never blocks the writer). Termination rides the wire's existing frame-order guarantee: a trailing `Ping` whose `Pong` proves every prior reply was consumed — no read timeouts, no protocol additions.
- **Tally semantics**: server `Err` replies consume their FIFO slot and are COUNTED in the returned `StreamSummary` (`server_errors`, `first_server_error` verbatim) instead of failing the call — by the time they could surface, the stream has fully drained, and failing would discard the whole run's counts (a `drop-new` shed exercised this end-to-end on the hive). Documented divergence from `produce_window`; transport-level problems (IO, decode, unexpected frame, reply-count mismatch) still fail the call.
- The reply classifier is extracted and SHARED by `produce_window` and the stream reader, so the two paths cannot drift.
- `bench --mode publish --stream` (requires `--pubwindow >= 2`): drives `produce_stream`; reports acked-only goodput; per-produce fsync cost is not attributed (the overlap makes a per-message share dishonest) and the JSON gains a `"stream"` field.

## Hive A/B (pre-merge cross-compiled armv7, 256 B realistic, 15 s runs)

| leg | half-duplex window | full-duplex `--stream` |
| --- | --- | --- |
| memory w=512 | 9,012/s | 87,368/s |
| memory w=1024 | 16,165/s | **92,801-93,097/s** |
| memory w=4096 | -- | 88,877/s |
| disk w=1024 (full fsync) | 9,346/s | **16,172/s** |

**NATS fairness rerun same day, same box, matched batch 1024**: JS memory async 28,337/s (consistent with the original 27,250), JS memory sync 2,555/s. IronBus memory stream = **3.3x NATS async**; disk full-fsync stream = **80x NATS sync-always**.

Win-condition scorecard: leg 1 parity (198-205 vs 191-203), leg 2 cleared 80x, leg 3 cleared 2.8x, leg 4 cleared 3.3x, leg 5 cleared (three legs >= 2x).

Guardrails: binary 1.55 MB (<= 3 MB); bounded-cap RSS 6.1 MB peak under stream load at a 2 MiB store cap with shedding active (<= 8 MB); ack-after-fdatasync default untouched; no new dependencies; full workspace suite green (40 suites).

## Tests

- `a_produce_stream_slides_its_window_full_duplex_against_a_real_server`: 100 messages through a window of 8 over the real wire; every message acked once, FIFO offsets, empty-stream no-op, connection fully usable afterwards (reader buffer restored).
- `the_stream_flag_parses_requires_a_window_and_lands_in_the_json`: default off, parse-cursor regression guard, usage errors without/with-window-1, JSON echo.
- Hive-validated under shedding: a 2 MiB-cap drop-new broker completes the stream and reports acked-only goodput.

Review-of-record (inline adversarial pass; panel capacity returns Jun 13):
1. *Can the reader deadlock in `read()` after the last reply?* No: the writer always sends the trailing Ping after the final flush, and the server's FIFO frame order emits the Pong only after every prior reply, so the reader's terminal frame always arrives. On a writer-side error the socket is shut down to release a parked reader.
2. *Can acks outrun the window math?* `done` counts every consumed slot (acks + dups + server errors), and the writer waits on `sent + buffered - done > window`, so a shed (Err) frees window room exactly like an ack.
3. *Is the client reusable after a stream?* Yes on success: the reader's leftover buffer is restored and the test proves a follow-up plain produce sees the next offset. On error the connection is undefined, same as an errored `produce_window`.
4. *Does the pool-cycled payload weaken entropy honesty?* The pool holds `window` distinct realistic payloads, the same working set the windowed path keeps in rotation; publish mode never reads payloads back, so the per-message stamps the windowed path embeds are dead bytes there too.
5. *Why is the broker untouched?* The session already parks produces and the 64 KiB chunk (#454) already carries hundreds of frames per pass; the missing piece was a client that never stops feeding. The thread-CPU table is the proof: the server had idle headroom at the old ceiling.