### PR TITLE
fix(docs): use the loopback OTLP endpoint in the co-located-collector example (#461)

### DIFF
--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -590,7 +590,7 @@ compiled in **only** with `otlp`.
 
 - **Transport: plaintext gRPC (tonic, no TLS).** This is the deliberate
   C-FFI-minimizing choice. OTLP to a co-located collector is plaintext
-  `http://host:4317`, so no TLS stack is linked: the otlp build pulls
+  `http://127.0.0.1:4317`, so no TLS stack is linked: the otlp build pulls
   **no** `rustls` / `ring` / `aws-lc` / `native-tls` / `openssl`, keeping even
   the feature build pure Rust (so the deny.toml `[bans]` C-FFI denylist, which
   `cargo deny check` evaluates over all features, stays green). The default graph


### PR DESCRIPTION
## What
The METRICS.md OTLP transport note used `http://host:4317` as its co-located-collector example. The weekly external-link check (`scripts/ci/external-link-check.sh`, #30) tried to resolve the literal host `host`, failed, and auto-filed #461.

## Fix
Co-located means loopback, so the example is now `http://127.0.0.1:4317` — the same endpoint the other OTLP examples in METRICS.md (lines 607, 624) and CLI.md already use, and which the checker skips as a loopback example endpoint. The false-positive dead link is gone; no other bare-hostname placeholder URLs exist in the docs. Docs-only, no behavior change.

Closes #461.

🤖 Generated with [Claude Code](https://claude.com/claude-code)