### PR TITLE
perf(server): right-size the in-memory boot RAM guard to 1x post-#492 (#520)

### DIFF
--- a/crates/ironbus-cli/src/main.rs
+++ b/crates/ironbus-cli/src/main.rs
@@ -2881,8 +2881,8 @@ fn validate_ram_ceiling(config: &ServeConfig) -> Result<(), CliError> {
         max_groups: u64::try_from(config.max_groups).unwrap_or(u64::MAX),
         max_in_flight: u64::from(config.max_in_flight),
         // The #445 store fold: in memory mode the store is RAM and is charged at its byte cap
-        // (times the durable-image clone, applied inside the model); on disk it is file-backed
-        // and stays uncharged, keeping the historical disk verdict bit-for-bit.
+        // (a single live image after #492; the model applies the multiplier); on disk it is
+        // file-backed and stays uncharged, keeping the historical disk verdict bit-for-bit.
         in_memory_store_bytes: match config.storage {
             StorageArg::Memory => config.max_total_bytes,
             StorageArg::Disk => 0,
@@ -2902,8 +2902,8 @@ fn validate_ram_ceiling(config: &ServeConfig) -> Result<(), CliError> {
             let store_note = match config.storage {
                 StorageArg::Memory => format!(
                     " Under `--storage memory` the footprint INCLUDES the in-RAM store: \
-                     `--max-total-bytes` ({max_total_bytes}) is charged TWICE (the live bytes plus \
-                     the durable-image clone the in-memory filesystem keeps at each sync), so the \
+                     `--max-total-bytes` ({max_total_bytes}) is charged ONCE (a single live byte \
+                     image; the production EphemeralFile backend keeps no durable clone), so the \
                      store alone accounts for {store_bytes} bytes of the worst case. Lower \
                      `--max-total-bytes` or raise the ceiling to cover the store. Note: the \
                      dead-letter sink is OUTSIDE this floor (it is deliberately uncapped, poison \
@@ -8994,8 +8994,8 @@ mod tests {
         // (~15 MiB worst case, comfortably under the 64 MiB ceiling), `--max-total-bytes 1GiB`
         // in memory mode BOOTED before this fold (the #115 guard modeled connections, credits,
         // groups, and in-flight only, never the store), which in memory mode is a silent OOM
-        // promise: the store itself is RAM. With the store folded in (charged at 2x for the
-        // in-memory durable-image clone) the same config is now a provable refusal that NAMES
+        // promise: the store itself is RAM. With the store folded in (charged at 1x for the
+        // single live image, post-#492) the same config is now a provable refusal that NAMES
         // the store term and the knob to lower. This test FAILS if the fold is removed. The
         // small buffer caps are what make that kill possible: under the balanced defaults the
         // ceiling is exceeded by the connection terms alone and a fold-less mutant still refuses.
@@ -9018,8 +9018,8 @@ mod tests {
                     "the refusal names the store knob to lower: {m}"
                 );
                 assert!(
-                    m.contains("durable-image clone"),
-                    "the refusal states the 2x clone headroom: {m}"
+                    m.contains("charged ONCE") && m.contains("no durable clone"),
+                    "the refusal states the 1x single-image charge: {m}"
                 );
                 assert_eq!(CliError::Usage(m).exit_code(), EXIT_USAGE);
             }
@@ -9040,41 +9040,36 @@ mod tests {
     }
 
     #[test]
-    fn the_store_fold_charges_two_images_a_one_image_mutant_boots_here() {
+    fn the_store_fold_charges_one_image_a_two_image_mutant_over_refuses_here() {
         // PINS THE MULTIPLIER at the validate level, where the model test alone cannot: the
         // edge-tiny buffer terms sum to ~15 MiB, so with a 32 MiB store cap the worst case is
-        // ~47 MiB charged at ONE image (fits the 64 MiB ceiling, boots) and ~79 MiB charged at
-        // TWO (refuses). The ceiling sits BETWEEN the one-image and two-image floors, so a
-        // mutant that forgets the durable-image clone and charges the cap once BOOTS this exact
-        // config and fails here. Companion to the rss model test, which pins the literal 2 in
-        // the formula; this one proves the 2 reaches the real boot verdict with no slack.
+        // ~47 MiB charged at ONE image (fits the 64 MiB ceiling, BOOTS — the correct post-#492
+        // verdict for the single-image EphemeralFile backend) and ~79 MiB charged at TWO
+        // (refuses). The ceiling sits BETWEEN the one-image and two-image floors, so a STALE 2x
+        // mutant (the pre-#492 InMemoryFile live+durable charge) OVER-refuses this exact valid
+        // config and fails here. Companion to the rss model test, which pins the literal 1 in the
+        // formula; this one proves the 1 reaches the real boot verdict with no slack. (The 1 GiB
+        // test above pins the OTHER direction: a fold-removal mutant that charges 0x boots a
+        // config that must refuse, so together they fix the multiplier at exactly 1.)
         let cfg = ServeConfig {
             storage: StorageArg::Memory,
             ephemeral_loss_ack: true,
             max_total_bytes: 32 * 1024 * 1024,
             ..edge_tiny_caps()
         };
-        match validate_serve_config(&cfg) {
-            Err(CliError::Usage(m)) => {
-                assert!(m.contains("refuses to boot"), "{m}");
-                assert!(
-                    m.contains("--max-total-bytes"),
-                    "the refusal names the store knob: {m}"
-                );
-            }
-            other => panic!(
-                "32 MiB of store cap is 64 MiB of store images; with ~15 MiB of buffers that \
-                 provably exceeds the 64 MiB ceiling, got {other:?}"
-            ),
-        }
+        assert!(
+            validate_serve_config(&cfg).is_ok(),
+            "32 MiB of store cap is 32 MiB of store image (post-#492 single image); with ~15 MiB \
+             of buffers that fits the 64 MiB ceiling and must boot — a stale 2x mutant over-refuses"
+        );
     }
 
     #[test]
     fn memory_storage_boots_when_the_ceiling_covers_the_store_and_buffers() {
         // The fold's accepting direction: a memory-mode config whose ceiling covers the buffer
-        // terms PLUS both store images (2 * max-total-bytes) validates and boots. 8 MiB of cap
-        // means 16 MiB of store images; with the ~15 MiB edge-tiny buffer worst case that sums
-        // well under the 64 MiB ceiling.
+        // terms PLUS the store image (1 * max-total-bytes, post-#492) validates and boots. 8 MiB
+        // of cap means 8 MiB of store image; with the ~15 MiB edge-tiny buffer worst case that
+        // sums well under the 64 MiB ceiling.
         let cfg = ServeConfig {
             storage: StorageArg::Memory,
             ephemeral_loss_ack: true,

--- a/crates/ironbus-cli/tests/golden_path.rs
+++ b/crates/ironbus-cli/tests/golden_path.rs
@@ -1859,8 +1859,8 @@ fn memory_mode_refuses_a_ram_ceiling_below_the_store_floor() {
     // 64 groups, 256 in-flight) sum to ~15 MiB, comfortably under the 64 MiB ceiling, so THIS
     // EXACT invocation booted before the fold (the #115 guard modeled connections, credits,
     // groups, and in-flight only; the store was honestly excluded as ~0 RSS, which is true only
-    // on disk). With the store folded in, the 1 GiB in-RAM cap is charged at two byte images
-    // (the live bytes plus the durable-image clone) and the same invocation must now refuse to
+    // on disk). With the store folded in, the 1 GiB in-RAM cap is charged at a single live byte
+    // image (post-#492; EphemeralFile keeps no durable clone) and the same invocation must now refuse to
     // boot (exit 1, usage, BEFORE any listener opens) with a message naming the store term and
     // the knob to lower. The small connection terms are load-bearing: under the balanced
     // defaults, term 1 alone (256 connections x 8 MiB credit bytes = 2 GiB) exceeds the ceiling
@@ -1924,7 +1924,7 @@ fn memory_mode_refuses_a_ram_ceiling_below_the_store_floor() {
         "the refusal names the store fold and the knob to lower: {stderr}"
     );
     assert!(
-        stderr.contains("durable-image clone"),
-        "the refusal states the 2x clone headroom: {stderr}"
+        stderr.contains("charged ONCE") && stderr.contains("no durable clone"),
+        "the refusal states the 1x single-image charge: {stderr}"
     );
 }

--- a/crates/ironbus-server/src/rss.rs
+++ b/crates/ironbus-server/src/rss.rs
@@ -129,22 +129,20 @@ pub const PER_CONNECTION_STACK_BYTES: u64 = 64 * 1024;
 /// both with margin.
 pub const PER_LEASE_BYTES: u64 = 64;
 
-/// How many full byte IMAGES of the store the in-memory backend (#443) retains at steady state,
-/// the multiplier the #445 footprint proof charges per stored byte under `--storage memory`. The
-/// in-memory `Filesystem` (`InMemoryFs` / `InMemoryFile` in `ironbus-storage`) keeps TWO byte
-/// images per file: the `live` bytes plus the `durable` image a `sync_data` clones them into (the
-/// power-loss simulation contract every conformance suite relies on). At steady state every stored
-/// byte therefore exists twice in RSS, so the worst-case in-memory store footprint is
-/// `2 * max_total_bytes`, not `max_total_bytes`. The directory-level `sync_dir` clone is only a
-/// map of `Arc` pointers (no third byte image), so 2 is the honest multiplier, not a guess.
+/// How many full byte IMAGES of the store the in-memory PRODUCTION backend retains at steady state,
+/// the multiplier the #445 footprint proof charges per stored byte under `--storage memory`. After
+/// #492, production `--storage memory` uses the single-image `EphemeralFile` / `EphemeralFs`
+/// (`ironbus-storage`): ONE `live` byte image and NO `durable` clone — an ephemeral store makes no
+/// power-loss promise, so it needs no second image — and the directory-level `sync_dir` clone copies
+/// only a map of `Arc` pointers (no byte image). Every stored byte therefore exists ONCE in RSS, so
+/// the worst-case in-memory store footprint is `1 * max_total_bytes`, not `2 * max_total_bytes`.
 ///
-/// The 2 is the steady-state RETAINED set, not an instantaneous bound: the durable image is
-/// refreshed by `clone_from` inside `sync_data`, and when that clone reallocates, the old durable
-/// allocation and the incoming bytes can briefly coexist, so an instant mid-sync can exceed two
-/// images. Amortized, exactly two images per file are retained, which is what a STEADY-STATE
-/// footprint proof may honestly charge (the transient is per-file and short-lived; the guard's
-/// fixed-overhead and slack terms absorb it in practice).
-pub const IN_MEMORY_STORE_IMAGES: u64 = 2;
+/// The 2x `live` + `durable` image survives ONLY in the `InMemoryFile` power-loss SIMULATION the
+/// conformance suites rely on. That is a TEST backend, never a production boot path, so the
+/// refuse-to-boot guard does not charge for it. (Pre-#492 the guard charged 2x here, which now
+/// over-refuses a valid 1x config on a RAM-tight edge box — see #520.) The guard stays conservative:
+/// it never under-charges the real production backend.
+pub const IN_MEMORY_STORE_IMAGES: u64 = 1;
 
 /// The configuration the refuse-to-boot RAM guard ([`fits_under_ram_ceiling`]) reasons about: the
 /// bounded-buffer knobs from `docs/RAM_BUDGET.md` plus `max_connections` (a server-level cap that
@@ -172,8 +170,9 @@ pub struct RamFootprintConfig {
     /// store (`--storage memory`, #443), and `0` when the store is on disk. On disk the store is
     /// file-backed (the active segment is ~0 in RSS, `docs/RAM_BUDGET.md` term 4), so it is not a
     /// RAM source and this stays `0`. In memory mode the store IS RAM: every stored byte lives in
-    /// the process, up to the byte cap, and is charged at [`IN_MEMORY_STORE_IMAGES`] images (the
-    /// live bytes plus the durable-image clone `sync_data` keeps). The caller passes the resolved
+    /// the process, up to the byte cap, and is charged at [`IN_MEMORY_STORE_IMAGES`] (a single
+    /// `live` image after #492; the production `EphemeralFile` backend keeps no durable clone). The
+    /// caller passes the resolved
     /// `max_total_bytes` here; memory mode refuses an unlimited (`0`) cap upstream, so a `0` always
     /// means "the store is not in RAM", never "unbounded RAM store".
     pub in_memory_store_bytes: u64,
@@ -218,8 +217,8 @@ pub struct RamFootprintConfig {
 ///   file) and is not charged. Under `--storage memory` (#443) the store ITSELF is RAM, so the
 ///   #445 memory-backend fold charges it: `in_memory_store_bytes` (the resolved
 ///   `--max-total-bytes` cap, the most stored bytes the engine ever retains) times
-///   [`IN_MEMORY_STORE_IMAGES`] (the live bytes PLUS the durable-image clone the in-memory
-///   filesystem keeps per file at every `sync_data`). Disk mode passes `0` here, so the disk
+///   [`IN_MEMORY_STORE_IMAGES`] (after #492, a single `live` image — the production `EphemeralFile`
+///   backend keeps no durable clone). Disk mode passes `0` here, so the disk
 ///   verdict is bit-for-bit the historical one.
 /// - **The dead-letter sink (the DLQ), a DELIBERATE memory-mode exclusion.** The DLQ's log is
 ///   byte-UNCAPPED by design (its `LogConfig.max_total_bytes` is `0`: a poison record is the
@@ -257,8 +256,8 @@ pub fn worst_case_buffer_bytes(config: &RamFootprintConfig) -> u64 {
         .saturating_mul(PER_LEASE_BYTES);
 
     // Term 4, the IN-MEMORY store (#445): zero on disk (file-backed, ~0 RSS); under `--storage
-    // memory` the byte cap times the two byte images (live + the durable clone) the in-memory
-    // filesystem holds per file. See `IN_MEMORY_STORE_IMAGES` for why the multiplier is exactly 2.
+    // memory` the byte cap times the SINGLE byte image the production `EphemeralFile` backend holds
+    // (#492 — one `live` image, no durable clone). See `IN_MEMORY_STORE_IMAGES`.
     let term4_memory_store = config
         .in_memory_store_bytes
         .saturating_mul(IN_MEMORY_STORE_IMAGES);
@@ -426,19 +425,18 @@ mod tests {
     }
 
     #[test]
-    fn the_in_memory_store_is_charged_at_two_byte_images() {
-        // THE #445 MEMORY-BACKEND FOLD: with the store in RAM, the worst case grows by EXACTLY
-        // twice the store cap over the same config with a disk store. The expectation is a HARD
-        // LITERAL 2, deliberately NOT `IN_MEMORY_STORE_IMAGES`: an expectation computed from the
-        // constant is self-referential and would silently follow a drifted constant (a mutant
-        // setting it to 1 passed the whole suite that way once). The 2 is derived from the
-        // in-memory filesystem itself: `InMemoryFile` retains exactly TWO byte images per file,
-        // `State.live` plus `State.durable` (the image `sync_data`'s `clone_from` refreshes),
-        // and the directory-level `sync_dir` clone copies only a map of `Arc` POINTERS, never a
-        // third byte image. That retained set is the steady state; `clone_from`'s realloc
-        // transient can briefly exceed it mid-sync (see `IN_MEMORY_STORE_IMAGES`). This test
-        // FAILS if the store term is dropped, the clone headroom is forgotten, or the constant
-        // drifts off 2 in either direction.
+    fn the_in_memory_store_is_charged_at_one_byte_image() {
+        // THE #445 MEMORY-BACKEND FOLD, post-#492: with the store in RAM via the production
+        // single-image `EphemeralFile` backend, the worst case grows by EXACTLY the store cap over
+        // the same config with a disk store. The expectation is a HARD LITERAL 1, deliberately NOT
+        // `IN_MEMORY_STORE_IMAGES`: an expectation computed from the constant is self-referential
+        // and would silently follow a drifted constant. The 1 is derived from the production backend
+        // itself: `EphemeralFile` retains ONE byte image per file (`State.live`), with NO `durable`
+        // clone (an ephemeral store makes no power-loss promise), and the directory-level `sync_dir`
+        // clone copies only a map of `Arc` POINTERS, never a byte image. (The 2x `live` + `durable`
+        // image lives only in the `InMemoryFile` SIMULATION, which is not a production boot path; see
+        // #520.) This test FAILS if the store term is dropped or the constant drifts off 1 in either
+        // direction.
         let disk = edge_tiny_footprint();
         let mem = RamFootprintConfig {
             in_memory_store_bytes: 8 * 1024 * 1024,
@@ -446,16 +444,16 @@ mod tests {
         };
         assert_eq!(
             worst_case_buffer_bytes(&mem),
-            worst_case_buffer_bytes(&disk) + 2 * 8 * 1024 * 1024,
-            "the in-memory store must be charged at live + durable-clone (exactly 2 images)"
+            worst_case_buffer_bytes(&disk) + 8 * 1024 * 1024,
+            "the in-memory store must be charged at the single live image (exactly 1 image)"
         );
     }
 
     #[test]
     fn a_memory_store_past_the_ceiling_is_refused_where_the_disk_config_fits() {
         // The issue-#445 headline: edge-tiny knobs FIT under 64 MiB on disk, but the SAME knobs
-        // with a 1 GiB in-RAM store provably cannot (2 GiB of store images alone), so the verdict
-        // flips from Fits to Exceeds purely on the store fold.
+        // with a 1 GiB in-RAM store provably cannot (1 GiB of store image alone, post-#492), so the
+        // verdict flips from Fits to Exceeds purely on the store fold.
         let disk = edge_tiny_footprint();
         assert!(matches!(
             fits_under_ram_ceiling(&disk),
@@ -469,9 +467,9 @@ mod tests {
             RamCeilingVerdict::Exceeds {
                 worst_case_bytes, ..
             } => assert!(
-                // A hard literal 2, not the constant, so a drifted multiplier cannot satisfy a
+                // A hard literal 1, not the constant, so a drifted multiplier cannot satisfy a
                 // bound computed from itself.
-                worst_case_bytes >= 2 * 1024 * 1024 * 1024,
+                worst_case_bytes >= 1024 * 1024 * 1024,
                 "the store images dominate the worst case, got {worst_case_bytes}"
             ),
             other => {


### PR DESCRIPTION
Closes #520. The refuse-to-boot RAM guard charged `IN_MEMORY_STORE_IMAGES = 2` (the `InMemoryFile` live+durable power-loss SIM). After #492, production `--storage memory` uses the single-image `EphemeralFile` backend (1x, no durable clone), so the 2x now exists ONLY in the test sim and the guard OVER-refuses valid 1x configs on RAM-tight edge boxes. Right-sized the multiplier to 1 and updated ALL now-wrong 2x language (rss const + field/term4 docs + inline, the CLI refusal message, the store-fold test comments in main.rs + golden_path). The drift-guard tests now pin the multiplier at EXACTLY 1 from both sides: the 1 GiB tests catch a 0x fold-removal, the 32 MiB mutant test catches a stale 2x over-refusal. Correctness-neutral right-sizing (the guard was conservative; it over-refused valid configs, never under-refused). Gates green (fmt + clippy -D warnings + full workspace test). M4 docs prose was fixed in #519; this is the code.