### PR TITLE
docs(m4): production --storage memory is 1x, not 2x, after the ephemeral backend

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -250,9 +250,10 @@ retention/reap decrement the record-region total in O(1), so it is the one basis
 reap can relieve. `ironbus_physical_bytes_written` is a write-AMPLIFICATION counter
 that **never decreases on a reap**, so capping on it would tighten after every reap
 and eventually wedge the writer; and the resident terms below are backend- and
-config-specific (the in-memory image is dropping from 2x to 1x in #492; disk
-preallocation depends on `segment_size`), so no single basis can honestly fold them
-in. The cap basis is therefore left untouched and the overhead is published here.
+config-specific (the production in-memory image is now 1x the record region after
+#492; disk preallocation depends on `segment_size`), so no single basis can honestly
+fold them in. The cap basis is therefore left untouched and the overhead is published
+here.
 
 Per-backend multiplier (record region → resident bytes):
 
@@ -260,7 +261,7 @@ Per-backend multiplier (record region → resident bytes):
 | --- | --- | --- |
 | Per-record framing | 44 B/record (36 B header + 8 B trailer) already INSIDE the record region | dominates at small payloads: a 1 B record frames to ~45 B → ~`1.85x` of payload |
 | Per-segment header/footer | 64 B/segment + 32 B/sealed segment | small unless `segment_size` is tiny (many segments) |
-| In-memory image (`--storage memory`) | historically **2x** the record region (the in-RAM copy); dropping to **1x** in #492 | up to 2x of resident until #492 lands |
+| In-memory image (`--storage memory`) | **1x** the record region after #492 — production `--storage memory` runs the single-`Vec` `EphemeralFile`/`EphemeralFs` backend (no `live`+`durable` copy); the historical **2x** in-RAM copy now exists ONLY in the `InMemoryFile` crash-recovery simulation | ~`1x` of the resident framed bytes (the boot RAM guard still charges 2x conservatively — see RAM_BUDGET.md) |
 | Per-segment index cache (memory + disk) | a few entries per segment | small |
 | Disk preallocation (`--storage disk`) | the ACTIVE segment is preallocated to `segment_size` (default 64 MiB) | up to one `segment_size` of apparent disk use beyond the resident framed bytes |
 
@@ -274,8 +275,11 @@ specific — add them from the table above). Practical sizing:
   segment's preallocation). To hold `max_total_bytes` of record bytes, provision at
   least `max_total_bytes + (segment_count × 96 B framing) + segment_size`.
 - **Memory budget** (`--storage memory`) ≈ `resident_bytes_estimate()` × the image
-  multiplier (2x today, 1x after #492). `max_total_bytes` is REQUIRED above `0` for
-  the memory backend precisely because it is the OOM guard — size it as
+  multiplier, which is **1x** after #492 (production runs the single-`Vec`
+  `EphemeralFile`/`EphemeralFs` backend, with no `live`+`durable` copy). The boot
+  RAM guard still charges 2x conservatively (see RAM_BUDGET.md), so a config that the
+  guard refuses still leaves headroom in practice. `max_total_bytes` is REQUIRED
+  above `0` for the memory backend precisely because it is the OOM guard — size it as
   `desired_RAM / image_multiplier`, then subtract the segment-framing overhead.
 
 ### Durability (`[durability]`)

--- a/docs/RAM_BUDGET.md
+++ b/docs/RAM_BUDGET.md
@@ -412,18 +412,28 @@ THE MEMORY-BACKEND STORE FOLD (#445, refs #443): on DISK the store is term 4 of
 the budget above, ~0 in RSS (written straight to file), so the guard does not
 charge it and the disk verdict is the historical one bit-for-bit. Under
 `--storage memory` the store ITSELF is RAM: the engine retains up to
-`--max-total-bytes` of stored bytes, and the in-memory filesystem keeps a SECOND
-byte image per file (the durable image each `sync_data` clones the live bytes
-into, the power-loss-simulation contract), so the guard charges
-`2 * max_total_bytes` and refuses a ceiling below the modeled floor. Memory mode
-already refuses an unlimited (`0`) byte cap at boot, so the store term is always
-finite there. Two honesty caveats on `term4mem`:
+`--max-total-bytes` of stored bytes. Production `--storage memory` now runs the
+single-`Vec` `EphemeralFile`/`EphemeralFs` backend (#492): ONE byte image per file,
+no `live`+`durable` copy, and an O(1) no-op `sync_*`, so the true production
+retained set is **~1x** `max_total_bytes`. The 2x `live`+`durable` byte image now
+exists ONLY in the `InMemoryFile` crash-recovery SIMULATION (the deterministic
+power-loss models), which production never runs. The boot guard nonetheless still
+charges `2 * max_total_bytes` (`IN_MEMORY_STORE_IMAGES = 2`) — a deliberately
+CONSERVATIVE over-charge it has not been retuned down to the ephemeral 1x — and
+refuses a ceiling below that floor, so a config the guard accepts has roughly double
+the store headroom it provably needs. Memory mode already refuses an unlimited (`0`)
+byte cap at boot, so the store term is always finite there. The live framed resident
+bytes are also available programmatically via `Log::resident_bytes_estimate()`
+(#493). Two honesty caveats on `term4mem`:
 
-- **The 2x is the steady-state RETAINED set, not an instantaneous bound.** The
-  durable image is refreshed by `clone_from` inside `sync_data`; when that clone
-  has to reallocate, the old durable allocation and the incoming bytes can
-  briefly coexist, so an instant mid-sync can exceed two images. Amortized and
-  at steady state, exactly two images are retained per file.
+- **The 2x charge is the boot guard's conservative bound, not the production
+  retained set.** Production runs the 1x `EphemeralFs` backend (#492), so the guard's
+  `2 * max_total_bytes` now over-charges by one image. The 2x retained set survives
+  only in the `InMemoryFile` simulation, where the durable image is refreshed by
+  `clone_from` inside `sync_data` and the simulated set is exactly two images per
+  file at steady state (a `clone_from` realloc can briefly exceed it mid-sync). The
+  guard tracks that simulation constant rather than the ephemeral 1x, on the safe
+  side of the ceiling.
 - **The dead-letter sink (the DLQ) is DELIBERATELY excluded.** The DLQ's log is
   byte-UNCAPPED by design (a poison record is the durable evidence of a dropped
   message and must never itself be shed), and in memory mode it lives on the


### PR DESCRIPTION
## What

The M4 "memory honesty" work landed two changes that made some docs language stale:

- **#492** — production `serve --storage memory` now runs a new single-`Vec` EPHEMERAL backend (`EphemeralFile`/`EphemeralFs`): ONE byte image per file, no `live`+`durable` 2x copy, and an O(1) no-op `sync_*`. The 2x `live`+`durable` image now exists ONLY in the `InMemoryFile` crash-recovery SIMULATION (the deterministic power-loss models), which production never runs.
- **#493** — `max_total_bytes` still caps the framed record region (basis unchanged), the per-backend overhead multiplier is documented in CONFIG.md, and a live `Log::resident_bytes_estimate()` is exposed.

This PR sweeps the docs for every claim that the in-memory backend retains a **2x (live+durable)** copy in **production** memory mode — now FALSE — and corrects it to **~1x** via the `EphemeralFile` backend, while preserving the still-true facts.

## Passages changed (file:line — before → after)

**`docs/CONFIG.md`**

- `:253` (cap-basis rationale) — before: "the in-memory image is **dropping from 2x to 1x in #492**" → after: "the production in-memory image is **now 1x** the record region **after #492**".
- `:263` (per-backend multiplier table row) — before: "historically **2x** the record region (the in-RAM copy); **dropping to 1x in #492**" / right col "up to 2x of resident **until #492 lands**" → after: "**1x** the record region after #492 — production runs the single-`Vec` `EphemeralFile`/`EphemeralFs` backend (no `live`+`durable` copy); the historical **2x** copy now exists ONLY in the `InMemoryFile` crash-recovery simulation" / right col "~`1x` of the resident framed bytes (the boot RAM guard still charges 2x conservatively — see RAM_BUDGET.md)".
- `:276-277` (memory-budget sizing bullet) — before: "× the image multiplier (**2x today, 1x after #492**)" → after: "× the image multiplier, which is **1x** after #492 (production runs the single-`Vec` `EphemeralFile`/`EphemeralFs` backend…); the boot RAM guard still charges 2x conservatively".

**`docs/RAM_BUDGET.md`** (the "refuse-to-boot RAM guard" section)

- `:414-426` (the MEMORY-BACKEND STORE FOLD paragraph + first caveat) — before: production "keeps a **SECOND byte image per file** (the durable image each `sync_data` clones … the power-loss-simulation contract)" and "the 2x is the steady-state RETAINED set" → after: production now runs the single-`Vec` `EphemeralFile`/`EphemeralFs` backend (#492) so the **true production retained set is ~1x**; the 2x `live`+`durable` image now exists **ONLY in the `InMemoryFile` crash-recovery SIMULATION**; the boot guard nonetheless still charges `2 * max_total_bytes` (`IN_MEMORY_STORE_IMAGES = 2`) as a **deliberately conservative over-charge** it has not been retuned down to the ephemeral 1x. Also notes the live `Log::resident_bytes_estimate()` (#493).

## Accuracy / scope

- Only **genuinely-stale production-2x claims** were changed. The boot guard's `2 * max_total_bytes` formula (`term4mem`, RAM_BUDGET.md) is **left intact** because `rss.rs` still computes it — #492 did not retune the guard, so the formula remains a faithful description of the guard; the prose now explains it is a conservative over-charge.
- **Untouched** (unrelated, still correct): the dedup "two structures" `VecDeque`+`HashMap` language, the "recovering twice" idempotence language, and all other content.
- Docs-only: no source changed. `cargo fmt --all --check`, the per-PR relative-link/anchor check, and the offline issue-index audit all pass locally (782 in-repo links, 0 problems; 131 nodes / 21 parents, 0 problems).

Refs #492, #493.