### PR TITLE
perf(loss): fold loss-report aggregations once instead of per-reason rescans (#504)

### DIFF
--- a/crates/ironbus-server/src/health.rs
+++ b/crates/ironbus-server/src/health.rs
@@ -360,59 +360,60 @@ where
     C: Clock + Clone + 'static,
     E: EngineAccess<F, C>,
 {
-    let mut snapshot = engine.with(|g| MetricsSnapshot {
-        committed: g.committed_offset().get(),
-        flushed: g.flushed_offset().get(),
-        in_flight: g.in_flight(),
-        healthy: g.is_healthy(),
-        recovered_truncated: g.recovered_truncated_bytes(),
-        quarantined: g.quarantined_bytes(),
-        recovery_loss: {
-            let r = g.loss_report();
-            ReasonCode::ALL.map(|rc| r.bytes_skipped_for(rc))
-        },
-        recovery_loss_records: {
-            let r = g.loss_report();
-            ReasonCode::ALL.map(|rc| r.records_lost_for(rc))
-        },
-        recovery_data_loss: g.loss_report().data_loss_bytes(),
-        // -1 is the unambiguous "none yet" sentinel (offsets are never negative).
-        last_dead_lettered: g
-            .last_dead_lettered_offset()
-            .map_or(-1i64, |o| i64::try_from(o.get()).unwrap_or(i64::MAX)),
-        dlq_records: g.dlq_records(),
-        counters: g.counters(),
-        fsync: g.fsync_histogram(),
-        // The edge write-amplification + RAM-headroom + daily-write-budget inputs (#118), read here
-        // so they share the snapshot's single instant. The RSS is filled in below, off the lock.
-        edge: EdgeMetrics {
-            logical_bytes_written: g.logical_bytes_written(),
-            physical_bytes_written: g.physical_bytes_written(),
-            ram_ceiling_bytes: g.ram_ceiling_bytes(),
-            daily_physical_write_budget_bytes: g.daily_physical_write_budget_bytes(),
-            physical_bytes_written_today: g.physical_bytes_written_today(),
-            daily_budget_sheds: g.daily_budget_sheds(),
-            produce_rejected: g.counters().produce_rejected,
-        },
-        // The durability observability inputs (#341, #379), read under the same lock: the active
-        // level, whether it waives I2 (the sticky power-loss-unsafe signal), and the live unsynced
-        // bytes-at-risk. All three are derived from the engine's level + storage state.
-        durability: DurabilityMetrics {
-            level: g.durability_level().as_str(),
-            power_loss_unsafe: g.power_loss_unsafe(),
-            unsynced_bytes: g.unsynced_bytes(),
-        },
-        // The backpressure controllers' observable state (#68, #69), read under the same lock.
-        backpressure: g.backpressure_snapshot(),
-        // Filled in below, outside the engine lock; `None` is the not-yet-read placeholder.
-        rss: None,
-        groups: g.group_consumer_stats(),
-        // The bounded metric registry (#97) is rendered into a String inside the actor job (it walks
-        // only the bounded series set and the fixed histograms, so the work is O(number of series),
-        // independent of the record count or disk size), then the body is assembled outside with the
-        // rest. The uptime series reads the live monotonic clock seam here so it advances between
-        // scrapes.
-        registry: registry_body(g.registry(), g.now_monotonic()),
+    let mut snapshot = engine.with(|g| {
+        // Fold the loss report ONCE into its per-reason and grand totals (#504). The standalone
+        // accessors each rescan the whole event list, so reading every per-reason series the old
+        // way was O(reasons · events); `aggregate` makes the scrape O(events). The per-reason
+        // arrays are already in `ReasonCode::ALL` order, the order these metric series render in.
+        let loss = g.loss_report().aggregate();
+        MetricsSnapshot {
+            committed: g.committed_offset().get(),
+            flushed: g.flushed_offset().get(),
+            in_flight: g.in_flight(),
+            healthy: g.is_healthy(),
+            recovered_truncated: g.recovered_truncated_bytes(),
+            quarantined: g.quarantined_bytes(),
+            recovery_loss: loss.bytes_skipped,
+            recovery_loss_records: loss.records_lost,
+            recovery_data_loss: loss.data_loss_bytes,
+            // -1 is the unambiguous "none yet" sentinel (offsets are never negative).
+            last_dead_lettered: g
+                .last_dead_lettered_offset()
+                .map_or(-1i64, |o| i64::try_from(o.get()).unwrap_or(i64::MAX)),
+            dlq_records: g.dlq_records(),
+            counters: g.counters(),
+            fsync: g.fsync_histogram(),
+            // The edge write-amplification + RAM-headroom + daily-write-budget inputs (#118), read here
+            // so they share the snapshot's single instant. The RSS is filled in below, off the lock.
+            edge: EdgeMetrics {
+                logical_bytes_written: g.logical_bytes_written(),
+                physical_bytes_written: g.physical_bytes_written(),
+                ram_ceiling_bytes: g.ram_ceiling_bytes(),
+                daily_physical_write_budget_bytes: g.daily_physical_write_budget_bytes(),
+                physical_bytes_written_today: g.physical_bytes_written_today(),
+                daily_budget_sheds: g.daily_budget_sheds(),
+                produce_rejected: g.counters().produce_rejected,
+            },
+            // The durability observability inputs (#341, #379), read under the same lock: the active
+            // level, whether it waives I2 (the sticky power-loss-unsafe signal), and the live unsynced
+            // bytes-at-risk. All three are derived from the engine's level + storage state.
+            durability: DurabilityMetrics {
+                level: g.durability_level().as_str(),
+                power_loss_unsafe: g.power_loss_unsafe(),
+                unsynced_bytes: g.unsynced_bytes(),
+            },
+            // The backpressure controllers' observable state (#68, #69), read under the same lock.
+            backpressure: g.backpressure_snapshot(),
+            // Filled in below, outside the engine lock; `None` is the not-yet-read placeholder.
+            rss: None,
+            groups: g.group_consumer_stats(),
+            // The bounded metric registry (#97) is rendered into a String inside the actor job (it walks
+            // only the bounded series set and the fixed histograms, so the work is O(number of series),
+            // independent of the record count or disk size), then the body is assembled outside with the
+            // rest. The uptime series reads the live monotonic clock seam here so it advances between
+            // scrapes.
+            registry: registry_body(g.registry(), g.now_monotonic()),
+        }
     })?;
     // Read this process's RSS OUTSIDE the engine lock (#118): a best-effort, no-`unsafe`
     // cross-platform read (`/proc/self/status` on Linux, `ps` on macOS), `None` where unavailable so

--- a/crates/ironbus-storage/src/loss.rs
+++ b/crates/ironbus-storage/src/loss.rs
@@ -83,6 +83,19 @@ impl ReasonCode {
         ReasonCode::UnresolvedDictId,
     ];
 
+    /// This reason's index into [`ReasonCode::ALL`] (and so into the per-reason arrays
+    /// [`LossAggregate`] produces). It is `code() - 1` today, but deriving it from the position in
+    /// `ALL` keeps the two in lockstep so a future reason that is appended (or, hypothetically,
+    /// given a non-contiguous code) cannot silently desync the array index from the metric order.
+    #[must_use]
+    fn all_index(self) -> usize {
+        // `ALL` is the frozen, append-only enumeration, so every variant is present exactly once.
+        ReasonCode::ALL
+            .iter()
+            .position(|&rc| rc == self)
+            .expect("every ReasonCode is in ReasonCode::ALL")
+    }
+
     /// A stable, lower-snake-case label for this reason, for a metric series or a log field.
     /// Frozen alongside [`ReasonCode::code`].
     #[must_use]
@@ -203,6 +216,34 @@ pub struct LossReport {
     pub events: Vec<LossEvent>,
 }
 
+/// Every per-reason and grand total a metrics scrape reads from a [`LossReport`], folded in a
+/// SINGLE pass by [`LossReport::aggregate`] instead of one whole-event-list rescan per accessor
+/// per reason (#504).
+///
+/// The per-reason arrays are indexed in [`ReasonCode::ALL`] order: `bytes_skipped[i]` and
+/// `records_lost[i]` are the totals for `ReasonCode::ALL[i]`, matching the order the metrics
+/// endpoint emits its series in. This is a derived, in-memory view of an existing report (not a
+/// persisted schema), so it carries no `serde` derive and adding to it never touches the frozen
+/// `ironbus.loss-report.v1` wire format.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct LossAggregate {
+    /// Bytes dropped per reason, indexed in [`ReasonCode::ALL`] order. Equals
+    /// [`LossReport::bytes_skipped_for`] for each reason.
+    pub bytes_skipped: [u64; ReasonCode::ALL.len()],
+    /// Estimated records dropped per reason, indexed in [`ReasonCode::ALL`] order. Equals
+    /// [`LossReport::records_lost_for`] for each reason.
+    pub records_lost: [u64; ReasonCode::ALL.len()],
+    /// The grand total of dropped bytes across all reasons. Equals
+    /// [`LossReport::total_bytes_skipped`].
+    pub total_bytes_skipped: u64,
+    /// The grand total of estimated records dropped across all reasons. Equals
+    /// [`LossReport::total_records_lost_estimate`].
+    pub total_records_lost_estimate: u64,
+    /// The bytes of real DATA loss (with [`ReasonCode::TornTail`] excluded). Equals
+    /// [`LossReport::data_loss_bytes`].
+    pub data_loss_bytes: u64,
+}
+
 impl LossReport {
     /// The current loss-report schema version. Bumped only on an incompatible change to the
     /// fields or their meaning; new [`ReasonCode`] variants do not bump it (readers ignore an
@@ -298,6 +339,39 @@ impl LossReport {
             .iter()
             .filter(|e| e.reason_code == reason)
             .fold(0u64, |acc, e| acc.saturating_add(e.records_lost_estimate))
+    }
+
+    /// Every per-reason and grand total a metrics scrape needs, computed in a SINGLE pass over the
+    /// events.
+    ///
+    /// The individual accessors ([`total_bytes_skipped`](LossReport::total_bytes_skipped),
+    /// [`data_loss_bytes`](LossReport::data_loss_bytes),
+    /// [`bytes_skipped_for`](LossReport::bytes_skipped_for),
+    /// [`records_lost_for`](LossReport::records_lost_for), …) each walk the whole event list, so a
+    /// scrape that asks for every per-reason series calls them once per reason: O(reasons · events).
+    /// This folds the same arithmetic ONCE into [`LossAggregate`]'s small fixed-size per-reason
+    /// arrays, so the scrape is O(events) regardless of how many reasons or series it renders (#504).
+    ///
+    /// The per-reason arrays are indexed in [`ReasonCode::ALL`] order (so `bytes_skipped[i]` is the
+    /// byte total for `ReasonCode::ALL[i]`), and every field matches its standalone accessor
+    /// exactly, saturating add for saturating add and `is_data_loss` filter for `is_data_loss`
+    /// filter, so this is purely the same answer computed once rather than rescanned per reason.
+    #[must_use]
+    pub fn aggregate(&self) -> LossAggregate {
+        let mut agg = LossAggregate::default();
+        for e in &self.events {
+            let i = e.reason_code.all_index();
+            agg.bytes_skipped[i] = agg.bytes_skipped[i].saturating_add(e.bytes_skipped);
+            agg.records_lost[i] = agg.records_lost[i].saturating_add(e.records_lost_estimate);
+            agg.total_bytes_skipped = agg.total_bytes_skipped.saturating_add(e.bytes_skipped);
+            agg.total_records_lost_estimate = agg
+                .total_records_lost_estimate
+                .saturating_add(e.records_lost_estimate);
+            if e.reason_code.is_data_loss() {
+                agg.data_loss_bytes = agg.data_loss_bytes.saturating_add(e.bytes_skipped);
+            }
+        }
+        agg
     }
 
     /// The global loss cap in bytes for a log holding `durable_bytes` of durable data, using
@@ -755,6 +829,89 @@ mod tests {
             ReasonCode::UnresolvedDictId
         ));
         assert!(ReasonCode::UnresolvedDictId.is_data_loss());
+    }
+
+    #[test]
+    fn aggregate_matches_the_per_reason_accessors_in_one_pass() {
+        // A report with several reasons (including repeats and a saturating-prone span) so the
+        // single-pass aggregate is exercised against every standalone accessor it replaces (#504).
+        let mut r = LossReport::new();
+        r.push(LossEvent::span(0, 0, 10, 2, ReasonCode::TornTail));
+        r.push(LossEvent::span(1, 0, 30, 7, ReasonCode::CorruptRecordBody));
+        r.push(LossEvent::span(2, 0, 5, 3, ReasonCode::TornTail));
+        r.push(LossEvent::span(3, 0, 40, 1, ReasonCode::ScrubberSuspect));
+        r.push(LossEvent::span(4, 0, 55, 4, ReasonCode::UnresolvedDictId));
+
+        let agg = r.aggregate();
+        // The grand totals match their accessors exactly.
+        assert_eq!(agg.total_bytes_skipped, r.total_bytes_skipped());
+        assert_eq!(
+            agg.total_records_lost_estimate,
+            r.total_records_lost_estimate()
+        );
+        assert_eq!(agg.data_loss_bytes, r.data_loss_bytes());
+        // The per-reason arrays match the per-reason accessors, in ReasonCode::ALL order.
+        for (i, &rc) in ReasonCode::ALL.iter().enumerate() {
+            assert_eq!(
+                agg.bytes_skipped[i],
+                r.bytes_skipped_for(rc),
+                "bytes for {rc:?}"
+            );
+            assert_eq!(
+                agg.records_lost[i],
+                r.records_lost_for(rc),
+                "records for {rc:?}"
+            );
+        }
+        // The per-reason arrays sum back to the grand totals (no event was dropped or double-counted).
+        assert_eq!(
+            agg.bytes_skipped.iter().sum::<u64>(),
+            agg.total_bytes_skipped
+        );
+        assert_eq!(
+            agg.records_lost.iter().sum::<u64>(),
+            agg.total_records_lost_estimate
+        );
+
+        // An empty report aggregates to all zeros.
+        assert_eq!(LossReport::new().aggregate(), LossAggregate::default());
+
+        // Saturation in the single pass matches the saturating accessors: two near-MAX torn tails
+        // saturate the total, and a non-torn near-MAX span saturates the data-loss total too.
+        let mut big = LossReport::new();
+        big.push(LossEvent::span(
+            0,
+            0,
+            u64::MAX,
+            u64::MAX,
+            ReasonCode::TornTail,
+        ));
+        big.push(LossEvent::span(
+            1,
+            0,
+            u64::MAX,
+            u64::MAX,
+            ReasonCode::TornTail,
+        ));
+        big.push(LossEvent::span(
+            2,
+            0,
+            u64::MAX,
+            u64::MAX,
+            ReasonCode::CorruptRecordBody,
+        ));
+        let bagg = big.aggregate();
+        assert_eq!(bagg.total_bytes_skipped, big.total_bytes_skipped());
+        assert_eq!(bagg.total_bytes_skipped, u64::MAX);
+        assert_eq!(
+            bagg.total_records_lost_estimate,
+            big.total_records_lost_estimate()
+        );
+        assert_eq!(bagg.data_loss_bytes, big.data_loss_bytes());
+        for (i, &rc) in ReasonCode::ALL.iter().enumerate() {
+            assert_eq!(bagg.bytes_skipped[i], big.bytes_skipped_for(rc));
+            assert_eq!(bagg.records_lost[i], big.records_lost_for(rc));
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #504.

## What

The loss-report aggregations each fold over **every** event: `total_bytes_skipped`, `data_loss_bytes`, `total_records_lost_estimate`, and the per-reason `bytes_skipped_for` / `records_lost_for`. A metrics scrape called the per-reason accessors **once per reason** — `ReasonCode::ALL.map(..)` for both the byte and the record series, plus a `data_loss_bytes()` walk — so reading a full loss scrape re-walked the whole event list ~14 times: **O(reasons · events)**.

This adds `LossReport::aggregate()`, which folds the report **once** into a small fixed-size `LossAggregate`: per-reason byte and record arrays (indexed in `ReasonCode::ALL` order) plus the grand totals and the data-loss-only total. The health `metrics_snapshot` now calls `aggregate()` a single time and reads its fields, so the scrape is **O(events)** regardless of how many reasons or series it renders.

```
O(reasons · events)  ->  O(events)
```

## Semantics preserved exactly

- Every field uses the **same saturating adds** and the **same `is_data_loss` filter** as its standalone accessor; per-reason ordering is unchanged.
- The raw `events` Vec and the **frozen `ironbus.loss-report.v1` wire format** are untouched — `LossAggregate` is a derived in-memory view with **no serde derive**, so the golden JSON/schema goldens are unaffected.
- The existing per-reason accessors stay for the other callers and tests that use them.
- A new test asserts `aggregate()` is **byte-for-byte equal** to those accessors, including saturation and the empty-report case.

Contained to `loss.rs` (the aggregation) and the one `health.rs` scrape site that consumes it.

## Local gates (RUSTFLAGS=-D warnings)

- `cargo fmt --all --check` — pass
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — pass (clean)
- `cargo test --workspace --all-features --locked` — pass (0 failures; new `loss::tests::aggregate_matches_the_per_reason_accessors_in_one_pass` ok)

🤖 Generated with [Claude Code](https://claude.com/claude-code)