### PR TITLE
perf(storage): OwnedRecord as refcounted Bytes slices, drop the per-record read copy (#480)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -761,6 +761,7 @@ dependencies = [
 name = "ironbus-cli"
 version = "0.0.0"
 dependencies = [
+ "bytes",
  "crc32c",
  "ironbus-client",
  "ironbus-core",
@@ -825,6 +826,7 @@ dependencies = [
 name = "ironbus-storage"
 version = "0.0.0"
 dependencies = [
+ "bytes",
  "crc32c",
  "criterion",
  "ironbus-core",

--- a/crates/ironbus-cli/Cargo.toml
+++ b/crates/ironbus-cli/Cargo.toml
@@ -84,6 +84,13 @@ signal-hook = { version = "0.3", default-features = false, features = ["iterator
 # lock is a CLI startup guard, off the record path.
 libc = "0.2"
 
+# TEST-ONLY (#480): a `#[cfg(test)]` redrive fixture seeds the DLQ with an `ironbus_storage`
+# `OwnedRecord`, whose key/headers/payload are now `bytes::Bytes` (refcounted read-buffer slices).
+# `bytes` is a DEV-dependency here, so it never enters the shipped CLI binary's dependency graph and
+# leaves the supply-chain / C-FFI gates untouched; it is pure Rust and already in the workspace tree.
+[dev-dependencies]
+bytes = { version = "1", default-features = false }
+
 [lints]
 workspace = true
 

--- a/crates/ironbus-cli/src/main.rs
+++ b/crates/ironbus-cli/src/main.rs
@@ -7484,6 +7484,7 @@ mod tests {
     /// so the redrive verb has poison to re-inject.
     #[cfg(unix)]
     fn seed_dlq(dir: &std::path::Path, poison: u64) {
+        use bytes::Bytes;
         use ironbus_core::types::{Offset, Seq};
         use ironbus_storage::dlq::DlqSink;
         use ironbus_storage::segment::OwnedRecord;
@@ -7495,9 +7496,10 @@ mod tests {
                 seq: Seq::new(500 + i),
                 timestamp_ms: 7000 + i,
                 flags: RecordFlags::EMPTY,
-                key: b"pk".to_vec(),
-                headers: b"".to_vec(),
-                payload: format!("poison-{i}").into_bytes(),
+                // `OwnedRecord`'s blobs are `Bytes` (#480); seed the test fixture with `Bytes`.
+                key: Bytes::from_static(b"pk"),
+                headers: Bytes::new(),
+                payload: Bytes::from(format!("poison-{i}").into_bytes()),
             };
             sink.append_poison("orders", &src, 6).unwrap();
         }

--- a/crates/ironbus-server/src/engine.rs
+++ b/crates/ironbus-server/src/engine.rs
@@ -5131,7 +5131,7 @@ mod tests {
 
         let d0 = message(e.poll(0).unwrap());
         assert_eq!(d0.offset, Offset::new(0));
-        assert_eq!(d0.record.payload, b"a");
+        assert_eq!(d0.record.payload.as_ref(), b"a");
         assert_eq!(d0.deliveries, 1);
         assert_eq!(e.ack(&d0.token), AckResult::Acked);
         assert_eq!(e.committed_offset(), Offset::new(1));
@@ -5191,7 +5191,7 @@ mod tests {
             match e.poll(0).unwrap() {
                 Poll::Message(d) => {
                     let off = d.offset.get();
-                    delivered.push((off, d.record.payload.clone()));
+                    delivered.push((off, d.record.payload.to_vec()));
                     assert_eq!(e.ack(&d.token), AckResult::Acked);
                 }
                 Poll::Compacted { from, to } => {
@@ -5390,7 +5390,7 @@ mod tests {
         match e.poll(40).unwrap() {
             Poll::Parked { offset, record } => {
                 assert_eq!(offset, Offset::new(0));
-                assert_eq!(record.payload, b"poison");
+                assert_eq!(record.payload.as_ref(), b"poison");
             }
             other => panic!("expected Parked, got {other:?}"),
         }
@@ -5513,7 +5513,7 @@ mod tests {
         // Drain the whole window: exactly offset 2 ("c") is deliverable.
         let mut delivered = Vec::new();
         while let Poll::Message(d) = e.poll(0).unwrap() {
-            delivered.push((d.offset.get(), d.record.payload.clone()));
+            delivered.push((d.offset.get(), d.record.payload.to_vec()));
         }
         assert_eq!(
             delivered,
@@ -5579,7 +5579,7 @@ mod tests {
         assert_eq!(e.committed_offset(), Offset::new(1));
         let mut delivered = Vec::new();
         while let Poll::Message(d) = e.poll(0).unwrap() {
-            delivered.push((d.offset.get(), d.record.payload.clone()));
+            delivered.push((d.offset.get(), d.record.payload.to_vec()));
         }
         assert_eq!(
             delivered,
@@ -5631,7 +5631,7 @@ mod tests {
         assert_eq!(e.committed_offset(), Offset::new(1));
         let d = message(e.poll(0).unwrap());
         assert_eq!(d.offset, Offset::new(1));
-        assert_eq!(d.record.payload, b"b");
+        assert_eq!(d.record.payload.as_ref(), b"b");
     }
 
     #[test]
@@ -5666,7 +5666,7 @@ mod tests {
         loop {
             match e.poll(0).unwrap() {
                 Poll::Message(d) => {
-                    delivered.push((d.offset.get(), d.record.payload.clone()));
+                    delivered.push((d.offset.get(), d.record.payload.to_vec()));
                     e.ack(&d.token);
                 }
                 Poll::Idle => break,
@@ -5858,7 +5858,7 @@ mod tests {
                 d.deliveries, 1,
                 "redelivery from zero is a fresh first delivery"
             );
-            delivered.push((d.offset.get(), d.record.payload.clone()));
+            delivered.push((d.offset.get(), d.record.payload.to_vec()));
             e.ack(&d.token);
         }
         assert_eq!(
@@ -6668,9 +6668,9 @@ mod tests {
         assert_eq!(e.committed_offset(), Offset::new(0));
         let d = message(e.poll(0).unwrap());
         assert_eq!(d.offset, Offset::new(0));
-        assert_eq!(d.record.payload, b"a");
+        assert_eq!(d.record.payload.as_ref(), b"a");
         let d_b = message(e.poll(0).unwrap());
-        assert_eq!(d_b.record.payload, b"b");
+        assert_eq!(d_b.record.payload.as_ref(), b"b");
     }
 
     #[cfg(unix)]
@@ -6704,7 +6704,7 @@ mod tests {
         assert_eq!(e.committed_offset(), Offset::new(1));
         let d = message(e.poll(0).unwrap());
         assert_eq!(d.offset, Offset::new(1));
-        assert_eq!(d.record.payload, b"b");
+        assert_eq!(d.record.payload.as_ref(), b"b");
     }
 
     #[cfg(unix)]
@@ -6739,7 +6739,7 @@ mod tests {
         assert_eq!(e.committed_offset_in(group), Offset::new(1));
         let d = message(e.poll_in(group, 0).unwrap());
         assert_eq!(d.offset, Offset::new(1));
-        assert_eq!(d.record.payload, b"b");
+        assert_eq!(d.record.payload.as_ref(), b"b");
         // The default group is unaffected on the same real directory.
         assert_eq!(e.committed_offset(), Offset::new(0));
     }
@@ -8150,7 +8150,7 @@ mod tests {
             Offset::new(1),
             "the resumed touched default group's unconsumed record survived retention"
         );
-        assert_eq!(d.record.payload, &[0xcd; 16]);
+        assert_eq!(d.record.payload.as_ref(), &[0xcd; 16]);
     }
 
     // ---- Count- and age-based retention end to end (refs #13, #80) ----
@@ -9391,7 +9391,7 @@ mod tests {
             // Poll as the owner until we get this key_a record (it may first serve "other").
             loop {
                 match e.poll_in_member("g", owner, 0).unwrap() {
-                    Poll::Message(d) if d.record.key == key_a => {
+                    Poll::Message(d) if d.record.key.as_ref() == key_a.as_slice() => {
                         assert_eq!(d.offset, expected_off, "per-key offset order preserved");
                         assert_eq!(e.ack_in("g", &d.token), AckResult::Acked);
                         break;
@@ -9821,7 +9821,7 @@ mod tests {
             Offset::new(2),
             "resumes at head; redelivers only the new record, nothing it had acked"
         );
-        assert_eq!(d.record.payload, b"c");
+        assert_eq!(d.record.payload.as_ref(), b"c");
     }
 
     #[test]
@@ -11374,7 +11374,8 @@ mod tests {
             d.record.flags
         );
         assert_ne!(
-            d.record.payload, original,
+            d.record.payload.as_ref(),
+            original.as_slice(),
             "the stored bytes are not the raw payload"
         );
         assert!(

--- a/crates/ironbus-server/src/server.rs
+++ b/crates/ironbus-server/src/server.rs
@@ -401,7 +401,7 @@ mod tests {
         // The message is durable in the engine and deliverable.
         let mut engine = recover_engine(handle, actor);
         match engine.poll(0).unwrap() {
-            Poll::Message(d) => assert_eq!(d.record.payload, b"net"),
+            Poll::Message(d) => assert_eq!(d.record.payload.as_ref(), b"net"),
             other => panic!("expected the produced message, got {other:?}"),
         }
     }

--- a/crates/ironbus-server/src/session.rs
+++ b/crates/ironbus-server/src/session.rs
@@ -3794,7 +3794,7 @@ mod tests {
         // The message is durable in the engine and deliverable.
         let polled = e.engine_mut().poll(0).unwrap();
         match polled {
-            Poll::Message(d) => assert_eq!(d.record.payload, b"hello"),
+            Poll::Message(d) => assert_eq!(d.record.payload.as_ref(), b"hello"),
             other => panic!("expected the produced message, got {other:?}"),
         }
     }

--- a/crates/ironbus-storage/Cargo.toml
+++ b/crates/ironbus-storage/Cargo.toml
@@ -19,6 +19,13 @@ zstd = ["ironbus-core/zstd"]
 
 [dependencies]
 crc32c = "0.6"
+# `bytes::Bytes` lets an `OwnedRecord` carry REFCOUNTED slices of the segment read buffer instead of
+# three per-record `Vec` deep copies (#480): a `read_from` reads the region into ONE buffer and each
+# materialized record's key/headers/payload is a `Bytes::slice_ref` (a refcount bump, byte-identical),
+# so a multi-record read is one alloc + refcounted slices, not O(records) allocs + O(bytes) copied, on
+# the consume hot path. `bytes` is pure Rust (no `links`, no C build script), already in the workspace
+# tree (a direct dependency of `ironbus-server`), and is on the pure-Rust data-path allow-list.
+bytes = { version = "1", default-features = false }
 ironbus-core = { path = "../ironbus-core", version = "0.0.0" }
 # `serde` (derive only) makes the structured loss report (`loss::LossReport`) a versioned,
 # stable, fixture-assertable artifact (#120). Kept derive-only so the static edge binary stays

--- a/crates/ironbus-storage/src/admin.rs
+++ b/crates/ironbus-storage/src/admin.rs
@@ -447,6 +447,7 @@ mod tests {
     use crate::fs::InMemoryFs;
     use crate::naming::segment_file_name;
     use crate::segment::{OwnedRecord, SegmentReader};
+    use bytes::Bytes;
     use ironbus_core::clock::ManualClock;
     use ironbus_core::types::Seq;
 
@@ -487,9 +488,9 @@ mod tests {
             seq: Seq::new(offset),
             timestamp_ms: 1000 + offset,
             flags: RecordFlags::EMPTY,
-            key: key.to_vec(),
-            headers: headers.to_vec(),
-            payload: payload.to_vec(),
+            key: Bytes::copy_from_slice(key),
+            headers: Bytes::copy_from_slice(headers),
+            payload: Bytes::copy_from_slice(payload),
         }
     }
 
@@ -629,7 +630,7 @@ mod tests {
         assert_eq!(after.len() as u64, before + 4);
         let tail: Vec<Vec<u8>> = after[after.len() - 4..]
             .iter()
-            .map(|r| r.payload.clone())
+            .map(|r| r.payload.to_vec())
             .collect();
         assert_eq!(
             tail,
@@ -654,9 +655,9 @@ mod tests {
             seq: Seq::new(100),
             timestamp_ms: 1100,
             flags: RecordFlags::COMPRESSED.with(RecordFlags::HAS_KEY),
-            key: b"k".to_vec(),
-            headers: b"hdr".to_vec(),
-            payload: compressed_payload.clone(),
+            key: Bytes::from_static(b"k"),
+            headers: Bytes::from_static(b"hdr"),
+            payload: Bytes::from(compressed_payload.clone()),
         };
         sink.append_poison("orders", &src, 6).unwrap();
 

--- a/crates/ironbus-storage/src/compaction.rs
+++ b/crates/ironbus-storage/src/compaction.rs
@@ -27,6 +27,7 @@
 use crate::fs::Filesystem;
 use crate::naming::{parse_segment_file_name, segment_file_name, segment_ids};
 use crate::segment::{OwnedRecord, SegmentReader, SegmentWriter, StorageError};
+use bytes::Bytes;
 use ironbus_core::clock::Clock;
 use ironbus_core::codec::RecordView;
 use ironbus_core::segment::{CompactionMeta, SegmentFooter, SegmentHeader};
@@ -195,7 +196,10 @@ fn select_survivors(sources: &[SourceSegment], now_ms: u64, tombstone_ttl_ms: u6
 
     // First pass: record, per key, the HIGHEST offset seen (the latest value for the key). This is
     // streamed in offset order; the map is the cost line that bounds N on an edge core.
-    let mut latest_for_key: HashMap<Vec<u8>, u64> = HashMap::new();
+    // Keyed on the survivor's `Bytes` key (#480): `OwnedRecord::key` is now a refcounted slice, so
+    // `rec.key.clone()` is a refcount bump rather than a `Vec` deep copy, and `get(&rec.key)` borrows
+    // the `Bytes` directly. `Bytes` is `Hash + Eq` over its bytes, so the per-key dedup is unchanged.
+    let mut latest_for_key: HashMap<Bytes, u64> = HashMap::new();
     for src in sources {
         for rec in &src.records {
             if !rec.key.is_empty() {
@@ -299,6 +303,7 @@ where
             seq: rec.seq,
             timestamp_ms: rec.timestamp_ms,
             flags: rec.flags,
+            // `OwnedRecord`'s blobs are `Bytes` (#480); deref to the `&[u8]` the borrowing view takes.
             key: &rec.key,
             headers: &rec.headers,
             payload: &rec.payload,
@@ -627,13 +632,13 @@ mod tests {
         let before = all_records(&log);
         let latest_alpha = before
             .iter()
-            .filter(|r| r.key == b"alpha")
+            .filter(|r| r.key.as_ref() == b"alpha")
             .map(|r| r.offset.get())
             .max()
             .unwrap();
         let latest_beta = before
             .iter()
-            .filter(|r| r.key == b"beta")
+            .filter(|r| r.key.as_ref() == b"beta")
             .map(|r| r.offset.get())
             .max()
             .unwrap();
@@ -645,7 +650,7 @@ mod tests {
             .get();
         let gamma_off = before
             .iter()
-            .find(|r| r.key == b"gamma")
+            .find(|r| r.key.as_ref() == b"gamma")
             .unwrap()
             .offset
             .get();
@@ -660,8 +665,11 @@ mod tests {
 
         // After compaction, the read path yields the SURVIVORS at their ORIGINAL offsets, sparse.
         let after = all_records(&log);
-        let alpha_records: Vec<_> = after.iter().filter(|r| r.key == b"alpha").collect();
-        let beta_records: Vec<_> = after.iter().filter(|r| r.key == b"beta").collect();
+        let alpha_records: Vec<_> = after
+            .iter()
+            .filter(|r| r.key.as_ref() == b"alpha")
+            .collect();
+        let beta_records: Vec<_> = after.iter().filter(|r| r.key.as_ref() == b"beta").collect();
         // Exactly one survivor per key (the latest), at its original offset, with its latest value.
         assert_eq!(alpha_records.len(), 1, "only the latest alpha survives");
         assert_eq!(
@@ -678,7 +686,7 @@ mod tests {
             .any(|r| r.key.is_empty() && r.offset.get() == keyless_off));
         assert!(after
             .iter()
-            .any(|r| r.key == b"gamma" && r.offset.get() == gamma_off));
+            .any(|r| r.key.as_ref() == b"gamma" && r.offset.get() == gamma_off));
         // Offsets never decreased and never repeated: I5 holds (monotonic, never reused).
         let offs: Vec<u64> = after.iter().map(|r| r.offset.get()).collect();
         let mut sorted = offs.clone();
@@ -718,7 +726,11 @@ mod tests {
             sources_loaded.push(read_source_segment(log.filesystem(), id).unwrap());
         }
         let within = select_survivors(&sources_loaded, 5_000, cfg.tombstone_ttl_ms);
-        let k_survivors: Vec<_> = within.keep.iter().filter(|r| r.key == b"k").collect();
+        let k_survivors: Vec<_> = within
+            .keep
+            .iter()
+            .filter(|r| r.key.as_ref() == b"k")
+            .collect();
         assert_eq!(k_survivors.len(), 1, "the tombstone is retained within TTL");
         assert!(
             k_survivors[0].payload.is_empty(),
@@ -729,7 +741,7 @@ mod tests {
         // reclaiming the key (no record for k at all).
         let aged = select_survivors(&sources_loaded, 1_000_000, cfg.tombstone_ttl_ms);
         assert!(
-            aged.keep.iter().all(|r| r.key != b"k"),
+            aged.keep.iter().all(|r| r.key.as_ref() != b"k"),
             "aged-out tombstone reclaims the key"
         );
     }

--- a/crates/ironbus-storage/src/dlq.rs
+++ b/crates/ironbus-storage/src/dlq.rs
@@ -184,9 +184,13 @@ pub fn decode_entry(record: &OwnedRecord) -> Option<DlqEntry> {
         source_offset: meta.source_offset,
         attempt: meta.attempt,
         timestamp_ms: record.timestamp_ms,
-        key: record.key.clone(),
+        // `DlqEntry` is the cold operator-facing dead-letter view (not the consume hot read path), so
+        // its key/payload stay owned `Vec`s: the `record` blobs are now `Bytes` (#480), so make the
+        // owning copy LOCALLY here rather than widen `DlqEntry`. This keeps the per-record-read win on
+        // the hot path while the DLQ decode keeps its existing owned-`Vec` contract.
+        key: record.key.to_vec(),
         headers: meta.original_headers,
-        payload: record.payload.clone(),
+        payload: record.payload.to_vec(),
         original_flags: record.flags,
     })
 }
@@ -393,6 +397,7 @@ pub fn read_dlq_entries<F: Filesystem>(parent_fs: &F) -> Result<Vec<DlqEntry>, S
 mod tests {
     use super::*;
     use crate::fs::InMemoryFs;
+    use bytes::Bytes;
     use ironbus_core::clock::ManualClock;
     use ironbus_core::types::Seq;
 
@@ -406,9 +411,9 @@ mod tests {
             seq: Seq::new(offset),
             timestamp_ms: 1234 + offset,
             flags: RecordFlags::EMPTY,
-            key: key.to_vec(),
-            headers: headers.to_vec(),
-            payload: payload.to_vec(),
+            key: Bytes::copy_from_slice(key),
+            headers: Bytes::copy_from_slice(headers),
+            payload: Bytes::copy_from_slice(payload),
         }
     }
 

--- a/crates/ironbus-storage/src/invariants.rs
+++ b/crates/ironbus-storage/src/invariants.rs
@@ -188,6 +188,7 @@ pub fn check_pure_recovery(
 mod tests {
     use super::*;
     use crate::loss::{LossEvent, ReasonCode};
+    use bytes::Bytes;
     use ironbus_core::types::{Offset, RecordFlags, Seq};
 
     fn rec(offset: u64, seq: u64) -> OwnedRecord {
@@ -196,9 +197,9 @@ mod tests {
             seq: Seq::new(seq),
             timestamp_ms: 0,
             flags: RecordFlags::EMPTY,
-            key: Vec::new(),
-            headers: Vec::new(),
-            payload: vec![u8::try_from(offset & 0xff).unwrap()],
+            key: Bytes::new(),
+            headers: Bytes::new(),
+            payload: Bytes::from(vec![u8::try_from(offset & 0xff).unwrap()]),
         }
     }
 
@@ -297,7 +298,7 @@ mod tests {
     fn i4_negative_fixture_diverging_payloads() {
         let a = prefix(3);
         let mut b = prefix(3);
-        b[1].payload = vec![0xff]; // a different payload at index 1
+        b[1].payload = Bytes::from_static(&[0xff]); // a different payload at index 1
         assert_eq!(
             check_pure_recovery(&a, &b),
             Err(InvariantViolation::Nondeterministic { index: 1 })

--- a/crates/ironbus-storage/src/log.rs
+++ b/crates/ironbus-storage/src/log.rs
@@ -2904,8 +2904,8 @@ mod tests {
         log.sync().unwrap();
         let records = read_back(log.filesystem(), 0);
         assert_eq!(records.len(), 2);
-        assert_eq!(records[0].payload, b"durable");
-        assert_eq!(records[1].payload, b"after");
+        assert_eq!(records[0].payload.as_ref(), b"durable");
+        assert_eq!(records[1].payload.as_ref(), b"after");
     }
 
     #[test]
@@ -2977,7 +2977,7 @@ mod tests {
         // The recovered log is fully appendable: the first record lands at offset 0.
         assert_eq!(log.append(&rec(b"first")).unwrap(), Offset::ZERO);
         log.sync().unwrap();
-        assert_eq!(read_back(log.filesystem(), 0)[0].payload, b"first");
+        assert_eq!(read_back(log.filesystem(), 0)[0].payload.as_ref(), b"first");
     }
 
     #[test]
@@ -3133,7 +3133,7 @@ mod tests {
             "a rolled-to segment re-attempted (and swallowed) the failing preallocate"
         );
         assert_eq!(
-            read_back(log.filesystem(), 0)[0].payload,
+            read_back(log.filesystem(), 0)[0].payload.as_ref(),
             b"payload-payload"
         );
     }
@@ -3721,8 +3721,8 @@ mod tests {
         let records = log.read_from(Offset::ZERO, 10).unwrap();
         assert_eq!(records.len(), 3);
         assert_eq!(records[0].offset, Offset::new(0));
-        assert_eq!(records[0].payload, b"a");
-        assert_eq!(records[2].payload, b"c");
+        assert_eq!(records[0].payload.as_ref(), b"a");
+        assert_eq!(records[2].payload.as_ref(), b"c");
     }
 
     #[test]
@@ -3734,7 +3734,7 @@ mod tests {
         assert_eq!(log.flushed_offset(), Offset::new(1));
         let records = log.read_from(Offset::ZERO, 10).unwrap();
         assert_eq!(records.len(), 1);
-        assert_eq!(records[0].payload, b"durable");
+        assert_eq!(records[0].payload.as_ref(), b"durable");
         // After sync the pending record becomes visible.
         log.sync().unwrap();
         assert_eq!(log.read_from(Offset::ZERO, 10).unwrap().len(), 2);
@@ -4341,7 +4341,7 @@ mod tests {
                                          // ...not yet: only a and b are durable.
         let records = log.read_from(Offset::ZERO, 100).unwrap();
         assert_eq!(records.len(), 2);
-        assert_eq!(records[1].payload, b"b");
+        assert_eq!(records[1].payload.as_ref(), b"b");
     }
 
     #[test]

--- a/crates/ironbus-storage/src/segment.rs
+++ b/crates/ironbus-storage/src/segment.rs
@@ -9,6 +9,7 @@
 
 use crate::io::RandomAccessFile;
 use crate::loss::{CapViolation, ReasonCode};
+use bytes::{Bytes, BytesMut};
 use ironbus_core::codec::{self, DecodeError, RecordView};
 use ironbus_core::format::{
     COMPACTION_META_LEN, RECORD_HEADER_LEN, SEGMENT_FOOTER_LEN, SEGMENT_HEADER_LEN,
@@ -231,8 +232,19 @@ impl StorageError {
     }
 }
 
-/// An owned copy of a decoded record (the codec yields a borrowed view; a scan owns
-/// its bytes).
+/// A materialized decoded record: the codec yields a borrowed [`RecordView`] over the read buffer;
+/// this owns the record so a scan can return it after the read.
+///
+/// The `key`, `headers`, and `payload` are [`Bytes`] handles (#480, the storage F2 finding): when a
+/// read materializes N records, the segment region is read into ONE buffer and each record's three
+/// blobs are REFCOUNTED slices of that shared buffer ([`Bytes::slice_ref`]) rather than three
+/// per-record `Vec` deep copies. A `read_from` is then one buffer allocation plus refcounted slices
+/// (a refcount bump per blob), not O(N) allocations and O(total bytes) copied, on the consume hot
+/// path. The materialized bytes are BYTE-IDENTICAL to a `to_vec` copy (a `Bytes` slice exposes the
+/// same bytes), and the frame's full CRC is validated by the codec BEFORE any slice is taken, so a
+/// handle is never a window into an unvalidated frame. `Bytes` derefs to `&[u8]`, so every reader
+/// that took `&[u8]` (the engine, compaction, the DLQ codec) is unchanged; a clone is a refcount
+/// bump, which is exactly the zero-copy fan-out the borrowed codec view was designed to enable.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct OwnedRecord {
     /// The log offset assigned to this record.
@@ -243,24 +255,31 @@ pub struct OwnedRecord {
     pub timestamp_ms: u64,
     /// Record flags as stored.
     pub flags: RecordFlags,
-    /// The routing or ordering key (empty if none).
-    pub key: Vec<u8>,
-    /// The record headers blob (empty if none).
-    pub headers: Vec<u8>,
-    /// The record payload.
-    pub payload: Vec<u8>,
+    /// The routing or ordering key (empty if none). A refcounted slice of the shared read buffer.
+    pub key: Bytes,
+    /// The record headers blob (empty if none). A refcounted slice of the shared read buffer.
+    pub headers: Bytes,
+    /// The record payload. A refcounted slice of the shared read buffer.
+    pub payload: Bytes,
 }
 
 impl OwnedRecord {
-    fn from_view(offset: Offset, v: &RecordView<'_>) -> OwnedRecord {
+    /// Materializes a record from a CRC-VALIDATED [`RecordView`] by taking refcounted slices of the
+    /// shared read `buf` the view borrows (#480). `buf` MUST be the exact buffer the `view` was
+    /// decoded from: [`Bytes::slice_ref`] resolves each blob's sub-range by its address WITHIN `buf`,
+    /// so the returned handles alias `buf` (one refcount bump each, no copy) and `buf` outlives every
+    /// record built from it (its bytes are freed when the last slice drops). The view's slices were
+    /// produced by `codec::decode`, which validates the whole frame's header and body CRC first, so a
+    /// slice is only ever taken over an already-validated frame — never a window into a torn frame.
+    fn from_view(offset: Offset, buf: &Bytes, v: &RecordView<'_>) -> OwnedRecord {
         OwnedRecord {
             offset,
             seq: v.seq,
             timestamp_ms: v.timestamp_ms,
             flags: v.flags,
-            key: v.key.to_vec(),
-            headers: v.headers.to_vec(),
-            payload: v.payload.to_vec(),
+            key: buf.slice_ref(v.key),
+            headers: buf.slice_ref(v.headers),
+            payload: buf.slice_ref(v.payload),
         }
     }
 }
@@ -829,10 +848,15 @@ impl<F: RandomAccessFile> SegmentReader<F> {
     ) -> Result<(Vec<OwnedRecord>, u64, bool), StorageError> {
         let body_len =
             usize::try_from(end.saturating_sub(start)).map_err(|_| StorageError::SegmentFull)?;
-        let mut body = vec![0u8; body_len];
+        // Read the region into ONE buffer and freeze it to a shared `Bytes` (#480): every record this
+        // walk materializes takes refcounted slices of `body` instead of three per-record `Vec`
+        // copies, so the whole scan is one allocation + refcount bumps. The frozen buffer outlives the
+        // returned records (each holds a ref), so it is freed only when the last record drops.
+        let mut buf = BytesMut::zeroed(body_len);
         if body_len > 0 {
-            self.file.read_exact_at(&mut body, start)?;
+            self.file.read_exact_at(&mut buf, start)?;
         }
+        let body = buf.freeze();
         let mut records = Vec::new();
         let mut cursor = 0usize;
         let mut clean = true;
@@ -849,7 +873,9 @@ impl<F: RandomAccessFile> SegmentReader<F> {
                     .get()
                     .saturating_add(records.len() as u64),
             );
-            records.push(OwnedRecord::from_view(offset, &view));
+            // The decode above validated the whole frame's CRC, so the view's slices are over an
+            // already-validated frame; `from_view` then refcount-slices them out of `body`.
+            records.push(OwnedRecord::from_view(offset, &body, &view));
             cursor += consumed;
         }
         Ok((records, cursor as u64, clean))
@@ -974,8 +1000,12 @@ impl<F: RandomAccessFile> SegmentReader<F> {
         }
         let len = usize::try_from(read_end.saturating_sub(start_byte))
             .map_err(|_| StorageError::SegmentFull)?;
-        let mut body = vec![0u8; len];
-        self.file.read_exact_at(&mut body, start_byte)?;
+        // ONE read into a shared `Bytes` buffer; each materialized record refcount-slices it (#480),
+        // so a seek-and-read-forward is one allocation + refcounted slices on the consume hot path,
+        // not O(records) allocations + O(bytes) copied. The buffer outlives the returned records.
+        let mut buf = BytesMut::zeroed(len);
+        self.file.read_exact_at(&mut buf, start_byte)?;
+        let body = buf.freeze();
         let mut records = Vec::with_capacity(max.min(64));
         let mut cursor = 0usize;
         let mut next_offset = start_offset.get();
@@ -984,7 +1014,12 @@ impl<F: RandomAccessFile> SegmentReader<F> {
             let Ok((view, consumed)) = codec::decode(&body[cursor..]) else {
                 break;
             };
-            records.push(OwnedRecord::from_view(Offset::new(next_offset), &view));
+            // Frame CRC-validated by the decode above before the slice is taken.
+            records.push(OwnedRecord::from_view(
+                Offset::new(next_offset),
+                &body,
+                &view,
+            ));
             next_offset = next_offset.saturating_add(1);
             cursor += consumed;
         }
@@ -1047,10 +1082,14 @@ impl<F: RandomAccessFile> SegmentReader<F> {
         let base_seq = self.header.base_seq.get();
         let body_len = usize::try_from(footer_start.saturating_sub(header_end))
             .map_err(|_| StorageError::SegmentFull)?;
-        let mut body = vec![0u8; body_len];
+        // The survivor region is read into ONE shared `Bytes` buffer and each survivor refcount-slices
+        // it (#480), the same one-alloc + refcounted-slices win as the dense path. The buffer outlives
+        // the returned survivors.
+        let mut bbuf = BytesMut::zeroed(body_len);
         if body_len > 0 {
-            self.file.read_exact_at(&mut body, header_end)?;
+            self.file.read_exact_at(&mut bbuf, header_end)?;
         }
+        let body = bbuf.freeze();
         let mut records: Vec<OwnedRecord> = Vec::new();
         let mut cursor = 0usize;
         let mut max_timestamp_ms = 0u64;
@@ -1075,7 +1114,8 @@ impl<F: RandomAccessFile> SegmentReader<F> {
             // Reconstruct the original offset from the constant offset-minus-seq delta.
             let offset = Offset::new(base_off.wrapping_add(seq.wrapping_sub(base_seq)));
             max_timestamp_ms = max_timestamp_ms.max(view.timestamp_ms);
-            records.push(OwnedRecord::from_view(offset, &view));
+            // Frame CRC-validated by the decode above before the slice is taken.
+            records.push(OwnedRecord::from_view(offset, &body, &view));
             cursor += consumed;
         }
         // The footer must describe THIS body and bind to THIS segment id.
@@ -1230,8 +1270,11 @@ impl<F: RandomAccessFile> SegmentReader<F> {
         }
         let len = usize::try_from(read_end.saturating_sub(start_byte))
             .map_err(|_| StorageError::SegmentFull)?;
-        let mut body = vec![0u8; len];
-        self.file.read_exact_at(&mut body, start_byte)?;
+        // ONE read into a shared `Bytes` buffer; each survivor refcount-slices it (#480), the same
+        // one-alloc + refcounted-slices win as the dense `scan_from`. The buffer outlives the records.
+        let mut buf = BytesMut::zeroed(len);
+        self.file.read_exact_at(&mut buf, start_byte)?;
+        let body = buf.freeze();
         let mut records = Vec::with_capacity(max.min(64));
         let mut cursor = 0usize;
         while cursor < body.len() && records.len() < max {
@@ -1243,7 +1286,8 @@ impl<F: RandomAccessFile> SegmentReader<F> {
             // identical reconstruction `scan_compacted` applies.
             let seq = view.seq.get();
             let offset = Offset::new(base_off.wrapping_add(seq.wrapping_sub(base_seq)));
-            records.push(OwnedRecord::from_view(offset, &view));
+            // Frame CRC-validated by the decode above before the slice is taken.
+            records.push(OwnedRecord::from_view(offset, &body, &view));
             cursor += consumed;
         }
         Ok(records)
@@ -1440,9 +1484,9 @@ mod tests {
         assert!(scan.footer.is_none());
         assert_eq!(scan.records.len(), 3);
         assert_eq!(scan.records[0].offset, Offset::new(0));
-        assert_eq!(scan.records[0].payload, b"one");
+        assert_eq!(scan.records[0].payload.as_ref(), b"one");
         assert_eq!(scan.records[2].seq, Seq::new(2));
-        assert_eq!(scan.records[2].payload, b"three");
+        assert_eq!(scan.records[2].payload.as_ref(), b"three");
     }
 
     #[test]
@@ -1500,7 +1544,7 @@ mod tests {
             .unwrap();
         assert!(!scan.clean);
         assert_eq!(scan.records.len(), 1);
-        assert_eq!(scan.records[0].payload, b"good1");
+        assert_eq!(scan.records[0].payload.as_ref(), b"good1");
         assert_eq!(scan.valid_end, after_first);
     }
 
@@ -1594,7 +1638,7 @@ mod tests {
             .scan_from(positions[0], Offset::new(0), valid_end, 10)
             .unwrap();
         assert_eq!(got.len(), 1);
-        assert_eq!(got[0].payload, b"good1");
+        assert_eq!(got[0].payload.as_ref(), b"good1");
     }
 
     #[test]
@@ -1665,7 +1709,7 @@ mod tests {
             .scan()
             .unwrap();
         assert_eq!(scan.records.len(), 1);
-        assert_eq!(scan.records[0].payload, b"durable");
+        assert_eq!(scan.records[0].payload.as_ref(), b"durable");
     }
 
     #[test]
@@ -1723,8 +1767,8 @@ mod tests {
         assert!(scan.footer.is_none());
         assert!(!scan.clean);
         assert_eq!(scan.records.len(), 2);
-        assert_eq!(scan.records[0].payload, b"a");
-        assert_eq!(scan.records[1].payload, b"b");
+        assert_eq!(scan.records[0].payload.as_ref(), b"a");
+        assert_eq!(scan.records[1].payload.as_ref(), b"b");
     }
 
     #[test]
@@ -1755,7 +1799,7 @@ mod tests {
         // Not falsely sealed; the un-corrupted prefix (the first record) survives.
         assert!(scan.footer.is_none());
         assert!(!scan.clean);
-        assert_eq!(scan.records[0].payload, b"small");
+        assert_eq!(scan.records[0].payload.as_ref(), b"small");
     }
 
     #[test]
@@ -1780,8 +1824,8 @@ mod tests {
             .unwrap();
         assert!(scan.footer.is_none());
         assert_eq!(scan.records.len(), 2);
-        assert_eq!(scan.records[0].payload, b"keep1");
-        assert_eq!(scan.records[1].payload, b"keep2");
+        assert_eq!(scan.records[0].payload.as_ref(), b"keep1");
+        assert_eq!(scan.records[1].payload.as_ref(), b"keep2");
     }
 
     #[test]
@@ -1957,7 +2001,7 @@ mod tests {
         assert_eq!(scan.records.len(), 3);
         assert_eq!(scan.records[1].seq, Seq::new(1));
         assert_eq!(scan.records[1].payload, big.as_slice());
-        assert_eq!(scan.records[2].payload, b"after");
+        assert_eq!(scan.records[2].payload.as_ref(), b"after");
 
         let streamed = SegmentReader::open(Arc::clone(&file))
             .unwrap()

--- a/crates/ironbus-storage/tests/compaction_crash.rs
+++ b/crates/ironbus-storage/tests/compaction_crash.rs
@@ -17,6 +17,7 @@
 //!   on the surviving offsets, and the offset monotonic / never-reuse invariant (I5) and I1 to I4
 //!   hold across the compaction + crash.
 
+use bytes::Bytes;
 use ironbus_core::clock::ManualClock;
 use ironbus_core::segment::SegmentHeader;
 use ironbus_core::types::Offset;
@@ -70,7 +71,7 @@ fn build_dirty_log(fs: InMemoryFs) -> (InMemoryFs, Vec<OwnedRecord>, Offset) {
 /// keep, with each survivor at its ORIGINAL offset.
 fn expected_survivors(records: &[OwnedRecord]) -> Vec<OwnedRecord> {
     use std::collections::HashMap;
-    let mut latest: HashMap<Vec<u8>, u64> = HashMap::new();
+    let mut latest: HashMap<Bytes, u64> = HashMap::new();
     for r in records {
         if !r.key.is_empty() {
             latest.insert(r.key.clone(), r.offset.get());

--- a/crates/ironbus-storage/tests/crash_recovery.rs
+++ b/crates/ironbus-storage/tests/crash_recovery.rs
@@ -754,7 +754,7 @@ proptest! {
             prop_assert_eq!(record.offset, Offset::new(i));
             prop_assert_eq!(record.seq, Seq::new(i));
             let expected = payload(i);
-            prop_assert_eq!(record.payload.as_slice(), expected.as_slice());
+            prop_assert_eq!(record.payload.as_ref(), expected.as_slice());
         }
     }
 
@@ -791,7 +791,7 @@ proptest! {
                 // that was dropped, or in the segment header), so a checksum that wrongly
                 // accepted a corrupt record would surface here as a mismatched payload.
                 let expected = payload(i);
-                prop_assert_eq!(record.payload.as_slice(), expected.as_slice());
+                prop_assert_eq!(record.payload.as_ref(), expected.as_slice());
             }
         }
     }
@@ -872,7 +872,7 @@ proptest! {
             prop_assert_eq!(record.offset, Offset::new(i));
             prop_assert_eq!(record.seq, Seq::new(i));
             let expected = payload(i);
-            prop_assert_eq!(record.payload.as_slice(), expected.as_slice());
+            prop_assert_eq!(record.payload.as_ref(), expected.as_slice());
         }
     }
 }
@@ -966,7 +966,7 @@ proptest! {
             prop_assert_eq!(record.offset, Offset::new(i));
             prop_assert_eq!(record.seq, Seq::new(i));
             let expected = payload(i);
-            prop_assert_eq!(record.payload.as_slice(), expected.as_slice());
+            prop_assert_eq!(record.payload.as_ref(), expected.as_slice());
         }
     }
 }

--- a/crates/ironbus-storage/tests/invariant_gate.rs
+++ b/crates/ironbus-storage/tests/invariant_gate.rs
@@ -19,6 +19,7 @@
 //! - The negative fixtures (`negative_fixtures`) feed each checker a deliberately-broken input and
 //!   assert it FAILS, so a checker that wrongly always passes would fail the gate here.
 
+use bytes::Bytes;
 use ironbus_core::clock::ManualClock;
 use ironbus_core::format::{RECORD_HEADER_LEN, RECORD_TRAILER_LEN};
 use ironbus_core::types::{Offset, RecordFlags, Seq};
@@ -301,9 +302,9 @@ fn negative_fixtures() {
             seq: Seq::new(seq),
             timestamp_ms: 0,
             flags: RecordFlags::EMPTY,
-            key: Vec::new(),
-            headers: Vec::new(),
-            payload: payload(offset),
+            key: Bytes::new(),
+            headers: Bytes::new(),
+            payload: Bytes::from(payload(offset)),
         }
     }
     let prefix: Vec<OwnedRecord> = (0..4).map(|i| rec(i, i)).collect();
@@ -360,7 +361,7 @@ fn negative_fixtures() {
 
     // I4: two recoveries that diverge (different payload at index 1) must be rejected.
     let mut diverged = prefix.clone();
-    diverged[1].payload = vec![0xff];
+    diverged[1].payload = Bytes::from_static(&[0xff]);
     assert_eq!(
         check_pure_recovery(&prefix, &diverged),
         Err(InvariantViolation::Nondeterministic { index: 1 }),


### PR DESCRIPTION
Closes #480.

## What

`OwnedRecord::from_view` did `key.to_vec()` + `headers.to_vec()` + `payload.to_vec()` — **three heap allocations and three copies per record** materialized, even though the codec's `RecordView` borrows the read buffer zero-copy. A `read_from` of N records was O(N) allocations + O(total bytes) copied on the consume hot path (the storage F2 finding).

`OwnedRecord` now carries `bytes::Bytes` for `key`/`headers`/`payload`. Each read path reads the segment region into one `BytesMut`, freezes it to a shared `Bytes`, and `from_view` takes refcounted slices of it via `Bytes::slice_ref`. A multi-record read is now **one buffer allocation plus a refcount bump per blob** — not O(records) allocations + O(bytes) copied. The shared buffer outlives the records it produced (each holds a ref) and is freed when the last record drops; a clone is now a refcount bump, the zero-copy fan-out the borrowed codec view was designed to enable.

## Correctness (byte-identical + CRC-before-slice)

- **Byte-identical**: a `Bytes` slice exposes the exact bytes a `to_vec` would have copied. The conformance byte-identity and all read/recovery suites pass unchanged.
- **Full CRC before slice**: `codec::decode` validates the whole frame (header + body CRC) *before* any slice is taken in `from_view`, so a handle is never a window into an unvalidated/torn frame.
- **Both seek paths**: the dense `scan_from` and the compacted `scan_compacted_from` (added in #483/#481) are both converted, alongside the buffered `scan_body` / `scan_compacted`. Bounds, offsets, and the `flushed`/`valid_end` semantics are unchanged.
- **Downstream `&[u8]`**: `Bytes` derefs to `&[u8]`, so the engine, compaction, and the DLQ codec are unchanged. The only owned-`Vec` consumer (the cold `dlq::decode_entry`) keeps its conversion local via `to_vec`, so the hot-path win is not undone.

`bytes` is added as a dependency of `ironbus-storage` (pure Rust, already in the workspace tree) and as a dev-dependency of `ironbus-cli` (a test-only DLQ fixture).

## Per-record allocation reduction

- Before: **3 allocs + 3 copies per record**, so N records = O(N) allocs + O(total bytes) copied.
- After: **1 buffer alloc per read** + a refcounted slice (refcount bump) per blob.

## Gate results

- `cargo fmt --all --check` — pass
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — pass
- `cargo test --workspace --all-features --locked` — pass (all suites, including the conformance byte-identity and crash/recovery corpora; 0 failed)

## What to scrutinize

- **The shared-buffer lifecycle**: the records returned from each read alias the frozen `Bytes`; it lives exactly as long as the longest-lived record (refcount), so there is no use-after-free and no premature drop.
- **CRC-before-slice ordering**: `from_view` is only ever called after a successful `codec::decode`, so every sliced frame is already CRC-validated.
- **Downstream `&[u8]` reliance**: confirmed no Vec-specific dependency on the hot path; the one place a real owned `Vec` is needed (the cold DLQ decode) converts locally.