### PR TITLE
docs: Grafana dashboard, Prometheus alerts & monitoring guide

### DIFF
--- a/docs/MONITORING.md
+++ b/docs/MONITORING.md
@@ -1,0 +1,141 @@
+# Monitoring IronBus (Grafana + Prometheus)
+
+This is the operator guide for watching a running broker. The normative metric
+catalog lives in [METRICS.md](METRICS.md) (every name is frozen by a CI test); this
+doc is the dashboard, the alerts, and the "what do I actually look at" map built on
+top of it.
+
+The artifacts live in [`packaging/grafana/`](../packaging/grafana/):
+
+| File | What it is |
+| --- | --- |
+| `ironbus-dashboard.json` | The importable Grafana dashboard (8 rows, ~32 panels). |
+| `dashboard_gen.py` | Generates the JSON from a curated panel spec (regenerate, do not hand-edit). |
+| `check_grounded.py` | Local check: every metric the dashboard references is one the broker emits. |
+| `ironbus-alerts.yml` | Prometheus alerting rules (critical / warning / info). |
+| `prometheus-scrape-example.yml` | Example scrape + `rule_files` config. |
+
+## What IronBus exposes
+
+The broker serves four loopback HTTP endpoints on `--health-addr` (off by default;
+set it, e.g. `serve --health-addr 127.0.0.1:9090`). The surface is unauthenticated,
+so `serve` refuses a non-loopback `--health-addr` without `--health-allow-public`
+(see [THREAT_MODEL.md](THREAT_MODEL.md)).
+
+- **`GET /metrics`** -- Prometheus text exposition (the dashboard + alerts source).
+- **`GET /healthz`** -- liveness (accept-loop watchdog). 200 while the loop ticks,
+  503 only after a full `--health-liveness-window-ms` with no progress.
+- **`GET /readyz`** -- readiness. 503 while the writer is frozen or shutting down,
+  200 once it accepts writes.
+- **`GET /admin`** -- opt-in (`serve --enable-admin`) read-only JSON snapshot, the
+  same data `ironbus admin` renders. Survives a metric rename (it parses no metric
+  names), so it is the fallback when a dashboard breaks.
+
+Distributed traces are a separate, opt-in path (OTLP/gRPC behind the non-default
+`otlp` Cargo feature + `--enable-otlp-export`); see the Tracing section of
+[METRICS.md](METRICS.md). Metrics below need none of it.
+
+## Quick start
+
+1. **Run the broker with the health endpoint:**
+   ```sh
+   ironbus serve --data-dir /var/lib/ironbus --addr 127.0.0.1:7777 --health-addr 127.0.0.1:9090
+   ```
+2. **Point Prometheus at it** (job name kept prefixed `ironbus` so the down-alert
+   matches) -- see `prometheus-scrape-example.yml`, which also wires `rule_files:
+   [ironbus-alerts.yml]`.
+3. **Import the dashboard:** Grafana -> Dashboards -> Import -> upload
+   `ironbus-dashboard.json`, then pick your Prometheus data source. The `Job` and
+   `Instance` variables default to "All", so it works for one broker or a fleet.
+
+## The dashboard, row by row
+
+Each row answers one operator question:
+
+1. **Golden signals** -- _is it alive and safe right now?_ `writer_healthy`,
+   `power-loss safety`, `produce saturated`, version, headline `consumer_lag`,
+   produce/ack rate, uptime. Glance here first; the three health tiles go red on an
+   incident.
+2. **Throughput** -- produce / deliver / ack / redeliver rates and bytes/s. Redeliver
+   rising while ack is flat = consumers not acking in time.
+3. **Durability-barrier latency** -- `fsync` and `append` p50/p99/p99.9 + a heatmap,
+   with the **6 ms p99 SLO** line ([SLO.md](SLO.md)). This is the headline perf signal;
+   the fsync is the real cost of a durable ack.
+4. **Consumer lag & delivery** -- default + per-group lag, in-flight, top-10
+   per-consumer lag, redelivery & dead-letter rates, DLQ depth.
+5. **Backpressure & shedding** -- every `*_shed_total` rate by reason plus the live
+   CoDel / retry / egress controller gauges. All zero unless a knob is enabled; a
+   rising series names exactly which control is shedding and why.
+6. **Data loss & integrity** -- _these should stay flat ZERO._ Force-reap and
+   consumer-truncation rates, last-recovery loss bytes (by reason), skips, and the
+   hard-crash checkpoint-repair counter. Any movement here is an incident, not noise.
+7. **Durability posture & edge resources** -- active durability level, unsynced
+   bytes at risk, flash write-amplification (with the **4x gate**), physical vs
+   logical bytes/s, the daily write-budget meter, and RAM headroom.
+8. **Retention & offsets** -- segment reclaim (loss-free vs lossy force-reap) and the
+   durable-head vs committed-cursor offsets.
+
+## Alerts
+
+`ironbus-alerts.yml` groups by severity. The ones that mean **act now**:
+
+| Alert | Fires when | Why it matters |
+| --- | --- | --- |
+| `IronbusDown` | scrape fails 1m | broker or health endpoint unreachable |
+| `IronbusWriterFrozen` | `ironbus_writer_healthy == 0` | a fatal fsync froze the writer; produces refused |
+| `IronbusForceReapDataLoss` | `segments_force_reaped_total` rises | drop-oldest deleted maybe-unconsumed data (disk at cap) |
+| `IronbusConsumerTruncation` | `truncations_total` rises | a live consumer lost a span of records |
+| `IronbusRecoveryDataLoss` | `recovery_data_loss_bytes > 0` | the last restart lost previously-durable data |
+
+Warnings cover degrading-but-not-down posture: `IronbusPowerLossUnsafe` (relaxed
+durability is active), `IronbusFsyncP99High` (> 6 ms SLO), `IronbusConsumerLagHigh`,
+`IronbusRedeliveryStorm`, `IronbusDeadLettering`, `IronbusBackpressureShedding`,
+`IronbusProduceSaturated`, `IronbusWriteAmplificationHigh` (>= 4x), `IronbusRamHeadroomLow`,
+`IronbusDailyWriteBudgetOver`. Info covers notable events that are not outages:
+`IronbusRestarted`, `IronbusHardCrashRecovered`, `IronbusConsumerOverflowSaturated`,
+`IronbusConsumerLabelsDropped`.
+
+Thresholds marked `TUNE` in the rules file (consumer lag, RAM floor, unsynced bytes)
+are deployment-specific starting points -- set them to your backlog and RAM budget.
+The fsync **6 ms** threshold is the SLO ([SLO.md](SLO.md)). The write-amplification
+alert fires at **~20x**, the live lz4 bound -- NOT 4x: 4x is the `--compression none`
+raw-bytes CI gate, and the live ratio is over STORED (post-lz4) bytes, so a healthy
+compressible workload runs above 4x ([EDGE_CONSTRAINTS.md](EDGE_CONSTRAINTS.md)).
+
+> **Note:** `IronbusDown` keys off `up{job=~"ironbus.*"}`, so the Prometheus scrape
+> job must be named with an `ironbus` prefix (the example scrape config does this). If
+> you rename the job, update the rule -- otherwise it silently stops detecting a down
+> broker (a false negative).
+
+## The "no silent loss" contract on the dashboard
+
+IronBus's design rule is that every shed / drop / skip / truncation / freeze
+increments a stable, documented counter ([METRICS.md](METRICS.md)). Row 6 is that
+contract made visual: in steady state every series there is **flat zero**, so the
+dashboard's job is to make any non-zero impossible to miss. If you only watch a few
+things, watch `ironbus_writer_healthy`, `ironbus_segments_force_reaped_total`,
+`ironbus_truncations_total`, and `ironbus_recovery_data_loss_bytes`.
+
+## Regenerating the dashboard
+
+The JSON is generated, not hand-edited. After changing a panel spec (or when the
+metric catalog moves):
+
+```sh
+python3 packaging/grafana/dashboard_gen.py     # rewrites ironbus-dashboard.json
+python3 packaging/grafana/check_grounded.py     # asserts every metric it references is emitted
+```
+
+`check_grounded.py` greps the server source for the authoritative `ironbus_*` names
+and fails if a panel references one the broker does not emit -- run it before
+committing a regenerated dashboard (it is not wired into the Rust CI). Validate the
+alert rules with `promtool check rules packaging/grafana/ironbus-alerts.yml` if you
+have the Prometheus toolchain.
+
+## See also
+
+- [METRICS.md](METRICS.md) -- the normative, CI-frozen metric catalog and the
+  resilience-observability contract.
+- [SLO.md](SLO.md) -- the performance targets the latency/throughput alerts key off.
+- [USAGE.md](USAGE.md) -- the operator guide; its "Health and metrics" section links
+  here.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -495,6 +495,10 @@ resilience event is ever silent. The full per-counter catalog, the
 shed-vs-drop-vs-skip-vs-dead-letter taxonomy, and the frozen-taxonomy contract
 are in [METRICS.md](METRICS.md).
 
+For a ready-made **Grafana dashboard**, **Prometheus alert rules**, a scrape config,
+and a row-by-row guide to what to watch (and what should stay flat zero), see
+[MONITORING.md](MONITORING.md) and [`packaging/grafana/`](../packaging/grafana/).
+
 ## A complete example
 
 ```sh

--- a/packaging/grafana/check_grounded.py
+++ b/packaging/grafana/check_grounded.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Local check: every ironbus_* metric the generated dashboard references is real.
+
+Greps the IronBus server source for the authoritative emitted `ironbus_*` names
+(the same set docs/METRICS.md catalogs and the frozen `(name, type)` test pins),
+then asserts the generated `ironbus-dashboard.json` references only those (allowing
+the Prometheus `_bucket` / `_sum` / `_count` histogram suffixes). Exit non-zero if a
+panel references a name the broker does not emit -- the thing that silently breaks a
+dashboard after a metric rename.
+
+Run from the repo root after regenerating:
+  python3 packaging/grafana/check_grounded.py
+"""
+import json, os, re, subprocess, sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.abspath(os.path.join(HERE, "..", ".."))
+DASH = os.path.join(HERE, "ironbus-dashboard.json")
+SRC = os.path.join(ROOT, "crates", "ironbus-server", "src")
+
+# Crate-path / partial-token false positives the source grep picks up that are NOT metrics.
+JUNK = {"ironbus_core", "ironbus_proto", "ironbus_storage", "ironbus_x_total", "ironbus_durability_"}
+
+
+def emitted_names():
+    out = subprocess.run(["grep", "-rhoE", "ironbus_[a-z0-9_]+", SRC],
+                         capture_output=True, text=True).stdout
+    base = {n for n in out.split() if n not in JUNK}
+    full = set(base)
+    for m in base:
+        full |= {m + "_bucket", m + "_sum", m + "_count"}
+    return full
+
+
+def main():
+    if not os.path.isdir(SRC):
+        sys.exit(f"server source not found at {SRC}; run from the repo root")
+    emitted = emitted_names()
+    refs = set(re.findall(r"ironbus_[a-z0-9_]+", open(DASH).read()))
+    missing = sorted(r for r in refs if r not in emitted)
+    print(f"dashboard references {len(refs)} distinct ironbus_* tokens; "
+          f"{len(emitted)} emitted names (with histogram suffixes) in the catalog")
+    if missing:
+        print("UNGROUNDED (not emitted by the broker):")
+        for m in missing:
+            print("  -", m)
+        sys.exit(1)
+    print("OK: every referenced metric is emitted by the broker.")
+
+
+if __name__ == "__main__":
+    main()

--- a/packaging/grafana/dashboard_gen.py
+++ b/packaging/grafana/dashboard_gen.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python3
+"""Generate the IronBus Grafana dashboard JSON from a compact panel spec.
+
+IronBus renders Prometheus text exposition on `GET /metrics` (see docs/METRICS.md,
+the CI-frozen catalog). This script turns a curated, data-driven panel spec into an
+importable Grafana dashboard, so the dashboard stays grounded in the real emitted
+`ironbus_*` metric names and is regenerated (not hand-edited) when the catalog moves.
+
+Every PromQL expression below references ONLY a name in the frozen catalog. The
+companion local check `check_grounded.py` re-parses the generated JSON and asserts
+each `ironbus_*` token it references is a real emitted metric (it greps the server
+source for the authoritative names), so a typo or a metric rename is caught before
+commit instead of silently breaking a panel. Run it after regenerating; it is not
+wired into the Rust CI, so run it by hand (see docs/MONITORING.md).
+
+Usage:
+  python3 dashboard_gen.py            # writes ironbus-dashboard.json next to this file
+  python3 dashboard_gen.py --stdout   # prints the JSON instead
+"""
+import argparse, json, os, sys
+
+# The standard per-broker selector. Panels filter by the templated job+instance so the
+# dashboard works for a single broker or a fleet (the variables default to "All").
+J = 'job=~"$job",instance=~"$instance"'
+RI = "$__rate_interval"  # Grafana's scrape-aware rate window
+PROM = {"type": "prometheus", "uid": "${datasource}"}
+
+# Grafana threshold-step colors.
+RED, GREEN, ORANGE, BLUE, TEXT = "red", "green", "orange", "blue", "text"
+
+
+def q(expr):
+    """A rate() over a counter, with the scrape-aware interval."""
+    return f"rate({expr}{{{J}}}[{RI}])"
+
+
+def hq(quantile, bucket):
+    """A histogram_quantile over a *_bucket series, summed by le (the correct shape)."""
+    return f"histogram_quantile({quantile}, sum by (le) (rate({bucket}{{{J}}}[{RI}])))"
+
+
+# ---- the curated rows. Each panel is a dict; `kind` picks the renderer. ----
+# kinds: stat | bool (red/green health stat) | ts (timeseries) | heatmap
+ROWS = [
+    ("Golden signals -- is the broker alive and safe?", [
+        {"kind": "bool", "title": "Writer healthy", "w": 6,
+         "expr": f"ironbus_writer_healthy{{{J}}}", "good": 1,
+         "map": {"1": ("HEALTHY", GREEN), "0": ("FROZEN", RED)},
+         "desc": "ironbus_writer_healthy: 1 live, 0 frozen by a fatal fsync (the integrity-freeze gauge). 0 is a hard incident: the durable-log writer has stopped."},
+        {"kind": "bool", "title": "Power-loss safety", "w": 6,
+         "expr": f"ironbus_durability_power_loss_unsafe{{{J}}}", "good": 0,
+         "map": {"0": ("SAFE", GREEN), "1": ("UNSAFE", RED)},
+         "desc": "ironbus_durability_power_loss_unsafe: 1 when the active durability level waives I2 (acked data can be lost on a power cut). 0 under the default `sync`."},
+        {"kind": "bool", "title": "Produce saturated", "w": 6,
+         "expr": f"ironbus_produce_saturated{{{J}}}", "good": 0,
+         "map": {"0": ("OK", GREEN), "1": ("SATURATED", RED)},
+         "desc": "ironbus_produce_saturated: 1 once the broker has shed at least one produce (admission exhaustion). The portable throughput-collapse signal."},
+        {"kind": "stat", "title": "Version", "w": 6, "unit": "none", "textMode": "name",
+         "expr": f"ironbus_build_info{{{J}}}", "legend": "{{version}}",
+         "desc": "ironbus_build_info{version=...}: the running build version (value is always 1; the version is the label)."},
+        {"kind": "stat", "title": "Consumer lag (default group)", "w": 6, "unit": "short",
+         "expr": f"ironbus_consumer_lag{{{J}}}", "legend": "lag",
+         "thresholds": [(None, GREEN), (10000, ORANGE), (100000, RED)],
+         "desc": "ironbus_consumer_lag = flushed head - committed cursor for the default group. The headline backlog signal."},
+        {"kind": "stat", "title": "Produce rate", "w": 6, "unit": "ops",
+         "expr": q("ironbus_produced_total"), "legend": "msg/s",
+         "desc": "rate(ironbus_produced_total): messages appended per second (the throughput baseline)."},
+        {"kind": "stat", "title": "Ack rate", "w": 6, "unit": "ops",
+         "expr": q("ironbus_acks_total"), "legend": "ack/s",
+         "desc": "rate(ironbus_acks_total): commits per second."},
+        {"kind": "stat", "title": "Uptime", "w": 6, "unit": "s",
+         "expr": f"ironbus_uptime_seconds{{{J}}}", "legend": "uptime",
+         "desc": "ironbus_uptime_seconds: seconds since the broker started (monotonic-derived; a sudden drop means a restart)."},
+    ]),
+    ("Throughput", [
+        {"kind": "ts", "title": "Message rates (produce / deliver / ack / redeliver)", "w": 12, "unit": "ops",
+         "targets": [(q("ironbus_produced_total"), "produced"),
+                     (q("ironbus_delivered_total"), "delivered"),
+                     (q("ironbus_acks_total"), "acked"),
+                     (q("ironbus_redelivered_total"), "redelivered")],
+         "desc": "The core flow rates. Redelivered rising while acked is flat means consumers are not acking inside the lease (at-least-once retries, not loss)."},
+        {"kind": "ts", "title": "Byte throughput (produced)", "w": 12, "unit": "Bps",
+         "targets": [(q("ironbus_produced_bytes_total"), "produced bytes/s")],
+         "desc": "rate(ironbus_produced_bytes_total): logical (key+headers+payload) bytes appended per second."},
+        {"kind": "ts", "title": "Dedup (idempotency window)", "w": 12, "unit": "ops",
+         "targets": [(q("ironbus_dedup_hits_total"), "dedup hits/s (benign)"),
+                     (q("ironbus_dedup_out_of_window_total"), "out-of-window/s")],
+         "desc": "rate(ironbus_dedup_hits_total) is idempotent retries absorbed (benign). rate(ironbus_dedup_out_of_window_total) rising means the dedup window is too small for the retry interval -- size --dedup-max-ids / --dedup-window-ms. Zero unless opt-in dedup is used."},
+    ]),
+    ("Durability-barrier latency (the headline performance signal)", [
+        {"kind": "ts", "title": "fsync latency (produce durability barrier)", "w": 12, "unit": "s",
+         "targets": [(hq("0.50", "ironbus_fsync_duration_seconds_bucket"), "p50"),
+                     (hq("0.99", "ironbus_fsync_duration_seconds_bucket"), "p99"),
+                     (hq("0.999", "ironbus_fsync_duration_seconds_bucket"), "p99.9")],
+         "slo_line": 0.006,
+         "desc": "histogram_quantile over ironbus_fsync_duration_seconds_bucket: the produce-time fdatasync latency. The dashed line is the 6 ms p99 SLO (docs/SLO.md)."},
+        {"kind": "ts", "title": "Append latency (append + fsync)", "w": 12, "unit": "s",
+         "targets": [(hq("0.50", "ironbus_append_duration_seconds_bucket"), "p50"),
+                     (hq("0.99", "ironbus_append_duration_seconds_bucket"), "p99"),
+                     (hq("0.999", "ironbus_append_duration_seconds_bucket"), "p99.9")],
+         "slo_line": 0.006,
+         "desc": "histogram_quantile over ironbus_append_duration_seconds_bucket: the whole durable-append (append + fsync) latency."},
+        {"kind": "heatmap", "title": "fsync latency distribution (heatmap)", "w": 24, "unit": "s",
+         "expr": f"sum by (le) (rate(ironbus_fsync_duration_seconds_bucket{{{J}}}[{RI}]))",
+         "desc": "The full fdatasync latency distribution over the fixed registry buckets. A widening high band is rising tail-latency / device pressure."},
+    ]),
+    ("Consumer lag & delivery", [
+        {"kind": "ts", "title": "Consumer lag (default + per work-group)", "w": 12, "unit": "short",
+         "targets": [(f"ironbus_consumer_lag{{{J}}}", "default"),
+                     (f"ironbus_group_consumer_lag{{{J}}}", "{{group}}")],
+         "desc": "ironbus_consumer_lag and ironbus_group_consumer_lag{group}: flushed head minus committed cursor. Rising = consumers falling behind."},
+        {"kind": "ts", "title": "In-flight (leased, not yet acked)", "w": 12, "unit": "short",
+         "targets": [(f"ironbus_in_flight{{{J}}}", "default"),
+                     (f"ironbus_group_in_flight{{{J}}}", "{{group}}")],
+         "desc": "ironbus_in_flight / ironbus_group_in_flight: messages leased to consumers but not yet acked. Pinned at max_in_flight means the consumer is the bottleneck."},
+        {"kind": "ts", "title": "Top 10 per-consumer lag", "w": 12, "unit": "short",
+         "targets": [(f'topk(10, ironbus_consumer_lag_records{{{J}}})', "{{consumer}}")],
+         "desc": "topk(10, ironbus_consumer_lag_records{consumer}): the laggiest consumers. {consumer=\"__overflow__\"} is the folded lag of all over-cap consumers past the 1024-series cap."},
+        {"kind": "ts", "title": "Redelivery & dead-letter rate", "w": 12, "unit": "ops",
+         "targets": [(q("ironbus_redelivered_total"), "redelivered/s"),
+                     (q("ironbus_dead_lettered_total"), "dead-lettered/s")],
+         "desc": "rate(ironbus_redelivered_total) is at-least-once retry pressure; rate(ironbus_dead_lettered_total) is poison messages exceeding MaxDeliver routed to the DLQ."},
+        {"kind": "ts", "title": "DLQ records (cumulative, survives restart)", "w": 12, "unit": "short",
+         "targets": [(f"ironbus_dlq_records_total{{{J}}}", "dlq records")],
+         "desc": "ironbus_dlq_records_total: records durably written to the dead-letter sink. The durable complement of dead_lettered."},
+        {"kind": "ts", "title": "Consumer cardinality (1024-series cap)", "w": 12, "unit": "short",
+         "targets": [(f"ironbus_consumer_overflow_saturated{{{J}}}", "overflow saturated (0/1)"),
+                     (f'increase(ironbus_consumer_labels_dropped_total{{{J}}}[1h])', "labels dropped (1h)")],
+         "desc": "ironbus_consumer_labels_dropped_total: distinct consumers past the 1024-series cap, folded into {consumer=\"__overflow__\"}. ironbus_consumer_overflow_saturated == 1 means that fold is now a lower bound (very high consumer cardinality)."},
+    ]),
+    ("Backpressure & shedding (the resilience taxonomy -- every shed is counted)", [
+        {"kind": "ts", "title": "Shed rates (by reason)", "w": 12, "unit": "ops", "stack": True,
+         "targets": [(q("ironbus_produce_rejected_total"), "disk-full drop-new"),
+                     (q("ironbus_codel_shed_total"), "codel (latency)"),
+                     (q("ironbus_codel_backstop_shed_total"), "codel backstop"),
+                     (q("ironbus_fire_and_forget_shed_total"), "fire-and-forget (QoS-0)"),
+                     (q("ironbus_egress_shed_total"), "egress AIMD"),
+                     (q("ironbus_wal_fsync_headroom_shed_total"), "wal fsync headroom"),
+                     (q("ironbus_daily_write_budget_sheds_total"), "daily write budget"),
+                     (f'rate(ironbus_retry_shed_total{{{J}}}[{RI}])', "retry budget ({{side}})")],
+         "desc": "Every backpressure shed counter, as a rate. All zero unless the matching knob is enabled. A rising series names exactly which control is shedding."},
+        {"kind": "ts", "title": "Backpressure controllers (live state)", "w": 12, "unit": "short",
+         "targets": [(f"ironbus_codel_sojourn_estimate_ms{{{J}}}", "codel sojourn (ms)"),
+                     (f"ironbus_egress_limit{{{J}}}", "egress limit (4-128)"),
+                     (f"ironbus_retry_ratio{{{J}}} / 1e6", "retry ratio (fraction)")],
+         "desc": "ironbus_codel_sojourn_estimate_ms (latency the CoDel law acts on), ironbus_egress_limit (AIMD concurrency, halves on a degrading sink), ironbus_retry_ratio/1e6 (shed fraction vs the budget)."},
+    ]),
+    ("Data loss & integrity (these should stay FLAT ZERO -- any movement is an incident)", [
+        {"kind": "ts", "title": "Force-reap & consumer truncation rate", "w": 12, "unit": "ops",
+         "targets": [(q("ironbus_segments_force_reaped_total"), "force-reaped segments/s"),
+                     (q("ironbus_truncations_total"), "consumer truncations/s"),
+                     (q("ironbus_truncated_records_total"), "truncated records/s")],
+         "desc": "ironbus_segments_force_reaped_total (drop-oldest deleting maybe-unconsumed data) and ironbus_truncations_total (a live consumer losing a span). Non-zero = real data loss."},
+        {"kind": "ts", "title": "Last-recovery loss (bytes)", "w": 12, "unit": "bytes",
+         "targets": [(f"ironbus_recovery_data_loss_bytes{{{J}}}", "data-loss bytes"),
+                     (f"ironbus_recovery_truncated_bytes{{{J}}}", "truncated bytes (incl torn tail)"),
+                     (f"ironbus_bytes_skipped{{{J}}}", "bytes skipped (recovery-loss total)"),
+                     (f"ironbus_quarantine_bytes{{{J}}}", "quarantine bytes")],
+         "desc": "ironbus_recovery_data_loss_bytes is the headline bytes-lost at the last recovery (torn tails excluded). ironbus_bytes_skipped is the reconciled recovery-loss byte total; ironbus_quarantine_bytes is the forensic corrupt-copy footprint on disk."},
+        {"kind": "ts", "title": "Last-recovery loss by reason", "w": 12, "unit": "short",
+         "targets": [(f"ironbus_recovery_loss_records{{{J}}}", "records: {{reason}}"),
+                     (f"ironbus_recovery_loss_bytes{{{J}}}", "bytes: {{reason}}")],
+         "desc": "ironbus_recovery_loss_records{reason} and ironbus_recovery_loss_bytes{reason}: records and bytes dropped at the last recovery, by ReasonCode (torn_tail, corrupt_record_*, sequence_gap, scrubber_suspect, unresolved_dict_id) -- the cause AND magnitude of an incident."},
+        {"kind": "ts", "title": "Skips & checkpoint-repair", "w": 12, "unit": "short",
+         "targets": [(f"ironbus_records_skipped{{{J}}}", "records skipped (recovery-loss total)"),
+                     (f'increase(ironbus_counter_checkpoint_repair_total{{{J}}}[1h])', "ckpt repairs (1h)")],
+         "desc": "ironbus_records_skipped is the reconciled recovery-loss record total. A non-zero ironbus_counter_checkpoint_repair_total means a hard crash (kill -9) occurred and reconciliation restored the lower bound."},
+        {"kind": "ts", "title": "Loss-locator offsets (where in the log)", "w": 12, "unit": "short",
+         "targets": [(f"ironbus_last_skip_offset{{{J}}}", "last skip offset (high-water)"),
+                     (f"ironbus_last_dead_lettered_offset{{{J}}}", "last dead-letter offset (-1=none)")],
+         "desc": "ironbus_last_skip_offset (highest log offset any skip/loss reached, cross-restart monotonic) and ironbus_last_dead_lettered_offset (-1 = none): when a loss/dead-letter alert fires, these say WHERE in the log to look."},
+    ]),
+    ("Durability posture & edge resources (flash / RAM)", [
+        {"kind": "stat", "title": "Active durability level", "w": 8, "unit": "none", "textMode": "name",
+         "expr": f"ironbus_durability_level_info{{{J}}}", "legend": "{{level}}",
+         "desc": "ironbus_durability_level_info{level=sync|interval|async|none}: the active level (value 1). `sync` is the power-loss-safe default."},
+        {"kind": "ts", "title": "Un-fsynced bytes at risk", "w": 16, "unit": "bytes",
+         "targets": [(f"ironbus_durability_unsynced_bytes{{{J}}}", "unsynced bytes")],
+         "desc": "ironbus_durability_unsynced_bytes: acked-but-not-yet-fdatasync'd bytes at risk on a power cut. Always 0 under `sync`; the live loss window under a relaxed level."},
+        {"kind": "ts", "title": "Flash write amplification", "w": 12, "unit": "none", "decimals": 3,
+         "targets": [(f"ironbus_write_amp_ratio{{{J}}}", "physical/logical")],
+         "slo_line": 20,
+         "desc": "ironbus_write_amp_ratio = physical / STORED (post-compression) bytes. The dashed line is the ~20x LIVE bound (docs/EDGE_CONSTRAINTS.md L217: derived 20x, observed ~7x healthy) -- NOT the 4x figure, which is the `--compression none` raw-bytes CI gate. Under the default lz4 codec the ratio inflates for small compressible payloads even as real flash wear falls, so 4x is normal here; correlate with rate(ironbus_physical_bytes_written)."},
+        {"kind": "ts", "title": "Flash bytes written (physical vs logical)", "w": 12, "unit": "Bps",
+         "targets": [(q("ironbus_physical_bytes_written"), "physical B/s (flash wear)"),
+                     (q("ironbus_logical_bytes_written"), "logical B/s (stored)")],
+         "desc": "rate of ironbus_physical_bytes_written (real flash-wear volume: frames + segment headers/footers) vs ironbus_logical_bytes_written (stored, post-compression)."},
+        {"kind": "ts", "title": "Daily physical write budget", "w": 12, "unit": "bytes",
+         "targets": [(f"ironbus_physical_bytes_written_today{{{J}}}", "written today"),
+                     (f"ironbus_daily_physical_write_budget_bytes{{{J}}}", "budget (0 = off)")],
+         "desc": "The opt-in flash-wear governor: ironbus_physical_bytes_written_today vs ironbus_daily_physical_write_budget_bytes (resets at the UTC day boundary). At the budget, produces shed."},
+        {"kind": "ts", "title": "RAM headroom (against the ceiling)", "w": 12, "unit": "bytes",
+         "targets": [(f"ironbus_ram_headroom_bytes{{{J}}} != -1", "ram headroom")],
+         "desc": "ironbus_ram_headroom_bytes = ram_ceiling_bytes - RSS. The -1 unavailable sentinel (no ceiling set, or RSS unreadable) is filtered out; falling toward 0 means the OOM cliff is near."},
+    ]),
+    ("Retention & offsets", [
+        {"kind": "ts", "title": "Segment reclaim rate", "w": 12, "unit": "ops",
+         "targets": [(q("ironbus_segments_reaped_total"), "reaped (loss-free)/s"),
+                     (q("ironbus_segments_force_reaped_total"), "force-reaped (lossy!)/s")],
+         "desc": "ironbus_segments_reaped_total is healthy consumer-safe reclaim; ironbus_segments_force_reaped_total is the drop-oldest lossy reclaim (should be zero)."},
+        {"kind": "ts", "title": "Log offsets (head vs committed)", "w": 12, "unit": "short",
+         "targets": [(f"ironbus_flushed_offset{{{J}}}", "flushed (durable head)"),
+                     (f"ironbus_committed_offset{{{J}}}", "committed (default cursor)")],
+         "desc": "ironbus_flushed_offset (durable log head) and ironbus_committed_offset (default-group cursor). The gap is the lag; both should climb together."},
+    ]),
+]
+
+
+# ---------------------------------------------------------------------------
+def thresholds(steps):
+    return {"mode": "absolute", "steps": [{"value": v, "color": c} for v, c in steps]}
+
+
+def mappings(m):
+    return [{"type": "value", "options": {k: {"text": t, "color": c} for k, (t, c) in m.items()}}]
+
+
+def base_fieldconfig(unit, decimals=None, thr=None, custom=None):
+    d = {"unit": unit}
+    if decimals is not None:
+        d["decimals"] = decimals
+    if thr is not None:
+        d["thresholds"] = thr
+    if custom is not None:
+        d["custom"] = custom
+    return {"defaults": d, "overrides": []}
+
+
+def panel_stat(spec, pid, gp):
+    is_bool = spec["kind"] == "bool"
+    fc = base_fieldconfig(
+        spec.get("unit", "none"),
+        decimals=spec.get("decimals"),
+        thr=thresholds(spec["thresholds"]) if "thresholds" in spec
+        else (thresholds([(None, GREEN if spec.get("good") == 1 else GREEN)]) if not is_bool else None),
+    )
+    if is_bool:
+        good = spec["good"]
+        steps = [(None, GREEN), (1, RED)] if good == 0 else [(None, RED), (1, GREEN)]
+        fc["defaults"]["thresholds"] = thresholds(steps)
+        fc["defaults"]["mappings"] = mappings(spec["map"])
+    return {
+        "id": pid, "type": "stat", "title": spec["title"], "gridPos": gp,
+        "datasource": PROM, "description": spec.get("desc", ""),
+        "fieldConfig": fc,
+        "options": {
+            "colorMode": "background" if is_bool else "value",
+            "graphMode": "none" if is_bool else "area",
+            "justifyMode": "auto", "textMode": spec.get("textMode", "auto"),
+            "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": False},
+        },
+        "targets": [{"refId": "A", "datasource": PROM, "expr": spec["expr"],
+                     "legendFormat": spec.get("legend", ""), "instant": True}],
+    }
+
+
+def panel_ts(spec, pid, gp):
+    custom = {
+        "drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 2,
+        "fillOpacity": 12 if not spec.get("stack") else 25, "showPoints": "never",
+        "spanNulls": True,
+    }
+    if spec.get("stack"):
+        custom["stacking"] = {"mode": "normal", "group": "A"}
+    thr = None
+    if "slo_line" in spec:
+        thr = thresholds([(None, GREEN), (spec["slo_line"], RED)])
+        custom["thresholdsStyle"] = {"mode": "line"}
+    fc = base_fieldconfig(spec.get("unit", "short"), decimals=spec.get("decimals"), thr=thr, custom=custom)
+    targets = [{"refId": chr(65 + i), "datasource": PROM, "expr": e, "legendFormat": lg}
+               for i, (e, lg) in enumerate(spec["targets"])]
+    return {
+        "id": pid, "type": "timeseries", "title": spec["title"], "gridPos": gp,
+        "datasource": PROM, "description": spec.get("desc", ""), "fieldConfig": fc,
+        "options": {"legend": {"displayMode": "list", "placement": "bottom", "calcs": ["lastNotNull", "max"]},
+                    "tooltip": {"mode": "multi", "sort": "desc"}},
+        "targets": targets,
+    }
+
+
+def panel_heatmap(spec, pid, gp):
+    return {
+        "id": pid, "type": "heatmap", "title": spec["title"], "gridPos": gp,
+        "datasource": PROM, "description": spec.get("desc", ""),
+        "options": {"calculate": False, "cellGap": 1, "color": {"scheme": "Spectral", "mode": "scheme"},
+                    "yAxis": {"unit": spec.get("unit", "s"), "axisPlacement": "left"},
+                    "tooltip": {"show": True, "yHistogram": True}},
+        "fieldConfig": {"defaults": {"custom": {"hideFrom": {"tooltip": False, "viz": False, "legend": False}}}, "overrides": []},
+        "targets": [{"refId": "A", "datasource": PROM, "expr": spec["expr"],
+                     "format": "heatmap", "legendFormat": "{{le}}"}],
+    }
+
+
+def build():
+    panels, pid, y = [], 1, 0
+    for row_title, specs in ROWS:
+        panels.append({"id": pid, "type": "row", "title": row_title, "collapsed": False,
+                       "gridPos": {"h": 1, "w": 24, "x": 0, "y": y}})
+        pid += 1
+        y += 1
+        x = 0
+        row_h = 0
+        for spec in specs:
+            w = spec.get("w", 12)
+            h = spec.get("h", 5 if spec["kind"] in ("stat", "bool") else 8)
+            if x + w > 24:
+                x = 0
+                y += row_h
+                row_h = 0
+            gp = {"h": h, "w": w, "x": x, "y": y}
+            if spec["kind"] in ("stat", "bool"):
+                panels.append(panel_stat(spec, pid, gp))
+            elif spec["kind"] == "heatmap":
+                panels.append(panel_heatmap(spec, pid, gp))
+            else:
+                panels.append(panel_ts(spec, pid, gp))
+            pid += 1
+            x += w
+            row_h = max(row_h, h)
+        y += row_h
+    return {
+        "title": "IronBus broker",
+        "uid": "ironbus-broker",
+        "tags": ["ironbus", "edge", "message-queue"],
+        "editable": True,
+        "schemaVersion": 39,
+        "version": 1,
+        "refresh": "30s",
+        "time": {"from": "now-6h", "to": "now"},
+        "timezone": "",
+        "templating": {"list": [
+            {"name": "datasource", "type": "datasource", "query": "prometheus",
+             "label": "Data source", "hide": 0, "current": {}, "refresh": 1},
+            {"name": "job", "type": "query", "datasource": PROM, "label": "Job",
+             "query": "label_values(ironbus_uptime_seconds, job)", "refresh": 2,
+             "multi": True, "includeAll": True, "allValue": ".*",
+             "current": {"text": "All", "value": "$__all"}},
+            {"name": "instance", "type": "query", "datasource": PROM, "label": "Instance",
+             "query": 'label_values(ironbus_uptime_seconds{job=~"$job"}, instance)', "refresh": 2,
+             "multi": True, "includeAll": True, "allValue": ".*",
+             "current": {"text": "All", "value": "$__all"}},
+        ]},
+        "annotations": {"list": [{
+            "name": "Restarts", "datasource": PROM, "enable": True, "iconColor": "orange",
+            "expr": f"changes(ironbus_start_time_seconds{{{J}}}[2m]) > 0",
+            "titleFormat": "broker restart", "step": "60s"}]},
+        "panels": panels,
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--stdout", action="store_true")
+    a = ap.parse_args()
+    dash = build()
+    out = json.dumps(dash, indent=2, sort_keys=False) + "\n"
+    if a.stdout:
+        sys.stdout.write(out)
+        return
+    dest = os.path.join(os.path.dirname(os.path.abspath(__file__)), "ironbus-dashboard.json")
+    with open(dest, "w") as f:
+        f.write(out)
+    sys.stderr.write(f"wrote {dest} ({len(dash['panels'])} panels)\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/packaging/grafana/ironbus-alerts.yml
+++ b/packaging/grafana/ironbus-alerts.yml
@@ -1,0 +1,202 @@
+# IronBus Prometheus alerting rules.
+#
+# Grounded in the frozen metric catalog (docs/METRICS.md) and the SLO targets
+# (docs/SLO.md): the marquee p99 fsync target is 6 ms and the flash write-
+# amplification gate is >= 4x. Load into Prometheus via `rule_files:` (or import
+# the same expressions into Grafana managed alerts).
+#
+# Thresholds marked "TUNE" are deployment-specific (lag, RAM, unsynced bytes):
+# the defaults are conservative starting points, not universal constants. Every
+# expression references only an emitted ironbus_* series, so each alert is backed
+# by a real, never-silent signal -- not a derived guess.
+#
+# Severity convention: critical = data integrity / availability at risk now;
+# warning = degrading or a relaxed-safety posture; info = a notable event that is
+# not itself an outage.
+groups:
+  # -------------------------------------------------------------------------
+  - name: ironbus.critical
+    rules:
+      - alert: IronbusDown
+        expr: up{job=~"ironbus.*"} == 0
+        for: 1m
+        labels: {severity: critical}
+        annotations:
+          summary: "IronBus broker {{ $labels.instance }} is down (scrape failing)"
+          description: "Prometheus cannot scrape /metrics on {{ $labels.instance }} for 1m. The broker process or its health endpoint is unreachable."
+
+      - alert: IronbusWriterFrozen
+        expr: ironbus_writer_healthy == 0
+        for: 30s
+        labels: {severity: critical}
+        annotations:
+          summary: "IronBus writer FROZEN on {{ $labels.instance }} (integrity freeze)"
+          description: "ironbus_writer_healthy == 0: a fatal fsync froze the durable-log writer. Produces are refused (fail-closed). /readyz is 503. Investigate the disk and restart."
+
+      - alert: IronbusForceReapDataLoss
+        expr: increase(ironbus_segments_force_reaped_total[5m]) > 0
+        for: 0m
+        labels: {severity: critical}
+        annotations:
+          summary: "IronBus is force-reaping segments on {{ $labels.instance }} (drop-oldest data loss)"
+          description: "ironbus_segments_force_reaped_total increased: the disk-full drop-oldest policy deleted sealed segments to make room, ignoring consumer safety. A slow consumer may have lost data (it will see a one-time truncation). The disk is at its byte cap."
+
+      - alert: IronbusConsumerTruncation
+        expr: increase(ironbus_truncations_total[5m]) > 0
+        for: 0m
+        labels: {severity: critical}
+        annotations:
+          summary: "IronBus consumer truncation on {{ $labels.instance }} (a live consumer lost data)"
+          description: "ironbus_truncations_total increased: a consumer's cursor fell below the oldest retained record (force-reaped out from under it) and was reset forward. The span [old_cursor, earliest_retained) is lost for that consumer."
+
+      - alert: IronbusRecoveryDataLoss
+        expr: ironbus_recovery_data_loss_bytes > 0
+        for: 0m
+        labels: {severity: critical}
+        annotations:
+          summary: "IronBus lost {{ $value | humanize1024 }}B at the last recovery on {{ $labels.instance }}"
+          description: "ironbus_recovery_data_loss_bytes > 0: the last crash recovery dropped previously-durable data (torn tails excluded). Check ironbus_recovery_loss_records{reason} for the cause (corruption vs sequence gap vs scrubber-suspect)."
+
+  # -------------------------------------------------------------------------
+  - name: ironbus.warning
+    rules:
+      - alert: IronbusPowerLossUnsafe
+        expr: ironbus_durability_power_loss_unsafe == 1
+        for: 5m
+        labels: {severity: warning}
+        annotations:
+          summary: "IronBus on {{ $labels.instance }} is in a power-loss-UNSAFE durability level"
+          description: "ironbus_durability_power_loss_unsafe == 1: a relaxed durability level is active, so acknowledged data can be lost on a power cut. ironbus_durability_unsynced_bytes is the live bytes-at-risk. Intentional only if a relaxed level was deliberately configured."
+
+      - alert: IronbusFsyncP99High
+        # The 6 ms p99 fsync SLO (docs/SLO.md). Histogram quantile summed by le.
+        expr: histogram_quantile(0.99, sum by (job, instance, le) (rate(ironbus_fsync_duration_seconds_bucket[5m]))) > 0.006
+        for: 10m
+        labels: {severity: warning}
+        annotations:
+          summary: "IronBus fsync p99 {{ $value | humanizeDuration }} > 6ms SLO on {{ $labels.instance }}"
+          description: "The produce-time durability-barrier (fdatasync) p99 latency is above the 6 ms SLO for 10m. The storage device is under pressure or failing."
+
+      - alert: IronbusUnsyncedBytesHigh
+        # Only non-zero under a relaxed durability level; TUNE per loss-window tolerance.
+        expr: ironbus_durability_unsynced_bytes > 8388608
+        for: 5m
+        labels: {severity: warning}
+        annotations:
+          summary: "IronBus has {{ $value | humanize1024 }}B unsynced (at risk on power loss) on {{ $labels.instance }}"
+          description: "ironbus_durability_unsynced_bytes > 8 MiB (TUNE): acknowledged-but-not-fdatasync'd bytes are accumulating under a relaxed durability level. This is the power-loss window. 0 under the default sync level."
+
+      - alert: IronbusConsumerLagHigh
+        # TUNE: 100k records is a placeholder; set to your backlog tolerance.
+        expr: ironbus_consumer_lag > 100000
+        for: 10m
+        labels: {severity: warning}
+        annotations:
+          summary: "IronBus consumer lag {{ $value }} on {{ $labels.instance }}"
+          description: "ironbus_consumer_lag (flushed head - committed cursor) is above 100000 (TUNE) for 10m. Consumers are not keeping up; the backlog is growing. Check per-group lag and in-flight."
+
+      - alert: IronbusRedeliveryStorm
+        expr: |
+          rate(ironbus_redelivered_total[5m])
+            / clamp_min(rate(ironbus_delivered_total[5m]), 1) > 0.2
+        for: 10m
+        labels: {severity: warning}
+        annotations:
+          summary: "IronBus redelivering {{ $value | humanizePercentage }} of deliveries on {{ $labels.instance }}"
+          description: "More than 20% of deliveries are redeliveries for 10m: consumers are not acking within the lease (slow consumers or expired leases). Not loss (at-least-once), but a sign of consumer trouble that ends in dead-lettering at MaxDeliver."
+
+      - alert: IronbusDeadLettering
+        expr: increase(ironbus_dead_lettered_total[15m]) > 0
+        for: 0m
+        labels: {severity: warning}
+        annotations:
+          summary: "IronBus dead-lettered {{ $value }} message(s) on {{ $labels.instance }}"
+          description: "ironbus_dead_lettered_total increased: poison messages exceeded MaxDeliver and were parked in the DLQ. Inspect the dead-letter sink (ironbus_dlq_records_total is the durable depth)."
+
+      - alert: IronbusBackpressureShedding
+        # Sum of the producer-refusing shed counters (excludes fire-and-forget QoS-0,
+        # which sheds by contract, and retry-shed, which defers rather than drops).
+        expr: |
+          sum by (job, instance) (rate(ironbus_produce_rejected_total[5m]))
+          + sum by (job, instance) (rate(ironbus_codel_shed_total[5m]))
+          + sum by (job, instance) (rate(ironbus_codel_backstop_shed_total[5m]))
+          + sum by (job, instance) (rate(ironbus_egress_shed_total[5m]))
+          + sum by (job, instance) (rate(ironbus_wal_fsync_headroom_shed_total[5m]))
+          + sum by (job, instance) (rate(ironbus_daily_write_budget_sheds_total[5m])) > 0
+        for: 5m
+        labels: {severity: warning}
+        annotations:
+          summary: "IronBus is shedding produces on {{ $labels.instance }} (backpressure active)"
+          description: "One or more admission controls is refusing produces (disk-full drop-new, CoDel latency, CoDel backstop, egress AIMD, WAL fsync headroom, or the daily write budget). Open the Backpressure panel to see which control and why."
+
+      - alert: IronbusProduceSaturated
+        expr: ironbus_produce_saturated == 1
+        for: 5m
+        labels: {severity: warning}
+        annotations:
+          summary: "IronBus produce SATURATED on {{ $labels.instance }} (throughput collapse signal)"
+          description: "ironbus_produce_saturated == 1: the broker has shed at least one produce (admission exhaustion). The portable throughput-collapse signal #118 defines."
+
+      - alert: IronbusWriteAmplificationHigh
+        # The LIVE bound is ~20x, NOT the 4x figure. The 4x is the `--compression none`
+        # raw-bytes CI gate; the live ratio is defined over STORED (post-lz4) bytes, so a
+        # healthy compressible workload runs well above 4x (docs/EDGE_CONSTRAINTS.md L217:
+        # derived 20x, observed ~7x healthy). Alerting at 4x here would be a false positive.
+        expr: ironbus_write_amp_ratio >= 20
+        for: 15m
+        labels: {severity: warning}
+        annotations:
+          summary: "IronBus flash write amplification {{ $value }}x on {{ $labels.instance }}"
+          description: "ironbus_write_amp_ratio (physical / STORED bytes) is at or above the ~20x LIVE bound for 15m -- NOT the 4x `--compression none` CI gate (4x is normal under lz4). At 20x the per-record framing is dominating real flash wear; correlate with rate(ironbus_physical_bytes_written) and the daily-write-budget meter."
+
+      - alert: IronbusRamHeadroomLow
+        # -1 means no ceiling set / RSS unreadable -- excluded. TUNE the 16 MiB floor.
+        expr: ironbus_ram_headroom_bytes != -1 and ironbus_ram_headroom_bytes < 16777216
+        for: 5m
+        labels: {severity: warning}
+        annotations:
+          summary: "IronBus RAM headroom {{ $value | humanize1024 }}B on {{ $labels.instance }}"
+          description: "ironbus_ram_headroom_bytes (ram_ceiling - RSS) is below 16 MiB (TUNE) and approaching the OOM cliff. -1 (no ceiling configured) is excluded."
+
+      - alert: IronbusDailyWriteBudgetOver
+        expr: ironbus_daily_write_budget_over == 1
+        for: 0m
+        labels: {severity: warning}
+        annotations:
+          summary: "IronBus daily flash write budget exhausted on {{ $labels.instance }}"
+          description: "ironbus_daily_write_budget_over == 1: today's physical writes reached the configured daily budget, so the flash-wear governor is shedding produces until the UTC day boundary."
+
+  # -------------------------------------------------------------------------
+  - name: ironbus.info
+    rules:
+      - alert: IronbusHardCrashRecovered
+        expr: increase(ironbus_counter_checkpoint_repair_total[10m]) > 0
+        for: 0m
+        labels: {severity: info}
+        annotations:
+          summary: "IronBus reconciled recovery-loss counters after a hard crash on {{ $labels.instance }}"
+          description: "ironbus_counter_checkpoint_repair_total increased: a hard crash (kill -9 / power loss) lost post-snapshot recovery-loss increments and checkpoint-plus-replay reconciliation restored the lower bound on open. Expected after an unclean stop; not itself loss."
+
+      - alert: IronbusRestarted
+        expr: changes(ironbus_start_time_seconds[10m]) > 0
+        for: 0m
+        labels: {severity: info}
+        annotations:
+          summary: "IronBus restarted on {{ $labels.instance }}"
+          description: "ironbus_start_time_seconds changed: the broker restarted within the last 10m. Confirm it was intended and check ironbus_recovery_data_loss_bytes for any recovery loss."
+
+      - alert: IronbusConsumerOverflowSaturated
+        expr: ironbus_consumer_overflow_saturated == 1
+        for: 0m
+        labels: {severity: info}
+        annotations:
+          summary: "IronBus consumer-label cardinality cap saturated on {{ $labels.instance }}"
+          description: "ironbus_consumer_overflow_saturated == 1: more than the bounded over-cap ledger of distinct consumers have been seen, so ironbus_consumer_lag_records{consumer=\"__overflow__\"} is now a monotonic lower bound rather than exact. A very-high-cardinality consumer population."
+
+      - alert: IronbusConsumerLabelsDropped
+        expr: increase(ironbus_consumer_labels_dropped_total[1h]) > 0
+        for: 0m
+        labels: {severity: info}
+        annotations:
+          summary: "IronBus folded {{ $value }} over-cap consumer label(s) into __overflow__ on {{ $labels.instance }}"
+          description: "ironbus_consumer_labels_dropped_total increased: distinct consumers past the 1024-series cardinality cap had their lag folded into {consumer=\"__overflow__\"}. Total lag stays visible; per-consumer detail for those is not."

--- a/packaging/grafana/ironbus-dashboard.json
+++ b/packaging/grafana/ironbus-dashboard.json
@@ -1,0 +1,2531 @@
+{
+  "title": "IronBus broker",
+  "uid": "ironbus-broker",
+  "tags": [
+    "ironbus",
+    "edge",
+    "message-queue"
+  ],
+  "editable": true,
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timezone": "",
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "label": "Data source",
+        "hide": 0,
+        "current": {},
+        "refresh": 1
+      },
+      {
+        "name": "job",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "label": "Job",
+        "query": "label_values(ironbus_uptime_seconds, job)",
+        "refresh": 2,
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        }
+      },
+      {
+        "name": "instance",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "label": "Instance",
+        "query": "label_values(ironbus_uptime_seconds{job=~\"$job\"}, instance)",
+        "refresh": 2,
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        }
+      }
+    ]
+  },
+  "annotations": {
+    "list": [
+      {
+        "name": "Restarts",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "enable": true,
+        "iconColor": "orange",
+        "expr": "changes(ironbus_start_time_seconds{job=~\"$job\",instance=~\"$instance\"}[2m]) > 0",
+        "titleFormat": "broker restart",
+        "step": "60s"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "row",
+      "title": "Golden signals -- is the broker alive and safe?",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      }
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Writer healthy",
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "ironbus_writer_healthy: 1 live, 0 frozen by a fatal fsync (the integrity-freeze gauge). 0 is a hard incident: the durable-log writer has stopped.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "red"
+              },
+              {
+                "value": 1,
+                "color": "green"
+              }
+            ]
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "1": {
+                  "text": "HEALTHY",
+                  "color": "green"
+                },
+                "0": {
+                  "text": "FROZEN",
+                  "color": "red"
+                }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ironbus_writer_healthy{job=~\"$job\",instance=~\"$instance\"}",
+          "legendFormat": "",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Power-loss safety",
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "ironbus_durability_power_loss_unsafe: 1 when the active durability level waives I2 (acked data can be lost on a power cut). 0 under the default `sync`.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "green"
+              },
+              {
+                "value": 1,
+                "color": "red"
+              }
+            ]
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "SAFE",
+                  "color": "green"
+                },
+                "1": {
+                  "text": "UNSAFE",
+                  "color": "red"
+                }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ironbus_durability_power_loss_unsafe{job=~\"$job\",instance=~\"$instance\"}",
+          "legendFormat": "",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Produce saturated",
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 1
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "ironbus_produce_saturated: 1 once the broker has shed at least one produce (admission exhaustion). The portable throughput-collapse signal.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "green"
+              },
+              {
+                "value": 1,
+                "color": "red"
+              }
+            ]
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "OK",
+                  "color": "green"
+                },
+                "1": {
+                  "text": "SATURATED",
+                  "color": "red"
+                }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ironbus_produce_saturated{job=~\"$job\",instance=~\"$instance\"}",
+          "legendFormat": "",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "Version",
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "ironbus_build_info{version=...}: the running build version (value is always 1; the version is the label).",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "textMode": "name",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ironbus_build_info{job=~\"$job\",instance=~\"$instance\"}",
+          "legendFormat": "{{version}}",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "stat",
+      "title": "Consumer lag (default group)",
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 6
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "ironbus_consumer_lag = flushed head - committed cursor for the default group. The headline backlog signal.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "green"
+              },
+              {
+                "value": 10000,
+                "color": "orange"
+              },
+              {
+                "value": 100000,
+                "color": "red"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ironbus_consumer_lag{job=~\"$job\",instance=~\"$instance\"}",
+          "legendFormat": "lag",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "stat",
+      "title": "Produce rate",
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 6
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "rate(ironbus_produced_total): messages appended per second (the throughput baseline).",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(ironbus_produced_total{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval])",
+          "legendFormat": "msg/s",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "type": "stat",
+      "title": "Ack rate",
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 6
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "rate(ironbus_acks_total): commits per second.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(ironbus_acks_total{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval])",
+          "legendFormat": "ack/s",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "type": "stat",
+      "title": "Uptime",
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 6
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "ironbus_uptime_seconds: seconds since the broker started (monotonic-derived; a sudden drop means a restart).",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ironbus_uptime_seconds{job=~\"$job\",instance=~\"$instance\"}",
+          "legendFormat": "uptime",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "row",
+      "title": "Throughput",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 11
+      }
+    },
+    {
+      "id": 11,
+      "type": "timeseries",
+      "title": "Message rates (produce / deliver / ack / redeliver)",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "The core flow rates. Redelivered rising while acked is flat means consumers are not acking inside the lease (at-least-once retries, not loss).",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(ironbus_produced_total{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval])",
+          "legendFormat": "produced"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(ironbus_delivered_total{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval])",
+          "legendFormat": "delivered"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(ironbus_acks_total{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval])",
+          "legendFormat": "acked"
+        },
+        {
+          "refId": "D",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(ironbus_redelivered_total{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval])",
+          "legendFormat": "redelivered"
+        }
+      ]
+    },
+    {
+      "id": 12,
+      "type": "timeseries",
+      "title": "Byte throughput (produced)",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "rate(ironbus_produced_bytes_total): logical (key+headers+payload) bytes appended per second.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(ironbus_produced_bytes_total{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval])",
+          "legendFormat": "produced bytes/s"
+        }
+      ]
+    },
+    {
+      "id": 13,
+      "type": "timeseries",
+      "title": "Dedup (idempotency window)",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 20
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "rate(ironbus_dedup_hits_total) is idempotent retries absorbed (benign). rate(ironbus_dedup_out_of_window_total) rising means the dedup window is too small for the retry interval -- size --dedup-max-ids / --dedup-window-ms. Zero unless opt-in dedup is used.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(ironbus_dedup_hits_total{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval])",
+          "legendFormat": "dedup hits/s (benign)"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(ironbus_dedup_out_of_window_total{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval])",
+          "legendFormat": "out-of-window/s"
+        }
+      ]
+    },
+    {
+      "id": 14,
+      "type": "row",
+      "title": "Durability-barrier latency (the headline performance signal)",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 28
+      }
+    },
+    {
+      "id": 15,
+      "type": "timeseries",
+      "title": "fsync latency (produce durability barrier)",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 29
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "histogram_quantile over ironbus_fsync_duration_seconds_bucket: the produce-time fdatasync latency. The dashed line is the 6 ms p99 SLO (docs/SLO.md).",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "green"
+              },
+              {
+                "value": 0.006,
+                "color": "red"
+              }
+            ]
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "spanNulls": true,
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(ironbus_fsync_duration_seconds_bucket{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "p50"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(ironbus_fsync_duration_seconds_bucket{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "p99"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.999, sum by (le) (rate(ironbus_fsync_duration_seconds_bucket{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "p99.9"
+        }
+      ]
+    },
+    {
+      "id": 16,
+      "type": "timeseries",
+      "title": "Append latency (append + fsync)",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 29
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "histogram_quantile over ironbus_append_duration_seconds_bucket: the whole durable-append (append + fsync) latency.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "green"
+              },
+              {
+                "value": 0.006,
+                "color": "red"
+              }
+            ]
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "spanNulls": true,
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(ironbus_append_duration_seconds_bucket{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "p50"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(ironbus_append_duration_seconds_bucket{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "p99"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.999, sum by (le) (rate(ironbus_append_duration_seconds_bucket{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "p99.9"
+        }
+      ]
+    },
+    {
+      "id": 17,
+      "type": "heatmap",
+      "title": "fsync latency distribution (heatmap)",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 37
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "The full fdatasync latency distribution over the fixed registry buckets. A widening high band is rising tail-latency / device pressure.",
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "color": {
+          "scheme": "Spectral",
+          "mode": "scheme"
+        },
+        "yAxis": {
+          "unit": "s",
+          "axisPlacement": "left"
+        },
+        "tooltip": {
+          "show": true,
+          "yHistogram": true
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            }
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (le) (rate(ironbus_fsync_duration_seconds_bucket{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval]))",
+          "format": "heatmap",
+          "legendFormat": "{{le}}"
+        }
+      ]
+    },
+    {
+      "id": 18,
+      "type": "row",
+      "title": "Consumer lag & delivery",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 45
+      }
+    },
+    {
+      "id": 19,
+      "type": "timeseries",
+      "title": "Consumer lag (default + per work-group)",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 46
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "ironbus_consumer_lag and ironbus_group_consumer_lag{group}: flushed head minus committed cursor. Rising = consumers falling behind.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ironbus_consumer_lag{job=~\"$job\",instance=~\"$instance\"}",
+          "legendFormat": "default"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ironbus_group_consumer_lag{job=~\"$job\",instance=~\"$instance\"}",
+          "legendFormat": "{{group}}"
+        }
+      ]
+    },
+    {
+      "id": 20,
+      "type": "timeseries",
+      "title": "In-flight (leased, not yet acked)",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 46
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "ironbus_in_flight / ironbus_group_in_flight: messages leased to consumers but not yet acked. Pinned at max_in_flight means the consumer is the bottleneck.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ironbus_in_flight{job=~\"$job\",instance=~\"$instance\"}",
+          "legendFormat": "default"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ironbus_group_in_flight{job=~\"$job\",instance=~\"$instance\"}",
+          "legendFormat": "{{group}}"
+        }
+      ]
+    },
+    {
+      "id": 21,
+      "type": "timeseries",
+      "title": "Top 10 per-consumer lag",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 54
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "topk(10, ironbus_consumer_lag_records{consumer}): the laggiest consumers. {consumer=\"__overflow__\"} is the folded lag of all over-cap consumers past the 1024-series cap.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "topk(10, ironbus_consumer_lag_records{job=~\"$job\",instance=~\"$instance\"})",
+          "legendFormat": "{{consumer}}"
+        }
+      ]
+    },
+    {
+      "id": 22,
+      "type": "timeseries",
+      "title": "Redelivery & dead-letter rate",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 54
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "rate(ironbus_redelivered_total) is at-least-once retry pressure; rate(ironbus_dead_lettered_total) is poison messages exceeding MaxDeliver routed to the DLQ.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(ironbus_redelivered_total{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval])",
+          "legendFormat": "redelivered/s"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(ironbus_dead_lettered_total{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval])",
+          "legendFormat": "dead-lettered/s"
+        }
+      ]
+    },
+    {
+      "id": 23,
+      "type": "timeseries",
+      "title": "DLQ records (cumulative, survives restart)",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 62
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "ironbus_dlq_records_total: records durably written to the dead-letter sink. The durable complement of dead_lettered.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ironbus_dlq_records_total{job=~\"$job\",instance=~\"$instance\"}",
+          "legendFormat": "dlq records"
+        }
+      ]
+    },
+    {
+      "id": 24,
+      "type": "timeseries",
+      "title": "Consumer cardinality (1024-series cap)",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 62
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "ironbus_consumer_labels_dropped_total: distinct consumers past the 1024-series cap, folded into {consumer=\"__overflow__\"}. ironbus_consumer_overflow_saturated == 1 means that fold is now a lower bound (very high consumer cardinality).",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ironbus_consumer_overflow_saturated{job=~\"$job\",instance=~\"$instance\"}",
+          "legendFormat": "overflow saturated (0/1)"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "increase(ironbus_consumer_labels_dropped_total{job=~\"$job\",instance=~\"$instance\"}[1h])",
+          "legendFormat": "labels dropped (1h)"
+        }
+      ]
+    },
+    {
+      "id": 25,
+      "type": "row",
+      "title": "Backpressure & shedding (the resilience taxonomy -- every shed is counted)",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 70
+      }
+    },
+    {
+      "id": 26,
+      "type": "timeseries",
+      "title": "Shed rates (by reason)",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 71
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Every backpressure shed counter, as a rate. All zero unless the matching knob is enabled. A rising series names exactly which control is shedding.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 25,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(ironbus_produce_rejected_total{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval])",
+          "legendFormat": "disk-full drop-new"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(ironbus_codel_shed_total{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval])",
+          "legendFormat": "codel (latency)"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(ironbus_codel_backstop_shed_total{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval])",
+          "legendFormat": "codel backstop"
+        },
+        {
+          "refId": "D",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(ironbus_fire_and_forget_shed_total{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval])",
+          "legendFormat": "fire-and-forget (QoS-0)"
+        },
+        {
+          "refId": "E",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(ironbus_egress_shed_total{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval])",
+          "legendFormat": "egress AIMD"
+        },
+        {
+          "refId": "F",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(ironbus_wal_fsync_headroom_shed_total{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval])",
+          "legendFormat": "wal fsync headroom"
+        },
+        {
+          "refId": "G",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(ironbus_daily_write_budget_sheds_total{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval])",
+          "legendFormat": "daily write budget"
+        },
+        {
+          "refId": "H",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(ironbus_retry_shed_total{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval])",
+          "legendFormat": "retry budget ({{side}})"
+        }
+      ]
+    },
+    {
+      "id": 27,
+      "type": "timeseries",
+      "title": "Backpressure controllers (live state)",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 71
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "ironbus_codel_sojourn_estimate_ms (latency the CoDel law acts on), ironbus_egress_limit (AIMD concurrency, halves on a degrading sink), ironbus_retry_ratio/1e6 (shed fraction vs the budget).",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ironbus_codel_sojourn_estimate_ms{job=~\"$job\",instance=~\"$instance\"}",
+          "legendFormat": "codel sojourn (ms)"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ironbus_egress_limit{job=~\"$job\",instance=~\"$instance\"}",
+          "legendFormat": "egress limit (4-128)"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ironbus_retry_ratio{job=~\"$job\",instance=~\"$instance\"} / 1e6",
+          "legendFormat": "retry ratio (fraction)"
+        }
+      ]
+    },
+    {
+      "id": 28,
+      "type": "row",
+      "title": "Data loss & integrity (these should stay FLAT ZERO -- any movement is an incident)",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 79
+      }
+    },
+    {
+      "id": 29,
+      "type": "timeseries",
+      "title": "Force-reap & consumer truncation rate",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 80
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "ironbus_segments_force_reaped_total (drop-oldest deleting maybe-unconsumed data) and ironbus_truncations_total (a live consumer losing a span). Non-zero = real data loss.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(ironbus_segments_force_reaped_total{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval])",
+          "legendFormat": "force-reaped segments/s"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(ironbus_truncations_total{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval])",
+          "legendFormat": "consumer truncations/s"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(ironbus_truncated_records_total{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval])",
+          "legendFormat": "truncated records/s"
+        }
+      ]
+    },
+    {
+      "id": 30,
+      "type": "timeseries",
+      "title": "Last-recovery loss (bytes)",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 80
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "ironbus_recovery_data_loss_bytes is the headline bytes-lost at the last recovery (torn tails excluded). ironbus_bytes_skipped is the reconciled recovery-loss byte total; ironbus_quarantine_bytes is the forensic corrupt-copy footprint on disk.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ironbus_recovery_data_loss_bytes{job=~\"$job\",instance=~\"$instance\"}",
+          "legendFormat": "data-loss bytes"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ironbus_recovery_truncated_bytes{job=~\"$job\",instance=~\"$instance\"}",
+          "legendFormat": "truncated bytes (incl torn tail)"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ironbus_bytes_skipped{job=~\"$job\",instance=~\"$instance\"}",
+          "legendFormat": "bytes skipped (recovery-loss total)"
+        },
+        {
+          "refId": "D",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ironbus_quarantine_bytes{job=~\"$job\",instance=~\"$instance\"}",
+          "legendFormat": "quarantine bytes"
+        }
+      ]
+    },
+    {
+      "id": 31,
+      "type": "timeseries",
+      "title": "Last-recovery loss by reason",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 88
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "ironbus_recovery_loss_records{reason} and ironbus_recovery_loss_bytes{reason}: records and bytes dropped at the last recovery, by ReasonCode (torn_tail, corrupt_record_*, sequence_gap, scrubber_suspect, unresolved_dict_id) -- the cause AND magnitude of an incident.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ironbus_recovery_loss_records{job=~\"$job\",instance=~\"$instance\"}",
+          "legendFormat": "records: {{reason}}"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ironbus_recovery_loss_bytes{job=~\"$job\",instance=~\"$instance\"}",
+          "legendFormat": "bytes: {{reason}}"
+        }
+      ]
+    },
+    {
+      "id": 32,
+      "type": "timeseries",
+      "title": "Skips & checkpoint-repair",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 88
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "ironbus_records_skipped is the reconciled recovery-loss record total. A non-zero ironbus_counter_checkpoint_repair_total means a hard crash (kill -9) occurred and reconciliation restored the lower bound.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ironbus_records_skipped{job=~\"$job\",instance=~\"$instance\"}",
+          "legendFormat": "records skipped (recovery-loss total)"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "increase(ironbus_counter_checkpoint_repair_total{job=~\"$job\",instance=~\"$instance\"}[1h])",
+          "legendFormat": "ckpt repairs (1h)"
+        }
+      ]
+    },
+    {
+      "id": 33,
+      "type": "timeseries",
+      "title": "Loss-locator offsets (where in the log)",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 96
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "ironbus_last_skip_offset (highest log offset any skip/loss reached, cross-restart monotonic) and ironbus_last_dead_lettered_offset (-1 = none): when a loss/dead-letter alert fires, these say WHERE in the log to look.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ironbus_last_skip_offset{job=~\"$job\",instance=~\"$instance\"}",
+          "legendFormat": "last skip offset (high-water)"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ironbus_last_dead_lettered_offset{job=~\"$job\",instance=~\"$instance\"}",
+          "legendFormat": "last dead-letter offset (-1=none)"
+        }
+      ]
+    },
+    {
+      "id": 34,
+      "type": "row",
+      "title": "Durability posture & edge resources (flash / RAM)",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 104
+      }
+    },
+    {
+      "id": 35,
+      "type": "stat",
+      "title": "Active durability level",
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 0,
+        "y": 105
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "ironbus_durability_level_info{level=sync|interval|async|none}: the active level (value 1). `sync` is the power-loss-safe default.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "textMode": "name",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ironbus_durability_level_info{job=~\"$job\",instance=~\"$instance\"}",
+          "legendFormat": "{{level}}",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 36,
+      "type": "timeseries",
+      "title": "Un-fsynced bytes at risk",
+      "gridPos": {
+        "h": 8,
+        "w": 16,
+        "x": 8,
+        "y": 105
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "ironbus_durability_unsynced_bytes: acked-but-not-yet-fdatasync'd bytes at risk on a power cut. Always 0 under `sync`; the live loss window under a relaxed level.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ironbus_durability_unsynced_bytes{job=~\"$job\",instance=~\"$instance\"}",
+          "legendFormat": "unsynced bytes"
+        }
+      ]
+    },
+    {
+      "id": 37,
+      "type": "timeseries",
+      "title": "Flash write amplification",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 113
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "ironbus_write_amp_ratio = physical / STORED (post-compression) bytes. The dashed line is the ~20x LIVE bound (docs/EDGE_CONSTRAINTS.md L217: derived 20x, observed ~7x healthy) -- NOT the 4x figure, which is the `--compression none` raw-bytes CI gate. Under the default lz4 codec the ratio inflates for small compressible payloads even as real flash wear falls, so 4x is normal here; correlate with rate(ironbus_physical_bytes_written).",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 3,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "green"
+              },
+              {
+                "value": 20,
+                "color": "red"
+              }
+            ]
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "spanNulls": true,
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ironbus_write_amp_ratio{job=~\"$job\",instance=~\"$instance\"}",
+          "legendFormat": "physical/logical"
+        }
+      ]
+    },
+    {
+      "id": 38,
+      "type": "timeseries",
+      "title": "Flash bytes written (physical vs logical)",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 113
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "rate of ironbus_physical_bytes_written (real flash-wear volume: frames + segment headers/footers) vs ironbus_logical_bytes_written (stored, post-compression).",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(ironbus_physical_bytes_written{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval])",
+          "legendFormat": "physical B/s (flash wear)"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(ironbus_logical_bytes_written{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval])",
+          "legendFormat": "logical B/s (stored)"
+        }
+      ]
+    },
+    {
+      "id": 39,
+      "type": "timeseries",
+      "title": "Daily physical write budget",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 121
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "The opt-in flash-wear governor: ironbus_physical_bytes_written_today vs ironbus_daily_physical_write_budget_bytes (resets at the UTC day boundary). At the budget, produces shed.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ironbus_physical_bytes_written_today{job=~\"$job\",instance=~\"$instance\"}",
+          "legendFormat": "written today"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ironbus_daily_physical_write_budget_bytes{job=~\"$job\",instance=~\"$instance\"}",
+          "legendFormat": "budget (0 = off)"
+        }
+      ]
+    },
+    {
+      "id": 40,
+      "type": "timeseries",
+      "title": "RAM headroom (against the ceiling)",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 121
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "ironbus_ram_headroom_bytes = ram_ceiling_bytes - RSS. The -1 unavailable sentinel (no ceiling set, or RSS unreadable) is filtered out; falling toward 0 means the OOM cliff is near.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ironbus_ram_headroom_bytes{job=~\"$job\",instance=~\"$instance\"} != -1",
+          "legendFormat": "ram headroom"
+        }
+      ]
+    },
+    {
+      "id": 41,
+      "type": "row",
+      "title": "Retention & offsets",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 129
+      }
+    },
+    {
+      "id": 42,
+      "type": "timeseries",
+      "title": "Segment reclaim rate",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 130
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "ironbus_segments_reaped_total is healthy consumer-safe reclaim; ironbus_segments_force_reaped_total is the drop-oldest lossy reclaim (should be zero).",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(ironbus_segments_reaped_total{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval])",
+          "legendFormat": "reaped (loss-free)/s"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(ironbus_segments_force_reaped_total{job=~\"$job\",instance=~\"$instance\"}[$__rate_interval])",
+          "legendFormat": "force-reaped (lossy!)/s"
+        }
+      ]
+    },
+    {
+      "id": 43,
+      "type": "timeseries",
+      "title": "Log offsets (head vs committed)",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 130
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "ironbus_flushed_offset (durable log head) and ironbus_committed_offset (default-group cursor). The gap is the lag; both should climb together.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ironbus_flushed_offset{job=~\"$job\",instance=~\"$instance\"}",
+          "legendFormat": "flushed (durable head)"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "ironbus_committed_offset{job=~\"$job\",instance=~\"$instance\"}",
+          "legendFormat": "committed (default cursor)"
+        }
+      ]
+    }
+  ]
+}

--- a/packaging/grafana/prometheus-scrape-example.yml
+++ b/packaging/grafana/prometheus-scrape-example.yml
@@ -1,0 +1,41 @@
+# Example Prometheus config snippet for scraping IronBus.
+#
+# IronBus exposes Prometheus text exposition on GET /metrics at the broker's
+# --health-addr (off by default; set it, e.g. `serve --health-addr 127.0.0.1:9090`).
+# The endpoint is UNAUTHENTICATED and serve REFUSES a non-loopback --health-addr
+# unless --health-allow-public is passed (see docs/METRICS.md, docs/THREAT_MODEL.md),
+# so scrape it over loopback or a trusted network only.
+#
+# The metric/label names are a stability contract (frozen by CI), so this scrape
+# config and the dashboard/alerts keep working across broker upgrades.
+
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+rule_files:
+  - ironbus-alerts.yml
+
+scrape_configs:
+  - job_name: ironbus            # keep the job name prefixed "ironbus" so IronbusDown matches
+    metrics_path: /metrics
+    scrape_interval: 15s
+    static_configs:
+      # The broker's --health-addr (NOT Prometheus's own 9090). One target per broker.
+      - targets:
+          - "127.0.0.1:9090"
+        labels:
+          service: ironbus
+
+    # Optional: also blackbox the liveness/readiness probes via relabeling or the
+    # blackbox_exporter. /healthz is liveness (accept-loop watchdog), /readyz is
+    # readiness (200 once the writer accepts writes; 503 while frozen or shutting
+    # down). They are plain HTTP 200/503, not metrics.
+
+# For a fleet, prefer service discovery over static_configs, e.g.:
+#   - job_name: ironbus
+#     file_sd_configs:
+#       - files: ['/etc/prometheus/ironbus_targets/*.yml']
+# so each target carries its own `instance` (and optional `region`/`site`) labels,
+# which the dashboard's $instance variable and the alerts' {{ $labels.instance }}
+# then key off.


### PR DESCRIPTION
Adds everything needed to watch a running IronBus broker in Grafana, grounded in the CI-frozen `/metrics` catalog ([docs/METRICS.md](docs/METRICS.md)).

## What's here (`packaging/grafana/`)
- **`ironbus-dashboard.json`** -- importable Grafana dashboard, **8 rows / 35 panels**: golden signals, throughput, fsync/append latency (with the 6 ms SLO line), consumer lag & delivery, backpressure & shedding, **data-loss & integrity (flat-zero panels)**, durability + flash/RAM, retention/offsets. Prometheus datasource templating + `job`/`instance` variables (single broker or fleet).
- **`dashboard_gen.py`** -- generates the JSON from a curated panel spec (regenerate, don't hand-edit).
- **`check_grounded.py`** -- local guard: every metric the dashboard references is one the broker emits (greps the server source). Run before committing a regen.
- **`ironbus-alerts.yml`** -- 5 critical / 11 warning / 4 info Prometheus rules. Criticals: down, writer frozen, force-reap data loss, consumer truncation, recovery data loss.
- **`prometheus-scrape-example.yml`** -- scrape + `rule_files` config.
- **`docs/MONITORING.md`** -- operator guide (setup, row-by-row "what to watch", alert catalog, the no-silent-loss panels), linked from `docs/USAGE.md`.

## Grounded thresholds
- fsync p99 **6 ms** = the SLO ([SLO.md](docs/SLO.md)).
- write-amp alert fires at **~20x**, the live lz4 bound -- **not 4x**, which is the `--compression none` CI gate (lz4 deflates the live ratio, so 4x is normal). See below.
- lag / RAM / unsynced-bytes thresholds are `TUNE`-marked (deployment-specific).

## Verified before publishing
A 4-lens adversarial review (PromQL type-correctness, alert-threshold safety on a zero-config broker, completeness vs the catalog, Grafana JSON validity) returned **ship-after-fixes**. PromQL, Grafana validity, and zero-config false-positive safety were clean. Its **one real defect** -- the write-amp alert reused the 4x bench gate as a live threshold (a false positive under lz4; docs cite a healthy ~7x and a ~20x bound) -- is fixed to the ~20x live bound, and the optional completeness gaps it found (loss-locator offsets, recovery-loss bytes by reason, dedup, consumer cardinality) are now panels.

## Validation
JSON parses with unique panel ids; every one of the 59 referenced `ironbus_*` tokens resolves in the emitted catalog (`check_grounded.py`); both YAML files parse. (No `promtool` in this env; validate rules with `promtool check rules` where available.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)