### PR TITLE
perf(produce): carry the publish payload as Bytes, drop the per-publish copy (#474)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -806,6 +806,7 @@ dependencies = [
 name = "ironbus-server"
 version = "0.0.0"
 dependencies = [
+ "bytes",
  "ironbus-core",
  "ironbus-proto",
  "ironbus-storage",

--- a/crates/ironbus-server/Cargo.toml
+++ b/crates/ironbus-server/Cargo.toml
@@ -35,6 +35,14 @@ ironbus-core = { path = "../ironbus-core", version = "0.0.0" }
 ironbus-proto = { path = "../ironbus-proto", version = "0.0.0" }
 ironbus-storage = { path = "../ironbus-storage", version = "0.0.0" }
 
+# Refcounted byte buffer for the produce hot path (#474). `OwnedAppend` carries the publish payload
+# (and key/headers/dedup ids) as `bytes::Bytes` so moving a produce across the append-actor channel is
+# a refcount bump, not a per-publish `Vec` deep copy. `bytes` is pure Rust (no `links`, no C build
+# script, no vendored crypto), MIT-licensed (already on the deny.toml allow-list via the otlp tree),
+# with an MSRV well below the workspace 1.78 floor. It is already resolved in the lockfile (1.11.x) by
+# the all-features otlp/tonic tree, so making it a first-class default dependency adds no new crate.
+bytes = { version = "1", default-features = false }
+
 # Structured tracing (#16, #99). `tracing` is the instrumentation facade; `tracing-subscriber` (the
 # `fmt` + `json` features only, no `env-filter`/`ansi`, to keep the transitive surface minimal)
 # provides the JSON log layer compiled in BY DEFAULT. Both, and their whole transitive tree

--- a/crates/ironbus-server/src/actor.rs
+++ b/crates/ironbus-server/src/actor.rs
@@ -32,6 +32,7 @@
 //!   [`ActorGone`], never a panic, so neither side hangs forever if the other dies.
 
 use crate::engine::{Engine, EngineError};
+use bytes::Bytes;
 use ironbus_core::clock::Clock;
 use ironbus_core::types::Offset;
 use ironbus_storage::fs::Filesystem;
@@ -103,6 +104,13 @@ fn pool_return(pool: &ReplyPool, channel: ReplyChannel) {
 /// A produce request's payload, OWNED so it can cross the channel to the actor (the wire [`Append`]
 /// borrows the connection's input buffer, which the actor cannot hold). The actor borrows it back as
 /// an [`Append`] to append it. Fields mirror [`Append`], plus the opt-in dedup identity (#33).
+///
+/// The byte fields are [`bytes::Bytes`] (refcounted) rather than `Vec<u8>` (#474): moving an
+/// `OwnedAppend` across the append-actor channel is already a move, but carrying the bytes as `Bytes`
+/// makes a CLONE (the `#[derive(Clone)]` used by the test/replay paths) and any future slice-of-the-
+/// read-buffer handoff a refcount bump instead of a deep copy. The storage encode still copies the
+/// payload into the segment buffer when it appends (the `Bytes` is consumed by the borrow there,
+/// exactly as the `Vec` was), so durability and the on-disk image are byte-identical.
 #[derive(Clone, Debug)]
 pub struct OwnedAppend {
     /// Producer timestamp, milliseconds since the Unix epoch.
@@ -111,11 +119,11 @@ pub struct OwnedAppend {
     /// wire-only dedup bit is masked OFF by the session before this crosses the channel.
     pub flags: u8,
     /// The routing or ordering key (empty if none).
-    pub key: Vec<u8>,
+    pub key: Bytes,
     /// The record headers blob (empty if none).
-    pub headers: Vec<u8>,
+    pub headers: Bytes,
     /// The record payload.
-    pub payload: Vec<u8>,
+    pub payload: Bytes,
     /// The OPT-IN dedup identity (#3, #33): `Some` iff the publish carried a `msg_id` (the dedup
     /// opt-in), owned so it can cross the channel. `None` is the default no-dedup produce.
     pub dedup: Option<OwnedDedup>,
@@ -141,11 +149,11 @@ pub struct OwnedAppend {
 #[derive(Clone, Debug)]
 pub struct OwnedDedup {
     /// The stable producer identity for dedup keying and epoch fencing (empty = anonymous).
-    pub producer_id: Vec<u8>,
+    pub producer_id: Bytes,
     /// The producer's monotonic epoch (the fencing token).
     pub epoch: u64,
     /// The idempotency key the broker deduplicates on (never the body).
-    pub msg_id: Vec<u8>,
+    pub msg_id: Bytes,
 }
 
 /// The outcome of a produce, mapped to the wire reply by the session. It carries enough to
@@ -1169,9 +1177,9 @@ mod tests {
         OwnedAppend {
             timestamp_ms: 0,
             flags: 0,
-            key: Vec::new(),
-            headers: Vec::new(),
-            payload: payload.to_vec(),
+            key: Bytes::new(),
+            headers: Bytes::new(),
+            payload: Bytes::copy_from_slice(payload),
             dedup: None,
             enqueue_monotonic_nanos: 0,
             fire_and_forget: false,
@@ -1192,13 +1200,13 @@ mod tests {
         OwnedAppend {
             timestamp_ms: 0,
             flags: 0,
-            key: Vec::new(),
-            headers: Vec::new(),
-            payload: payload.to_vec(),
+            key: Bytes::new(),
+            headers: Bytes::new(),
+            payload: Bytes::copy_from_slice(payload),
             dedup: Some(OwnedDedup {
-                producer_id: producer_id.to_vec(),
+                producer_id: Bytes::copy_from_slice(producer_id),
                 epoch,
-                msg_id: msg_id.to_vec(),
+                msg_id: Bytes::copy_from_slice(msg_id),
             }),
             enqueue_monotonic_nanos: 0,
             fire_and_forget: false,

--- a/crates/ironbus-server/src/session.rs
+++ b/crates/ironbus-server/src/session.rs
@@ -20,6 +20,7 @@ use crate::actor::{
     ActorGone, EngineAccess, OwnedAppend, OwnedDedup, ProduceOutcome, ProduceSubmission,
 };
 use crate::engine::{AckResult, EngineError, NackResult, Poll, ProgressResult};
+use bytes::Bytes;
 use ironbus_core::clock::Clock;
 use ironbus_core::compress::{validate_descriptor_shape, DEFAULT_MAX_DECOMPRESSED_BYTES};
 use ironbus_core::dedup::{MAX_MSG_ID_LEN, MAX_PRODUCER_ID_LEN};
@@ -633,19 +634,26 @@ impl Session {
         // epoch / msg_id to the engine's dedup window. Mask the WIRE-only dedup bit OUT of the stored
         // record flags so it never becomes a record flag (it is a wire signal, not stored state).
         let dedup = msg.dedup.map(|d| OwnedDedup {
-            producer_id: d.producer_id.to_vec(),
+            producer_id: Bytes::copy_from_slice(d.producer_id),
             epoch: d.epoch,
-            msg_id: d.msg_id.to_vec(),
+            msg_id: Bytes::copy_from_slice(d.msg_id),
         });
+        // Carry the produce's bytes as refcounted `Bytes` (#474) so moving/cloning the `OwnedAppend`
+        // across the append-actor channel is a refcount bump, not a `Vec` deep copy. The wire body
+        // still borrows the connection's input buffer (which the actor cannot hold), so this fill
+        // copies the slice ONCE here at the boundary; the FULL zero-copy (a `Bytes` slice OF the read
+        // buffer, retired by refcount) is the follow-on read-buffer rework flagged on #474. The
+        // storage encode copies the payload into the segment buffer when it appends regardless, so
+        // durability and the on-disk image are unchanged.
         let append = OwnedAppend {
             timestamp_ms: msg.timestamp_ms,
             // Mask BOTH wire-only PUB flag bits (dedup bit 7, fire-and-forget bit 6) out of the
             // stored record flags (#33, #11): neither is record state. The fire-and-forget marker is
             // carried in its own field below, not in the stored flags.
             flags: msg.flags & !PUB_WIRE_ONLY_FLAGS,
-            key: msg.key.to_vec(),
-            headers: msg.headers.to_vec(),
-            payload: msg.payload.to_vec(),
+            key: Bytes::copy_from_slice(msg.key),
+            headers: Bytes::copy_from_slice(msg.headers),
+            payload: Bytes::copy_from_slice(msg.payload),
             dedup,
             // Stamp the ENQUEUE instant from the engine's clock seam (a LOCAL read, no actor
             // round-trip), so the engine can measure the admission SOJOURN for the CoDel shed (#68).
@@ -5639,9 +5647,9 @@ mod tests {
             .produce_submit(crate::actor::OwnedAppend {
                 timestamp_ms: 0,
                 flags: 0,
-                key: Vec::new(),
-                headers: Vec::new(),
-                payload: b"primer".to_vec(),
+                key: Bytes::new(),
+                headers: Bytes::new(),
+                payload: Bytes::from_static(b"primer"),
                 dedup: None,
                 enqueue_monotonic_nanos: 0,
                 fire_and_forget: false,


### PR DESCRIPTION
Closes #474.

## What

`OwnedAppend` (and `OwnedDedup`) now carry the payload, key, headers, and dedup ids as `bytes::Bytes` instead of `Vec<u8>`. Moving a produce across the append-actor channel was already a move; with `Bytes`, a **clone** (the `#[derive(Clone)]` replay path) and any future slice-of-the-read-buffer handoff become a refcount bump instead of a deep copy. The whole produce type contract now carries `Bytes` end-to-end.

## Full zero-copy or partial: this is the SAFE PARTIAL

The connection read buffer is still a `Vec<u8>` and `decode_pub` still returns a **borrowed** `PubBody`, so `handle_pub` copies each field **once** at the wire boundary (`Bytes::copy_from_slice`). That single fill is the only remaining produce-path payload copy.

The **full zero-copy** — read into a `BytesMut`, `split`/`freeze` per frame so each payload is a refcount-retired `Bytes` slice **of** the read buffer — requires threading `Bytes` through the conformance-tested `decode_frame` / `decode_pub` / `FrameDecode` / `PubBody` / `Session::process` API **and** reworking the connection read-loop's inbuf lifecycle (the buffer can no longer be reused-in-place while a `Bytes` slice is outstanding). That is the invasive, framing-sensitive part #474 calls out, so it is **left as a follow-on** rather than ship a subtly-wrong frame-reassembly path. This PR puts the type contract in place so the follow-on is a read-buffer-side change only, with no downstream type churn.

## Preserved exactly

- **I2 (ack-after-fsync):** untouched. The actor still releases a produce reply only after the covering `commit_batch` fsync; payload carriage never touches the ack/reply path.
- **Storage encode:** the engine copies the payload into the segment buffer regardless, consuming the `Bytes` through the same `&[u8]` borrow the `Vec` gave (`Append` / `DedupRequest` still take `&[u8]` via `Bytes`'s `Deref`), so durability and the on-disk image are byte-identical.
- **Frame reassembly / partial frames:** the read loop, the `needed` hint, and `consumed`/`drain` are completely unchanged.
- Fire-and-forget QoS-0 no-frame contract and dedup keying are unchanged.

## Dependency

`bytes` is added as a default `ironbus-server` dependency. It was already resolved (1.11.x) in the lockfile via the all-features otlp/tonic tree, so **no new crate** enters the graph — `Cargo.lock` gains a single dependency-list line. `bytes` is pure Rust (no `links`, no C build script), MIT (already on the deny.toml allow-list), MSRV well below the 1.78 floor.

## Gates (all pass)

- `cargo fmt --all --check` — clean
- `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — 0 warnings
- `cargo test --workspace --all-features --locked` — 1534 passed, 0 failed

## Reviewer focus

- The `Bytes`/`&[u8]` deref-coercion at the `Append` view and `DedupRequest` sites (engine sees identical bytes).
- That I2 and framing/reassembly are genuinely unaffected (no read-loop changes here).
- The safe-partial boundary: confirm the single `copy_from_slice` fill is acceptable and the full read-buffer zero-copy is correctly deferred.