### PR TITLE
fix(produce): connection-thread fast-reject for the byte-cap shed, no client block (#476)

### DIFF
--- a/crates/ironbus-server/src/actor.rs
+++ b/crates/ironbus-server/src/actor.rs
@@ -31,7 +31,8 @@
 //! - No lost replies / no deadlock: every command gets exactly one reply; a closed channel is a typed
 //!   [`ActorGone`], never a panic, so neither side hangs forever if the other dies.
 
-use crate::engine::{Engine, EngineError};
+use crate::engine::{DiskFullPolicy, Engine, EngineError};
+use crate::produce_gate::ProduceCapGate;
 use bytes::Bytes;
 use ironbus_core::clock::Clock;
 use ironbus_core::types::Offset;
@@ -335,6 +336,15 @@ pub struct EngineHandle<F: Filesystem, C: Clock> {
     /// pool is only ever locked by the owning connection thread (uncontended). It carries no produce
     /// state: it is purely an allocation cache, so it never affects reply ORDER or I2.
     reply_pool: ReplyPool,
+    /// The connection-thread byte-cap fast-reject gate (#476, fixes #465): a relaxed-atomic snapshot
+    /// of the durable-log byte-cap shed state the connection thread reads BEFORE the blocking
+    /// `tx.send`, so an at-or-over-cap produce is replied `AtCapacity` immediately WITHOUT enqueuing
+    /// onto a possibly-full (blocking) actor channel. SHARED across every connection (one gate per
+    /// actor), so a `clone` keeps the SAME `Arc` (unlike `reply_pool`): the actor publishes the one
+    /// authoritative byte total here and every connection reads it. The gate is a fast-reject FILTER
+    /// only; the actor's own byte-cap check stays authoritative (I2 / ordering), and the gate is
+    /// engineered to NEVER false-reject (see [`crate::produce_gate`]).
+    cap_gate: Arc<ProduceCapGate>,
 }
 
 // Derived `Clone` would demand `F: Clone`; the handle clones the `SyncSender` and the clock (`C` is
@@ -349,6 +359,9 @@ impl<F: Filesystem, C: Clock + Clone> Clone for EngineHandle<F, C> {
             // recycled reply channels stay strictly per-connection and never cross-deliver. The pool
             // warms lazily on that connection's first produces.
             reply_pool: Arc::new(Mutex::new(Vec::new())),
+            // The SAME shared gate (#476): every connection reads the one byte-cap snapshot the actor
+            // publishes, so the `Arc` is shared on clone (NOT freshened like `reply_pool`).
+            cap_gate: Arc::clone(&self.cap_gate),
         }
     }
 }
@@ -387,6 +400,26 @@ impl<F: Filesystem + 'static, C: Clock + 'static> EngineHandle<F, C> {
     /// # Errors
     /// Returns [`ActorGone`] if the actor exited before the produce could be enqueued.
     pub fn produce_submit(&self, append: OwnedAppend) -> Result<ProduceSubmission, ActorGone> {
+        // CONNECTION-THREAD FAST-REJECT (#476, fixes #465): an O(1) relaxed-atomic read of the
+        // byte-cap shed state BEFORE the blocking `tx.send`. When the gate is SURE the actor would
+        // shed this produce with `AtCapacity` (the log is at or over its drop-new byte cap), reply
+        // `AtCapacity` IMMEDIATELY without enqueuing — so a saturated channel can no longer make a
+        // client BLOCK on `send` ahead of a shed it was always going to get (the #465 symptom).
+        //
+        // It is a fast-reject FILTER, never the source of truth: the actor's own byte-cap check
+        // (`Engine::append_no_sync` -> `Log::append`) is UNCHANGED and still authoritative for I2 and
+        // the single total order. The gate is engineered to NEVER false-reject (it only fires when the
+        // snapshot is provably still over cap at the actor, and disengages under drop-oldest); when it
+        // is not sure it returns `false` and the produce takes the normal, fully-authoritative path.
+        // The `Ready` arm short-circuits the whole channel round-trip, exactly like the direct-engine
+        // submission, so the session maps it through the identical `AtCapacity` reply seam.
+        if self.cap_gate.would_shed() {
+            // Count the fast-reject so it is NOT a silent shed (#476): the actor folds this into the
+            // engine's authoritative `produce_rejected` on its next batch, so a fast-reject is counted
+            // exactly like an in-actor `AtCapacity` shed. Then reply `AtCapacity` immediately.
+            self.cap_gate.record_fast_reject();
+            return Ok(ProduceSubmission::Ready(ProduceOutcome::AtCapacity));
+        }
         // Take a RECYCLED reply channel from this connection's pool (#475) instead of allocating a
         // fresh `sync_channel(1)` per publish. Clone its `tx` into the command (a cheap `Arc` bump);
         // the pair's `rx` rides with the submission and recycles on `wait`.
@@ -788,9 +821,24 @@ where
     // Snapshot the static per-consumer credit caps (#292) BEFORE the engine moves into the actor, so
     // the Connect handshake can negotiate them off the actor's hot path (no round-trip, #177).
     let consumer_credit_caps = (engine.consumer_credit(), engine.consumer_credit_bytes());
+    // Build the connection-thread byte-cap fast-reject gate (#476) BEFORE the engine moves into the
+    // actor. The cap is fixed for the engine's life (not live-reloadable), so it is snapshotted once
+    // here; the live byte total and the policy sentinel are published by the actor as it runs. The
+    // gate is shared (one `Arc` for every connection), and the SAME `Arc` is seeded into the actor so
+    // the actor's publishes and the connections' reads see one value.
+    let cap_gate = Arc::new(ProduceCapGate::new(engine.max_total_bytes()));
+    // Seed the gate to the engine's CURRENT durable bytes and policy, so a broker recovered ALREADY
+    // over its cap (a restart on a full log) fast-rejects from the very first produce rather than
+    // waiting for the first commit to publish a reading. Publish-only (no reconcile): nothing has run
+    // yet, so there are no fast-rejects to fold, and `&engine` is still borrowed before the move.
+    match engine.disk_full_policy() {
+        DiskFullPolicy::DropNew => cap_gate.publish_drop_new(engine.durable_record_bytes()),
+        _ => cap_gate.disengage(),
+    }
+    let actor_gate = Arc::clone(&cap_gate);
     let join = std::thread::Builder::new()
         .name("ironbus-append-actor".to_string())
-        .spawn(move || run_actor(engine, &rx, gather_micros))
+        .spawn(move || run_actor(engine, &rx, gather_micros, &actor_gate))
         // A thread-spawn failure at startup is unrecoverable for the server, but the no-panic bar is
         // for the LIBRARY hot paths; spawning the single actor at boot is a startup step. Surface it
         // by propagating the panic only here (boot), never on a request path.
@@ -803,9 +851,43 @@ where
             // The base handle's pool (#475); each per-connection `clone` gets its own fresh pool, so
             // this one is only used if the base handle itself produces (e.g. in tests).
             reply_pool: Arc::new(Mutex::new(Vec::new())),
+            // The shared fast-reject gate (#476); every connection `clone` shares this same `Arc`.
+            cap_gate,
         },
         join,
     )
+}
+
+/// Refreshes the connection-thread fast-reject gate (#476) AND reconciles its fast-reject count into
+/// the engine's authoritative shed counters. Called by the actor thread ONLY — after each
+/// `commit_batch` (the one place the durable bytes change) and after a config reload that can flip the
+/// policy — so it runs once per batch, amortized with the fsync, never per message.
+///
+/// Two jobs, both on the actor:
+/// 1. RECONCILE: fold any fast-rejects the connection threads performed since the last call into the
+///    engine's `produce_rejected` (and the backstop / retry-budget shed signals), so a connection-
+///    thread fast-reject is counted EXACTLY like an in-actor `AtCapacity` shed (never a silent shed).
+/// 2. PUBLISH the gate's next snapshot. Under [`DiskFullPolicy::DropNew`] it publishes the live
+///    `durable_record_bytes` (the gate may then fast-reject an at-or-over-cap produce); under
+///    [`DiskFullPolicy::DropOldest`] it DISENGAGES the gate (the under-cap sentinel), because that
+///    policy ACCEPTS an over-cap produce after a force-reap, so a connection-thread fast-reject would
+///    be a false reject. See [`crate::produce_gate`] for the full no-false-reject argument.
+fn refresh_cap_gate<F, C>(gate: &ProduceCapGate, engine: &mut Engine<F, C>)
+where
+    F: Filesystem,
+    C: Clock + Clone,
+{
+    // 1. Count the fast-rejects performed off the actor since last time (a fast-reject is never
+    //    silent). The delta is exact (monotonic total minus the actor's high-water mark).
+    engine.record_fast_reject_sheds(gate.take_unreconciled_fast_rejects());
+    // 2. Publish the gate's next snapshot from the now-current byte total and overflow policy.
+    match engine.disk_full_policy() {
+        DiskFullPolicy::DropNew => gate.publish_drop_new(engine.durable_record_bytes()),
+        // Drop-oldest accepts over-cap produces (force-reap then append), so the gate must not fire.
+        // `#[non_exhaustive]` enum: any future non-drop-new policy also disengages, which is the
+        // conservative default (fall through to the authoritative actor path).
+        _ => gate.disengage(),
+    }
 }
 
 /// The bounded group-commit gather (#454): keeps collecting commands into `commands` for up to
@@ -860,6 +942,7 @@ fn run_actor<F, C>(
     mut engine: Engine<F, C>,
     rx: &Receiver<Command<F, C>>,
     gather_micros: u64,
+    cap_gate: &ProduceCapGate,
 ) -> Engine<F, C>
 where
     F: Filesystem,
@@ -1013,7 +1096,18 @@ where
                 // order, so flush the parked produces (one fsync) BEFORE it runs.
                 Command::Run(job) => {
                     flush_pending(&mut engine, &mut pending);
+                    // Reconcile any off-actor fast-rejects into the engine's shed counters BEFORE the
+                    // job runs (#476), so a job that READS those counters — e.g. the `/metrics`
+                    // snapshot — observes the fast-rejects already folded in. Without this ordering a
+                    // scrape could under-report `produce_rejected` by the fast-rejects not yet folded.
+                    engine.record_fast_reject_sheds(cap_gate.take_unreconciled_fast_rejects());
                     job(&mut engine);
+                    // A `Run` job can move BOTH the byte total (a job that reaps) AND the overflow
+                    // policy (the live config reload, the only mutator of `disk_full_policy`), so
+                    // refresh the gate's published snapshot from the engine's now-current state (#476).
+                    // Doing it AFTER the job keeps the gate's policy view in lock-step with a reload
+                    // before any later produce reads it (a flip to drop-oldest never false-rejects).
+                    refresh_cap_gate(cap_gate, &mut engine);
                 }
                 // Graceful drain (#195): flush the pending batch, checkpoint every group, reply the
                 // result, and exit. The flush happens first so a produce acked-by-being-in-the-batch
@@ -1029,6 +1123,14 @@ where
         // The drain is exhausted: commit the parked produces with the ONE covering fsync, then release
         // their replies. This is the steady-state group commit boundary.
         flush_pending(&mut engine, &mut pending);
+        // The batch just changed the durable byte total (an append grows it; a post-commit retention
+        // reap can shrink it), so refresh the connection-thread fast-reject gate with the now-current
+        // reading (#476). This is the ONE refresh that matters for steady-state load: a produce that
+        // pushed the log at/over its drop-new cap is now visible to every connection's pre-check, so
+        // the NEXT saturating produce fast-rejects instead of blocking on a full channel (the #465
+        // fix). It runs once per drained batch (amortized with the fsync), never per message. It also
+        // reconciles any fast-rejects performed off the actor into the engine's shed counters (#476).
+        refresh_cap_gate(cap_gate, &mut engine);
         // The admission queue drained to empty: tell CoDel so the controlled-delay window closes and
         // a bursty-but-healthy queue never lingers in the dropping state (#68). A no-op when CoDel is
         // disabled (the default), so the steady-state loop is unchanged for a broker that has not
@@ -1254,6 +1356,203 @@ mod tests {
         .unwrap();
         let (handle, actor) = spawn_actor(engine, DEFAULT_CHANNEL_BOUND);
         (handle, actor, control)
+    }
+
+    /// The actor test config with a hard durable-log byte cap and the overflow policy overridden
+    /// (#476), sharing the default test knobs. Lets the connection-thread fast-reject tests drive the
+    /// real append-actor byte-cap shed path under a chosen policy.
+    fn config_capped(cap: u64, policy: DiskFullPolicy) -> EngineConfig {
+        EngineConfig {
+            log: LogConfig::default().with_max_total_bytes(cap),
+            disk_full_policy: policy,
+            ..config()
+        }
+    }
+
+    /// Builds a fault-fs + `ManualClock` rig over `config_capped(cap, policy)` and spawns the append
+    /// actor, returning the handle, the actor join handle, and the fault control (#476).
+    #[allow(clippy::type_complexity)]
+    fn rig_capped(
+        cap: u64,
+        policy: DiskFullPolicy,
+    ) -> (
+        EngineHandle<FaultFs<InMemoryFs>, ManualClock>,
+        std::thread::JoinHandle<Engine<FaultFs<InMemoryFs>, ManualClock>>,
+        FaultControl,
+    ) {
+        let (fs, control) = FaultFs::new(InMemoryFs::new());
+        let engine = Engine::open(fs, ManualClock::new(), config_capped(cap, policy)).unwrap();
+        let (handle, actor) = spawn_actor(engine, DEFAULT_CHANNEL_BOUND);
+        (handle, actor, control)
+    }
+
+    /// Produces `payload` (awaiting each, so the actor commits and refreshes the fast-reject gate)
+    /// until the engine's durable byte total has reached `cap`, i.e. until the next produce is a
+    /// byte-cap shed. Returns how many records were accepted. Used to drive the log to its cap
+    /// deterministically without hard-coding the per-record framed byte size.
+    fn fill_to_cap(
+        handle: &EngineHandle<FaultFs<InMemoryFs>, ManualClock>,
+        payload: &[u8],
+        cap: u64,
+    ) -> u64 {
+        let mut accepted = 0u64;
+        loop {
+            match handle.produce(append(payload)).unwrap() {
+                ProduceOutcome::Appended(_) => accepted += 1,
+                // The cap was reached by a prior record (the authoritative actor shed this one); the
+                // log is now at/over cap, which is exactly the state we wanted to reach.
+                ProduceOutcome::AtCapacity => break,
+                other => panic!("unexpected fill outcome: {other:?}"),
+            }
+            if handle.with(|e| e.durable_record_bytes()).unwrap() >= cap {
+                break;
+            }
+        }
+        accepted
+    }
+
+    #[test]
+    fn an_over_cap_produce_fast_rejects_on_the_connection_thread_without_blocking() {
+        // THE #465 FIX over the REAL append actor (#476): once the durable log is at/over its drop-new
+        // byte cap, a produce must get a PROMPT `AtCapacity` on the CONNECTION thread, WITHOUT
+        // enqueuing onto (and blocking on) the bounded actor channel. We prove "without enqueuing /
+        // without blocking" by the SUBMISSION SHAPE: `produce_submit` returns `Ready(AtCapacity)`,
+        // which ONLY the connection-thread fast-reject path produces — the channel path always returns
+        // `Pending`. So a `Ready` is proof the produce never touched `tx.send` (and so could never
+        // block on a full channel, the #465 symptom).
+        const FAST_REJECTS: u64 = 8;
+        let cap = 512;
+        let (handle, actor, _control) = rig_capped(cap, DiskFullPolicy::DropNew);
+        // Drive the log to its cap; the actor publishes the over-cap byte total to the gate on its
+        // post-commit refresh.
+        let accepted = fill_to_cap(&handle, &[0x5a_u8; 64], cap);
+        assert!(accepted > 0, "some records were accepted before the cap");
+        let bytes = handle.with(|e| e.durable_record_bytes()).unwrap();
+        assert!(bytes >= cap, "the log is at/over its cap: {bytes}/{cap}");
+
+        // The `produce_rejected` counter the broker has observed SO FAR (a `with` is a `Run` job, so
+        // this also reconciles any pending fast-rejects first — here there are none yet). Some of
+        // `fill_to_cap`'s tail produces may have been shed by the authoritative actor, so capture the
+        // baseline rather than assuming zero.
+        let rejected_before = handle.with(|e| e.counters().produce_rejected).unwrap();
+
+        // The over-cap produce returns a fast `Ready(AtCapacity)` — no enqueue, no block. Repeated, to
+        // show the gate stays engaged while the log stays over cap (every saturating produce gets the
+        // prompt shed rather than stalling behind a full channel).
+        for attempt in 0..FAST_REJECTS {
+            match handle.produce_submit(append(b"over-cap")).unwrap() {
+                ProduceSubmission::Ready(ProduceOutcome::AtCapacity) => {}
+                ProduceSubmission::Ready(other) => {
+                    panic!("attempt {attempt}: expected a Ready(AtCapacity) fast-reject, got Ready({other:?})")
+                }
+                ProduceSubmission::Pending { .. } => panic!(
+                    "attempt {attempt}: the over-cap produce was ENQUEUED (Pending) instead of \
+                     fast-rejected: it would have blocked on a saturated channel — the #465 bug"
+                ),
+            }
+        }
+
+        // A FAST-REJECT IS NEVER SILENT (#476): the actor reconciles the 8 connection-thread
+        // fast-rejects into the engine's authoritative `produce_rejected`, so the counter the broker
+        // exports matches the rejections the producer actually saw — exactly the equality the CLI
+        // acceptance test asserts against `/metrics`. The `with` runs as a `Run` job, which folds the
+        // pending fast-rejects in BEFORE the counter read.
+        let rejected_after = handle.with(|e| e.counters().produce_rejected).unwrap();
+        assert_eq!(
+            rejected_after - rejected_before,
+            FAST_REJECTS,
+            "every connection-thread fast-reject is counted in produce_rejected (never a silent shed)"
+        );
+        let _ = recover(handle, actor);
+    }
+
+    #[test]
+    fn a_near_cap_but_admissible_produce_is_not_falsely_rejected() {
+        // NO FALSE REJECTS (the conservatism property, #476): a produce that the authoritative actor
+        // WOULD accept must never be fast-rejected. We sit the log JUST UNDER the cap (under-cap byte
+        // total) and assert the next produce is genuinely `Appended`, going through the normal actor
+        // path — the gate falls through, never short-circuits.
+        let cap = 4_096;
+        let (handle, actor, _control) = rig_capped(cap, DiskFullPolicy::DropNew);
+        // One small record: the log is now far under the cap, so the gate must NOT fire.
+        let first = handle.produce(append(b"small")).unwrap();
+        assert!(
+            matches!(first, ProduceOutcome::Appended(_)),
+            "the first record is accepted: {first:?}"
+        );
+        // Confirm we are genuinely near-but-under the cap, then the next produce must be admitted (the
+        // submission goes through the channel — `Pending`/`Appended` — never a fast `AtCapacity`).
+        let bytes = handle.with(|e| e.durable_record_bytes()).unwrap();
+        assert!(
+            bytes > 0 && bytes < cap,
+            "near cap but under it: {bytes}/{cap}"
+        );
+        let submission = handle.produce_submit(append(b"also-small")).unwrap();
+        match submission {
+            // The expected path: the produce was enqueued (NOT fast-rejected) and the actor accepts it.
+            ProduceSubmission::Pending { .. } => {
+                let outcome = submission_for_test_wait(submission);
+                assert!(
+                    matches!(outcome, ProduceOutcome::Appended(_)),
+                    "an under-cap produce is accepted, never falsely rejected: {outcome:?}"
+                );
+            }
+            ProduceSubmission::Ready(ProduceOutcome::AtCapacity) => {
+                panic!("FALSE REJECT: an under-cap produce was fast-rejected as AtCapacity")
+            }
+            ProduceSubmission::Ready(other) => panic!("unexpected Ready outcome: {other:?}"),
+        }
+        let _ = recover(handle, actor);
+    }
+
+    #[test]
+    fn drop_oldest_never_fast_rejects_even_when_over_cap() {
+        // CONSERVATISM UNDER POLICY (#476): under drop-oldest the connection-thread fast-reject must
+        // NEVER fire, because that policy ACCEPTS an over-cap produce after a force-reap (a fast
+        // `AtCapacity` would be a false reject). The actor publishes the under-cap sentinel while the
+        // policy is drop-oldest, so the gate stays DISENGAGED no matter how full the log gets. The
+        // authoritative actor may still legitimately return `AtCapacity` through the CHANNEL in its
+        // documented wedge-guard fall-back (only the active segment left to reap) — that is correct
+        // and is NOT a gate decision; the property under test is strictly that no produce is short-
+        // circuited as a `Ready(AtCapacity)` fast-reject on the connection thread.
+        let cap = 512;
+        let (handle, actor, _control) = rig_capped(cap, DiskFullPolicy::DropOldest);
+        // Drive well past the cap. Every submission must go through the channel (`Pending`) — the gate
+        // is disengaged under drop-oldest, so it never produces a `Ready(AtCapacity)`. The actor's own
+        // outcome (Appended when it can reap, or the wedge-guard AtCapacity) is whatever it authorit-
+        // atively decides; what matters here is that it was NEVER fast-rejected before the channel.
+        let mut fast_reject_seen = false;
+        let mut appended = 0u64;
+        for _ in 0..64u64 {
+            match handle.produce_submit(append(&[0x5a_u8; 64])).unwrap() {
+                ProduceSubmission::Ready(ProduceOutcome::AtCapacity) => fast_reject_seen = true,
+                ProduceSubmission::Ready(other) => panic!("unexpected Ready outcome: {other:?}"),
+                // The normal, authoritative path: drain the outcome so its reply channel recycles.
+                ProduceSubmission::Pending { channel, pool } => {
+                    if matches!(channel.rx.recv(), Ok(ProduceOutcome::Appended(_))) {
+                        appended += 1;
+                    }
+                    drop(pool);
+                }
+            }
+        }
+        assert!(
+            !fast_reject_seen,
+            "FALSE REJECT under drop-oldest: the connection-thread gate fired (it must stay \
+             disengaged under a policy that accepts over-cap produces)"
+        );
+        assert!(
+            appended > 0,
+            "drop-oldest admitted produces via the authoritative path (the gate never blocked them)"
+        );
+        let _ = recover(handle, actor);
+    }
+
+    /// Awaits a `Pending` submission's outcome in a test, recycling its channel like the real `wait`.
+    /// A tiny helper so a test can assert on the SHAPE of the submission first (Pending vs Ready) and
+    /// then collect its outcome without re-implementing the recv/return dance inline.
+    fn submission_for_test_wait(submission: ProduceSubmission) -> ProduceOutcome {
+        submission.wait().unwrap()
     }
 
     #[test]

--- a/crates/ironbus-server/src/engine.rs
+++ b/crates/ironbus-server/src/engine.rs
@@ -2937,6 +2937,33 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         self.backpressure.wal_headroom_shed = self.backpressure.wal_headroom_shed.saturating_add(1);
     }
 
+    /// Accounts `n` byte-cap sheds that the CONNECTION-THREAD fast-reject already performed off the
+    /// actor (#476, fixes #465), so a fast-reject is counted EXACTLY like the authoritative actor-side
+    /// byte-cap shed — never silent. The connection thread replies `AtCapacity` without enqueuing, so
+    /// it cannot touch these actor-owned counters itself; the actor folds the accumulated fast-reject
+    /// delta in here once per batch (the reconcile in `actor::run_actor`). It bumps the SAME three
+    /// signals an in-actor `AtCapacity` shed does — `produce_rejected` (the drop-new shed counter),
+    /// the unified sojourn-independent backstop shed, and the per-client retry-budget shed — so
+    /// `ironbus_produce_rejected_total` stays equal to the rejections the producers actually saw,
+    /// whether they were shed on the actor or fast-rejected on the connection thread. A no-op for
+    /// `n == 0`. All bumps saturate. Idempotent only in the sense that the caller passes a DELTA it
+    /// has not folded before (the gate hands out each fast-reject exactly once).
+    pub fn record_fast_reject_sheds(&mut self, n: u64) {
+        if n == 0 {
+            return;
+        }
+        self.counters.produce_rejected = self.counters.produce_rejected.saturating_add(n);
+        let now = self.log.now_monotonic();
+        for _ in 0..n {
+            // Mirror the per-shed accounting of the in-actor byte-cap path exactly (one backstop shed
+            // and one retry-budget shed per rejected produce), so the two paths are observationally
+            // identical. Both are saturating no-ops when their controller is disabled (the default).
+            self.backpressure.codel_backstop_shed =
+                self.backpressure.codel_backstop_shed.saturating_add(1);
+            self.backpressure.retry_budget.record_shed(now);
+        }
+    }
+
     /// The broker-side per-client retry-budget re-check (#69): records one ORIGINAL request the
     /// broker ACCEPTED at the current monotonic instant, feeding the accept-based throttle so the
     /// observed retry ratio stays meaningful. Called when a produce (or other request) is admitted.
@@ -4761,6 +4788,25 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
     #[must_use]
     pub fn durable_record_bytes(&self) -> u64 {
         self.log.durable_record_bytes()
+    }
+
+    /// The configured durable-log byte cap (`LogConfig::max_total_bytes`, the quantity
+    /// [`Engine::durable_record_bytes`] is shed against). `0` means UNLIMITED (the cap is off). Fixed
+    /// for the engine's life: the cap is layout/contract-bound and NOT live-reloadable (a change
+    /// requires a restart), so a one-time snapshot of it (e.g. for the #476 connection-thread
+    /// fast-reject gate) never drifts.
+    #[must_use]
+    pub fn max_total_bytes(&self) -> u64 {
+        self.log.config().max_total_bytes
+    }
+
+    /// The CURRENT durable-log overflow policy ([`EngineConfig::disk_full_policy`]). Unlike the cap,
+    /// this IS live-reloadable ([`Engine::apply_reloadable_config`]), but only between batches on the
+    /// append-actor thread, so reading it on that thread (e.g. to refresh the #476 fast-reject gate
+    /// after a commit or a reload) observes a stable value for the current pass.
+    #[must_use]
+    pub fn disk_full_policy(&self) -> DiskFullPolicy {
+        self.disk_full_policy
     }
 
     /// The log's total durable RECORD COUNT (the quantity the count-retention bound,

--- a/crates/ironbus-server/src/lib.rs
+++ b/crates/ironbus-server/src/lib.rs
@@ -9,6 +9,7 @@ pub mod health;
 pub mod liveness;
 pub mod metrics;
 pub mod obs;
+pub mod produce_gate;
 pub mod registry;
 pub mod rss;
 pub mod server;

--- a/crates/ironbus-server/src/produce_gate.rs
+++ b/crates/ironbus-server/src/produce_gate.rs
@@ -1,0 +1,313 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! The connection-thread produce fast-reject gate (#476, fixes #465).
+//!
+//! ## The bug (#465)
+//!
+//! Every produce-side load-shed decision — the CoDel controlled-delay shed, the fsync-headroom shed,
+//! and the durable-log byte-cap [`AtCapacity`](crate::actor::ProduceOutcome::AtCapacity) shed — runs
+//! on the SINGLE append-actor thread, AFTER the connection handler's blocking send into the bounded
+//! actor channel (`EngineHandle::produce_submit` → `tx.send`, bound
+//! [`DEFAULT_CHANNEL_BOUND`](crate::actor::DEFAULT_CHANNEL_BOUND)). When the broker is saturated the
+//! channel fills, so the client BLOCKS on `send` and cannot reach the cheap shed: backpressure
+//! front-runs the load-shed. A produce that should have been a prompt, immediate `AtCapacity`
+//! rejection instead stalls behind the full channel until the actor drains — the #465 symptom
+//! (pre-loading a `--storage memory` broker past its byte cap "did not return"; the client waited
+//! on an ack it could not get).
+//!
+//! ## The fix (#476)
+//!
+//! A connection-thread **fast-reject pre-check** that runs BEFORE the blocking `tx.send`. It reads an
+//! O(1) relaxed-atomic snapshot of the engine's durable-byte-cap state (this gate) and, when it is
+//! SURE the actor would shed the produce with `AtCapacity`, replies `AtCapacity` IMMEDIATELY without
+//! enqueuing and without blocking. The authoritative actor-side byte-cap check
+//! ([`Engine::append_no_sync`](crate::engine::Engine) → `Log::append`) is UNCHANGED and remains the
+//! source of truth (it must, for I2 / single-total-order correctness); this gate is purely a
+//! fast-reject FILTER in front of it, exactly the same seam shape as the off-actor consume path.
+//!
+//! ## Conservatism (the load-bearing property): NO false rejects
+//!
+//! A false reject — fast-rejecting a produce the actor would have ACCEPTED — is lost throughput / a
+//! dropped good message, so it is forbidden. This gate fast-rejects ONLY when it is certain the actor
+//! would shed. The guarantee rests on three facts, all of which hold because the bytes value and the
+//! overflow policy are mutated EXCLUSIVELY on the append-actor thread (see `actor::run_actor` and the
+//! `engine.with(...)` config-reload path, which both run on that one thread, serialized):
+//!
+//! 1. **The authoritative predicate is monotone-safe to snapshot.** The actor sheds `AtCapacity`
+//!    exactly when `cap != 0 && durable_record_bytes >= cap && durable_record_bytes > 0`
+//!    (`Log::append`). The cap (`max_total_bytes`) is NOT live-reloadable (it is layout/contract-bound
+//!    and requires a restart), so it is fixed for the engine's life and can be snapshotted once. The
+//!    only quantity that moves is `durable_record_bytes`, and it changes ONLY on the actor thread:
+//!    it GROWS on an append (inside `commit_batch`) and SHRINKS only on a reap (also inside
+//!    `commit_batch`, or on a config-reload reap — both on the actor).
+//!
+//! 2. **A stale snapshot under drop-new can only be too LOW, never falsely too high.** The actor
+//!    refreshes this gate's bytes value right AFTER every `commit_batch` (the one place bytes change).
+//!    Between that refresh and the actor next processing a produce, NOTHING lowers the real bytes (a
+//!    reap only runs during a `commit_batch`, which is when/after the pre-checked produce is itself
+//!    processed). So if the snapshot reads "at/over cap," the real value is still at/over cap when the
+//!    actor checks it — the fast-reject matches the authoritative outcome. A snapshot that lags LOW
+//!    (e.g. a not-yet-published recent append) merely makes the gate fall through to the actor, which
+//!    is always safe.
+//!
+//! 3. **Drop-oldest never fast-rejects.** Under [`DiskFullPolicy::DropOldest`](crate::engine) an
+//!    over-cap produce is ACCEPTED after a force-reap, so an over-cap snapshot does NOT imply a shed.
+//!    The policy is live-reloadable (on the actor), so to stay conservative across a flip the actor
+//!    publishes a SENTINEL (`bytes = 0`, which always reads as under-cap) whenever the policy is
+//!    drop-oldest, and re-publishes the real bytes only while it is drop-new. A flip to drop-oldest
+//!    therefore disables the gate before any produce is accepted under the new policy; a flip back to
+//!    drop-new starting from the `0` sentinel only ever UNDER-reports (falls through to the actor)
+//!    until the next commit refreshes it. Either direction is safe.
+//!
+//! The net effect: the gate can fast-reject a produce the actor would have rejected (the #465 fix),
+//! and can NEVER fast-reject a produce the actor would have accepted (no false rejects). When it is
+//! not sure, it returns `false` and the produce takes the normal, fully-authoritative actor path.
+
+use core::sync::atomic::{AtomicU64, Ordering};
+
+/// A shared, relaxed-atomic snapshot of the durable-log byte-cap shed state the connection thread
+/// reads to fast-reject an at-or-over-cap produce BEFORE the blocking actor-channel send (#476).
+///
+/// One `AtomicU64`, relaxed ordering (the value is an advisory fast-reject hint, not a synchronization
+/// point for any other state — the actor's own check stays authoritative). The configured cap is held
+/// as a plain field because it never changes after open (`max_total_bytes` is not live-reloadable).
+///
+/// `bytes` carries the live `durable_record_bytes` the actor publishes after each commit WHILE the
+/// overflow policy is drop-new, and the sentinel `0` whenever the policy is drop-oldest (so the gate
+/// disengages under drop-oldest, which accepts over-cap produces). See the module docs for the full
+/// no-false-reject argument.
+#[derive(Debug)]
+pub struct ProduceCapGate {
+    /// The configured durable-log byte cap (`LogConfig::max_total_bytes`). `0` means the cap is OFF
+    /// (unlimited): the gate then never fast-rejects, exactly matching the actor, which never sheds
+    /// `AtCapacity` with no cap. Fixed for the engine's life (not live-reloadable).
+    cap: u64,
+    /// The most recently published shed-eligible `durable_record_bytes`, or the `0` sentinel under
+    /// drop-oldest. Read relaxed by the connection thread, stored relaxed by the actor thread.
+    bytes: AtomicU64,
+    /// A MONOTONIC running total of fast-rejects performed on the connection thread (#476), so a
+    /// fast-reject is never a SILENT shed. The connection thread bumps it (relaxed `fetch_add`) every
+    /// time [`ProduceCapGate::would_shed`] short-circuits a produce; the actor reads it once per batch
+    /// and folds the DELTA since its last read into the engine's authoritative shed counters
+    /// (`Engine::record_fast_reject_sheds`), so `ironbus_produce_rejected_total` counts a fast-reject
+    /// exactly like an in-actor `AtCapacity` shed. Monotonic + delta-reconciled, so the count is
+    /// exact under any number of concurrent connection threads with no lock and no double-count.
+    fast_rejects: AtomicU64,
+    /// The fast-reject high-water mark the ACTOR has already folded into the engine's authoritative
+    /// shed counters (#476). Touched ONLY by the actor thread (in `take_unreconciled_fast_rejects`),
+    /// so it needs no compare-and-swap: the actor reads `fast_rejects - reconciled` as the new delta,
+    /// then advances `reconciled` to the value it just observed. An `AtomicU64` (not a plain field)
+    /// only because the gate is shared behind an `Arc`.
+    reconciled: AtomicU64,
+}
+
+impl ProduceCapGate {
+    /// Creates a gate for a log whose byte cap is `cap` (`0` = unlimited / cap off). Seeded with
+    /// `bytes = 0` (under cap), so a freshly opened broker never fast-rejects until the actor has
+    /// published a real over-cap reading — the conservative starting point.
+    #[must_use]
+    pub fn new(cap: u64) -> ProduceCapGate {
+        ProduceCapGate {
+            cap,
+            bytes: AtomicU64::new(0),
+            fast_rejects: AtomicU64::new(0),
+            reconciled: AtomicU64::new(0),
+        }
+    }
+
+    /// Publishes the current shed-eligible durable byte total (the actor thread calls this).
+    ///
+    /// Pass the engine's live `durable_record_bytes` WHILE the overflow policy is drop-new, or the
+    /// sentinel `0` whenever it is drop-oldest (so the gate disengages under a policy that accepts
+    /// over-cap produces). A single relaxed store; called once per `commit_batch` and once per policy
+    /// reload, never on the per-message connection hot path. See [`ProduceCapGate::publish_drop_new`]
+    /// and [`ProduceCapGate::disengage`] for the two intent-named wrappers the actor uses.
+    pub fn publish(&self, shed_eligible_bytes: u64) {
+        self.bytes.store(shed_eligible_bytes, Ordering::Relaxed);
+    }
+
+    /// Publishes `durable_record_bytes` as the shed-eligible total: the actor calls this after a
+    /// commit WHILE the overflow policy is drop-new (the only policy under which an over-cap produce
+    /// is actually shed). A thin, intent-named wrapper over [`ProduceCapGate::publish`].
+    pub fn publish_drop_new(&self, durable_record_bytes: u64) {
+        self.publish(durable_record_bytes);
+    }
+
+    /// Disengages the gate (publishes the `0` sentinel): the actor calls this whenever the overflow
+    /// policy is drop-oldest, under which an over-cap produce is ACCEPTED after a force-reap, so the
+    /// connection-thread fast-reject must never fire. A thin, intent-named wrapper over
+    /// [`ProduceCapGate::publish`].
+    pub fn disengage(&self) {
+        self.publish(0);
+    }
+
+    /// The connection-thread fast-reject decision: returns `true` ONLY when the gate is SURE the
+    /// actor would shed this produce with `AtCapacity`, so the caller may reply `AtCapacity`
+    /// immediately WITHOUT enqueuing onto the (possibly full, blocking) actor channel — the #476 fix.
+    ///
+    /// Mirrors the authoritative `Log::append` predicate EXACTLY (`cap != 0 && bytes >= cap &&
+    /// bytes > 0`) over the last-published snapshot. Because the snapshot can only lag LOW under
+    /// drop-new and is forced to the under-cap sentinel under drop-oldest (see the module docs), a
+    /// `true` here implies the actor would also shed — never a false reject. A `false` means "not
+    /// sure / would succeed," and the produce falls through to the normal authoritative actor path.
+    #[must_use]
+    pub fn would_shed(&self) -> bool {
+        let cap = self.cap;
+        if cap == 0 {
+            // No cap configured: the actor never sheds `AtCapacity`, so the gate never fires.
+            return false;
+        }
+        let bytes = self.bytes.load(Ordering::Relaxed);
+        // The at-or-over check, identical to `Log::append`: `bytes > 0` keeps the empty-log rule (an
+        // oversized first record is always written, never wedged out by a fast-reject).
+        bytes >= cap && bytes > 0
+    }
+
+    /// Records that the connection thread just fast-rejected a produce (#476): bumps the monotonic
+    /// fast-reject total so the actor can later count the shed in the engine's authoritative
+    /// `produce_rejected` (a fast-reject is never silent). A single relaxed `fetch_add` on the produce
+    /// fast-path; the caller invokes it exactly once per [`ProduceCapGate::would_shed`] that fired.
+    pub fn record_fast_reject(&self) {
+        self.fast_rejects.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// The MONOTONIC running total of fast-rejects performed on the connection thread (#476). A single
+    /// relaxed load. Exposed for tests/observability; the actor uses
+    /// [`ProduceCapGate::take_unreconciled_fast_rejects`] to fold the delta into the engine counters.
+    #[must_use]
+    pub fn fast_reject_total(&self) -> u64 {
+        self.fast_rejects.load(Ordering::Relaxed)
+    }
+
+    /// Returns the number of fast-rejects performed since the LAST call and advances the reconciled
+    /// high-water mark (#476). Called ONLY by the actor thread, once per batch, so it needs no CAS:
+    /// it reads the connection threads' monotonic total, subtracts what it has already folded, and
+    /// records the new high-water mark. The returned delta is then folded into the engine's
+    /// authoritative shed counters (`Engine::record_fast_reject_sheds`), so every fast-reject is
+    /// counted exactly once and a fast-reject is never a silent shed. `saturating_sub` guards the
+    /// (impossible-under-the-single-actor-invariant) case of a reordered read seeing a total below the
+    /// high-water mark: it then reports `0` rather than a wrapped delta.
+    pub fn take_unreconciled_fast_rejects(&self) -> u64 {
+        let total = self.fast_rejects.load(Ordering::Relaxed);
+        let already = self.reconciled.load(Ordering::Relaxed);
+        let delta = total.saturating_sub(already);
+        if delta != 0 {
+            self.reconciled.store(total, Ordering::Relaxed);
+        }
+        delta
+    }
+
+    /// The configured cap (`0` = unlimited). Exposed for tests and observability.
+    #[must_use]
+    pub fn cap(&self) -> u64 {
+        self.cap
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_disabled_cap_never_fast_rejects() {
+        // cap == 0 is the default (unlimited): the actor never sheds `AtCapacity`, so neither does the
+        // gate, no matter how large the published byte total grows.
+        let gate = ProduceCapGate::new(0);
+        assert!(!gate.would_shed());
+        gate.publish_drop_new(u64::MAX);
+        assert!(!gate.would_shed(), "no cap => never fast-reject");
+    }
+
+    #[test]
+    fn a_fresh_gate_is_under_cap() {
+        // Seeded at 0 bytes: a freshly opened broker is under cap and never fast-rejects until the
+        // actor publishes a real over-cap reading (the conservative starting point).
+        let gate = ProduceCapGate::new(1_000);
+        assert!(!gate.would_shed());
+    }
+
+    #[test]
+    fn it_fast_rejects_only_at_or_over_cap() {
+        // Mirrors `Log::append` exactly: under cap => fall through; AT cap or OVER => fast-reject.
+        let gate = ProduceCapGate::new(1_000);
+        gate.publish_drop_new(999);
+        assert!(!gate.would_shed(), "below cap is not a shed");
+        gate.publish_drop_new(1_000);
+        assert!(gate.would_shed(), "at cap sheds (at-or-over)");
+        gate.publish_drop_new(2_500);
+        assert!(gate.would_shed(), "over cap sheds");
+        // A reap drops it back under the cap: the gate disengages again, so a later produce is not
+        // falsely rejected.
+        gate.publish_drop_new(500);
+        assert!(
+            !gate.would_shed(),
+            "a reap back under cap re-opens the gate"
+        );
+    }
+
+    #[test]
+    fn the_empty_log_rule_is_preserved() {
+        // `bytes == 0` is never a shed even when the cap is tiny: the empty-log first record is always
+        // written (an oversized first record is not wedged out), exactly as `Log::append`'s
+        // `total > 0` clause guarantees.
+        let gate = ProduceCapGate::new(1);
+        assert!(!gate.would_shed(), "empty log: first record always written");
+        gate.publish_drop_new(0);
+        assert!(!gate.would_shed());
+    }
+
+    #[test]
+    fn drop_oldest_disengages_the_gate() {
+        // Under drop-oldest an over-cap produce is ACCEPTED after a force-reap, so the actor publishes
+        // the `0` sentinel via `disengage()` and the gate must never fire even though the real byte
+        // total is over cap.
+        let gate = ProduceCapGate::new(1_000);
+        gate.publish_drop_new(5_000); // would fast-reject under drop-new
+        assert!(gate.would_shed());
+        gate.disengage(); // a flip to drop-oldest
+        assert!(
+            !gate.would_shed(),
+            "drop-oldest accepts over-cap; the gate must disengage (no false reject)"
+        );
+    }
+
+    #[test]
+    fn fast_rejects_are_counted_and_reconciled_as_exact_deltas() {
+        // A fast-reject is never a SILENT shed: each `record_fast_reject` bumps the monotonic total,
+        // and the actor's `take_unreconciled_fast_rejects` hands back EXACTLY the new ones since the
+        // last reconcile (so the engine's `produce_rejected` ends up equal to the rejections the
+        // producers actually saw — no under- or double-count).
+        let gate = ProduceCapGate::new(1_000);
+        assert_eq!(gate.fast_reject_total(), 0);
+        assert_eq!(
+            gate.take_unreconciled_fast_rejects(),
+            0,
+            "nothing to fold yet"
+        );
+
+        gate.record_fast_reject();
+        gate.record_fast_reject();
+        gate.record_fast_reject();
+        assert_eq!(gate.fast_reject_total(), 3);
+        // The actor folds all 3 at once.
+        assert_eq!(gate.take_unreconciled_fast_rejects(), 3);
+        // A second reconcile with no new fast-rejects folds nothing (no double-count).
+        assert_eq!(gate.take_unreconciled_fast_rejects(), 0);
+
+        // More fast-rejects accrue; only the NEW ones are folded next time.
+        gate.record_fast_reject();
+        gate.record_fast_reject();
+        assert_eq!(gate.fast_reject_total(), 5, "the total stays monotonic");
+        assert_eq!(
+            gate.take_unreconciled_fast_rejects(),
+            2,
+            "only the 2 new ones"
+        );
+        assert_eq!(gate.take_unreconciled_fast_rejects(), 0);
+    }
+
+    #[test]
+    fn cap_is_reported() {
+        assert_eq!(ProduceCapGate::new(4_096).cap(), 4_096);
+        assert_eq!(ProduceCapGate::new(0).cap(), 0);
+    }
+}


### PR DESCRIPTION
Closes #476 (fixes #465).

## What

The produce byte-cap shed (`AtCapacity`) — like the CoDel and fsync-headroom sheds — ran on the single append-actor thread **after** the connection handler's blocking send into the bounded actor channel. When the broker is saturated the channel fills, so the client **blocks on `send`** and never reaches the cheap shed: backpressure front-runs the load-shed, and a produce that should have been a prompt `AtCapacity` rejection stalls instead (the #465 symptom — pre-loading a memory broker past its byte cap did not return).

This adds an O(1) **connection-thread fast-reject pre-check** that runs *before* the blocking send. A new `ProduceCapGate` holds a relaxed `AtomicU64` snapshot of the durable byte-cap state; `produce_submit` reads it and, **only when it is sure the actor would shed**, replies `AtCapacity` immediately (a `Ready` submission) without enqueuing and without blocking.

## Conservatism — no false rejects (the load-bearing property)

A false reject (fast-rejecting a produce the actor would have accepted) is lost throughput / a dropped good message, so it is forbidden. The gate fast-rejects **only when certain**:

- It mirrors the authoritative `Log::append` predicate **exactly** (`cap != 0 && bytes >= cap && bytes > 0`, including the empty-log first-record rule).
- The cap (`max_total_bytes`) is fixed for the engine's life (not live-reloadable), so it is snapshotted once.
- `durable_record_bytes` changes **only on the actor thread**; the actor republishes it after **every commit** — the one place the bytes move — so a stale snapshot can only lag **low** (fall through to the actor), never falsely high.
- Under `DropOldest` (which *accepts* an over-cap produce after a force-reap) the actor publishes an under-cap sentinel, so the gate **disengages**. The policy is live-reloadable but only on the actor (serialized), so a flip can never false-reject.
- When unsure the gate returns `false` and the produce takes the normal, fully-authoritative path.

## Authoritative check preserved

The actor-side byte-cap check (`Engine::append_no_sync` → `Log::append`) is **unchanged** and remains the source of truth for I2 and the single total order. The gate is purely a fast-reject **filter** in front of it — the same seam shape as the off-actor consume path. I2, fire-and-forget, and the pipelined-publish window are untouched.

## A fast-reject is never silent

Because a fast-reject bypasses the actor, it would otherwise miss `ironbus_produce_rejected_total`. The gate counts each fast-reject; the actor reconciles the delta into the engine's authoritative `produce_rejected` (and the backstop / retry-budget shed signals) once per batch, **before** any `/metrics` read — so the exported counter still equals the rejections producers actually saw.

## Tests

- An over-cap produce gets a fast `Ready(AtCapacity)` **without enqueuing**, and the fast-rejects are counted in `produce_rejected` (the #465 fix + no-silent-shed).
- A near-cap-but-admissible produce is **not** falsely rejected (the conservatism property).
- `DropOldest` never fast-rejects even when over cap.
- Gate-unit tests for the predicate, the empty-log rule, the drop-oldest sentinel, and exact reconcile deltas.

## Gates (all pass; RUSTFLAGS `-D warnings`, MSRV 1.78)

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — clean
- `cargo test --workspace --all-features --locked` — 1554 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)