### PR TITLE
perf(produce): sane group-commit default to batch fsyncs (#472)

### DIFF
--- a/crates/ironbus-cli/src/bench_run.rs
+++ b/crates/ironbus-cli/src/bench_run.rs
@@ -17,7 +17,7 @@ use crate::{open_disk_engine, open_memory_engine, CliError, ServeConfig, Storage
 use ironbus_client::{Client, ClientConfig, ClientError};
 use ironbus_core::clock::Clock; // the monotonic seam the serve loop's liveness beacon (#95) reads
 use ironbus_proto::message::PubBody;
-use ironbus_server::actor::{spawn_actor, DEFAULT_CHANNEL_BOUND};
+use ironbus_server::actor::{spawn_actor_with_gather, DEFAULT_CHANNEL_BOUND};
 use ironbus_server::server::serve;
 use ironbus_storage::fs::{Filesystem, InMemoryFs, StdFs};
 use std::net::TcpListener;
@@ -210,7 +210,12 @@ impl<F: Filesystem + 'static> IsolatedBroker<F> {
         engine: ironbus_server::engine::Engine<F, ironbus_server::clock::SystemClock>,
         config: &ServeConfig,
     ) -> Result<IsolatedBroker<F>, CliError> {
-        let (handle, actor) = spawn_actor(engine, DEFAULT_CHANNEL_BOUND);
+        // Honor the resolved group-commit gather (#454, #472), so the bench broker reflects the
+        // SAME default as the real `serve` path (`run_broker` wires `config.commit_gather_us` the
+        // same way). Without this the bench would always run the gather-off actor and never measure
+        // the shipped default's effect on a concurrent publisher.
+        let (handle, actor) =
+            spawn_actor_with_gather(engine, DEFAULT_CHANNEL_BOUND, config.commit_gather_us);
         let listener = TcpListener::bind("127.0.0.1:0")
             .map_err(|e| CliError::Internal(format!("bench: cannot bind a loopback port: {e}")))?;
         let addr = listener

--- a/crates/ironbus-cli/src/main.rs
+++ b/crates/ironbus-cli/src/main.rs
@@ -255,6 +255,31 @@ const DEFAULT_FLUSH_INTERVAL_MS: u64 = 1_000;
 /// is the smaller of the time and byte triggers.
 const DEFAULT_FLUSH_MAX_BYTES: u64 = 1024 * 1024;
 
+/// The default `--commit-gather-us`: the bounded group-commit GATHER window (#454, #472) in
+/// MICROSECONDS the append actor keeps collecting commands once a drain pass already holds TWO OR
+/// MORE produces (evidence of a pipelining / concurrent publisher), so that publisher's whole
+/// in-flight set lands under ONE covering `fdatasync` instead of self-sizing slivers (the default
+/// drain only sees what arrived during the PREVIOUS batch's fsync, so a concurrent producer was
+/// committing only a few records per fsync — the bulk of the ~186x durable-produce gap, #472).
+///
+/// The default is `200` (microseconds), NOT `0`, so out-of-the-box durable produce batches fsyncs.
+/// It is deliberately CONSERVATIVE and cannot weaken durability or change the synchronous `produce`
+/// contract:
+/// - I2 (ack-implies-durable) is untouched: an ack is still released only AFTER the covering
+///   `commit_batch` `fdatasync` (the gather only changes which commands share that one fsync, never
+///   the order of ack-vs-fsync).
+/// - A SINGLE in-flight producer (send, await each ack) NEVER engages the gather: a drain pass
+///   holding fewer than two produces returns immediately, so the unpipelined `produce` path keeps
+///   its exact historical ack latency and its one-fsync-per-message accounting.
+/// - It is far smaller than one edge-device `fdatasync` (hundreds of microseconds to low
+///   milliseconds), so the window closes well before a lone fsync would have completed; it adds at
+///   most ~200 us of commit latency to a BURST of concurrent produces in exchange for collapsing
+///   their many fsyncs into one. This mirrors the `MySQL` `binlog_group_commit_sync_delay` /
+///   `PostgreSQL` `commit_delay` precedent (tens to a few hundred microseconds). An operator may set
+///   `0` to restore the byte-identical historical actor, or raise it (bounded to 1 s) for fewer,
+///   larger barriers.
+const DEFAULT_COMMIT_GATHER_US: u64 = 200;
+
 /// The default CoDel TARGET (ms) for `serve` (#68), aliased to the engine's default so the CLI and
 /// engine stay one source of truth. `0` = DISABLED (CoDel off, the default), so a zero-config broker
 /// is unchanged; an operator opts in by setting a non-zero target.
@@ -2295,8 +2320,17 @@ fn parse_serve_flags_with_env_and_reader(
                 env,
                 DEFAULT_FLUSH_MAX_BYTES,
             )?,
-            // The group-commit gather (#454): default 0 = off, the byte-identical historical actor.
-            commit_gather_us: resolve_number("--commit-gather-us", f.commit_gather_us, env, 0)?,
+            // The group-commit gather (#454, #472): default [`DEFAULT_COMMIT_GATHER_US`] (a small,
+            // conservative window) so out-of-the-box durable produce batches fsyncs under a
+            // concurrent publisher. `0` restores the byte-identical historical actor; a single
+            // in-flight producer never engages the window (it only triggers on a pass holding >= 2
+            // produces), so the synchronous `produce` contract and I2 are unchanged.
+            commit_gather_us: resolve_number(
+                "--commit-gather-us",
+                f.commit_gather_us,
+                env,
+                DEFAULT_COMMIT_GATHER_US,
+            )?,
             async_loss_ack: resolve_bool("--async-loss-ack", f.async_loss_ack, env)?,
             // The storage backend (#443), resolved above (flag > env > default `disk`); the
             // ephemeral consent resolves like the other bare safety flags. `memory` without the
@@ -3060,15 +3094,17 @@ struct ServeConfig {
     /// (`DEFAULT_FLUSH_MAX_BYTES`); `0` disables the byte trigger (the time window alone forces the
     /// sync). The EFFECTIVE worst-case loss bound is the smaller of the time and byte triggers.
     flush_max_bytes: u64,
-    /// The opt-in GROUP-COMMIT GATHER window in MICROSECONDS (#454): when a drain pass already
-    /// holds at least TWO produces (evidence of a pipelining publisher; a single-produce pass
-    /// never gathers, so an unpipelined producer pays no window), the append actor keeps
-    /// collecting commands for up to this long before committing, so the publisher's whole
-    /// in-flight window lands under ONE covering fsync instead of arrival-rate-sized slivers. `0` (the default) disables the gather and the
-    /// actor is byte-identical to the historical drain. Durability is UNTOUCHED: acks still mean
-    /// fsynced-durable; the knob trades up to this much added commit latency under produce bursts
-    /// for fewer, larger sync barriers (the `MySQL` `binlog_group_commit_sync_delay` precedent).
-    /// Bounded at 1 second by validation so a typo cannot stall acks indefinitely.
+    /// The GROUP-COMMIT GATHER window in MICROSECONDS (#454, #472): when a drain pass already
+    /// holds at least TWO produces (evidence of a pipelining / concurrent publisher; a
+    /// single-produce pass never gathers, so an unpipelined producer pays no window), the append
+    /// actor keeps collecting commands for up to this long before committing, so the publisher's
+    /// whole in-flight window lands under ONE covering fsync instead of arrival-rate-sized slivers.
+    /// Defaults to [`DEFAULT_COMMIT_GATHER_US`] (a small, conservative window, #472) so out-of-the-
+    /// box durable produce batches fsyncs; `0` disables the gather and the actor is byte-identical
+    /// to the historical drain. Durability is UNTOUCHED: acks still mean fsynced-durable (I2); the
+    /// knob trades up to this much added commit latency under produce bursts for fewer, larger sync
+    /// barriers (the `MySQL` `binlog_group_commit_sync_delay` precedent). Bounded at 1 second by
+    /// validation so a typo cannot stall acks indefinitely.
     commit_gather_us: u64,
     /// The explicit DATA-LOSS ACKNOWLEDGEMENT for the unbounded-loss levels (#49, #379): the
     /// `--async-loss-ack` (a.k.a. `i-accept-acknowledged-data-loss`) bare flag. `async` and `none`
@@ -3182,7 +3218,9 @@ impl ServeConfig {
             compression: CompressionArg::Lz4,
             flush_interval_ms: DEFAULT_FLUSH_INTERVAL_MS,
             flush_max_bytes: DEFAULT_FLUSH_MAX_BYTES,
-            commit_gather_us: 0,
+            // The shipped default group-commit gather (#454, #472): the bench broker must match the
+            // `serve` default so its measured durable produce reflects what operators actually run.
+            commit_gather_us: DEFAULT_COMMIT_GATHER_US,
             async_loss_ack: false,
             // The default storage backend (#443): the durable on-disk store, no ephemeral consent.
             storage: StorageArg::Disk,
@@ -9208,14 +9246,27 @@ mod tests {
     }
 
     #[test]
-    fn the_commit_gather_flag_parses_defaults_off_echoes_and_caps_at_one_second() {
-        // The group-commit gather knob (#454). Default OFF: an untouched serve resolves to 0 and
-        // the actor stays byte-identical. The flag parses WITHOUT swallowing the next flag (the
+    fn the_commit_gather_flag_resolves_the_default_window_echoes_and_caps_at_one_second() {
+        // The group-commit gather knob (#454, #472). DEFAULT: an untouched serve resolves to the
+        // shipped small conservative window (`DEFAULT_COMMIT_GATHER_US`), so out-of-the-box durable
+        // produce batches fsyncs under a concurrent publisher. An EXPLICIT `0` still restores the
+        // byte-identical historical actor. The flag parses WITHOUT swallowing the next flag (the
         // `--pubwindow` parse-cursor regression class), the materialized-config line echoes the
         // resolved value, and validation refuses a window past one second (an ms-pasted-as-us typo
         // must not become a silent multi-second ack stall).
-        let off = parse_serve_flags(&serve_args(&[])).unwrap().config;
-        assert_eq!(off.commit_gather_us, 0, "gather defaults off");
+        let defaulted = parse_serve_flags(&serve_args(&[])).unwrap().config;
+        assert_eq!(
+            defaulted.commit_gather_us, DEFAULT_COMMIT_GATHER_US,
+            "gather resolves the shipped default window when unset"
+        );
+        // An operator can still opt fully OUT, restoring the historical gather-off actor.
+        let disabled = parse_serve_flags(&serve_args(&["--commit-gather-us", "0"]))
+            .unwrap()
+            .config;
+        assert_eq!(
+            disabled.commit_gather_us, 0,
+            "an explicit 0 disables the gather (historical byte-identical actor)"
+        );
         let on = parse_serve_flags(&serve_args(&[
             "--commit-gather-us",
             "3000",

--- a/crates/ironbus-server/src/actor.rs
+++ b/crates/ironbus-server/src/actor.rs
@@ -648,9 +648,11 @@ where
     spawn_actor_with_gather(engine, channel_bound, 0)
 }
 
-/// Like [`spawn_actor`] with an opt-in bounded GROUP-COMMIT GATHER (#454). With `gather_micros`
-/// of 0 (the default everywhere except an operator's explicit `--commit-gather-us`) the actor is
-/// byte-identical to the historical drain. With a window set, a drain pass that already holds at
+/// Like [`spawn_actor`] with a bounded GROUP-COMMIT GATHER (#454, #472). With `gather_micros`
+/// of 0 the actor is byte-identical to the historical drain (this is what [`spawn_actor`] passes,
+/// and what an operator gets from `--commit-gather-us 0`; the shipped CLI default is a small
+/// non-zero window so out-of-the-box durable produce batches fsyncs, #472). With a window set, a
+/// drain pass that already holds at
 /// least TWO produces (evidence of a pipelining publisher; a single-produce pass never gathers,
 /// so an unpipelined producer pays no window) keeps collecting commands for up to the window
 /// before committing, so a pipelined publisher's whole in-flight window lands under ONE covering
@@ -1463,6 +1465,65 @@ mod tests {
             started.elapsed()
         );
         assert_eq!(control.sync_count() - before, 1, "one produce, one fsync");
+        drop(handle);
+        actor.join().unwrap();
+    }
+
+    #[test]
+    fn a_gather_enabled_concurrent_batch_acks_only_after_one_covering_fsync() {
+        // The SHIPPED-DEFAULT guarantee (#472): turning the gather ON (the CLI now defaults to a
+        // small non-zero window) must NOT weaken I2 (ack-implies-durable) or split a concurrent
+        // batch across fsyncs. The sync gate makes it deterministic and clock-independent (no
+        // dependence on the real window length, so it is not racy): close the gate so the actor
+        // parks on the FIRST covering fsync, queue several more produces behind it, then assert (a)
+        // no ack has been released while the fsync is still parked (I2: an ack never precedes its
+        // covering fsync), and (b) once the gate opens the whole queued batch is covered by exactly
+        // ONE additional fsync. Run with a non-trivial gather window to exercise the on path.
+        let (fs, control) = FaultFs::new(InMemoryFs::new());
+        let engine = Engine::open(fs, ManualClock::new(), config()).unwrap();
+        let (handle, actor) = spawn_actor_with_gather(engine, DEFAULT_CHANNEL_BOUND, 50_000);
+        control.close_sync_gate();
+        // The primer parks the actor inside its covering fsync (the gate holds it there).
+        let primer = handle.produce_async(append(b"primer")).unwrap();
+        control.wait_for_sync_gate_entered(1);
+        // Queue a concurrent batch behind the parked fsync; these all land in ONE drain pass (>= 2
+        // produces, so the gather engages) and must share a single covering fsync.
+        let queued: Vec<_> = (0..4)
+            .map(|i| {
+                handle
+                    .produce_async(append(format!("queued-{i}").as_bytes()))
+                    .unwrap()
+            })
+            .collect();
+        let before = control.sync_count();
+        // I2 PROOF: while the covering fsync is still parked, NOT ONE reply may have been released.
+        for reply in &queued {
+            assert!(
+                matches!(reply.try_recv(), Err(std::sync::mpsc::TryRecvError::Empty)),
+                "a queued produce was acked BEFORE its covering fsync returned (I2 violated)"
+            );
+        }
+        control.open_sync_gate();
+        // The primer acks at offset 0; the gate is open so its parked fsync now returns.
+        match primer.recv().unwrap() {
+            ProduceOutcome::Appended(o) => assert_eq!(o.get(), 0),
+            other => panic!("expected Appended primer, got {other:?}"),
+        }
+        let mut offsets = Vec::new();
+        for reply in queued {
+            match reply.recv().unwrap() {
+                ProduceOutcome::Appended(o) => offsets.push(o.get()),
+                other => panic!("expected Appended, got {other:?}"),
+            }
+        }
+        assert_eq!(offsets, vec![1, 2, 3, 4], "all four appended in send order");
+        // ONE-FSYNC PROOF: the four queued produces are covered by exactly ONE fsync (the gather
+        // collapses the concurrent batch), not one per produce.
+        assert_eq!(
+            control.sync_count() - before,
+            1,
+            "the concurrent batch of four is covered by exactly ONE fsync"
+        );
         drop(handle);
         actor.join().unwrap();
     }

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -242,7 +242,7 @@ field and flag are the #4/#87 implementation residual.
 | `durability_level` | `--durability-level` / `IRONBUS_DURABILITY_LEVEL` | enum | `sync` (`DEFAULT_DURABILITY_LEVEL`) | -- | `sync \| interval \| async \| none` | COLD (coupled with the flush knobs and `async_loss_ack`) |
 | `flush_interval_ms` | `--flush-interval-ms` / `IRONBUS_FLUSH_INTERVAL_MS` | u64 | `1000` (`DEFAULT_FLUSH_INTERVAL_MS`) | ms | `>= 0` (`0` disables the time trigger) | COLD (coupled with `durability_level`) |
 | `flush_max_bytes` | `--flush-max-bytes` / `IRONBUS_FLUSH_MAX_BYTES` | size | `1048576` (1 MiB, `DEFAULT_FLUSH_MAX_BYTES`) | bytes | `>= 0` (`0` disables the byte trigger) | COLD (coupled with `durability_level`) |
-| (no file key: flag/env ONLY) | `--commit-gather-us` / `IRONBUS_COMMIT_GATHER_US` | u64 | `0` (off) | us | `0..=1000000` (`0` disables the gather) | COLD (an actor-spawn decision) (#454) |
+| (no file key: flag/env ONLY) | `--commit-gather-us` / `IRONBUS_COMMIT_GATHER_US` | u64 | `200` (`DEFAULT_COMMIT_GATHER_US`) | us | `0..=1000000` (`0` disables the gather) | COLD (an actor-spawn decision) (#454, #472) |
 | `async_loss_ack` | `--async-loss-ack` / `IRONBUS_ASYNC_LOSS_ACK` | bool | `false` | -- | `true` to enable `async` / `none` | COLD (coupled with `durability_level`) |
 
 The durability `durability_level` enum is now IMPLEMENTED (#341, #379). The DEFAULT

--- a/docs/PERF_LEDGER.md
+++ b/docs/PERF_LEDGER.md
@@ -127,10 +127,13 @@ actor waits out the gather. The two waits compound; nothing feeds.
 1. Read chunk 4 KiB -> 64 KiB zero-page heap buffer (the actual win). A pass now carries
    hundreds of frames, so the pass-scoped window group-commits in a few fsyncs, not ~40.
    Untouched pages cost no RSS; idle/ping-only connections still touch about a page.
-2. serve --commit-gather-us (default 0 = off, validation-capped at 1 s) kept as the OPT-IN
-   multi-producer lever: many connections each trickling singles can amortize one fsync. It
-   only engages when a drain pass already holds >= 2 produces (a single-produce pass never
-   gathers, so an unpipelined producer pays no window; the MySQL no-delay-count analogue).
+2. serve --commit-gather-us (validation-capped at 1 s) as the multi-producer lever: many
+   connections each trickling singles can amortize one fsync. It only engages when a drain
+   pass already holds >= 2 produces (a single-produce pass never gathers, so an unpipelined
+   producer pays no window; the MySQL no-delay-count analogue). Originally shipped default-OFF
+   (`0`); #472 changed the SHIPPED DEFAULT to a small conservative window (200 us,
+   `DEFAULT_COMMIT_GATHER_US`) so out-of-the-box durable produce batches fsyncs under a
+   concurrent publisher. `0` still restores the byte-identical historical actor.
 
 ### Measured (hive, 256B realistic, 15s runs, pre-merge cross-compiled, scratch broker)
 


### PR DESCRIPTION
Closes #472.

## The lever
The append actor already group-commits a drained batch under ONE covering `fdatasync` (#177), and #454 added a bounded **gather** window so a continuously-arriving / concurrent publisher lands its whole in-flight set under one fsync instead of arrival-rate-sized slivers. But the shipped **default** for `--commit-gather-us` was `0` (gather off), so out-of-the-box durable produce still self-sized to a few records per fsync under a streaming publisher — the bulk of the measured ~186x durable-produce gap (#472).

This PR changes the **shipped default** of `--commit-gather-us` from `0` to **`200` microseconds** (`DEFAULT_COMMIT_GATHER_US`), and wires the bench broker to honor `config.commit_gather_us` (it was hardcoding `0`, so bench never reflected the serve default).

## Why 200 us, and why it is safe
- **I2 (ack-implies-durable) is untouched.** An ack is still released only AFTER the covering `commit_batch` `fdatasync`. The gather only changes *which commands share one fsync*, never the ack-vs-fsync order. A failed fsync still fails every parked produce.
- **The synchronous `produce` contract is unchanged.** A single in-flight producer (send, await each ack) NEVER engages the gather: a drain pass holding fewer than two produces returns immediately. So the unpipelined path keeps its exact historical ack latency and one-fsync-per-message accounting.
- **Durability under `--durability sync` is not weakened.** `sync` still issues the covering fsync before any ack; the gather only batches concurrent commands into that one fsync.
- 200 us is far below one edge-device `fdatasync` (hundreds of us to low ms), so the window closes well before a lone fsync would complete; it adds at most ~200 us of commit latency to a *burst* of concurrent produces in exchange for collapsing their many fsyncs into one (the MySQL `binlog_group_commit_sync_delay` / PostgreSQL `commit_delay` precedent). An operator can set `0` to restore the byte-identical historical actor, or raise it (bounded to 1 s by existing validation).

## Before/after (local macOS, isolated disk broker, 256B realistic payloads, publish)
Local absolute numbers differ from CI; the same-box delta is the signal.

| shape | BEFORE (origin/main) | AFTER | delta |
| --- | --- | --- | --- |
| `--stream --pubwindow 64` (continuous concurrent producer — the gather's target shape) | ~8.1k-8.6k msg/s | ~11.8k-14.9k msg/s | **~1.45-1.8x** |
| `--pubwindow 1` (synchronous, gather never engages) | ~200-250 msg/s | ~200-250 msg/s | unchanged (fsync-physics-bound) |

Exact AFTER command: `ironbus bench --duration 10 --mode publish --payload-bytes 256 --payload-shape realistic --pubwindow 64 --stream --storage disk --json` (BEFORE: same, against an `origin/main` build).

## Tests
- New `actor.rs` test `a_gather_enabled_concurrent_batch_acks_only_after_one_covering_fsync`: with the gather ON, a concurrent batch parked behind the sync gate has NO ack released while the covering fsync is parked (I2), and the whole batch is covered by exactly ONE fsync once it returns.
- Updated the CLI default test: an untouched `serve` now resolves `--commit-gather-us` to `DEFAULT_COMMIT_GATHER_US`, and an explicit `0` still restores the gather-off actor.

## Local gates
- `cargo fmt --all --check`: pass
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`: pass (compiles all test targets clean)
- `cargo test --workspace --all-features --locked`: could not complete locally — the dev box hit a host-level disk-full (ENOSPC) condition (shared with parallel jobs), not a test failure. **CI should run the full suite as the source of truth.**

## For the reviewer to sign off
This changes a **shipped default** (a behavior/config-contract change), even though it cannot weaken durability or alter the synchronous `produce` contract. Please confirm the chosen default value (200 us) and that flipping the gather on by default is acceptable for the edge profile. `0` remains available to opt fully out.