### PR TITLE
feat(consume): batch-pull fetch (max_records/max_bytes/expires/no_wait) (#489)

### DIFF
--- a/crates/ironbus-client/src/lib.rs
+++ b/crates/ironbus-client/src/lib.rs
@@ -28,8 +28,9 @@ use ironbus_core::types::RecordFlags;
 use ironbus_proto::frame::{decode_frame, encode_frame, FrameDecode, FrameError, FrameType};
 use ironbus_proto::message::{
     decode_dead_letter, decode_deliver, decode_gap_marker, decode_info, decode_pub_ack,
-    decode_truncated, encode_ack, encode_connect, encode_cumulative_ack, encode_pub, encode_sub,
-    AckBody, AckOp, BodyError, ConnectBody, CumulativeAckBody, PubBody, SubBody,
+    decode_truncated, encode_ack, encode_connect, encode_cumulative_ack, encode_fetch, encode_pub,
+    encode_sub, AckBody, AckOp, BodyError, ConnectBody, CumulativeAckBody, FetchBody, PubBody,
+    SubBody,
 };
 use std::io::{self, Read, Write};
 use std::net::{TcpStream, ToSocketAddrs};
@@ -908,6 +909,21 @@ impl Client {
         // slot yields at most one delivery OR one dead-letter advisory OR one truncation advisory,
         // so a buggy or hostile server cannot stream any of them without bound.
         let limit = usize::try_from(max).unwrap_or(usize::MAX);
+        self.read_fetch_response(limit)
+    }
+
+    /// Reads and decodes a batch delivery response (the shared tail of [`Client::fetch`] and
+    /// [`Client::fetch_batch`]): a run of `Deliver` frames (transparently decompressed, #430), with any
+    /// interleaved `DeadLetter` / `Truncated` / `GapMarker` advisories, terminated by exactly one
+    /// `FlowEnd` (or an `Err`). `limit` bounds the TOTAL advisory + delivery frames the server may stream
+    /// before the terminator, so a buggy or hostile server cannot stream without bound. The batch-pull
+    /// fetch (#489) reuses this verbatim because its wire response is byte-for-byte a `Flow` response past
+    /// the request frame.
+    ///
+    /// # Errors
+    /// Returns a [`ClientError`] on an IO error, a server error, a decode failure, or a server that
+    /// streams more frames than `limit`.
+    fn read_fetch_response(&mut self, limit: usize) -> Result<Fetch, ClientError> {
         let mut messages = Vec::new();
         let mut dead_letters = Vec::new();
         let mut truncations = Vec::new();
@@ -1038,6 +1054,62 @@ impl Client {
                 (other, _) => return Err(ClientError::Unexpected(other)),
             }
         }
+    }
+
+    /// Batch-pull FETCH (#489): drains up to `max_records` records (and at most `max_bytes` total
+    /// payload-equivalent bytes) in ONE round-trip, the amortized twin of [`Client::fetch`]. The server
+    /// runs the SAME per-record poll the per-record path runs, so a batch fetch delivers EXACTLY the
+    /// records that many successive [`Client::fetch`] calls would, leasing each one identically and
+    /// preserving the at-least-once contract and the broadcast/`key_shared`/competing semantics — it only
+    /// amortizes the actor hop and per-poll read cost across the batch.
+    ///
+    /// - `max_records`: the most records to return. As with [`Client::fetch`], it is capped at the
+    ///   NEGOTIATED per-consumer credit (#292) when the server advertised one, so the client honors what
+    ///   it agreed to (the server enforces the same ceiling independently).
+    /// - `max_bytes`: the byte budget for the batch (`0` = unbounded by bytes; the record count, credit,
+    ///   and deadline still bind). The server applies the floor-of-one, so a single over-budget record is
+    ///   never wedged.
+    /// - `expires`: a deadline budget; the server returns whatever it has gathered by the deadline. `0`
+    ///   means no deadline. Ignored when `no_wait` is set.
+    /// - `no_wait`: when `true`, the server returns IMMEDIATELY with whatever is ready (a single drain
+    ///   pass), never waiting out `expires` — the NATS pull-consumer `no_wait` behavior.
+    ///
+    /// The response is byte-for-byte a [`Client::fetch`] response past the request frame (a run of
+    /// deliveries plus any advisories, terminated by `FlowEnd`), so the returned [`Fetch`] is shaped
+    /// identically.
+    ///
+    /// # Errors
+    /// Returns a [`ClientError`] on an IO error, a server error, or a server that delivers more frames
+    /// than the requested record cap.
+    pub fn fetch_batch(
+        &mut self,
+        max_records: u32,
+        max_bytes: u64,
+        expires: Duration,
+        no_wait: bool,
+    ) -> Result<Fetch, ClientError> {
+        // Cap the record request at the negotiated credit (when known): the negotiated value governs the
+        // pull, exactly as `fetch` does, so the client never over-requests past what it agreed to.
+        let max_records = match self.negotiated_credit {
+            Some(credit) => max_records.min(credit),
+            None => max_records,
+        };
+        // The deadline budget in milliseconds, saturated to u64 so an absurd Duration cannot overflow.
+        let expires_ms = u64::try_from(expires.as_millis()).unwrap_or(u64::MAX);
+        let req = FetchBody {
+            max_records,
+            max_bytes,
+            expires_ms,
+            no_wait,
+        };
+        let mut body = Vec::new();
+        encode_fetch(&req, &mut body);
+        self.send(FrameType::Fetch, &body)?;
+        // The record cap bounds the TOTAL delivery + advisory frames the server may stream before
+        // FlowEnd, exactly as the per-record credit does for `fetch`: each granted slot yields at most one
+        // such frame, so a buggy or hostile server cannot stream without bound.
+        let limit = usize::try_from(max_records).unwrap_or(usize::MAX);
+        self.read_fetch_response(limit)
     }
 
     /// Acknowledges a fetched message by its offset and fencing generation. Returns `true`
@@ -1665,6 +1737,107 @@ mod tests {
         // Nothing left to fetch.
         assert!(c.fetch(10).unwrap().messages.is_empty());
 
+        shutdown.store(true, Ordering::Release);
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn fetch_batch_round_trips_against_a_real_server() {
+        // #489: a batch-pull fetch_batch drains the produced records in ONE round-trip, identically to
+        // the per-record fetch path, and each delivered record can be acked with the lease generation it
+        // carried (the lease the batch hands out is the same fencing lease the per-record poll hands out).
+        let (addr, shutdown, handle) = start_server();
+        let mut c = Client::connect(addr).unwrap();
+        let n = 5u8;
+        for i in 0..n {
+            c.produce(&PubBody {
+                flags: 0,
+                timestamp_ms: 0,
+                key: b"",
+                headers: b"",
+                dedup: None,
+                fire_and_forget: false,
+                payload: &[i; 8],
+            })
+            .unwrap();
+        }
+
+        // One batch fetch drains all n records.
+        let fetched = c
+            .fetch_batch(u32::from(n), 0, std::time::Duration::from_secs(1), false)
+            .unwrap();
+        assert_eq!(
+            fetched.messages.len(),
+            usize::from(n),
+            "all records in one round-trip"
+        );
+        for (i, m) in fetched.messages.iter().enumerate() {
+            assert_eq!(
+                m.offset,
+                u64::try_from(i).unwrap(),
+                "offsets are in log order"
+            );
+        }
+        // Ack them all with the generations the batch carried, proving the leases are the real fencing
+        // leases (at-least-once / lease semantics preserved).
+        for m in &fetched.messages {
+            assert!(
+                c.ack(m.offset, m.generation).unwrap(),
+                "the fetch-leased record commits"
+            );
+        }
+        // Nothing left.
+        assert!(c
+            .fetch_batch(u32::from(n), 0, std::time::Duration::ZERO, true)
+            .unwrap()
+            .messages
+            .is_empty());
+
+        shutdown.store(true, Ordering::Release);
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn fetch_batch_no_wait_on_an_empty_queue_returns_immediately() {
+        // #489 no_wait: a fetch against an empty queue returns an empty batch immediately, never hanging.
+        let (addr, shutdown, handle) = start_server();
+        let mut c = Client::connect(addr).unwrap();
+        let fetched = c
+            .fetch_batch(10, 0, std::time::Duration::ZERO, true)
+            .unwrap();
+        assert!(
+            fetched.messages.is_empty(),
+            "no_wait on an empty queue returns nothing"
+        );
+        shutdown.store(true, Ordering::Release);
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn fetch_batch_max_records_bounds_the_batch_against_a_real_server() {
+        // #489: max_records caps the batch below what is available, end-to-end over the wire.
+        let (addr, shutdown, handle) = start_server();
+        let mut c = Client::connect(addr).unwrap();
+        for i in 0..10u8 {
+            c.produce(&PubBody {
+                flags: 0,
+                timestamp_ms: 0,
+                key: b"",
+                headers: b"",
+                dedup: None,
+                fire_and_forget: false,
+                payload: &[i; 4],
+            })
+            .unwrap();
+        }
+        let fetched = c
+            .fetch_batch(3, 0, std::time::Duration::from_secs(1), false)
+            .unwrap();
+        assert_eq!(
+            fetched.messages.len(),
+            3,
+            "max_records bounds the batch to 3 of 10"
+        );
         shutdown.store(true, Ordering::Release);
         handle.join().unwrap();
     }

--- a/crates/ironbus-proto/src/frame.rs
+++ b/crates/ironbus-proto/src/frame.rs
@@ -119,6 +119,21 @@ pub enum FrameType {
     /// 2 = dead-lettered). PROTO/CODEC ONLY in this phase: this frame is DEFINED here but NOTHING
     /// sends it yet (the server emit path is phase #497).
     ProduceConfirm,
+    /// Consumer batch-pull FETCH request (#489): a NATS pull-consumer-style request that drains up to
+    /// `max_records` / `max_bytes` of deliverable records in ONE round-trip, amortizing the per-poll
+    /// actor hop and read cost across the whole batch. It is the BATCH twin of [`FrameType::Flow`]
+    /// (tag 10): the server runs the SAME per-record poll the `Flow` path does (same lease/credit,
+    /// at-least-once, broadcast/`key_shared`/competing semantics, never over-delivering past
+    /// `max_in_flight`), so a batch fetch delivers EXACTLY the records N successive per-record polls
+    /// would, just in one request. The RESPONSE reuses the existing delivery frames verbatim — a run
+    /// of [`FrameType::Deliver`] (with any interleaved [`FrameType::DeadLetter`],
+    /// [`FrameType::Truncated`], or [`FrameType::GapMarker`] advisories), terminated by exactly one
+    /// [`FrameType::FlowEnd`] carrying the delivered count — so no new response frame is introduced.
+    /// It is a NEW append-only request tag: an old client never sends it and the existing `Flow`
+    /// wire (tag 10) is byte-for-byte unchanged. Body: a [`crate::message::FetchBody`]
+    /// (`max_records: u32`, `max_bytes: u64`, `expires_ms: u64` relative deadline budget, and a
+    /// `no_wait` flag), versioned and forward-compatible.
+    Fetch,
 }
 
 impl FrameType {
@@ -148,6 +163,7 @@ impl FrameType {
             FrameType::PubAckDuplicate => 20,
             FrameType::GapMarker => 21,
             FrameType::ProduceConfirm => 22,
+            FrameType::Fetch => 23,
         }
     }
 
@@ -178,6 +194,7 @@ impl FrameType {
             20 => FrameType::PubAckDuplicate,
             21 => FrameType::GapMarker,
             22 => FrameType::ProduceConfirm,
+            23 => FrameType::Fetch,
             _ => return None,
         })
     }
@@ -310,7 +327,7 @@ mod tests {
     use super::*;
     use proptest::prelude::*;
 
-    const ALL_TYPES: [FrameType; 22] = [
+    const ALL_TYPES: [FrameType; 23] = [
         FrameType::Connect,
         FrameType::Info,
         FrameType::Ping,
@@ -333,6 +350,7 @@ mod tests {
         FrameType::PubAckDuplicate,
         FrameType::GapMarker,
         FrameType::ProduceConfirm,
+        FrameType::Fetch,
     ];
 
     #[test]
@@ -373,17 +391,15 @@ mod tests {
         assert_eq!(FrameType::PubAckDuplicate.as_u8(), 20);
         assert_eq!(FrameType::GapMarker.as_u8(), 21);
         assert_eq!(FrameType::ProduceConfirm.as_u8(), 22);
+        assert_eq!(FrameType::Fetch.as_u8(), 23);
     }
 
     #[test]
-    fn produce_confirm_is_the_next_free_tag_and_frames() {
-        // #494: ProduceConfirm takes tag 22, the next FREE tag after GapMarker (21). It was previously
-        // an UNKNOWN tag, so this pins it as a known type now and confirms it frames at the envelope
-        // level like any other.
+    fn produce_confirm_is_a_frozen_tag_and_frames() {
+        // #494: ProduceConfirm holds tag 22 (the FREE tag after GapMarker, 21); pinned here so a
+        // future reorder breaks a test, not the wire, and confirmed to frame at the envelope level.
         assert_eq!(FrameType::ProduceConfirm.as_u8(), 22);
         assert_eq!(FrameType::from_u8(22), Some(FrameType::ProduceConfirm));
-        // 23 is the new next-free tag (still unknown), so it frames but is not a known type.
-        assert_eq!(FrameType::from_u8(23), None);
         let mut buf = Vec::new();
         encode_frame(FrameType::ProduceConfirm, b"\x01\x02", &mut buf).unwrap();
         match decode_frame(&buf).unwrap() {
@@ -393,6 +409,28 @@ mod tests {
                     Some(FrameType::ProduceConfirm)
                 );
                 assert_eq!(body, b"\x01\x02");
+            }
+            FrameDecode::Incomplete { .. } => panic!("complete"),
+        }
+    }
+
+    #[test]
+    fn fetch_is_the_next_free_tag_and_frames() {
+        // #489: Fetch takes tag 23, the next FREE tag after ProduceConfirm (22). It was previously an
+        // UNKNOWN tag, so this pins it as a known type now and confirms it frames at the envelope level
+        // like any other. The existing Flow wire (tag 10) is unchanged: this is an ADDITIVE request tag.
+        assert_eq!(FrameType::Fetch.as_u8(), 23);
+        assert_eq!(FrameType::from_u8(23), Some(FrameType::Fetch));
+        // The existing Flow tag is untouched (the batch fetch is additive, not a replacement).
+        assert_eq!(FrameType::Flow.as_u8(), 10);
+        // 24 is the new next-free tag (still unknown), so it frames but is not a known type.
+        assert_eq!(FrameType::from_u8(24), None);
+        let mut buf = Vec::new();
+        encode_frame(FrameType::Fetch, b"\x03\x04", &mut buf).unwrap();
+        match decode_frame(&buf).unwrap() {
+            FrameDecode::Frame { type_tag, body, .. } => {
+                assert_eq!(FrameType::from_u8(type_tag), Some(FrameType::Fetch));
+                assert_eq!(body, b"\x03\x04");
             }
             FrameDecode::Incomplete { .. } => panic!("complete"),
         }
@@ -581,7 +619,7 @@ mod tests {
         /// An unknown type tag still decodes at the envelope level (forward compatibility):
         /// the body and length are recovered; only `from_u8` reports it unknown.
         #[test]
-        fn an_unknown_type_tag_still_frames(tag in 23u8..=255, body in prop::collection::vec(any::<u8>(), 0..256)) {
+        fn an_unknown_type_tag_still_frames(tag in 24u8..=255, body in prop::collection::vec(any::<u8>(), 0..256)) {
             let frame_len = 1u32 + u32::try_from(body.len()).unwrap();
             let mut buf = frame_len.to_le_bytes().to_vec();
             buf.push(tag);

--- a/crates/ironbus-proto/src/message.rs
+++ b/crates/ironbus-proto/src/message.rs
@@ -1199,6 +1199,115 @@ pub fn decode_info(body: &[u8]) -> Result<InfoBody, BodyError> {
     })
 }
 
+/// The version of the `Fetch` (batch-pull) body framing (#489). Version `1` is the first (and only)
+/// layout. Carried as a leading byte so a future version can extend the body without a wire break: a
+/// reader rejects a version it does not understand rather than mis-parsing it.
+pub const FETCH_BODY_VERSION: u8 = 1;
+
+/// The `Fetch` flag bit (#489) marking the request NO-WAIT: the server returns IMMEDIATELY with
+/// whatever records are ready, draining a single pass and never waiting out the `expires` deadline for
+/// more to arrive. When clear, the server may drain up to the `expires` deadline. The bit is the
+/// direct analogue of a NATS pull consumer's `no_wait`.
+pub const FETCH_FLAG_NO_WAIT: u8 = 0b0000_0001;
+
+/// A consumer batch-pull FETCH request (the `Fetch` frame body, #489): a NATS pull-consumer-style
+/// request to drain up to `max_records` / `max_bytes` of deliverable records in ONE round-trip,
+/// amortizing the per-poll actor hop and read cost across the whole batch. It is the BATCH twin of the
+/// per-record `Flow` request; the server runs the SAME per-record poll (preserving the lease/credit,
+/// at-least-once, and broadcast/`key_shared`/competing semantics exactly), so a batch fetch delivers
+/// EXACTLY the records N successive per-record polls would, just in one request. The effective batch is
+/// further bounded server-side by the negotiated per-consumer credit and byte budget (#292/#275) and
+/// the group's `max_in_flight` window, so a generous `max_records` / `max_bytes` never over-delivers.
+///
+/// Layout (version+length framed, forward-compatible, mirroring [`ConnectBody`]): `body_version: u8`
+/// ([`FETCH_BODY_VERSION`]), `field_len: u16` (the length of the v1 known-field block that follows),
+/// then the v1 block: `flags: u8`, `max_records: u32 LE`, `max_bytes: u64 LE`, `expires_ms: u64 LE`.
+/// Bytes past `field_len` (a future version's appended fields) are TOLERATED and ignored by a v1
+/// reader.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct FetchBody {
+    /// The maximum number of records to deliver in this batch. The server delivers at most this many
+    /// (and possibly fewer: the negotiated credit, the byte budget, the group's available records, the
+    /// byte cap, and the deadline all bind first). A value of `0` requests nothing.
+    pub max_records: u32,
+    /// The maximum total payload-equivalent bytes to deliver in this batch (key + headers + payload per
+    /// record, matching the per-consumer byte-budget accounting). `0` means UNBOUNDED by bytes (only the
+    /// record count, credit, and deadline bind). The server stops once delivering the next record would
+    /// exceed this, EXCEPT the floor-of-one (a batch always delivers at least one ready record so a
+    /// single over-cap record never wedges the consumer), exactly the existing per-consumer byte-budget
+    /// floor.
+    pub max_bytes: u64,
+    /// The batch's deadline budget in milliseconds: the maximum wall-clock time the server spends
+    /// draining this batch before terminating it with whatever it has gathered. `0` means NO deadline
+    /// (drain until a bound binds). Measured on the server's monotonic clock; it bounds server WORK and
+    /// never changes WHICH records are delivered (the engine poll is non-blocking, so the deadline only
+    /// caps how long a large drain may run). Ignored when `no_wait` is set (a no-wait fetch is a single
+    /// immediate pass).
+    pub expires_ms: u64,
+    /// Whether this fetch is NO-WAIT (#489): when `true`, the server drains a single pass and returns
+    /// immediately with whatever is ready, never waiting out `expires_ms`. When `false`, the server may
+    /// drain up to the `expires_ms` deadline. The direct analogue of a NATS pull consumer's `no_wait`.
+    /// Carried in the [`FETCH_FLAG_NO_WAIT`] bit of the body's `flags`.
+    pub no_wait: bool,
+}
+
+/// The number of bytes in the `Fetch` v1 known-field block: `flags: u8` + `max_records: u32` +
+/// `max_bytes: u64` + `expires_ms: u64`.
+const FETCH_V1_FIELD_LEN: u16 = 1 + 4 + 8 + 8;
+
+/// Encodes a `Fetch` body onto the end of `out` (#489): the version byte, the v1 field-block length,
+/// then the v1 block. The `no_wait` field is derived into the [`FETCH_FLAG_NO_WAIT`] bit of the written
+/// `flags`, so the flag and the field can never disagree.
+pub fn encode_fetch(req: &FetchBody, out: &mut Vec<u8>) {
+    out.push(FETCH_BODY_VERSION);
+    out.extend_from_slice(&FETCH_V1_FIELD_LEN.to_le_bytes());
+    let mut flags = 0u8;
+    if req.no_wait {
+        flags |= FETCH_FLAG_NO_WAIT;
+    }
+    out.push(flags);
+    out.extend_from_slice(&req.max_records.to_le_bytes());
+    out.extend_from_slice(&req.max_bytes.to_le_bytes());
+    out.extend_from_slice(&req.expires_ms.to_le_bytes());
+}
+
+/// Decodes a `Fetch` body (#489), cap-before-alloc and panic-free.
+///
+/// The body MUST carry the version byte and the `u16` field-length; the v1 known fields are read from
+/// the front of the declared block and any trailing bytes (a future version's appended fields) are
+/// tolerated and ignored, so a newer client's longer body still decodes its v1 fields here. A body too
+/// short to hold the `field_len` it declares is a typed [`BodyError`], never a panic or an over-read
+/// (the `field_len` is bounded against the actual body by [`Reader::take`] BEFORE any read). Unlike the
+/// handshake bodies an EMPTY body is NOT a valid `Fetch` (there is no historical empty-`Fetch` case: the
+/// frame type itself is new), so it is a typed [`BodyError::Truncated`].
+///
+/// # Errors
+/// Returns [`BodyError::Truncated`] if the body is too short for the version/length header or the
+/// declared field block, or [`BodyError::BadHandshakeVersion`] for an unknown body version.
+pub fn decode_fetch(body: &[u8]) -> Result<FetchBody, BodyError> {
+    let mut r = Reader::new(body);
+    let version = r.u8()?;
+    if version != FETCH_BODY_VERSION {
+        return Err(BodyError::BadHandshakeVersion { version });
+    }
+    let field_len = r.u16()? as usize;
+    let block = r.take(field_len)?;
+    let mut fr = Reader::new(block);
+    // Every v1 slot occupies a fixed position and is always consumed in order; a short block (a sender
+    // that declared fewer bytes) reads what is present and defaults the rest, never panicking.
+    let flags = fr.u8().unwrap_or(0);
+    let max_records = fr.u32().unwrap_or(0);
+    let max_bytes = fr.u64().unwrap_or(0);
+    let expires_ms = fr.u64().unwrap_or(0);
+    let no_wait = flags & FETCH_FLAG_NO_WAIT != 0;
+    Ok(FetchBody {
+        max_records,
+        max_bytes,
+        expires_ms,
+        no_wait,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1726,6 +1835,70 @@ mod tests {
         assert_eq!(decode_ack(&[0u8; 26]), Err(BodyError::TrailingBytes));
     }
 
+    #[test]
+    fn fetch_round_trips_and_derives_the_no_wait_bit() {
+        // #489: every field round-trips, and `no_wait` is carried in the FETCH_FLAG_NO_WAIT bit.
+        let req = FetchBody {
+            max_records: 0x0102_0304,
+            max_bytes: 0x0506_0708_090a_0b0c,
+            expires_ms: 5_000,
+            no_wait: true,
+        };
+        let mut buf = Vec::new();
+        encode_fetch(&req, &mut buf);
+        // version(1) + field_len(2) + flags(1) + max_records(4) + max_bytes(8) + expires_ms(8) = 24.
+        assert_eq!(buf.len(), 1 + 2 + 1 + 4 + 8 + 8);
+        // The no_wait field set the flag bit on the wire (the flags byte is the first block byte).
+        assert_eq!(buf[3] & FETCH_FLAG_NO_WAIT, FETCH_FLAG_NO_WAIT);
+        assert_eq!(decode_fetch(&buf).unwrap(), req);
+
+        // A waiting (no_wait = false) fetch clears the bit.
+        let waiting = FetchBody {
+            no_wait: false,
+            ..req
+        };
+        let mut buf2 = Vec::new();
+        encode_fetch(&waiting, &mut buf2);
+        assert_eq!(buf2[3] & FETCH_FLAG_NO_WAIT, 0);
+        assert_eq!(decode_fetch(&buf2).unwrap(), waiting);
+    }
+
+    #[test]
+    fn fetch_rejects_an_empty_or_short_body_and_an_unknown_version() {
+        // The Fetch frame type is new, so there is NO historical empty-body case: an empty body is a
+        // typed Truncated, never a default request.
+        assert_eq!(decode_fetch(&[]), Err(BodyError::Truncated));
+        // A non-empty body too short to hold the version+length header is Truncated, not a panic.
+        assert_eq!(
+            decode_fetch(&[FETCH_BODY_VERSION]),
+            Err(BodyError::Truncated)
+        );
+        // An unknown body version is a typed reject (a future layout this build cannot interpret).
+        let mut bad = Vec::new();
+        encode_fetch(&FetchBody::default(), &mut bad);
+        bad[0] = 2; // bump the version byte past what this build knows
+        assert_eq!(
+            decode_fetch(&bad),
+            Err(BodyError::BadHandshakeVersion { version: 2 })
+        );
+    }
+
+    #[test]
+    fn fetch_tolerates_a_future_appended_field() {
+        // A newer client may append fields past the declared v1 block; a v1 reader decodes its known
+        // fields and ignores the tail (forward-compat), exactly like the handshake bodies.
+        let req = FetchBody {
+            max_records: 7,
+            max_bytes: 4096,
+            expires_ms: 250,
+            no_wait: false,
+        };
+        let mut buf = Vec::new();
+        encode_fetch(&req, &mut buf);
+        buf.extend_from_slice(b"future-fields"); // appended past field_len
+        assert_eq!(decode_fetch(&buf).unwrap(), req);
+    }
+
     proptest! {
         #[test]
         fn any_pub_round_trips(
@@ -1968,6 +2141,30 @@ mod tests {
             } else {
                 prop_assert!(c.is_ok() && i.is_ok());
             }
+        }
+
+        /// A Fetch body round-trips every field for any inputs (#489): the encoder is the exact inverse
+        /// of the decoder, and the `no_wait` flag bit and the field agree.
+        #[test]
+        fn any_fetch_round_trips(
+            max_records in any::<u32>(),
+            max_bytes in any::<u64>(),
+            expires_ms in any::<u64>(),
+            no_wait in any::<bool>(),
+        ) {
+            let req = FetchBody { max_records, max_bytes, expires_ms, no_wait };
+            let mut buf = Vec::new();
+            encode_fetch(&req, &mut buf);
+            prop_assert_eq!(decode_fetch(&buf).unwrap(), req);
+        }
+
+        /// Decoding ARBITRARY bytes as a Fetch body never panics and never over-allocates: a hostile
+        /// version/length is always a typed Result, mirroring the handshake-body fuzz property.
+        #[test]
+        fn decode_fetch_on_arbitrary_bytes_never_panics(
+            bytes in prop::collection::vec(any::<u8>(), 0..64),
+        ) {
+            let _ = decode_fetch(&bytes);
         }
     }
 

--- a/crates/ironbus-server/src/session.rs
+++ b/crates/ironbus-server/src/session.rs
@@ -29,10 +29,10 @@ use ironbus_core::lease::LeaseToken;
 use ironbus_core::types::{Offset, RecordFlags};
 use ironbus_proto::frame::{decode_frame, encode_frame, FrameDecode, FrameError, FrameType};
 use ironbus_proto::message::{
-    decode_ack, decode_connect, decode_cumulative_ack, decode_pub, decode_sub, encode_dead_letter,
-    encode_deliver, encode_gap_marker, encode_info, encode_pub_ack, encode_truncated, gap_reason,
-    AckOp, CreditAdvert, DeadLetterBody, DeliverBody, GapMarkerBody, InfoBody, PubAckBody,
-    TruncatedBody, DEAD_LETTER_MAX_DELIVER, PUB_WIRE_ONLY_FLAGS,
+    decode_ack, decode_connect, decode_cumulative_ack, decode_fetch, decode_pub, decode_sub,
+    encode_dead_letter, encode_deliver, encode_gap_marker, encode_info, encode_pub_ack,
+    encode_truncated, gap_reason, AckOp, CreditAdvert, DeadLetterBody, DeliverBody, GapMarkerBody,
+    InfoBody, PubAckBody, TruncatedBody, DEAD_LETTER_MAX_DELIVER, PUB_WIRE_ONLY_FLAGS,
 };
 use ironbus_storage::fs::Filesystem;
 use std::collections::HashMap;
@@ -451,6 +451,10 @@ impl Session {
                 self.handle_cumulative_ack(engine, body, out).map(|()| true)
             }
             Some(FrameType::Flow) => self.handle_flow(engine, body, out).map(|()| true),
+            // The batch-pull FETCH (#489): the amortized twin of Flow. It runs the SAME per-record poll
+            // loop bounded by max_records/max_bytes/expires/no_wait, so it returns `true` to run the
+            // interval checkpoint exactly like Flow (it commits cursor progress the same way).
+            Some(FrameType::Fetch) => self.handle_fetch(engine, body, out).map(|()| true),
             Some(FrameType::Sub) => self.handle_sub(engine, body, out).map(|()| false),
             Some(FrameType::Unsub) => self.handle_unsub(engine, out).map(|()| true),
             // The standalone Nack frame type (a client sends a nack as an Ack frame with the
@@ -1167,6 +1171,196 @@ impl Session {
         Ok(())
     }
 
+    /// Handles a batch-pull `Fetch` (#489): the AMORTIZED twin of [`Session::handle_flow`]. It drains up
+    /// to `max_records` / `max_bytes` of deliverable records in ONE round-trip by running the SAME
+    /// per-record poll the `Flow` path runs, so it delivers EXACTLY the records that many successive
+    /// per-record `Flow`/poll calls would, leasing each one identically. The whole at-least-once,
+    /// lease/credit, and broadcast/`key_shared`/competing contract is preserved verbatim because every
+    /// delivery goes through the same [`Engine::poll_now_in_member`] + `leased` insert as `handle_flow`;
+    /// the batch only changes HOW MANY polls one request performs, never WHAT a poll does.
+    ///
+    /// The bounds compose as the MIN of: `max_records`, the per-consumer remaining credit
+    /// (`ceiling - leased.len()`, #65), the egress AIMD grant (#69), the group's `max_in_flight` window
+    /// (the engine returns `Poll::Idle` when it is full, ending the batch early, so the server never
+    /// over-delivers), `max_bytes` (the per-consumer byte budget, #275, with the same floor-of-one), and
+    /// the `expires` deadline. A `no_wait` fetch makes a SINGLE drain pass and returns whatever is ready
+    /// immediately, never waiting out the deadline. Because the engine poll is non-blocking (no record
+    /// arrives mid-call), `expires` bounds only the WORK a large drain may do; it never changes which
+    /// records are delivered. The response reuses the existing delivery frames (`Deliver` /`DeadLetter`/
+    /// `Truncated`/`GapMarker`) terminated by a single `FlowEnd`, byte-for-byte the `Flow` response, so a
+    /// fetch and an equivalent flow are indistinguishable on the wire past the request frame.
+    // The fetch drain is one cohesive loop (deadline, byte cap, claim, disposition, advisories), the
+    // batch analogue of `handle_flow` plus the #489 bounds; splitting it would scatter the single
+    // in-flight-window walk across helpers and obscure the order the bounds must bind in. Mirrors the
+    // `Engine::poll_in` allowance for the same reason.
+    #[allow(clippy::too_many_lines)]
+    fn handle_fetch<F: Filesystem + 'static, C: Clock + Clone + 'static, E: EngineAccess<F, C>>(
+        &mut self,
+        engine: &E,
+        body: &[u8],
+        out: &mut Vec<u8>,
+    ) -> Result<(), SessionError> {
+        if !self.connected {
+            reply_err(out, "not connected");
+            return Ok(());
+        }
+        let Ok(req) = decode_fetch(body) else {
+            reply_err(out, "malformed fetch body");
+            return Ok(());
+        };
+        // Redelivery accounting (#65): free the slots of any leases this connection no longer holds
+        // (expired-and-redelivered, or committed) BEFORE computing remaining credit, exactly as the
+        // per-record Flow path does, so a stuck consumer's expired leases stop counting against it.
+        self.release_stale_leases(engine)?;
+        // The per-consumer remaining message credit: the ceiling minus what this connection already
+        // holds un-acked (identical to `handle_flow`). The batch is bounded by the MIN of the requested
+        // `max_records`, this remaining credit, and the egress AIMD grant, so a generous `max_records`
+        // can NEVER over-deliver past the negotiated ceiling — the same guard the per-record path uses.
+        let ceiling = self.credit_ceiling(engine)?;
+        let held = u32::try_from(self.leased.len()).unwrap_or(u32::MAX);
+        let remaining = ceiling.saturating_sub(held);
+        // The requested record cap, clamped to the per-consumer remaining credit (the negotiated #292
+        // ceiling binds before the engine ever leases an offset this connection cannot deliver).
+        let want = req.max_records.min(remaining);
+        // EGRESS AIMD (#69, #402), identical to `handle_flow`: keep the effective egress credit within
+        // the negotiated ceiling, and count a real would-block (the consumer wants more than the limiter
+        // grants while already holding near a grant's worth un-acked) as a falling-behind signal.
+        let aimd_grant = engine.with(move |e| e.egress_grant_within(ceiling))?;
+        let credits = want.min(aimd_grant);
+        if aimd_grant < want && held >= aimd_grant {
+            engine.with(crate::engine::Engine::egress_falling_behind)?;
+        }
+        // The per-consumer BYTE budget (#275): `0` is unlimited. The fetch also carries its OWN
+        // `max_bytes` cap; the effective byte ceiling is the MIN of the two (each treated as unlimited
+        // when `0`). The floor-of-one is preserved: a connection holding nothing in-flight always gets at
+        // least one record even if it alone exceeds the budget, so a single over-budget record never
+        // wedges the consumer — exactly the per-record semantics.
+        let ceiling_bytes = self.credit_ceiling_bytes(engine)?;
+        let byte_cap = min_budget(ceiling_bytes, req.max_bytes);
+        // The deadline (#489): `expires_ms == 0` means no deadline. Read the monotonic clock ONCE at the
+        // start; a `no_wait` fetch ignores it entirely (a single immediate pass). The engine poll never
+        // blocks, so the deadline only bounds the WORK of a large drain, never which records are
+        // delivered (no record appears mid-call to be missed). `started` is `None` when there is no
+        // deadline to check, so the common path reads the clock zero extra times. `deadline` is `None`
+        // when there is no deadline to check (no_wait or a zero budget).
+        let deadline = if req.no_wait || req.expires_ms == 0 {
+            None
+        } else {
+            let now = engine.with(|e| e.now_monotonic())?;
+            // ms -> ns, saturating so a huge `expires_ms` cannot overflow into a too-early deadline.
+            let budget_nanos = req.expires_ms.saturating_mul(1_000_000);
+            Some(now.saturating_add(budget_nanos))
+        };
+        let mut delivered = 0u32;
+        for _ in 0..credits {
+            // The deadline binds (#489): once the monotonic clock has reached it, end the batch with
+            // whatever was gathered. Skipped for a no-wait / no-deadline fetch (`deadline` is `None`).
+            if let Some(deadline) = deadline {
+                if engine.with(|e| e.now_monotonic())? >= deadline {
+                    break;
+                }
+            }
+            // The byte cap binds (#275/#489): stop once delivering would exceed the cap, unless this
+            // connection holds nothing in-flight AND this batch has delivered nothing (the floor-of-one).
+            // A cap of 0 is unlimited, so it never binds. Mirrors the per-record byte-budget check, with
+            // the in-flight total taken as the connection's standing in-flight bytes (the budget is
+            // per-connection, so a fetch's own running total is already included once it leases).
+            if byte_cap != 0
+                && !(self.leased.is_empty() && delivered == 0)
+                && self.in_flight_bytes() >= byte_cap
+            {
+                break;
+            }
+            // Member-aware poll (#64): IDENTICAL to the per-record Flow path — one poll = one actor
+            // round-trip, routing by the connection's member for a key_shared group and behaving as a
+            // plain competing poll otherwise. This is THE shared primitive that makes a batch fetch
+            // deliver the same records, in the same order, leased the same way, as N per-record polls.
+            let group = self.subscription.clone();
+            let member = self.member_id;
+            match engine.with(move |e| e.poll_now_in_member(&group, member))? {
+                Ok(Poll::Message(d)) => {
+                    let msg = DeliverBody {
+                        offset: d.offset.get(),
+                        generation: d.token.generation,
+                        flags: d.record.flags.bits(),
+                        timestamp_ms: d.record.timestamp_ms,
+                        key: &d.record.key,
+                        headers: &d.record.headers,
+                        payload: &d.record.payload,
+                    };
+                    let mut frame_body = Vec::new();
+                    if encode_deliver(&msg, &mut frame_body).is_err() {
+                        break;
+                    }
+                    reply(out, FrameType::Deliver, &frame_body);
+                    // Lease ownership and byte accounting are IDENTICAL to `handle_flow`: only this
+                    // session can later act on the lease (#175), and the byte size feeds the byte budget
+                    // (#275). At-least-once holds because the record stays leased until acked.
+                    let bytes = lease_bytes(&d.record);
+                    self.leased.insert(
+                        d.offset.get(),
+                        Lease {
+                            generation: d.token.generation,
+                            bytes,
+                        },
+                    );
+                    delivered += 1;
+                }
+                // A parked (poison) message: the same in-band dead-letter advisory as `handle_flow`. It
+                // consumes a credit slot (it ran a poll) but does not count toward `delivered`.
+                Ok(Poll::Parked { offset, .. }) => {
+                    let mut frame_body = Vec::new();
+                    encode_dead_letter(
+                        &DeadLetterBody {
+                            offset: offset.get(),
+                            reason: DEAD_LETTER_MAX_DELIVER,
+                        },
+                        &mut frame_body,
+                    );
+                    reply(out, FrameType::DeadLetter, &frame_body);
+                }
+                // A below-earliest truncation: identical handling to `handle_flow` — drop the now-meaningless
+                // leases below the reset and emit the in-band advisory (GapMarker or Truncated per the
+                // negotiated capability), then keep draining.
+                Ok(Poll::Truncated {
+                    earliest_retained,
+                    skipped,
+                }) => {
+                    self.leased
+                        .retain(|&offset, _| offset >= earliest_retained.get());
+                    self.emit_truncation(out, earliest_retained.get(), skipped);
+                }
+                // A key-compaction hole: identical to `handle_flow` — a gap-marker-capable consumer gets
+                // the COMPACTED marker, a non-capable one silently advances. Keep draining.
+                Ok(Poll::Compacted { from, to }) => {
+                    if self.gap_marker_enabled {
+                        Self::emit_compaction(out, from.get(), to.get());
+                    }
+                }
+                // Nothing more deliverable right now: end the batch early (the no_wait / ready-now case).
+                Ok(Poll::Idle) => break,
+                Err(e) if e.is_fatal() => {
+                    reply_err(out, "fatal storage error");
+                    return Err(SessionError::EngineFatal(e));
+                }
+                Err(_) => {
+                    // The Err is this batch's terminator; do NOT also send a FlowEnd (that would desync
+                    // the client, which expects exactly one terminator per fetch), matching `handle_flow`.
+                    reply_err(out, "fetch failed");
+                    return Ok(());
+                }
+            }
+        }
+        // Drop ownership of any offset now committed, keeping `leased` bounded — identical to `handle_flow`.
+        let group = self.subscription.clone();
+        let committed = engine.with(move |e| e.committed_offset_in(&group).get())?;
+        self.leased.retain(|&offset, _| offset >= committed);
+        // The batch terminates with the SAME FlowEnd the Flow path uses (its body the delivered count),
+        // so the response is byte-for-byte a Flow response past the request frame.
+        reply(out, FrameType::FlowEnd, &delivered.to_le_bytes());
+        Ok(())
+    }
+
     /// Emits the in-band advisory for a `Poll::Truncated` skip: a consumer that negotiated the
     /// gap-marker capability (#346) gets the richer, consumer-visible `GapMarker` (tag 21) for the
     /// skipped span `[from, to)` where `to == earliest_retained` (delivery resumes at the oldest
@@ -1406,6 +1600,17 @@ fn lease_bytes(record: &ironbus_storage::segment::OwnedRecord) -> u64 {
         .saturating_add(record.headers.len())
         .saturating_add(record.payload.len());
     u64::try_from(len).unwrap_or(u64::MAX)
+}
+
+/// Combines two byte budgets into the EFFECTIVE one, where `0` means UNLIMITED on EITHER side (#489,
+/// #275): the per-consumer byte budget and a fetch's own `max_bytes`. When both are non-zero the tighter
+/// (`min`) binds; when one is `0` (unlimited) the other binds; when both are `0` the result is `0`
+/// (unlimited). So a fetch can only ever TIGHTEN the negotiated byte budget, never loosen it.
+fn min_budget(a: u64, b: u64) -> u64 {
+    match (a, b) {
+        (0, x) | (x, 0) => x,
+        (a, b) => a.min(b),
+    }
 }
 
 /// The #292 per-consumer MESSAGE-credit negotiation. A finite request tightens via `min(request,
@@ -5715,5 +5920,334 @@ mod tests {
         let _ = handle.shutdown();
         drop(handle);
         let _ = actor.join().unwrap();
+    }
+
+    // -----------------------------------------------------------------------
+    // #489 batch-pull FETCH: the amortized twin of the per-record Flow path.
+    // -----------------------------------------------------------------------
+
+    /// Builds a Fetch request frame body from its fields (the wire a client's `fetch_batch` sends).
+    fn fetch_frame(max_records: u32, max_bytes: u64, expires_ms: u64, no_wait: bool) -> Vec<u8> {
+        let mut body = Vec::new();
+        ironbus_proto::message::encode_fetch(
+            &ironbus_proto::message::FetchBody {
+                max_records,
+                max_bytes,
+                expires_ms,
+                no_wait,
+            },
+            &mut body,
+        );
+        frame(FrameType::Fetch, &body)
+    }
+
+    #[test]
+    fn batch_fetch_delivers_the_same_records_and_leases_as_n_per_record_polls() {
+        // THE core #489 contract: a single batch fetch delivers EXACTLY the records (offsets AND lease
+        // generations) that N successive per-record Flow(1) polls would, leasing each one the same way.
+        // Two identical engines, two fresh sessions: one drained by a batch fetch, the other by N
+        // per-record polls. The delivered (offset, generation) sequences must be byte-for-byte equal.
+        const N: u8 = 6;
+
+        // The batch path.
+        let e_batch = DirectEngine::new(engine());
+        for i in 0..N {
+            produce(&e_batch, &[i; 8]);
+        }
+        let mut s_batch = connected_session(&e_batch);
+        let mut out_batch = Vec::new();
+        s_batch
+            .process(
+                &e_batch,
+                &fetch_frame(u32::from(N), 0, 0, false),
+                &mut out_batch,
+            )
+            .unwrap();
+        let batch_tokens = delivered_tokens(&out_batch);
+
+        // The per-record path: N successive Flow(1) calls on an identical fresh engine/session.
+        let e_poll = DirectEngine::new(engine());
+        for i in 0..N {
+            produce(&e_poll, &[i; 8]);
+        }
+        let mut s_poll = connected_session(&e_poll);
+        let mut poll_tokens = Vec::new();
+        for _ in 0..N {
+            let mut out = Vec::new();
+            s_poll
+                .process(
+                    &e_poll,
+                    &frame(FrameType::Flow, &1u32.to_le_bytes()),
+                    &mut out,
+                )
+                .unwrap();
+            poll_tokens.extend(delivered_tokens(&out));
+        }
+
+        assert_eq!(
+            batch_tokens, poll_tokens,
+            "the batch fetch delivers the same (offset, generation) sequence as N per-record polls"
+        );
+        assert_eq!(
+            batch_tokens.len(),
+            usize::from(N),
+            "all {N} records delivered"
+        );
+        // The batch terminates with exactly one FlowEnd whose count equals the deliveries (same wire
+        // terminator as the Flow path).
+        let frames = decode_all(&out_batch);
+        let flow_ends: Vec<_> = frames
+            .iter()
+            .filter(|(ty, _)| *ty == FrameType::FlowEnd)
+            .collect();
+        assert_eq!(flow_ends.len(), 1, "exactly one FlowEnd terminator");
+        assert_eq!(
+            u32::from_le_bytes(flow_ends[0].1.as_slice().try_into().unwrap()),
+            u32::from(N),
+            "the FlowEnd count equals the delivered records"
+        );
+    }
+
+    #[test]
+    fn batch_fetch_preserves_at_least_once_an_unacked_batch_redelivers() {
+        // At-least-once: a fetched-but-unacked record stays leased and REDELIVERS after the lease
+        // expires, exactly as a per-record poll does. The batch is an amortization, not a fire-and-forget.
+        let clock = Arc::new(ManualClock::new());
+        let e = DirectEngine::new(engine_with(Arc::clone(&clock), 5));
+        produce(&e, b"x");
+        let mut s = connected_session(&e);
+        let mut out = Vec::new();
+        s.process(&e, &fetch_frame(10, 0, 0, false), &mut out)
+            .unwrap();
+        let first = delivered_tokens(&out);
+        assert_eq!(first.len(), 1, "the one record is delivered");
+        assert_eq!(
+            e.engine_mut().committed_offset().get(),
+            0,
+            "an unacked fetched record does NOT advance the committed cursor"
+        );
+
+        // Expire the lease (visibility + hard cap are tiny in engine_with), then re-fetch: the unacked
+        // record redelivers (at-least-once), with a FRESH lease generation.
+        clock.advance_monotonic_nanos(10_000);
+        let mut out2 = Vec::new();
+        s.process(&e, &fetch_frame(10, 0, 0, false), &mut out2)
+            .unwrap();
+        let redelivered = delivered_tokens(&out2);
+        assert_eq!(redelivered.len(), 1, "the unacked record redelivers");
+        assert_eq!(redelivered[0].0, first[0].0, "same offset redelivers");
+    }
+
+    #[test]
+    fn batch_fetch_acking_a_delivered_record_commits_it_like_a_poll() {
+        // A record delivered by a batch fetch is leased identically: acking it (with the lease
+        // generation the fetch carried) commits it, proving the lease the batch hands out is the SAME
+        // fencing lease the per-record poll hands out.
+        let e = DirectEngine::new(engine());
+        produce(&e, b"a");
+        produce(&e, b"b");
+        let mut s = connected_session(&e);
+        let mut out = Vec::new();
+        s.process(&e, &fetch_frame(10, 0, 0, false), &mut out)
+            .unwrap();
+        let tokens = delivered_tokens(&out);
+        assert_eq!(tokens.len(), 2);
+        // Ack the first delivered record with the generation the FETCH carried.
+        let ack = AckBody {
+            offset: tokens[0].0,
+            generation: tokens[0].1,
+            op: AckOp::Ack,
+            delay_ms: 0,
+        };
+        let mut body = Vec::new();
+        encode_ack(&ack, &mut body);
+        out.clear();
+        s.process(&e, &frame(FrameType::Ack, &body), &mut out)
+            .unwrap();
+        assert_eq!(
+            one_response(&out),
+            (FrameType::AckStatus, vec![1]),
+            "the fetch-leased record commits on ack"
+        );
+        assert_eq!(e.engine_mut().committed_offset().get(), 1);
+    }
+
+    #[test]
+    fn batch_fetch_max_records_bounds_the_batch() {
+        // max_records caps the batch below what is available: 10 records present, max_records = 3.
+        let e = DirectEngine::new(engine());
+        for i in 0..10u8 {
+            produce(&e, &[i; 4]);
+        }
+        let mut s = connected_session(&e);
+        let mut out = Vec::new();
+        s.process(&e, &fetch_frame(3, 0, 0, false), &mut out)
+            .unwrap();
+        assert_eq!(
+            delivered_tokens(&out).len(),
+            3,
+            "max_records bounds the batch to 3 of the 10 available"
+        );
+    }
+
+    #[test]
+    fn batch_fetch_max_bytes_bounds_the_batch_with_a_floor_of_one() {
+        // max_bytes caps the batch with EXACTLY the per-record byte-budget semantics (#275): the check
+        // is BEFORE each poll, so the in-flight total may overshoot the cap by at most one record (the
+        // standard credit semantics the per-record Flow path also uses). Each record's lease size is
+        // key+headers+payload (here just the 4-byte payload). With max_bytes = 4, after the first record
+        // in-flight bytes reach 4 (>= the cap), so the batch stops at exactly 1.
+        let e = DirectEngine::new(engine());
+        for i in 0..5u8 {
+            produce(&e, &[i; 4]);
+        }
+        let mut s = connected_session(&e);
+        let mut out = Vec::new();
+        s.process(&e, &fetch_frame(10, 4, 0, false), &mut out)
+            .unwrap();
+        assert_eq!(
+            delivered_tokens(&out).len(),
+            1,
+            "max_bytes (with the floor-of-one and the at-most-one overshoot) bounds the batch to one record"
+        );
+
+        // A single record larger than the whole budget is STILL delivered (the floor-of-one prevents a
+        // wedge), exactly the per-consumer byte-budget floor.
+        let e2 = DirectEngine::new(engine());
+        produce(&e2, &[0xff; 64]);
+        let mut s2 = connected_session(&e2);
+        let mut out2 = Vec::new();
+        s2.process(&e2, &fetch_frame(10, 8, 0, false), &mut out2)
+            .unwrap();
+        assert_eq!(
+            delivered_tokens(&out2).len(),
+            1,
+            "the floor-of-one delivers a single over-budget record"
+        );
+    }
+
+    #[test]
+    fn batch_fetch_no_wait_returns_immediately_with_whatever_is_ready() {
+        // no_wait returns what is ready right now (a single drain pass): with 2 records available and a
+        // generous max_records, all ready records come back, and an empty queue returns an empty batch
+        // (just the FlowEnd terminator) without waiting.
+        let e = DirectEngine::new(engine());
+        produce(&e, b"a");
+        produce(&e, b"b");
+        let mut s = connected_session(&e);
+        let mut out = Vec::new();
+        s.process(&e, &fetch_frame(10, 0, 1_000, true), &mut out)
+            .unwrap();
+        assert_eq!(
+            delivered_tokens(&out).len(),
+            2,
+            "no_wait returns the 2 ready records immediately"
+        );
+
+        // A second no_wait fetch on the now-empty (all leased) queue returns nothing but the terminator.
+        let mut out2 = Vec::new();
+        s.process(&e, &fetch_frame(10, 0, 1_000, true), &mut out2)
+            .unwrap();
+        let frames = decode_all(&out2);
+        assert!(
+            !frames.iter().any(|(ty, _)| *ty == FrameType::Deliver),
+            "no_wait on a drained queue delivers nothing: {frames:?}"
+        );
+        assert_eq!(
+            frames.last().map(|(ty, _)| *ty),
+            Some(FrameType::FlowEnd),
+            "no_wait still terminates with FlowEnd"
+        );
+    }
+
+    #[test]
+    fn batch_fetch_expires_bounds_work_not_which_records_are_delivered() {
+        // The `expires` deadline bounds the WORK a drain may do, never WHICH records a ready queue yields:
+        // the engine poll is non-blocking, so no record arrives mid-call to be missed, and under the
+        // deterministic ManualClock the clock does not tick mid-call, so a generous deadline delivers the
+        // whole ready batch. (This is the property #489 relies on for the same-records-as-poll argument:
+        // the deadline is a work cap, not a selection filter.)
+        let e = DirectEngine::new(engine());
+        for i in 0..4u8 {
+            produce(&e, &[i; 4]);
+        }
+        let mut s = connected_session(&e);
+        let mut out = Vec::new();
+        s.process(&e, &fetch_frame(10, 0, 60_000, false), &mut out)
+            .unwrap();
+        assert_eq!(
+            delivered_tokens(&out).len(),
+            4,
+            "a generous deadline does not cut a ready batch short"
+        );
+    }
+
+    #[test]
+    fn batch_fetch_respects_the_per_consumer_credit_ceiling() {
+        // The negotiated per-consumer credit ceiling binds the batch even past max_records: an undersized
+        // ceiling caps the batch, and held (unacked) leases reduce the remaining credit, so a batch never
+        // over-delivers past the ceiling (the same guard the per-record Flow path enforces).
+        let clock = Arc::new(ManualClock::new());
+        let e = DirectEngine::new(engine_with(Arc::clone(&clock), 5));
+        for i in 0..20u8 {
+            produce(&e, &[i; 4]);
+        }
+        // Connect requesting a small credit of 3 (the negotiation clamps to min(request, cap)).
+        let mut s = Session::new();
+        let mut out = Vec::new();
+        let mut connect_body = Vec::new();
+        ironbus_proto::message::encode_connect(
+            &ironbus_proto::message::ConnectBody {
+                requested_credit: Some(3),
+                requested_credit_bytes: None,
+                wants_gap_marker: false,
+                default_ack_level: None,
+            },
+            &mut connect_body,
+        );
+        s.process(&e, &frame(FrameType::Connect, &connect_body), &mut out)
+            .unwrap();
+        out.clear();
+        // A generous max_records still cannot exceed the negotiated ceiling of 3.
+        s.process(&e, &fetch_frame(100, 0, 0, false), &mut out)
+            .unwrap();
+        assert_eq!(
+            delivered_tokens(&out).len(),
+            3,
+            "the per-consumer credit ceiling of 3 bounds the batch, not max_records=100"
+        );
+        // Those 3 are held unacked, so remaining credit is 0: a second fetch (before any ack/expiry)
+        // delivers nothing, proving the ceiling is enforced across the in-flight set, never over-delivered.
+        out.clear();
+        s.process(&e, &fetch_frame(100, 0, 0, false), &mut out)
+            .unwrap();
+        assert_eq!(
+            delivered_tokens(&out).len(),
+            0,
+            "a saturated consumer (3/3 held) gets an empty batch"
+        );
+    }
+
+    #[test]
+    fn batch_fetch_rejects_a_malformed_body_without_dropping_the_connection() {
+        // A malformed Fetch body is a typed Err reply, never a panic, and the session stays open.
+        let e = DirectEngine::new(engine());
+        let mut s = connected_session(&e);
+        let mut out = Vec::new();
+        // A 1-byte body with a bogus version cannot decode.
+        s.process(&e, &frame(FrameType::Fetch, &[9u8]), &mut out)
+            .expect("the session stays open after a malformed fetch");
+        assert_eq!(one_response(&out).0, FrameType::Err);
+    }
+
+    #[test]
+    fn batch_fetch_before_connect_is_rejected() {
+        // A Fetch before Connect is rejected (the same guard as Flow), and the session stays open.
+        let e = DirectEngine::new(engine());
+        let mut s = Session::new();
+        let mut out = Vec::new();
+        s.process(&e, &fetch_frame(10, 0, 0, false), &mut out)
+            .expect("the session stays open");
+        assert_eq!(one_response(&out).0, FrameType::Err);
     }
 }


### PR DESCRIPTION
Closes #489.

## What

Consume was a per-record `poll`: one credit grant, one actor hop, one read per record. This adds a NATS pull-consumer-style **batch FETCH** that amortizes the actor hop AND the per-poll read cost across many records in **one round-trip**.

- **Proto** — new additive `Fetch` `FrameType` (tag **23**, the next free tag after `ProduceConfirm`=22) + a `FetchBody` codec carrying `max_records: u32`, `max_bytes: u64`, `expires_ms: u64` (a deadline budget), and a `no_wait` flag. Version+length framed and forward-compatible (a future field is tolerated and ignored).
- **Server** — a `Fetch` handler that runs the **same per-record poll** the `Flow` path runs, bounded by the MIN of `max_records`, the per-consumer remaining credit, the egress AIMD grant, the group `max_in_flight` window, `max_bytes`, and the `expires` deadline. `no_wait` makes a single immediate drain pass; `expires` (non-no_wait) returns what is available by the deadline.
- **Client** — a `fetch_batch(max_records, max_bytes, expires, no_wait)` API that shares the existing fetch response reader.

## Same records as the per-record poll

The batch is a pure **amortization** of the existing poll: every delivery goes through the same member-aware `poll_now_in_member` + `leased` insert the per-record path uses, so a batch fetch delivers **exactly the records (offsets and lease generations) that N successive per-record polls would**, in one request. A test asserts the two delivery sequences are byte-for-byte equal. Because the engine poll is non-blocking, the `expires` deadline bounds only the *work* a large drain may do — it never changes *which* records are delivered.

## Preserved exactly

- **At-least-once** — an unacked batch stays leased and redelivers after the lease expires (tested).
- **Lease / credit** — each fetched record is leased identically; the batch never over-delivers past the negotiated per-consumer ceiling or the group `max_in_flight` window (a saturated consumer gets an empty batch).
- **Per-consumer byte budget** — `max_bytes` composes with the negotiated byte budget as the tighter of the two, with the same floor-of-one (a single over-budget record is never wedged).
- **broadcast / key_shared / competing** — the poll is the same member-aware primitive.

## Additive (old clients unaffected)

The existing `Flow` wire (tag 10) is **byte-for-byte unchanged**; the new tag is append-only, so an old client never sends or receives it. The response reuses the existing `Deliver`/`DeadLetter`/`Truncated`/`GapMarker` frames terminated by a single `FlowEnd` — byte-for-byte a `Flow` response past the request frame. The conformance byte-identity gate is unaffected.

## Gates

- `cargo fmt --all --check` — pass
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — pass
- `cargo test --workspace --all-features --locked` — pass (1577 passing, 0 failing; includes the conformance vectors gate). MSRV 1.78.

Tests added: a batch fetch delivers the same records (and leases them the same) as N per-record polls; at-least-once redelivery of an unacked batch; ack-commits a fetch-leased record; `max_records` / `max_bytes` (with the floor-of-one) bound the batch; `no_wait` returns immediately; `expires` bounds work not selection; the per-consumer credit ceiling binds; malformed-body and before-connect rejects; proto codec round-trip + fuzz; and end-to-end client `fetch_batch` over a real server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)