### PR TITLE
perf(storage): ephemeral in-memory backend without the 2x durable copy (#492)

### DIFF
--- a/crates/ironbus-cli/src/bench_run.rs
+++ b/crates/ironbus-cli/src/bench_run.rs
@@ -19,7 +19,7 @@ use ironbus_core::clock::Clock; // the monotonic seam the serve loop's liveness 
 use ironbus_proto::message::PubBody;
 use ironbus_server::actor::{spawn_actor_with_gather, DEFAULT_CHANNEL_BOUND};
 use ironbus_server::server::serve;
-use ironbus_storage::fs::{Filesystem, InMemoryFs, StdFs};
+use ironbus_storage::fs::{EphemeralFs, Filesystem, StdFs};
 use std::net::TcpListener;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -193,11 +193,13 @@ impl IsolatedBroker<StdFs> {
     }
 }
 
-impl IsolatedBroker<InMemoryFs> {
-    /// Spawns the MEMORY broker (#445): the same engine over a fresh in-memory filesystem via the
+impl IsolatedBroker<EphemeralFs> {
+    /// Spawns the MEMORY broker (#445): the same engine over a fresh ephemeral filesystem via the
     /// shared `open_memory_engine`, so the bench broker is the REAL `serve --storage memory`
-    /// engine path. No file is created and nothing needs cleanup afterwards.
-    fn spawn_memory(config: &ServeConfig) -> Result<IsolatedBroker<InMemoryFs>, CliError> {
+    /// engine path — including the #492 single-image `EphemeralFs` (no durable shadow), so the
+    /// bench measures the production in-RAM backend, not the simulation one. No file is created and
+    /// nothing needs cleanup afterwards.
+    fn spawn_memory(config: &ServeConfig) -> Result<IsolatedBroker<EphemeralFs>, CliError> {
         let engine = open_memory_engine(config, &[], &[])?;
         IsolatedBroker::from_engine(engine, config)
     }

--- a/crates/ironbus-cli/src/main.rs
+++ b/crates/ironbus-cli/src/main.rs
@@ -122,7 +122,7 @@ use ironbus_storage::dict_store::{CachingDictResolver, DictSidecarStore, DICTS_S
 #[cfg(unix)]
 use ironbus_storage::dlq::{read_dlq_entries, DlqEntry};
 #[cfg(unix)]
-use ironbus_storage::fs::{Filesystem, InMemoryFs, StdFs};
+use ironbus_storage::fs::{EphemeralFs, Filesystem, StdFs};
 #[cfg(unix)]
 use ironbus_storage::log::LogConfig;
 #[cfg(unix)]
@@ -471,8 +471,8 @@ impl CompressionArg {
 /// lives in the (non-Unix-gated) [`ServeConfig`] and is parsed/validated on EVERY platform; only the
 /// Unix serve path opens an engine over it. The default is [`StorageArg::Disk`], the durable on-disk
 /// store: a broker that passes no `--storage` is byte-for-byte the historical broker. `memory` runs
-/// the SAME engine and the SAME `EngineConfig` over [`ironbus_storage::fs::InMemoryFs`] (the
-/// deterministic in-memory filesystem every engine test and conformance suite already exercises):
+/// the SAME engine and the SAME `EngineConfig` over [`ironbus_storage::fs::EphemeralFs`] (the
+/// single-image in-RAM filesystem, #492 — no `durable` shadow, so RSS is ~1x the cap, not ~2x):
 /// NO files, NO fsync, and explicitly NO power-loss or restart durability, for hot-path fan-out,
 /// spill-to-RAM buffering, and test rigs where flash wear or fsync latency is the binding
 /// constraint. It is gated behind the explicit `--ephemeral-loss-ack` consent and a non-zero
@@ -482,8 +482,8 @@ impl CompressionArg {
 enum StorageArg {
     /// The DEFAULT durable on-disk store rooted at `--data-dir` (byte-for-byte unchanged behavior).
     Disk,
-    /// OPT-IN ephemeral in-memory store: the same engine over `InMemoryFs`, no files, no fsync; a
-    /// clean stop or crash loses every acked message by contract. Gated behind
+    /// OPT-IN ephemeral in-memory store: the same engine over `EphemeralFs` (#492), no files, no
+    /// fsync; a clean stop or crash loses every acked message by contract. Gated behind
     /// `--ephemeral-loss-ack` and an explicit `--max-total-bytes`.
     Memory,
 }
@@ -3115,8 +3115,8 @@ struct ServeConfig {
     async_loss_ack: bool,
     /// The storage BACKEND (#443): [`StorageArg::Disk`] (the default, the durable on-disk store,
     /// byte-for-byte unchanged behavior) or the opt-in ephemeral [`StorageArg::Memory`] (the SAME
-    /// engine and the SAME `EngineConfig` over `InMemoryFs`: no files, no fsync, NO power-loss or
-    /// restart durability; a clean stop or crash loses every acked message by contract).
+    /// engine and the SAME `EngineConfig` over `EphemeralFs` (#492): no files, no fsync, NO power-loss
+    /// or restart durability; a clean stop or crash loses every acked message by contract).
     /// Platform-neutral so it is parsed/validated on every platform; the Unix serve path dispatches
     /// on it statically (one monomorphized run per backend, no dyn dispatch on the hot path).
     storage: StorageArg,
@@ -3505,7 +3505,7 @@ fn cmd_serve(
     };
 
     // The storage-backend dispatch (#443): a TWO-ARMED STATIC match, each arm monomorphizing the
-    // generic [`run_broker`] over its concrete filesystem (`StdFs` / `InMemoryFs`). The whole serve
+    // generic [`run_broker`] over its concrete filesystem (`StdFs` / `EphemeralFs`). The whole serve
     // stack (engine, append actor, sessions, health) is already generic over `Filesystem`, so the
     // backend is decided ONCE here at startup and there is NO dyn dispatch on the hot path.
     match config.storage {
@@ -3540,7 +3540,7 @@ fn cmd_serve(
         }
         StorageArg::Memory => {
             // The OPT-IN ephemeral in-memory broker (#443): the SAME engine and the SAME
-            // `EngineConfig` over `InMemoryFs::new()`. NO data dir is prepared and NO exclusive
+            // `EngineConfig` over `EphemeralFs::new()` (#492). NO data dir is prepared and NO exclusive
             // data-dir lock is taken: serve's lock exists to stop two brokers writing one
             // directory, and each memory-mode process owns its own PRIVATE in-memory filesystem,
             // so the lock is meaningless here and there is no path to lock (nothing on the lock
@@ -4480,20 +4480,26 @@ fn open_disk_engine(
 
 /// Opens the OPT-IN ephemeral in-memory broker engine (#443): the SAME engine and, via the shared
 /// [`open_engine_with`], the SAME `EngineConfig` the disk path builds, over a fresh
-/// [`InMemoryFs::new()`] (the deterministic in-memory `Filesystem` every engine test and
-/// conformance suite already exercises). No file is created and no fsync is issued; the stored
-/// format, CRC-over-stored-bytes, retention, compression (#430), the produce gate (#438), and the
+/// [`EphemeralFs::new()`]. No file is created and no fsync is issued; the stored format,
+/// CRC-over-stored-bytes, retention, compression (#430), the produce gate (#438), and the
 /// checkpoint machinery (group cursors, which drive redelivery semantics WITHIN the process
 /// lifetime) all hold identically. The loss contract is enforced upstream by `validate_storage`:
 /// this is only reachable with `--ephemeral-loss-ack` and a non-zero `--max-total-bytes`.
+///
+/// The backend is [`EphemeralFs`], NOT the simulation's `InMemoryFs` (#492): an ephemeral broker
+/// models no power loss, so the `durable` second copy `InMemoryFs`/`InMemoryFile` keep solely for
+/// the crash-recovery simulation is pure waste here — it doubled RSS to ~2x the `--max-total-bytes`
+/// cap (the production memory blowup) and made every `sync_*` clone the whole file/map. `EphemeralFs`
+/// holds a single image, so RSS is ~1x the cap and `sync_*` is O(1). The crash-recovery simulation
+/// keeps using `InMemoryFs` (which still carries the durable copy `simulate_power_loss` reverts to).
 #[cfg(unix)]
 fn open_memory_engine(
     config: &ServeConfig,
     key_shared_groups: &[String],
     broadcast_groups: &[String],
-) -> Result<Engine<InMemoryFs, SystemClock>, CliError> {
+) -> Result<Engine<EphemeralFs, SystemClock>, CliError> {
     open_engine_with(
-        InMemoryFs::new(),
+        EphemeralFs::new(),
         config,
         key_shared_groups,
         broadcast_groups,

--- a/crates/ironbus-storage/src/fs.rs
+++ b/crates/ironbus-storage/src/fs.rs
@@ -7,7 +7,7 @@
 //! fully controls, including directory-entry durability across a simulated power loss
 //! (a created-but-not-dir-synced segment vanishes; a not-yet-durable removal is undone).
 
-use crate::io::{InMemoryFile, RandomAccessFile};
+use crate::io::{EphemeralFile, InMemoryFile, RandomAccessFile};
 use std::collections::BTreeMap;
 use std::io;
 use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
@@ -284,6 +284,139 @@ impl Filesystem for InMemoryFs {
         // for the DLQ probe).
         let dir_prefix = format!("{}{name}/", self.prefix);
         Ok(self.lock().live.keys().any(|k| k.starts_with(&dir_prefix)))
+    }
+}
+
+/// An EPHEMERAL in-memory [`Filesystem`] for the real `--storage memory` broker (#492).
+///
+/// It is the directory-level companion to [`EphemeralFile`]: a flat namespace of named ephemeral
+/// files with NO `durable` directory shadow and a no-op `sync_dir`. [`InMemoryFs`] keeps a second
+/// `durable` `BTreeMap` (and each file keeps its own `durable` byte image) ONLY so the deterministic
+/// crash-recovery simulation can revert created/removed entries and unsynced bytes at a modelled
+/// power loss. The real `--storage memory` path models no power loss — it is ephemeral, a crash
+/// loses everything — so that second map is pure overhead, the directory half of the ~2x RSS blowup
+/// (#492). This backend drops it, so directory state is ~1x and `sync_dir` is O(1).
+///
+/// It is deliberately MISSING `simulate_power_loss` / `simulate_power_loss_reorder`: the crash
+/// simulation must keep using [`InMemoryFs`], which still carries the durable images those models
+/// revert to. Like [`InMemoryFs`], a clone aliases the SAME backing store (an `Arc`) and a
+/// [`subdir`](Filesystem::subdir) is a key-prefix view over it (the DLQ sink lives there), so the
+/// engine's subdirectory and multi-handle behavior is unchanged.
+///
+/// [`EphemeralFile`]: crate::io::EphemeralFile
+#[derive(Clone, Debug, Default)]
+pub struct EphemeralFs {
+    /// The single live directory image, shared behind an `Arc` so a clone aliases the same store.
+    /// There is no `durable` companion map: an ephemeral directory has no power loss to model.
+    files: Arc<Mutex<BTreeMap<String, Arc<EphemeralFile>>>>,
+    /// The key prefix this handle operates under, so a [`subdir`](Filesystem::subdir) view shares
+    /// the SAME backing store while seeing only the keys under its prefix. The root handle's prefix
+    /// is empty; the flat store models a subdirectory as a `"<name>/"` key prefix, exactly as
+    /// [`InMemoryFs`] does.
+    prefix: String,
+}
+
+impl EphemeralFs {
+    /// Creates an empty ephemeral in-memory directory.
+    #[must_use]
+    pub fn new() -> EphemeralFs {
+        EphemeralFs::default()
+    }
+
+    // As in [`InMemoryFs::lock`]: recovering a poisoned guard keeps the broker process alive, and
+    // the only mutations are map and `Arc` operations that never leave the state structurally torn.
+    fn lock(&self) -> MutexGuard<'_, BTreeMap<String, Arc<EphemeralFile>>> {
+        self.files.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    /// Maps a caller-visible name to its backing-store key by prepending this handle's prefix.
+    fn key(&self, name: &str) -> String {
+        format!("{}{}", self.prefix, name)
+    }
+}
+
+impl Filesystem for EphemeralFs {
+    type File = Arc<EphemeralFile>;
+
+    fn open(&self, name: &str) -> io::Result<Self::File> {
+        self.lock()
+            .get(&self.key(name))
+            .map(Arc::clone)
+            .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "no such file"))
+    }
+
+    fn create_new(&self, name: &str) -> io::Result<Self::File> {
+        let key = self.key(name);
+        let mut g = self.lock();
+        if g.contains_key(&key) {
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                "file already exists",
+            ));
+        }
+        let file = Arc::new(EphemeralFile::new());
+        g.insert(key, Arc::clone(&file));
+        Ok(file)
+    }
+
+    fn remove(&self, name: &str) -> io::Result<()> {
+        if self.lock().remove(&self.key(name)).is_some() {
+            Ok(())
+        } else {
+            Err(io::Error::new(io::ErrorKind::NotFound, "no such file"))
+        }
+    }
+
+    fn list(&self) -> io::Result<Vec<String>> {
+        // Only the entries directly under this handle's prefix (not a deeper subdirectory's), with
+        // the prefix stripped — exactly the InMemoryFs flat-listing rule.
+        Ok(self
+            .lock()
+            .keys()
+            .filter_map(|k| k.strip_prefix(&self.prefix))
+            .filter(|rest| !rest.is_empty() && !rest.contains('/'))
+            .map(ToOwned::to_owned)
+            .collect())
+    }
+
+    fn exists(&self, name: &str) -> io::Result<bool> {
+        Ok(self.lock().contains_key(&self.key(name)))
+    }
+
+    // No durable directory image to advance and no device to flush: directory durability is not a
+    // concept for an ephemeral store, so this is a faithful O(1) no-op (cf. InMemoryFs::sync_dir,
+    // which clones the whole live map into a durable shadow purely for the power-loss simulation).
+    fn sync_dir(&self) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn subdir(&self, name: &str) -> io::Result<EphemeralFs> {
+        if !is_plain_component(name) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "subdirectory name must be a single path component",
+            ));
+        }
+        // A subdirectory is a deeper key prefix over the SAME shared store, so the subdir's files
+        // share the parent's image (the DLQ sink, #63). The flat store materializes a directory
+        // lazily as its files appear, so nothing is created here.
+        Ok(EphemeralFs {
+            files: Arc::clone(&self.files),
+            prefix: format!("{}{name}/", self.prefix),
+        })
+    }
+
+    fn subdir_exists(&self, name: &str) -> io::Result<bool> {
+        if !is_plain_component(name) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "subdirectory name must be a single path component",
+            ));
+        }
+        // The flat store has no standalone directory entries: a subdirectory "exists" iff at least
+        // one key under its `<prefix><name>/` namespace is present.
+        let dir_prefix = format!("{}{name}/", self.prefix);
+        Ok(self.lock().keys().any(|k| k.starts_with(&dir_prefix)))
     }
 }
 
@@ -607,6 +740,115 @@ mod tests {
         g.read_exact_at(&mut buf, 0).unwrap();
         assert_eq!(&buf, b"ORIGINAL");
         assert_eq!(g.len().unwrap(), 8);
+    }
+}
+
+#[cfg(test)]
+mod ephemeral_fs_tests {
+    use super::*;
+
+    fn write_all(f: &Arc<EphemeralFile>, bytes: &[u8]) {
+        f.write_all_at(bytes, 0).unwrap();
+    }
+
+    #[test]
+    fn create_open_list_remove_roundtrip() {
+        let fs = EphemeralFs::new();
+        let a = fs.create_new("a.log").unwrap();
+        write_all(&a, b"alpha");
+        fs.create_new("b.log").unwrap();
+        let mut names = fs.list().unwrap();
+        names.sort();
+        assert_eq!(names, vec!["a.log".to_owned(), "b.log".to_owned()]);
+        // Opening returns a handle to the same bytes (the same Arc-backed file).
+        let again = fs.open("a.log").unwrap();
+        let mut buf = [0u8; 5];
+        again.read_exact_at(&mut buf, 0).unwrap();
+        assert_eq!(&buf, b"alpha");
+        // Remove drops it; create_new refuses an existing name; open of a missing name errors.
+        fs.remove("a.log").unwrap();
+        assert!(!fs.exists("a.log").unwrap());
+        assert_eq!(
+            fs.create_new("b.log").unwrap_err().kind(),
+            io::ErrorKind::AlreadyExists
+        );
+        assert_eq!(
+            fs.open("a.log").unwrap_err().kind(),
+            io::ErrorKind::NotFound
+        );
+        assert_eq!(
+            fs.remove("a.log").unwrap_err().kind(),
+            io::ErrorKind::NotFound
+        );
+    }
+
+    #[test]
+    fn a_clone_aliases_the_same_disk_with_no_durable_revert() {
+        // A clone shares the one backing store. The whole point of #492: there is NO durable shadow,
+        // so syncs are no-ops and nothing is ever reverted — the live bytes are the only truth.
+        let fs = EphemeralFs::new();
+        let probe = fs.clone();
+        let f = fs.create_new("seg").unwrap();
+        write_all(&f, b"hello");
+        f.sync_all().unwrap();
+        fs.sync_dir().unwrap();
+        assert!(probe.exists("seg").unwrap());
+        // An overwrite is immediately visible on the clone; a sync changes nothing (no revert).
+        f.write_all_at(b"WORLD", 0).unwrap();
+        let mut buf = [0u8; 5];
+        probe
+            .open("seg")
+            .unwrap()
+            .read_exact_at(&mut buf, 0)
+            .unwrap();
+        assert_eq!(&buf, b"WORLD");
+    }
+
+    #[test]
+    fn a_subdir_is_isolated_and_shares_the_store() {
+        let fs = EphemeralFs::new();
+        fs.create_new("seg-0.log").unwrap();
+        assert!(!fs.subdir_exists("dlq").unwrap());
+        let dlq = fs.subdir("dlq").unwrap();
+        dlq.create_new("seg-0.log").unwrap();
+        dlq.create_new("seg-1.log").unwrap();
+        assert!(fs.subdir_exists("dlq").unwrap());
+        // The subdir sees only its own files; the parent's flat list never surfaces the deeper keys.
+        let mut sub = dlq.list().unwrap();
+        sub.sort();
+        assert_eq!(sub, vec!["seg-0.log".to_owned(), "seg-1.log".to_owned()]);
+        assert_eq!(fs.list().unwrap(), vec!["seg-0.log".to_owned()]);
+        // Same-named files in the parent and the subdir are distinct objects.
+        dlq.open("seg-0.log")
+            .unwrap()
+            .write_all_at(b"sub", 0)
+            .unwrap();
+        fs.open("seg-0.log")
+            .unwrap()
+            .write_all_at(b"PARENT", 0)
+            .unwrap();
+        let mut buf = [0u8; 3];
+        dlq.open("seg-0.log")
+            .unwrap()
+            .read_exact_at(&mut buf, 0)
+            .unwrap();
+        assert_eq!(&buf, b"sub");
+    }
+
+    #[test]
+    fn subdir_rejects_an_unsafe_name() {
+        let fs = EphemeralFs::new();
+        for bad in ["", ".", "..", "a/b", "with\0nul"] {
+            assert_eq!(
+                fs.subdir(bad).unwrap_err().kind(),
+                io::ErrorKind::InvalidInput,
+                "subdir name {bad:?} should be rejected"
+            );
+            assert_eq!(
+                fs.subdir_exists(bad).unwrap_err().kind(),
+                io::ErrorKind::InvalidInput,
+            );
+        }
     }
 }
 

--- a/crates/ironbus-storage/src/io.rs
+++ b/crates/ironbus-storage/src/io.rs
@@ -799,6 +799,181 @@ mod tests {
         f.read_exact_at(&mut buf, 0).unwrap();
         assert_eq!(&buf, b"ok");
     }
+
+    #[test]
+    fn ephemeral_read_write_set_len_match_the_in_memory_file() {
+        // The ephemeral backend's read/write/set_len/len contract is byte-for-byte the in-memory
+        // file's, only without the durable bookkeeping. Mirror the core round-trips so a regression
+        // that diverged the production in-RAM path from the simulation one is caught.
+        let f = EphemeralFile::new();
+        assert!(f.is_empty().unwrap());
+        f.write_all_at(b"hello", 0).unwrap();
+        let mut buf = [0u8; 5];
+        assert_eq!(f.read_at(&mut buf, 0).unwrap(), 5);
+        assert_eq!(&buf, b"hello");
+        assert_eq!(f.len().unwrap(), 5);
+        assert_eq!(f.snapshot(), b"hello");
+        // A past-EOF write zero-fills the gap, exactly like InMemoryFile.
+        f.write_all_at(b"ab", 7).unwrap();
+        assert_eq!(f.snapshot(), b"hello\x00\x00ab");
+        // read past end is 0; a partial read near the end returns the remainder.
+        let mut tail = [0u8; 8];
+        assert_eq!(f.read_at(&mut tail, 9).unwrap(), 0);
+        let n = f.read_at(&mut tail, 7).unwrap();
+        assert_eq!(&tail[..n], b"ab");
+        // set_len truncates then zero-fill-extends.
+        f.set_len(3).unwrap();
+        assert_eq!(f.snapshot(), b"hel");
+        f.set_len(5).unwrap();
+        assert_eq!(f.snapshot(), b"hel\x00\x00");
+        // read_exact_at fills exactly or errors UnexpectedEof.
+        let mut three = [0u8; 3];
+        f.read_exact_at(&mut three, 0).unwrap();
+        assert_eq!(&three, b"hel");
+        assert_eq!(
+            f.read_exact_at(&mut [0u8; 6], 0).unwrap_err().kind(),
+            io::ErrorKind::UnexpectedEof
+        );
+    }
+
+    #[test]
+    fn ephemeral_sync_is_a_noop_and_never_loses_live_bytes() {
+        // The whole point of #492: sync_data/sync_all do nothing (no durable copy to refresh, no
+        // device to flush) and are O(1). After a sync the bytes are simply still the bytes — there
+        // is no power loss to model, so nothing is ever reverted.
+        let f = EphemeralFile::new();
+        f.write_all_at(b"durable-by-process-lifetime", 0).unwrap();
+        f.sync_data().unwrap();
+        f.sync_all().unwrap();
+        assert_eq!(f.snapshot(), b"durable-by-process-lifetime");
+        // A write after a sync is immediately visible; there is no "unsynced tail" concept.
+        f.write_all_at(b"!", 27).unwrap();
+        f.sync_all().unwrap();
+        assert_eq!(f.snapshot(), b"durable-by-process-lifetime!");
+    }
+
+    #[test]
+    fn ephemeral_default_preallocate_is_a_noop_and_changes_nothing() {
+        // EphemeralFile does not override preallocate: the trait default no-op applies, reserving
+        // nothing and leaving the bytes and length untouched (a Vec has no up-front reservation a
+        // reader could observe).
+        let f = EphemeralFile::new();
+        f.write_all_at(b"ok", 0).unwrap();
+        f.preallocate(1 << 20).unwrap();
+        assert_eq!(f.len().unwrap(), 2);
+        assert_eq!(f.snapshot(), b"ok");
+    }
+
+    #[test]
+    fn ephemeral_shared_across_threads_as_trait_object() {
+        let f: Arc<dyn RandomAccessFile> = Arc::new(EphemeralFile::new());
+        let f2 = Arc::clone(&f);
+        std::thread::scope(|s| {
+            s.spawn(move || f2.write_all_at(b"data", 0).unwrap());
+        });
+        let mut buf = [0u8; 4];
+        assert_eq!(f.read_at(&mut buf, 0).unwrap(), 4);
+        assert_eq!(&buf, b"data");
+    }
+}
+
+/// An EPHEMERAL in-memory [`RandomAccessFile`] for the real `--storage memory` broker: a single
+/// `Vec` of bytes, NO durable second copy, and `sync_data`/`sync_all` no-ops.
+///
+/// This is the production in-RAM backend (#492). The deterministic simulation backend
+/// [`InMemoryFile`] keeps TWO images — `live` plus a `durable` copy taken at each sync — purely so
+/// [`simulate_power_loss`](InMemoryFile::simulate_power_loss) can model a crash by reverting the
+/// unsynced tail. The real `--storage memory` path models no power loss (it is ephemeral: a crash
+/// loses everything, there is no restart durability to simulate), so that `durable` copy is pure
+/// overhead: it doubles RSS to ~2x the configured cap and makes every `sync_all` clone the whole
+/// file (O(file)). This backend drops it. RSS is ~1x the cap and a sync is O(1).
+///
+/// Durability semantics: there are none, by design. `sync_data`/`sync_all` succeed without doing
+/// anything — there is no device, so there is nothing to flush. Within the process the bytes are
+/// always the live bytes; the [`RandomAccessFile`] read/write/`set_len`/`len` contract is identical
+/// to [`InMemoryFile`]'s, only WITHOUT the durable-image bookkeeping, so the engine, recovery scan,
+/// CRC checks, retention, and compression all behave exactly the same while the process is alive.
+/// There is deliberately NO `simulate_power_loss` on this type: the crash-recovery simulation must
+/// stay on [`InMemoryFile`], which retains the `durable` copy it depends on.
+#[derive(Debug, Default)]
+pub struct EphemeralFile {
+    /// The one and only image: the current bytes. No `durable` shadow, no `dirty` ledger — an
+    /// ephemeral file has no power loss to model and no sync barrier to honor.
+    bytes: Mutex<Vec<u8>>,
+}
+
+impl EphemeralFile {
+    /// Creates an empty ephemeral file.
+    #[must_use]
+    pub fn new() -> EphemeralFile {
+        EphemeralFile::default()
+    }
+
+    // As in [`InMemoryFile::lock`]: the only mutations are `Vec` slice copies and resizes, none of
+    // which unwind partway through a structurally invalid state, so recovering a poisoned guard
+    // keeps the broker process alive rather than cascading a panic.
+    fn lock(&self) -> std::sync::MutexGuard<'_, Vec<u8>> {
+        self.bytes.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    /// Returns a copy of the current bytes (the only image there is).
+    #[must_use]
+    pub fn snapshot(&self) -> Vec<u8> {
+        self.lock().clone()
+    }
+}
+
+impl RandomAccessFile for EphemeralFile {
+    fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<usize> {
+        let off = usize::try_from(offset).map_err(|_| invalid_input("offset out of range"))?;
+        let bytes = self.lock();
+        if off >= bytes.len() {
+            return Ok(0);
+        }
+        let n = (bytes.len() - off).min(buf.len());
+        buf[..n].copy_from_slice(&bytes[off..off + n]);
+        Ok(n)
+    }
+
+    fn write_all_at(&self, buf: &[u8], offset: u64) -> io::Result<()> {
+        let off = usize::try_from(offset).map_err(|_| invalid_input("offset out of range"))?;
+        let end = off
+            .checked_add(buf.len())
+            .ok_or_else(|| invalid_input("write extends past the addressable range"))?;
+        let mut bytes = self.lock();
+        if bytes.len() < end {
+            bytes.resize(end, 0);
+        }
+        bytes[off..end].copy_from_slice(buf);
+        Ok(())
+    }
+
+    // No device, nothing to flush: the bytes are already the live bytes and there is no durable
+    // image to advance. O(1), unlike [`InMemoryFile`]'s dirty-range copy. There is no power loss to
+    // survive, so this is a faithful no-op, not a weakened barrier.
+    fn sync_data(&self) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn sync_all(&self) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn len(&self) -> io::Result<u64> {
+        Ok(self.lock().len() as u64)
+    }
+
+    fn set_len(&self, len: u64) -> io::Result<()> {
+        let len = usize::try_from(len).map_err(|_| invalid_input("length out of range"))?;
+        // Truncation drops the tail, extension zero-fills, exactly like [`InMemoryFile::set_len`]
+        // and [`StdFile::set_len`] — minus the durable-image truncation-is-metadata bookkeeping,
+        // which is meaningless without a durable image.
+        self.lock().resize(len, 0);
+        Ok(())
+    }
+
+    // `preallocate` keeps the trait default (a no-op): an in-RAM `Vec` reserves nothing up front and
+    // a reservation that changed no bytes would be invisible anyway, exactly the default's contract.
 }
 
 /// A production [`RandomAccessFile`] backed by an OS file, using cursor-free


### PR DESCRIPTION
Closes #492.

## What

The real `--storage memory` broker ran over `InMemoryFs`/`InMemoryFile`, which each keep a second `durable` copy of every byte (and clone the whole file/map on `sync_*`) purely so the crash-recovery **simulation** can model a power loss. An ephemeral broker models no power loss — it is ephemeral; a crash loses everything, there is no restart durability to simulate — so that `durable` copy was pure overhead on the production path: **RSS ~2x the `--max-total-bytes` cap** (the in-memory memory blowup this issue tracks) and `sync_all`/`sync_dir` at O(file)/O(map).

This adds a dedicated ephemeral backend and routes only the production memory path to it:

- `EphemeralFile` (in `io.rs`): a single `Vec`, **no `durable` shadow, no dirty ledger**; `sync_data`/`sync_all` are no-ops (O(1)); `read_at`/`write_all_at`/`set_len`/`len` are byte-for-byte the `InMemoryFile` contract minus the durable bookkeeping. No `simulate_power_loss` (by design).
- `EphemeralFs` (in `fs.rs`): a single live `BTreeMap` of `Arc<EphemeralFile>`, **no `durable` directory shadow**; `sync_dir` is a no-op; `subdir`/`subdir_exists` keep the same key-prefix model (the DLQ sink still works).
- `open_memory_engine` now builds `EphemeralFs::new()` instead of `InMemoryFs::new()`. Bench's isolated memory broker (which is documented as the *real* `serve --storage memory` engine path) is re-routed too, so the bench measures the production backend.

Result: ephemeral memory RSS **~2x → ~1x** the cap; `sync_*` **O(file)/O(map) → O(1)**.

## Routing decision (please scrutinize)

The split hinges on this: the crash-recovery **simulation does not go through `open_memory_engine`**. Every power-loss / crash test constructs `InMemoryFs`/`InMemoryFile` directly and drives `simulate_power_loss` / `simulate_power_loss_reorder` on those exact instances. `open_memory_engine` (and bench's memory broker) is the **only** production caller of the in-RAM filesystem. So re-routing just those two call sites moves production onto the ephemeral backend while leaving the simulation entirely on the original types.

## Crash-recovery simulation kept fully intact

`InMemoryFs` and `InMemoryFile` are **untouched** — they still carry `durable` + `dirty` + `simulate_power_loss` + `simulate_power_loss_reorder` + `preallocated_to`. No simulation type, test, or fixture was modified. Every power-loss / crash / recovery sim test still passes (`fs::tests::power_loss_*`, `io::tests::*power_loss*`, `engine::tests::*crash*`/`*recover*`, `checkpoint::tests::power_loss_*`, `crash_recovery`, `compaction_crash`, `seeded_faults`, `invariant_gate`).

## Gates

- `cargo fmt --all --check`: clean
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` (RUSTFLAGS `-D warnings`): clean
- `cargo test --workspace --all-features --locked`: **1530 passed, 0 failed**

## What a reviewer should scrutinize

- That `EphemeralFile`/`EphemeralFs` reproduce the `InMemoryFile`/`InMemoryFs` read/write/`set_len`/`list`/`subdir` semantics exactly (only durability removed), so the engine, recovery scan, CRC, retention, and compression behave identically within the process lifetime.
- That no production code path relies on the memory backend ever reverting unsynced bytes (it never did — memory mode is ephemeral by contract), i.e. dropping the durable copy changes no observed behavior, only RSS and sync cost.
- The two re-routed call sites (`open_memory_engine`, bench `spawn_memory`) are the complete set of production callers.