### PR TITLE
feat(produce): Level-2 server+client ack via a bounded producer-notify registry (#497)

### DIFF
--- a/crates/ironbus-client/src/lib.rs
+++ b/crates/ironbus-client/src/lib.rs
@@ -27,10 +27,11 @@ use ironbus_core::compress::{
 use ironbus_core::types::RecordFlags;
 use ironbus_proto::frame::{decode_frame, encode_frame, FrameDecode, FrameError, FrameType};
 use ironbus_proto::message::{
-    decode_dead_letter, decode_deliver, decode_gap_marker, decode_info, decode_pub_ack,
-    decode_truncated, encode_ack, encode_connect, encode_cumulative_ack, encode_fetch, encode_pub,
-    encode_sub, AckBody, AckLevel, AckOp, BodyError, ConnectBody, CumulativeAckBody, FetchBody,
-    PubBody, SubBody, PUB_FLAG_ACK_LEVEL_MASK, PUB_FLAG_ACK_LEVEL_SHIFT,
+    decode_dead_letter, decode_deliver, decode_gap_marker, decode_info, decode_produce_confirm,
+    decode_pub_ack, decode_truncated, encode_ack, encode_connect, encode_cumulative_ack,
+    encode_fetch, encode_pub, encode_sub, produce_confirm_status, AckBody, AckLevel, AckOp,
+    BodyError, ConnectBody, CumulativeAckBody, FetchBody, PubBody, SubBody,
+    PUB_FLAG_ACK_LEVEL_MASK, PUB_FLAG_ACK_LEVEL_SHIFT,
 };
 use std::io::{self, Read, Write};
 use std::net::{TcpStream, ToSocketAddrs};
@@ -290,6 +291,43 @@ pub struct ProduceAck {
     pub duplicate: bool,
 }
 
+/// The terminal outcome of a Level-2 (server+client-ack) produce confirmation (#497), returned by
+/// [`Client::produce_confirmed`]. The record was ALREADY made durable (the durability `PubAck` arrived
+/// before the wait began, I2); this is the SECOND ack, reporting what became of it CONSUMER-side.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ConfirmOutcome {
+    /// A consumer in the broker's designated group ACKED the record: the Level-2 produce is fully
+    /// confirmed (durable AND consumed), the success terminal.
+    Consumed,
+    /// No consumer acked the record within the broker's confirm window, so the broker timed the
+    /// confirmation out: it will never arrive. The record stayed durable (its `PubAck` was returned),
+    /// but its consumption is unconfirmed.
+    TimedOut,
+    /// The record was dead-lettered (poison / force-reaped) or the broker's bounded confirm registry
+    /// dropped the pending confirmation before any consumer acked it: the consumed confirmation can
+    /// never be satisfied. The record stayed durable; only its consumed-confirmation is lost.
+    DeadLettered,
+    /// The CLIENT-side wait elapsed before any terminal `ProduceConfirm` arrived (distinct from the
+    /// BROKER-side `TimedOut`: this is the local deadline the caller passed expiring). The record is
+    /// durable; the caller may keep using the connection and a later confirmation, if any, will arrive
+    /// on a subsequent pass. Carries the durable offset so the caller can correlate or re-await.
+    LocalTimeout,
+    /// The broker sent a confirmation `status` byte this client build does not recognize (a forward-
+    /// compatible future status). The record is durable; the specific consumer-side outcome is unknown
+    /// to this build. Carries the raw status byte.
+    Unknown(u8),
+}
+
+/// A Level-2 produce confirmation (#497): the durable `offset` (the same one the durability `PubAck`
+/// returned) plus its terminal [`ConfirmOutcome`]. Returned by [`Client::produce_confirmed`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ProduceConfirmation {
+    /// The durable offset the confirmation is keyed to.
+    pub offset: u64,
+    /// What became of the record consumer-side (consumed / timed-out / dead-lettered / local-timeout).
+    pub outcome: ConfirmOutcome,
+}
+
 /// The outcome of a [`Client::progress`] call.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ProgressOutcome {
@@ -423,6 +461,18 @@ fn with_ack_level_bits(flags: u8, level: AckLevel) -> u8 {
     (flags & !PUB_FLAG_ACK_LEVEL_MASK) | bits
 }
 
+/// Maps a wire `ProduceConfirm` status byte (#497) to a client [`ConfirmOutcome`]. An unknown future
+/// status decodes to [`ConfirmOutcome::Unknown`] (forward-compatible: the codec already tolerated it),
+/// never an error.
+fn confirm_outcome(status: u8) -> ConfirmOutcome {
+    match status {
+        produce_confirm_status::CONSUMED => ConfirmOutcome::Consumed,
+        produce_confirm_status::TIMED_OUT => ConfirmOutcome::TimedOut,
+        produce_confirm_status::DEAD_LETTERED => ConfirmOutcome::DeadLettered,
+        other => ConfirmOutcome::Unknown(other),
+    }
+}
+
 fn classify_pub_reply(ty: FrameType, body: &[u8]) -> Result<PubReply, ClientError> {
     match ty {
         FrameType::PubAck => {
@@ -519,6 +569,13 @@ pub struct Client {
     /// (an old server, or the client did not advertise), a skipped span arrives in
     /// [`Fetch::truncations`] as the legacy advisory.
     gap_marker_enabled: bool,
+    /// Level-2 `ProduceConfirm`s (#497) that arrived for an offset OTHER than the one a
+    /// [`Client::produce_confirmed`] call was awaiting, cached so a later call for that offset returns
+    /// without re-waiting. Bounded in practice by the number of in-flight L2 produces a single
+    /// half-duplex producer can have outstanding (it awaits each before issuing the next), so this
+    /// stays tiny; entries are removed on the matching call. Empty for any connection that never uses
+    /// `produce_confirmed`.
+    confirm_cache: Vec<(u64, ConfirmOutcome)>,
 }
 
 impl Client {
@@ -550,6 +607,7 @@ impl Client {
             negotiated_credit: None,
             negotiated_credit_bytes: None,
             gap_marker_enabled: false,
+            confirm_cache: Vec::new(),
         };
         // The #292 handshake: send a versioned Connect body carrying any requested credit (an
         // all-absent body when the caller requested nothing, which the server reads as "use my
@@ -791,6 +849,143 @@ impl Client {
                 self.produce(&leveled).map(Some)
             }
         }
+    }
+
+    /// Produces a message at Level 2 (server+client ack, #497, part of #499) and AWAITS its
+    /// `ProduceConfirm`: the publish is confirmed only after a CONSUMER acks it, so this returns once
+    /// the record is BOTH durable AND consumed (or a terminal failure / the `timeout` elapses).
+    ///
+    /// TWO acks, in order:
+    /// 1. The DURABILITY ack: the publish goes out at Level 2 and this first awaits the `PubAck` after
+    ///    the covering group-commit fsync (I2), exactly like [`Client::produce`]. If this fails (a
+    ///    server `Err`, a transport error) the call returns that error and never reaches the wait.
+    /// 2. The CONSUMED ack: the broker registered the durable offset in its bounded confirm registry;
+    ///    when a consumer in the broker's designated group acks the record, the broker sends a
+    ///    server->producer `ProduceConfirm{offset, status}` frame, which this awaits (keyed by the
+    ///    offset the `PubAck` returned) up to `timeout`.
+    ///
+    /// ## How the wait works (and why it polls)
+    ///
+    /// The broker is a blocking, thread-per-connection, request-response server: it only writes a
+    /// connection's socket from THAT connection's own pass, so it cannot push a confirm to a producer
+    /// blocked in `read`. This call therefore DRIVES the broker to flush by interleaving lightweight
+    /// `Ping`s while it waits: each round sends a `Ping` and reads the frames the broker returns
+    /// (`Pong` plus any ready `ProduceConfirm`s for this connection), until the matching confirm
+    /// arrives or `timeout` elapses. A confirm for a DIFFERENT offset (an earlier L2 publish on the
+    /// same connection) is matched and CACHED so a later `produce_confirmed` for that offset returns it
+    /// without re-waiting. The poll keeps the await fully within the existing wire/threading contract:
+    /// no out-of-band push, no second socket, no new race.
+    ///
+    /// Returns a [`ProduceConfirmation`] carrying the durable `offset` and the terminal
+    /// [`ConfirmOutcome`] (`Consumed` / `TimedOut` / `DeadLettered` / `LocalTimeout` / `Unknown`). A
+    /// `LocalTimeout` means the local deadline elapsed first; the record is durable regardless, and the
+    /// connection stays usable.
+    ///
+    /// This is ADDITIVE and SEPARATE from [`Client::produce_with_ack_level`]: that method records the
+    /// Level-2 intent on the wire but returns at the durability ack (it does NOT await the consumer-ack
+    /// confirmation); this method is the one that awaits the `ProduceConfirm`.
+    ///
+    /// # Errors
+    /// Returns a [`ClientError`] on a transport error, an over-large field, an unexpected frame, or a
+    /// server `Err` for the durability ack. A broker-side timeout / dead-letter is NOT an error: it is
+    /// reported as the corresponding [`ConfirmOutcome`].
+    pub fn produce_confirmed(
+        &mut self,
+        message: &PubBody<'_>,
+        timeout: Duration,
+    ) -> Result<ProduceConfirmation, ClientError> {
+        // Step 1 — the durability ack. Send at Level 2 (the ack-level field on the wire) and await the
+        // PubAck, exactly like `produce`. `produce` forces the faf bit clear, so this is at-least-once.
+        let leveled = PubBody {
+            flags: with_ack_level_bits(message.flags, AckLevel::ServerAndClientAck),
+            ..*message
+        };
+        let offset = self.produce(&leveled)?;
+        // A confirm for THIS offset may already be cached from an earlier round (a prior
+        // `produce_confirmed` drained it while waiting on a different offset). Serve it without waiting.
+        if let Some(outcome) = self.take_cached_confirm(offset) {
+            return Ok(ProduceConfirmation { offset, outcome });
+        }
+        // Step 2 — the consumed ack. Poll for the matching `ProduceConfirm` within the deadline,
+        // driving broker passes with Pings.
+        let outcome = self.await_produce_confirm(offset, timeout)?;
+        Ok(ProduceConfirmation { offset, outcome })
+    }
+
+    /// Awaits the `ProduceConfirm` for `offset` up to `timeout` (#497), driving broker passes with
+    /// `Ping`s (see [`Client::produce_confirmed`]). Returns the terminal [`ConfirmOutcome`], or
+    /// `LocalTimeout` if the deadline elapses first. A `ProduceConfirm` for a DIFFERENT offset is
+    /// cached for a later `produce_confirmed`. A read that times out (the connection read timeout) is
+    /// treated as "no confirm this round" while the deadline has not passed.
+    fn await_produce_confirm(
+        &mut self,
+        offset: u64,
+        timeout: Duration,
+    ) -> Result<ConfirmOutcome, ClientError> {
+        let deadline = std::time::Instant::now() + timeout;
+        loop {
+            // Drive a broker pass: a Ping makes the connection do a `process` pass, which flushes any
+            // ready ProduceConfirms for this connection alongside the Pong.
+            self.send(FrameType::Ping, &[])?;
+            // Read frames until this round yields the Pong boundary (every ready confirm precedes or
+            // accompanies it in the same flush), the matching confirm arrives, or the read times out.
+            loop {
+                match self.read_frame_or_timeout()? {
+                    Some((FrameType::ProduceConfirm, body)) => {
+                        let confirm = decode_produce_confirm(&body).map_err(|_| {
+                            ClientError::BadResponse("produce-confirm body was not nine bytes")
+                        })?;
+                        let outcome = confirm_outcome(confirm.status);
+                        if confirm.offset == offset {
+                            return Ok(outcome);
+                        }
+                        // A confirm for an earlier L2 publish on this connection: cache it so a later
+                        // `produce_confirmed` for that offset returns without re-waiting.
+                        self.confirm_cache.push((confirm.offset, outcome));
+                    }
+                    // Two round-ending cases, same action (stop reading, re-check the deadline,
+                    // re-Ping): `None` is a read timeout with no frame, and `Pong` is this round's
+                    // flush boundary (every ready confirm precedes or accompanies it in the same flush).
+                    None | Some((FrameType::Pong, _)) => break,
+                    // An Err for a Ping is not expected; surface it. Any other frame (e.g. a stray
+                    // Deliver on a mixed producer/consumer connection) is not what this wait is for.
+                    Some((FrameType::Err, body)) => {
+                        return Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
+                    }
+                    Some((other, _)) => return Err(ClientError::Unexpected(other)),
+                }
+            }
+            if std::time::Instant::now() >= deadline {
+                return Ok(ConfirmOutcome::LocalTimeout);
+            }
+        }
+    }
+
+    /// Reads one frame, returning `Ok(None)` if the connection read TIMED OUT (the OS read timeout
+    /// elapsed) rather than propagating it as an error (#497): the confirm-await poll treats a timed-out
+    /// read as "no confirm yet this round". A genuine close or malformed frame still errors.
+    fn read_frame_or_timeout(&mut self) -> Result<Option<(FrameType, Vec<u8>)>, ClientError> {
+        match self.read_frame() {
+            Ok(frame) => Ok(Some(frame)),
+            // A read timeout surfaces as a `WouldBlock`/`TimedOut` IO error on a blocking socket with a
+            // read timeout set; that is "no data yet", not a fatal error, during the bounded poll.
+            Err(ClientError::Io(e))
+                if matches!(
+                    e.kind(),
+                    io::ErrorKind::WouldBlock | io::ErrorKind::TimedOut
+                ) =>
+            {
+                Ok(None)
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Removes and returns a cached `ProduceConfirm` outcome for `offset` if one arrived on an earlier
+    /// round (#497), else `None`.
+    fn take_cached_confirm(&mut self, offset: u64) -> Option<ConfirmOutcome> {
+        let pos = self.confirm_cache.iter().position(|&(o, _)| o == offset)?;
+        Some(self.confirm_cache.swap_remove(pos).1)
     }
 
     /// Produces a WINDOW of messages PIPELINED (#450): every `Pub` frame is written before any
@@ -2157,6 +2352,91 @@ mod tests {
         assert_eq!(messages[0].payload, b"l0");
         assert_eq!(messages[1].payload, b"l1");
         assert_eq!(messages[2].payload, b"l2");
+
+        shutdown.store(true, Ordering::Release);
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn produce_confirmed_returns_consumed_once_a_consumer_acks_against_a_real_server() {
+        // #497 end-to-end against the REAL wire server: a producer calls `produce_confirmed` (send L2,
+        // await the durability PubAck, then poll for the ProduceConfirm). A SEPARATE consumer thread
+        // fetches the record and acks it, which fires the server->producer Consumed confirm. The
+        // producer's call returns `Consumed` keyed to the produced offset.
+        let (addr, shutdown, handle) = start_server();
+        let mut producer = Client::connect(addr).unwrap();
+
+        // The consumer runs on its own thread: it fetches the one record and acks it (in the default
+        // group, the broker's designated confirm group), which is what fires the producer's confirm.
+        let consumer = std::thread::spawn({
+            move || {
+                let mut c = Client::connect(addr).unwrap();
+                // Retry the fetch until the record is visible (the producer's L2 publish lands first).
+                loop {
+                    let messages = c.fetch(10).unwrap().messages;
+                    if let Some(m) = messages.first() {
+                        assert!(c.ack(m.offset, m.generation).unwrap());
+                        return m.offset;
+                    }
+                    std::thread::sleep(Duration::from_millis(5));
+                }
+            }
+        });
+
+        let body = PubBody {
+            flags: 0,
+            timestamp_ms: 0,
+            key: b"",
+            headers: b"",
+            dedup: None,
+            fire_and_forget: false,
+            payload: b"l2-confirmed",
+        };
+        let confirmation = producer
+            .produce_confirmed(&body, Duration::from_secs(5))
+            .unwrap();
+        let acked_offset = consumer.join().unwrap();
+        assert_eq!(
+            confirmation.offset, acked_offset,
+            "the confirm is keyed to the produced offset"
+        );
+        assert_eq!(
+            confirmation.outcome,
+            ConfirmOutcome::Consumed,
+            "a consumer ack confirms the L2 produce as consumed"
+        );
+
+        shutdown.store(true, Ordering::Release);
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn produce_confirmed_reports_local_timeout_when_no_consumer_acks() {
+        // #497: with no consumer ever acking, `produce_confirmed` returns `LocalTimeout` once the
+        // caller's deadline elapses (the record stayed durable; only its consumed-confirmation is
+        // pending). The broker-side TTL is far longer than this local deadline, so the LOCAL deadline
+        // is what fires here, exactly as documented.
+        let (addr, shutdown, handle) = start_server();
+        let mut producer = Client::connect(addr).unwrap();
+        let body = PubBody {
+            flags: 0,
+            timestamp_ms: 0,
+            key: b"",
+            headers: b"",
+            dedup: None,
+            fire_and_forget: false,
+            payload: b"unconfirmed",
+        };
+        let confirmation = producer
+            .produce_confirmed(&body, Duration::from_millis(150))
+            .unwrap();
+        assert_eq!(
+            confirmation.outcome,
+            ConfirmOutcome::LocalTimeout,
+            "no consumer acked within the local deadline"
+        );
+        // The record is durable regardless: a fetch sees it.
+        assert_eq!(producer.fetch(10).unwrap().messages.len(), 1);
 
         shutdown.store(true, Ordering::Release);
         handle.join().unwrap();

--- a/crates/ironbus-core/src/confirm.rs
+++ b/crates/ironbus-core/src/confirm.rs
@@ -1,0 +1,539 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! The bounded Level-2 produce-confirm registry (#497, part of #499): the per-offset map that
+//! turns a CONSUMER ack into a server->producer `ProduceConfirm`.
+//!
+//! ## What it is
+//!
+//! Level 2 (server+client ack) of the tunable produce ack-level spectrum (#499) confirms a publish
+//! only after a CONSUMER has acked it: the record is DURABLE first (the ordinary Level-1 `PubAck`,
+//! I2), and THEN, when a consumer drains and acks it, the producer is told `ProduceConfirm{offset,
+//! status = consumed}`. This structure is the bridge between the two halves. On an L2 produce the
+//! caller [`ConfirmRegistry::register`]s the durable offset against the producer's stable connection
+//! id; when the DESIGNATED consumer group's committed cursor later advances past that offset the
+//! caller calls [`ConfirmRegistry::confirm_up_to`], which moves the entry to a READY terminal the
+//! producer drains.
+//!
+//! ## Why a single DESIGNATED group (not "any"/"all")
+//!
+//! A record is delivered to EVERY consumer group; "consumed" is therefore ambiguous unless we pick
+//! ONE group to mean it. Keying the confirm to whichever group acks FIRST ("any group") is
+//! non-deterministic and lets an unrelated group race the confirm; firing only after ALL groups ack
+//! ("all groups") is unbounded (groups come and go, and a never-subscribed group would pin the
+//! confirm forever). So the confirm is keyed to ONE designated group, chosen by the engine
+//! (the default/broadcast group unless an operator names another), exactly the group whose
+//! cursor-commit the caller hooks. This keeps "consumed" well-defined and the registry bounded.
+//!
+//! ## Failure modes (all terminal, all bounded)
+//!
+//! - **No consumer ever acks** -> the entry ages past the TTL and the idle/retention sweep
+//!   ([`ConfirmRegistry::sweep_timed_out`]) fires `status = timed_out`.
+//! - **Dead-lettered / force-reaped before any ack** -> the caller calls
+//!   [`ConfirmRegistry::terminate`] with `status = dead_lettered`, so the producer learns the
+//!   confirmation can never be satisfied instead of waiting out the whole TTL.
+//! - **Producer disconnects** -> [`ConfirmRegistry::drop_member`] removes every entry for that
+//!   connection (pending AND ready): nobody is waiting, so no terminal is produced.
+//! - **The registry is full** -> a [`ConfirmRegistry::register`] at the cap evicts the OLDEST
+//!   pending entry as `status = dropped` (drop-oldest), so a slow or absent consumer can never grow
+//!   it without bound (the same threat class as the dedup window cap and the lease-heap bound). The
+//!   READY queue is bounded the same way: an over-cap ready terminal drops the oldest ready one.
+//!
+//! ## Time and IO
+//!
+//! PURE and IO-free, like [`crate::cursor::AckCursor`] and [`crate::dedup::DedupRegistry`]: the
+//! caller supplies monotonic time (`now`, nanoseconds, from the clock seam) on register/sweep, so an
+//! NTP wall-clock step never mis-expires a confirm (I6). The registry is in-memory and session-scoped
+//! (lost on restart): a producer awaiting an L2 confirm across a broker crash sees its blocking call
+//! time out, which is the correct signal (the broker has no memory of the wait), while the record
+//! itself stayed durable via its Level-1 `PubAck`. Restoring L2 waits across a restart would need a
+//! durable confirm log and is out of scope here.
+//!
+//! ## Memory
+//!
+//! Both the pending map and the ready queue are HARD-capped ([`ConfirmConfig::max_pending`]), and
+//! the TTL bounds how long any single pending entry lives. The total worst case is thus
+//! `2 * max_pending` entries, each a fixed `(u64 offset, u64 member, u64 instant[, u8 status])`, so
+//! the structure costs nothing until a producer opts into Level 2 and can never OOM the node it runs
+//! on. See `docs/RAM_BUDGET.md`.
+
+use crate::types::Offset;
+use std::collections::BTreeMap;
+use std::collections::VecDeque;
+
+/// The default cap on the number of PENDING (and, separately, READY) Level-2 confirms a broker holds
+/// at once (#497). Past it a fresh [`ConfirmRegistry::register`] drop-oldests the eldest pending
+/// confirm (and an over-cap ready terminal drop-oldests the eldest ready one), so a slow or absent
+/// consumer can never grow the registry without bound. Sized generously for a real in-flight L2
+/// window on an edge node while keeping the worst-case memory a small, fixed budget.
+pub const DEFAULT_MAX_PENDING: usize = 65_536;
+
+/// The default TTL for a pending Level-2 confirm, in NANOSECONDS of monotonic time (#497): a confirm
+/// no consumer acks within this window is swept to `status = timed_out`, so a producer awaiting it is
+/// never told to wait forever. Five minutes is comfortably above a slow consumer's drain latency yet
+/// finite, matching the dedup window's "finite but generous" sizing.
+pub const DEFAULT_CONFIRM_TTL_NANOS: u64 = 5 * 60 * 1_000_000_000;
+
+/// The terminal status of a Level-2 confirm, mirroring the wire
+/// [`ironbus_proto`-style](crate) `produce_confirm_status` values (#494) WITHOUT a dependency on the
+/// proto crate (core stays proto-free). The server maps each variant to the corresponding wire byte.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ConfirmStatus {
+    /// A consumer in the designated group acked the record: the Level-2 produce is confirmed (the
+    /// success terminal). Maps to the wire `CONSUMED` (0).
+    Consumed,
+    /// No consumer acked within the TTL: the confirmation timed out (a non-success terminal). Maps to
+    /// the wire `TIMED_OUT` (1).
+    TimedOut,
+    /// The record was dead-lettered (poison / force-reaped) before any ack, so the confirmation can
+    /// never be satisfied (a non-success terminal). Maps to the wire `DEAD_LETTERED` (2).
+    DeadLettered,
+    /// The registry evicted this pending confirm under its cap (drop-oldest) before any consumer
+    /// acked: a bounded-registry shed, surfaced as a terminal so the producer stops waiting rather
+    /// than blocking out the whole TTL. Maps to the wire `DEAD_LETTERED` (2) (a non-success terminal:
+    /// the record stayed durable, but the broker no longer tracks its consumed confirmation).
+    Dropped,
+}
+
+/// A READY Level-2 confirm: a terminal outcome whose producer connection has not yet drained it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ReadyConfirm {
+    /// The durable offset the confirm is keyed to (the offset the producer's `PubAck` returned).
+    pub offset: u64,
+    /// The producer connection's stable id (the same id [`ConfirmRegistry::register`] recorded), so
+    /// the caller routes the terminal to the right producer and nobody else.
+    pub member: u64,
+    /// The terminal status to report to the producer.
+    pub status: ConfirmStatus,
+}
+
+/// Tunables for a [`ConfirmRegistry`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ConfirmConfig {
+    /// The hard cap on PENDING confirms (and, separately, on READY confirms): at the pending cap a
+    /// fresh register drop-oldests the eldest pending entry; at the ready cap a fresh terminal
+    /// drop-oldests the eldest ready entry. `0` is treated as 1 (a hard floor of one) so the registry
+    /// is always usable.
+    pub max_pending: usize,
+    /// The TTL for a pending confirm, in NANOSECONDS of monotonic time: a confirm older than this on
+    /// a sweep is timed out. `0` DISABLES the TTL sweep (only the cap bounds the registry).
+    pub ttl_nanos: u64,
+}
+
+impl Default for ConfirmConfig {
+    fn default() -> ConfirmConfig {
+        ConfirmConfig {
+            max_pending: DEFAULT_MAX_PENDING,
+            ttl_nanos: DEFAULT_CONFIRM_TTL_NANOS,
+        }
+    }
+}
+
+/// One pending Level-2 confirm: which producer is waiting and when it was registered (for the TTL).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct Pending {
+    /// The producer connection's stable id.
+    member: u64,
+    /// The monotonic instant (nanoseconds, clock seam) the confirm was registered, the TTL anchor.
+    registered_nanos: u64,
+}
+
+/// The bounded per-offset Level-2 produce-confirm registry (#497).
+///
+/// `pending` keys a producer's awaited confirm by the record's durable offset; `ready` queues the
+/// terminal outcomes a producer connection has not yet drained. Both are hard-bounded by
+/// [`ConfirmConfig::max_pending`]; the TTL bounds how long a pending entry lives. The structure is
+/// pure and IO-free (the caller supplies monotonic time), and empty until a producer opts into
+/// Level 2, so a broker no producer uses Level 2 on pays nothing.
+#[derive(Clone, Debug, Default)]
+pub struct ConfirmRegistry {
+    config: ConfirmConfig,
+    /// Pending confirms keyed by durable offset. `BTreeMap` so [`ConfirmRegistry::confirm_up_to`]
+    /// drains the contiguous prefix below a committed watermark in offset order without a scan of the
+    /// whole map, and so the OLDEST-offset drop-oldest victim under the cap is the map's first key
+    /// (offsets are assigned monotonically, so the lowest offset is the earliest-registered entry).
+    pending: BTreeMap<u64, Pending>,
+    /// Terminal confirms awaiting drain by their producer connection, oldest first.
+    ready: VecDeque<ReadyConfirm>,
+}
+
+impl ConfirmRegistry {
+    /// A fresh, empty registry with the given bounds. A `max_pending` of `0` is floored to 1.
+    #[must_use]
+    pub fn new(config: ConfirmConfig) -> ConfirmRegistry {
+        ConfirmRegistry {
+            config: ConfirmConfig {
+                max_pending: config.max_pending.max(1),
+                ttl_nanos: config.ttl_nanos,
+            },
+            pending: BTreeMap::new(),
+            ready: VecDeque::new(),
+        }
+    }
+
+    /// The number of PENDING confirms (awaiting a consumer ack, a TTL timeout, or a terminate).
+    #[must_use]
+    pub fn pending_len(&self) -> usize {
+        self.pending.len()
+    }
+
+    /// The number of READY terminals not yet drained by their producer.
+    #[must_use]
+    pub fn ready_len(&self) -> usize {
+        self.ready.len()
+    }
+
+    /// Registers a pending Level-2 confirm: the record at `offset` (already DURABLE, its Level-1
+    /// `PubAck` sent) is awaiting a consumer ack, and `member` is the producer connection to notify.
+    /// `now` is the clock-seam monotonic instant, the TTL anchor.
+    ///
+    /// BOUNDED (drop-oldest): if the pending map is already at the cap, the OLDEST pending confirm is
+    /// evicted as a `Dropped` terminal (queued ready for ITS producer) before this one is inserted,
+    /// so a slow or absent consumer can never grow the registry past the cap. A re-register of an
+    /// offset already pending overwrites it (a benign no-op in practice: offsets are unique per
+    /// produce), so the map can never hold two entries for one offset.
+    pub fn register(&mut self, offset: Offset, member: u64, now: u64) {
+        let offset = offset.get();
+        // Drop-oldest under the cap, but never evict the very offset we are about to (re-)insert: an
+        // overwrite of an existing key does not grow the map, so only a genuinely NEW key past the cap
+        // forces an eviction. Loop in case the cap was lowered below the current size.
+        while self.pending.len() >= self.config.max_pending && !self.pending.contains_key(&offset) {
+            // `pop_first` removes the LOWEST-offset entry, i.e. the earliest-registered pending confirm
+            // (offsets are monotonic), without an `expect`-guarded re-lookup. Evict it as a
+            // bounded-registry shed terminal. `None` is unreachable (the loop guard proved the map is
+            // non-empty), but handling it as `break` keeps the method panic-free by construction.
+            let Some((victim_offset, victim)) = self.pending.pop_first() else {
+                break;
+            };
+            self.push_ready(ReadyConfirm {
+                offset: victim_offset,
+                member: victim.member,
+                status: ConfirmStatus::Dropped,
+            });
+        }
+        self.pending.insert(
+            offset,
+            Pending {
+                member,
+                registered_nanos: now,
+            },
+        );
+    }
+
+    /// Fires a `Consumed` terminal for every pending confirm whose offset is STRICTLY BELOW
+    /// `committed` (the designated group's freshly-advanced committed watermark, EXCLUSIVE), moving
+    /// each to the ready queue. This is the cursor-commit hook: the caller invokes it after the
+    /// designated group's `AckCursor` advances (an ack, a cumulative ack), so a confirm fires exactly
+    /// when the record it keys becomes consumed. Returns the number of confirms fired.
+    ///
+    /// Draining the BELOW-watermark prefix (not an exact-offset match) is what makes the hook correct
+    /// under out-of-order acks: the committed watermark is the offset below which EVERY record is
+    /// acked, so any pending confirm below it is genuinely consumed, and an out-of-order ack that does
+    /// not yet advance the watermark correctly fires nothing.
+    pub fn confirm_up_to(&mut self, committed: Offset) -> usize {
+        let committed = committed.get();
+        let mut fired = 0;
+        // Drain the contiguous low-offset prefix below the watermark. `BTreeMap` keeps the keys
+        // sorted, so peeking the first key and `pop_first`ing it stops at the first offset at or above
+        // `committed` without scanning the rest and without an `expect`-guarded re-lookup.
+        while self
+            .pending
+            .first_key_value()
+            .is_some_and(|(&o, _)| o < committed)
+        {
+            let Some((offset, pending)) = self.pending.pop_first() else {
+                break;
+            };
+            self.push_ready(ReadyConfirm {
+                offset,
+                member: pending.member,
+                status: ConfirmStatus::Consumed,
+            });
+            fired += 1;
+        }
+        fired
+    }
+
+    /// Terminates the pending confirm at `offset` with `status` (a non-`Consumed` terminal), moving it
+    /// to the ready queue. The caller uses this when a record can never be consumed: it was
+    /// dead-lettered or force-reaped before any consumer acked it ([`ConfirmStatus::DeadLettered`]).
+    /// A no-op (returns `false`) if no confirm is pending for `offset` (it already fired, timed out,
+    /// or was never an L2 produce).
+    pub fn terminate(&mut self, offset: Offset, status: ConfirmStatus) -> bool {
+        let offset = offset.get();
+        match self.pending.remove(&offset) {
+            Some(pending) => {
+                self.push_ready(ReadyConfirm {
+                    offset,
+                    member: pending.member,
+                    status,
+                });
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Terminates every pending confirm whose offset is STRICTLY BELOW `floor` with `status` (a
+    /// non-`Consumed` terminal), moving each to the ready queue. The caller uses this when a SPAN of
+    /// records can never be consumed: the disk-full drop-oldest policy force-reaped the oldest
+    /// segment(s) out from under every consumer, so every pending confirm below the new
+    /// earliest-retained offset is unsatisfiable. Returns the number terminated. Like
+    /// [`ConfirmRegistry::confirm_up_to`], it drains the contiguous low-offset prefix in order without
+    /// scanning the whole map.
+    pub fn terminate_below(&mut self, floor: Offset, status: ConfirmStatus) -> usize {
+        let floor = floor.get();
+        let mut terminated = 0;
+        while self
+            .pending
+            .first_key_value()
+            .is_some_and(|(&o, _)| o < floor)
+        {
+            let Some((offset, pending)) = self.pending.pop_first() else {
+                break;
+            };
+            self.push_ready(ReadyConfirm {
+                offset,
+                member: pending.member,
+                status,
+            });
+            terminated += 1;
+        }
+        terminated
+    }
+
+    /// Sweeps out every pending confirm older than the TTL, firing a `TimedOut` terminal for each, the
+    /// "no consumer ever acks" failure mode. `now` is the clock-seam monotonic instant. A no-op when
+    /// the TTL is disabled (`ttl_nanos == 0`). Returns the number timed out. Called from the engine's
+    /// existing idle/retention tick, so it adds no new timer.
+    pub fn sweep_timed_out(&mut self, now: u64) -> usize {
+        if self.config.ttl_nanos == 0 {
+            return 0;
+        }
+        let ttl = self.config.ttl_nanos;
+        // Collect the timed-out offsets first (we cannot mutate the map while iterating it). The
+        // collection is bounded by `max_pending`, the same bound the whole registry lives under.
+        let expired: Vec<u64> = self
+            .pending
+            .iter()
+            .filter(|(_, p)| now.saturating_sub(p.registered_nanos) >= ttl)
+            .map(|(&offset, _)| offset)
+            .collect();
+        for offset in &expired {
+            if let Some(pending) = self.pending.remove(offset) {
+                self.push_ready(ReadyConfirm {
+                    offset: *offset,
+                    member: pending.member,
+                    status: ConfirmStatus::TimedOut,
+                });
+            }
+        }
+        expired.len()
+    }
+
+    /// Removes every entry (PENDING and READY) for a producer connection that has disconnected, the
+    /// "producer disconnect" failure mode: nobody is waiting on `member` any more, so no terminal is
+    /// produced (the entries are simply dropped). Returns the number of entries removed. Bounds the
+    /// registry against a producer that opens L2 produces then vanishes.
+    pub fn drop_member(&mut self, member: u64) -> usize {
+        let before = self.pending.len() + self.ready.len();
+        self.pending.retain(|_, p| p.member != member);
+        self.ready.retain(|r| r.member != member);
+        before - (self.pending.len() + self.ready.len())
+    }
+
+    /// Drains every READY terminal for `member` (a producer connection draining its confirms on its
+    /// own pass), in oldest-first order, removing them from the queue. Other producers' ready
+    /// terminals are left in place. Returns the drained terminals (possibly empty).
+    pub fn drain_ready_for(&mut self, member: u64) -> Vec<ReadyConfirm> {
+        // Partition the queue: keep the ready terminals for OTHER members, take this member's. Rebuild
+        // preserving order so a producer that drains repeatedly still sees FIFO confirms.
+        let mut mine = Vec::new();
+        let mut others = VecDeque::with_capacity(self.ready.len());
+        for r in self.ready.drain(..) {
+            if r.member == member {
+                mine.push(r);
+            } else {
+                others.push_back(r);
+            }
+        }
+        self.ready = others;
+        mine
+    }
+
+    /// Pushes a terminal onto the ready queue, BOUNDED the same way as the pending map: at the cap the
+    /// OLDEST ready terminal is dropped (a producer that never drains its confirms cannot grow the
+    /// queue without bound). A dropped-from-ready terminal is simply discarded: the producer either
+    /// disconnected or stopped reading, so there is nobody to deliver it to anyway.
+    fn push_ready(&mut self, confirm: ReadyConfirm) {
+        while self.ready.len() >= self.config.max_pending {
+            self.ready.pop_front();
+        }
+        self.ready.push_back(confirm);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn off(n: u64) -> Offset {
+        Offset::new(n)
+    }
+
+    fn cfg(max_pending: usize, ttl_nanos: u64) -> ConfirmConfig {
+        ConfirmConfig {
+            max_pending,
+            ttl_nanos,
+        }
+    }
+
+    #[test]
+    fn a_consumer_ack_past_the_offset_fires_a_consumed_confirm() {
+        let mut r = ConfirmRegistry::new(ConfirmConfig::default());
+        r.register(off(5), 1, 0);
+        assert_eq!(r.pending_len(), 1);
+        // A committed watermark at or below the offset fires nothing (not yet consumed).
+        assert_eq!(
+            r.confirm_up_to(off(5)),
+            0,
+            "watermark == offset is exclusive"
+        );
+        assert_eq!(r.pending_len(), 1);
+        // A watermark PAST the offset fires the consumed confirm.
+        assert_eq!(r.confirm_up_to(off(6)), 1);
+        assert_eq!(r.pending_len(), 0);
+        let ready = r.drain_ready_for(1);
+        assert_eq!(
+            ready,
+            vec![ReadyConfirm {
+                offset: 5,
+                member: 1,
+                status: ConfirmStatus::Consumed,
+            }]
+        );
+    }
+
+    #[test]
+    fn confirm_up_to_fires_the_whole_below_watermark_prefix_in_order() {
+        let mut r = ConfirmRegistry::new(ConfirmConfig::default());
+        for n in [3, 7, 4, 10] {
+            r.register(off(n), 1, 0);
+        }
+        // Committing past 8 fires 3, 4, 7 (below 8) but leaves 10.
+        assert_eq!(r.confirm_up_to(off(8)), 3);
+        let ready = r.drain_ready_for(1);
+        assert_eq!(
+            ready.iter().map(|c| c.offset).collect::<Vec<_>>(),
+            vec![3, 4, 7],
+            "fired in ascending offset order"
+        );
+        assert_eq!(r.pending_len(), 1, "offset 10 still pending");
+    }
+
+    #[test]
+    fn a_timed_out_confirm_fires_when_no_consumer_acks_within_the_ttl() {
+        let mut r = ConfirmRegistry::new(cfg(16, 1_000));
+        r.register(off(0), 9, 0);
+        // Before the TTL: nothing.
+        assert_eq!(r.sweep_timed_out(999), 0);
+        assert_eq!(r.pending_len(), 1);
+        // At/after the TTL: timed out.
+        assert_eq!(r.sweep_timed_out(1_000), 1);
+        assert_eq!(r.pending_len(), 0);
+        let ready = r.drain_ready_for(9);
+        assert_eq!(ready[0].status, ConfirmStatus::TimedOut);
+        // A disabled TTL never times anything out.
+        let mut r2 = ConfirmRegistry::new(cfg(16, 0));
+        r2.register(off(0), 1, 0);
+        assert_eq!(r2.sweep_timed_out(u64::MAX), 0);
+        assert_eq!(r2.pending_len(), 1);
+    }
+
+    #[test]
+    fn a_dead_letter_terminates_the_pending_confirm() {
+        let mut r = ConfirmRegistry::new(ConfirmConfig::default());
+        r.register(off(2), 4, 0);
+        assert!(r.terminate(off(2), ConfirmStatus::DeadLettered));
+        assert_eq!(r.pending_len(), 0);
+        let ready = r.drain_ready_for(4);
+        assert_eq!(ready[0].status, ConfirmStatus::DeadLettered);
+        // Terminating an unknown offset is a no-op.
+        assert!(!r.terminate(off(99), ConfirmStatus::DeadLettered));
+    }
+
+    #[test]
+    fn a_producer_disconnect_drops_its_pending_and_ready_entries() {
+        let mut r = ConfirmRegistry::new(ConfirmConfig::default());
+        r.register(off(0), 1, 0); // member 1 pending
+        r.register(off(1), 2, 0); // member 2 pending
+        r.terminate(off(1), ConfirmStatus::DeadLettered); // member 2 now ready
+        r.register(off(2), 1, 0); // member 1 second pending
+                                  // Member 1 disconnects: both its pending entries gone, member 2's ready terminal stays.
+        let removed = r.drop_member(1);
+        assert_eq!(removed, 2);
+        assert!(r.drain_ready_for(1).is_empty());
+        assert_eq!(r.drain_ready_for(2).len(), 1, "member 2 untouched");
+    }
+
+    #[test]
+    fn the_pending_registry_is_bounded_drop_oldest_under_the_cap() {
+        let mut r = ConfirmRegistry::new(cfg(3, 0));
+        // Fill to the cap.
+        r.register(off(0), 1, 0);
+        r.register(off(1), 1, 0);
+        r.register(off(2), 1, 0);
+        assert_eq!(r.pending_len(), 3);
+        // The fourth evicts the OLDEST (offset 0) as a Dropped terminal.
+        r.register(off(3), 1, 0);
+        assert_eq!(r.pending_len(), 3, "still capped");
+        let ready = r.drain_ready_for(1);
+        assert_eq!(ready.len(), 1);
+        assert_eq!(ready[0].offset, 0);
+        assert_eq!(ready[0].status, ConfirmStatus::Dropped);
+        // The surviving pending offsets are the three newest.
+        assert_eq!(r.confirm_up_to(off(4)), 3);
+        let fired: Vec<u64> = r.drain_ready_for(1).iter().map(|c| c.offset).collect();
+        assert_eq!(fired, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn a_re_register_of_a_pending_offset_does_not_grow_or_evict() {
+        let mut r = ConfirmRegistry::new(cfg(2, 0));
+        r.register(off(0), 1, 0);
+        r.register(off(1), 1, 0);
+        // Re-registering an existing offset overwrites, never evicts (the map does not grow).
+        r.register(off(1), 2, 5);
+        assert_eq!(r.pending_len(), 2);
+        assert!(r.drain_ready_for(1).is_empty(), "no eviction happened");
+        // The overwrite took the new member.
+        assert_eq!(r.confirm_up_to(off(2)), 2);
+        let members: Vec<u64> = r.drain_ready_for(2).iter().map(|c| c.member).collect();
+        assert_eq!(members, vec![2], "offset 1 now routes to member 2");
+    }
+
+    #[test]
+    fn the_ready_queue_is_bounded() {
+        let mut r = ConfirmRegistry::new(cfg(2, 0));
+        // Terminate more confirms than the ready cap; the oldest ready ones drop.
+        for n in 0..5 {
+            r.register(off(n), 1, 0);
+            r.terminate(off(n), ConfirmStatus::DeadLettered);
+        }
+        assert!(r.ready_len() <= 2, "ready queue capped");
+    }
+
+    #[test]
+    fn drain_ready_preserves_fifo_and_isolates_members() {
+        let mut r = ConfirmRegistry::new(ConfirmConfig::default());
+        r.register(off(0), 1, 0);
+        r.register(off(1), 2, 0);
+        r.register(off(2), 1, 0);
+        r.confirm_up_to(off(3));
+        // Member 1 sees its two confirms in FIFO offset order; member 2 sees its one.
+        let m1: Vec<u64> = r.drain_ready_for(1).iter().map(|c| c.offset).collect();
+        assert_eq!(m1, vec![0, 2]);
+        let m2: Vec<u64> = r.drain_ready_for(2).iter().map(|c| c.offset).collect();
+        assert_eq!(m2, vec![1]);
+        // Draining again yields nothing.
+        assert!(r.drain_ready_for(1).is_empty());
+    }
+}

--- a/crates/ironbus-core/src/lib.rs
+++ b/crates/ironbus-core/src/lib.rs
@@ -15,6 +15,7 @@ pub mod clock;
 pub mod codec;
 pub mod compress;
 pub mod config;
+pub mod confirm;
 pub mod cursor;
 pub mod dedup;
 pub mod delivery;

--- a/crates/ironbus-server/src/engine.rs
+++ b/crates/ironbus-server/src/engine.rs
@@ -26,6 +26,7 @@ use ironbus_core::clock::Clock;
 use ironbus_core::compress::{
     compress_payload, Codec, CompressConfig, DEFAULT_MAX_DECOMPRESSED_BYTES,
 };
+use ironbus_core::confirm::{ConfirmConfig, ConfirmRegistry, ConfirmStatus, ReadyConfirm};
 use ironbus_core::cursor::AckCursor;
 use ironbus_core::delivery::{DeliveryConfig, Disposition};
 use ironbus_core::keyshared::{KeyOrdering, KeyRouter, MemberId, RouteDecision};
@@ -1833,6 +1834,26 @@ pub struct Engine<F: Filesystem, C: Clock> {
     /// ([`Engine::append_no_sync`]); a `Codec::None` codec makes the seam a pass-through, so the
     /// historical broker is byte-for-byte unchanged.
     compress: CompressConfig<'static>,
+    /// The bounded Level-2 produce-confirm registry (#497, part of #499): the per-offset map keying a
+    /// producer's awaited `ProduceConfirm` to the durable offset and the producer connection. EMPTY
+    /// until a producer publishes at Level 2 (`AckLevel::ServerAndClientAck`), so a broker no producer
+    /// uses Level 2 on pays nothing here. A Level-2 produce registers its durable offset
+    /// ([`Engine::register_l2_confirm`]) AFTER its Level-1 `PubAck` (the record is durable first, I2);
+    /// when the DESIGNATED group's committed cursor advances past that offset (the cursor-commit hook
+    /// in [`Engine::ack_in`] / [`Engine::cumulative_ack_in`]) a `Consumed` confirm fires; a
+    /// dead-letter / force-reap before any ack fires a `DeadLettered` confirm; the idle/retention tick
+    /// sweeps a confirm no consumer acks within the TTL to `TimedOut`; a producer disconnect drops its
+    /// entries. HARD-bounded (a max pending count AND a TTL), so a slow or absent consumer can never
+    /// grow it without bound (the same threat class as the dedup window cap).
+    confirm_registry: ConfirmRegistry,
+    /// The name of the ONE designated consumer group whose ack confirms a Level-2 produce (#497).
+    /// "Consumed" is ambiguous across the many groups a record is delivered to, so the confirm is
+    /// keyed to a SINGLE group: the default group (`""`, the wire's unnamed group) unless an operator
+    /// names another, exactly the group whose cursor-commit the engine hooks. Keyed to ONE group (not
+    /// "any group", which is non-deterministic, nor "all groups", which is unbounded). The engine
+    /// fires `Consumed` only when THIS group's cursor advances; an ack in any other group is ignored
+    /// by the confirm path (its own delivery and acking are unaffected).
+    confirm_group: String,
 }
 
 /// The file name of the work-group's durable committed-cursor checkpoint.
@@ -2059,6 +2080,15 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
             // The #430 write-path compression seam; `Codec::None` makes it a pass-through,
             // so the disk image is byte-for-byte historical.
             compress: compress_config(config.compression),
+            // The bounded Level-2 produce-confirm registry (#497), at its default cap + TTL. Empty
+            // until a producer publishes at Level 2, so a no-L2 broker pays nothing. NOT a new
+            // `EngineConfig` field (the registry is self-bounded by internal defaults); a knob can be
+            // threaded later without touching every config construction site.
+            confirm_registry: ConfirmRegistry::new(ConfirmConfig::default()),
+            // The designated group whose ack confirms a Level-2 produce (#497): the default/unnamed
+            // group, which every plain producer/consumer uses. An operator can redesignate it via
+            // `set_confirm_group` server-side (NOT on the wire).
+            confirm_group: DEFAULT_GROUP.to_string(),
         };
         engine.seed_registry_from_recovered_state(flushed);
         Ok(engine)
@@ -3224,6 +3254,13 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         // here therefore reclaims only groups that were already idle AND caught up before this batch.
         let now = self.log.now_monotonic();
         self.sweep_idle_groups(now)?;
+        // The Level-2 confirm-timeout sweep (#497): on the SAME produce/group-commit tick, time out
+        // any pending L2 confirm no consumer has acked within the registry TTL, so a slow or absent
+        // consumer cannot pin a confirm (or grow the registry) forever. A no-op unless the TTL is set
+        // AND an L2 confirm is outstanding, so a no-L2 broker is unaffected. It rides this existing
+        // tick rather than a new timer, and runs regardless of the idle-eviction window so the TTL
+        // bound holds even when group idle-eviction is disabled.
+        self.sweep_l2_confirm_timeouts();
         Ok(())
     }
 
@@ -3419,6 +3456,15 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
                         self.counters.segments_force_reaped =
                             self.counters.segments_force_reaped.saturating_add(1);
                         forced_this_pass = true;
+                        // The Level-2 force-reap terminal (#497): the forced drop-oldest just deleted
+                        // the oldest sealed segment out from under any slow consumer, so a record
+                        // below the NEW earliest-retained offset can never be consumed (acked) by the
+                        // designated group. Fire a `DeadLettered` `ProduceConfirm` for every pending
+                        // L2 confirm now below that floor, so the producer is not left awaiting a
+                        // confirm the broker has made impossible. A no-op unless an L2 confirm was
+                        // pending in the reaped span. Same threat class as the dead-letter terminal.
+                        let earliest = self.log.earliest_offset().get();
+                        self.terminate_confirms_below(earliest, ConfirmStatus::DeadLettered);
                     }
                     // Only the active segment remains: nothing left to free, so the wedge guard
                     // returns the rejection and `produce` sheds (drop-new fall-back).
@@ -3972,6 +4018,18 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         self.sync_consumer_lag(group, committed);
         self.counters.dead_lettered += 1;
         self.last_dead_lettered = Some(off);
+        // The Level-2 dead-letter terminal (#497): if the DESIGNATED confirm group dead-lettered this
+        // offset, its record can never be consumed (acked) by that group, so fire a `DeadLettered`
+        // `ProduceConfirm` instead of leaving the producer to wait out the whole TTL. A no-op unless
+        // an L2 confirm was actually pending for this offset in the designated group. The cursor
+        // commit above ALSO ran the per-offset `confirm_up_to` via no hook here on purpose: a
+        // dead-letter is NOT a consume, so it must surface a NON-success terminal, which `terminate`
+        // does. `terminate` removes the pending entry, so the later `confirm_designated_commit` paths
+        // can never double-fire it.
+        if group == self.confirm_group {
+            self.confirm_registry
+                .terminate(off, ConfirmStatus::DeadLettered);
+        }
         Ok(Poll::Parked {
             offset: off,
             record,
@@ -4522,6 +4580,82 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         self.poll_in_member(group, member, now)
     }
 
+    /// The name of the ONE designated group whose ack confirms a Level-2 produce (#497). Defaults to
+    /// the default/unnamed group; see [`Engine::set_confirm_group`].
+    #[must_use]
+    pub fn confirm_group(&self) -> &str {
+        &self.confirm_group
+    }
+
+    /// Redesignates the group whose ack confirms a Level-2 produce (#497), server-side (NOT on the
+    /// wire). The default is the default/unnamed group. Changing it does not retroactively re-key
+    /// already-pending confirms (they fire on the newly-designated group's commit going forward);
+    /// pending entries that the old group would have confirmed eventually time out, so the registry
+    /// stays bounded. Intended to be set once at serve time, like `set_broadcast_in`.
+    pub fn set_confirm_group(&mut self, group: &str) {
+        self.confirm_group = group.to_string();
+    }
+
+    /// Registers a Level-2 (server+client-ack) produce's DURABLE offset against the producer
+    /// connection awaiting its `ProduceConfirm` (#497). The caller (the session) invokes this AFTER
+    /// the record's Level-1 `PubAck` is determined, so the record is durable first (I2) and the
+    /// confirm wait is layered ON TOP of, never instead of, the durability ack. BOUNDED: a register at
+    /// the registry cap drop-oldests the eldest pending confirm (queued as a `Dropped` terminal for
+    /// its producer), so a slow or absent consumer can never grow the registry. `member` is the
+    /// producer connection's stable id (its `MemberId`).
+    pub fn register_l2_confirm(&mut self, offset: Offset, member: MemberId) {
+        let now = self.log.now_monotonic();
+        self.confirm_registry.register(offset, member.get(), now);
+    }
+
+    /// Drains every READY `ProduceConfirm` terminal for the producer connection `member` (#497), in
+    /// FIFO order, so the session can write them to that producer on its own pass. Other producers'
+    /// ready terminals are left in place. Returns the drained terminals (possibly empty); the common
+    /// no-L2 case returns an empty `Vec` without touching the registry's internals.
+    pub fn drain_l2_confirms(&mut self, member: MemberId) -> Vec<ReadyConfirm> {
+        self.confirm_registry.drain_ready_for(member.get())
+    }
+
+    /// Drops every Level-2 confirm entry (pending AND ready) for a producer connection that has
+    /// disconnected (#497): nobody is waiting, so no terminal is produced and the registry is bounded
+    /// against a producer that opens L2 produces then vanishes. Called from the connection cleanup
+    /// path on every exit, like the `key_shared` leave and the subscription deregister.
+    pub fn drop_l2_confirms(&mut self, member: MemberId) {
+        self.confirm_registry.drop_member(member.get());
+    }
+
+    /// Fires a `Consumed` `ProduceConfirm` for every pending Level-2 confirm below `committed`, but
+    /// ONLY when `group` is the designated confirm group (#497). This is the cursor-commit hook: every
+    /// site that advances a group's `AckCursor` (an ack, a cumulative ack) calls it AFTER the advance,
+    /// passing the group's fresh committed watermark, so a confirm fires exactly when the record it
+    /// keys becomes consumed by the designated group. An ack in any OTHER group is ignored here (its
+    /// own delivery/acking is unaffected), keeping "consumed" well-defined and the hook a pure,
+    /// additive overlay on the unchanged consume/ack path.
+    fn confirm_designated_commit(&mut self, group: &str, committed: u64) {
+        if group == self.confirm_group {
+            self.confirm_registry.confirm_up_to(Offset::new(committed));
+        }
+    }
+
+    /// Terminates every pending Level-2 confirm below `floor` with `status` (#497): the disk-full
+    /// force-reap path uses it to surface a `DeadLettered` terminal for every confirm whose record was
+    /// force-reaped out from under every consumer. Group-agnostic on purpose: a force-reap deletes the
+    /// record for ALL groups, so a confirm keyed to the designated group below the new floor is
+    /// unsatisfiable regardless. A no-op unless a confirm is pending in the reaped span.
+    fn terminate_confirms_below(&mut self, floor: u64, status: ConfirmStatus) {
+        self.confirm_registry
+            .terminate_below(Offset::new(floor), status);
+    }
+
+    /// Sweeps every pending Level-2 confirm older than the registry TTL to a `TimedOut` terminal
+    /// (#497), the "no consumer ever acks" failure mode. Driven from the existing idle/retention tick
+    /// ([`Engine::sweep_idle_groups`]), so it adds no new timer; a no-op when the TTL is disabled or no
+    /// L2 confirm is outstanding. Reads the clock seam for `now`.
+    fn sweep_l2_confirm_timeouts(&mut self) {
+        let now = self.log.now_monotonic();
+        self.confirm_registry.sweep_timed_out(now);
+    }
+
     /// Pushes `group`'s current committed offset (a record count) to the metric registry's
     /// per-consumer lag series (#97), so the scrape reads `head - committed` without ever walking
     /// the log. Called at EVERY committed-advancing site (ack, dead-letter commit, below-earliest
@@ -4568,6 +4702,13 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
                 // without ever walking the log. Read it before the borrow ends.
                 let committed = g.cursor.committed().get();
                 self.sync_consumer_lag(group, committed);
+                // The Level-2 cursor-commit hook (#497): if THIS is the designated confirm group and
+                // its watermark just advanced past a pending L2 produce, fire its `Consumed`
+                // `ProduceConfirm`. ADDITIVE — a no-op unless `group` is the designated group AND a
+                // confirm is pending below the new watermark, so the consume/ack path is otherwise
+                // byte-for-byte unchanged. The `g` borrow has ended (`sync_consumer_lag` above took
+                // `&mut self`), so this re-borrows `self` safely.
+                self.confirm_designated_commit(group, committed);
                 AckResult::Acked
             }
             AckOutcome::Fenced => AckResult::Fenced,
@@ -4651,6 +4792,13 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         // (`leases.ack`); this is the bulk equivalent, and idempotent on a re-ack (nothing remains
         // leased below an already-committed `up_to`).
         g.leases.release_below(up_to);
+        // Capture the watermark before the borrow ends, then fire the Level-2 cursor-commit hook
+        // (#497) once `g` is released. A broadcast group can be the designated confirm group, so a
+        // bulk cumulative ack confirms every pending L2 produce below the new watermark in one move,
+        // exactly as a sequence of per-message acks would. ADDITIVE: a no-op unless this is the
+        // designated group with confirms pending.
+        let committed = g.cursor.committed().get();
+        self.confirm_designated_commit(group, committed);
         Ok(())
     }
 
@@ -8465,6 +8613,47 @@ mod tests {
             e.durable_record_bytes(),
             5 * one
         );
+    }
+
+    #[test]
+    fn force_reaping_an_l2_records_segment_dead_letters_its_pending_confirm() {
+        // #497: an L2 produce at offset 0 registers a pending confirm. If the disk-full drop-oldest
+        // policy FORCE-reaps the oldest segment (deleting offset 0 out from under every consumer)
+        // before any consumer acked it, the pending confirm can never be satisfied, so a DEAD_LETTERED
+        // terminal fires to the producer instead of leaving it waiting out the whole TTL.
+        let one = one_record_bytes();
+        let mut e = open(config_disk_full(4 * one, DiskFullPolicy::DropOldest));
+        let producer = MemberId::new(42);
+
+        // The first record (offset 0) is an L2 produce: register its pending confirm.
+        produce(&mut e, &[0xab; 16]);
+        e.register_l2_confirm(Offset::new(0), producer);
+        assert_eq!(
+            e.drain_l2_confirms(producer).len(),
+            0,
+            "no terminal yet (nothing reaped)"
+        );
+
+        // A fast producer fills past the cap; drop-oldest force-reaps segment 0 (offset 0 is gone).
+        for _ in 0..20 {
+            e.produce(&Append {
+                timestamp_ms: 0,
+                flags: RecordFlags::EMPTY,
+                key: b"",
+                headers: b"",
+                payload: &[0xab; 16],
+            })
+            .expect("drop-oldest accepts the produce");
+        }
+        assert!(
+            e.earliest_retained_offset().get() > 0,
+            "offset 0 was force-reaped"
+        );
+        // The producer's pending confirm for the reaped offset became a DEAD_LETTERED terminal.
+        let ready = e.drain_l2_confirms(producer);
+        assert_eq!(ready.len(), 1, "exactly one terminal for the reaped offset");
+        assert_eq!(ready[0].offset, 0);
+        assert_eq!(ready[0].status, ConfirmStatus::DeadLettered);
     }
 
     #[test]

--- a/crates/ironbus-server/src/server.rs
+++ b/crates/ironbus-server/src/server.rs
@@ -148,6 +148,15 @@ where
     // cleanup directly above; there is no panic source in those lib paths today, so it is not a
     // live bug, but a future panic-prone refactor of the loop must keep this on every exit path.
     let _ = session.leave_current_subscription(engine);
+    // Drop this connection's Level-2 produce-confirm entries (#497): a producer that opened L2
+    // produces then disconnected has nobody awaiting its `ProduceConfirm`s, so the engine's bounded
+    // registry drops every pending AND ready entry for this member rather than letting them sit until
+    // the TTL. Best-effort like the cleanups above: a gone actor is a no-op. This is the "producer
+    // disconnect" failure mode of the bounded registry. GATED on `produced_l2` so an L0/L1-only or
+    // pure-consumer connection never routes this through the actor (it has nothing to drop).
+    if session.produced_l2() {
+        let _ = engine.with(move |e| e.drop_l2_confirms(member_id));
+    }
     let group = session.subscription().to_string();
     let _ = engine.with(move |e| {
         let _ = e.checkpoint_group(&group);

--- a/crates/ironbus-server/src/session.rs
+++ b/crates/ironbus-server/src/session.rs
@@ -23,6 +23,7 @@ use crate::engine::{AckResult, EngineError, NackResult, Poll, ProgressResult};
 use bytes::Bytes;
 use ironbus_core::clock::Clock;
 use ironbus_core::compress::{validate_descriptor_shape, DEFAULT_MAX_DECOMPRESSED_BYTES};
+use ironbus_core::confirm::{ConfirmStatus, ReadyConfirm};
 use ironbus_core::dedup::{MAX_MSG_ID_LEN, MAX_PRODUCER_ID_LEN};
 use ironbus_core::keyshared::{KeyOrdering, MemberId};
 use ironbus_core::lease::LeaseToken;
@@ -30,10 +31,10 @@ use ironbus_core::types::{Offset, RecordFlags};
 use ironbus_proto::frame::{decode_frame, encode_frame, FrameDecode, FrameError, FrameType};
 use ironbus_proto::message::{
     decode_ack, decode_connect, decode_cumulative_ack, decode_fetch, decode_pub, decode_sub,
-    encode_dead_letter, encode_deliver, encode_gap_marker, encode_info, encode_pub_ack,
-    encode_truncated, gap_reason, pub_ack_level, AckLevel, AckOp, CreditAdvert, DeadLetterBody,
-    DeliverBody, GapMarkerBody, InfoBody, PubAckBody, TruncatedBody, DEAD_LETTER_MAX_DELIVER,
-    PUB_WIRE_ONLY_FLAGS,
+    encode_dead_letter, encode_deliver, encode_gap_marker, encode_info, encode_produce_confirm,
+    encode_pub_ack, encode_truncated, gap_reason, produce_confirm_status, pub_ack_level, AckLevel,
+    AckOp, CreditAdvert, DeadLetterBody, DeliverBody, GapMarkerBody, InfoBody, ProduceConfirmBody,
+    PubAckBody, TruncatedBody, DEAD_LETTER_MAX_DELIVER, PUB_WIRE_ONLY_FLAGS,
 };
 use ironbus_storage::fs::Filesystem;
 use std::collections::HashMap;
@@ -268,6 +269,17 @@ pub struct Session {
     /// double-signal and an old consumer that would error on an unknown frame is never sent the new
     /// tag. Default `false` (backward-compatible).
     gap_marker_enabled: bool,
+    /// Whether this connection has EVER published a Level-2 (server+client-ack) produce (#497): set
+    /// when an L2 publish is registered for confirmation, and NEVER cleared. It is the gate that keeps
+    /// the per-pass `ProduceConfirm` drain off the actor for a connection that never opted into Level 2
+    /// — CRITICALLY a ping-only or pure-consumer connection, which must answer a `Ping` WITHOUT touching
+    /// the actor so a stalled produce fsync on another connection cannot head-of-line-block it (#177,
+    /// invariant 4). Only a connection that actually produced an L2 publish ever routes the confirm
+    /// drain through the actor, and such a connection opted into the L2 protocol (its
+    /// `produce_confirmed` already tolerates the wait), so the head-of-line property holds for every
+    /// connection that did not. `false` by default, so an L0/L1-only connection is byte-for-byte
+    /// unchanged.
+    produced_l2: bool,
 }
 
 impl Session {
@@ -295,6 +307,14 @@ impl Session {
     #[must_use]
     pub fn subscription(&self) -> &str {
         &self.subscription
+    }
+
+    /// Whether this connection ever published a Level-2 (server+client-ack) produce (#497). The
+    /// connection-cleanup path consults it so only an L2 producer routes the confirm-registry cleanup
+    /// through the actor; an L0/L1-only or pure-consumer connection skips it entirely.
+    #[must_use]
+    pub fn produced_l2(&self) -> bool {
+        self.produced_l2
     }
 
     /// Processes the complete frames at the front of `input`, dispatching each to the engine (via
@@ -337,6 +357,10 @@ impl Session {
     ) -> Result<Progress, SessionError> {
         let mut consumed = 0;
         let mut committed_progress = false;
+        // This connection's stable id (#64), captured up front (it is `Copy`) so the parked-window
+        // drain can register a Level-2 produce's confirm (#497) against this producer without
+        // re-borrowing `self` while `handle_pub`/`dispatch` hold it.
+        let member_id = self.member_id;
         // The pass-scoped pipelined window (#450): produces submitted to the actor but not yet
         // awaited. Scoped to ONE pass so the caller's flush boundary is unchanged: every parked ack
         // is released into `out` before this method returns.
@@ -377,7 +401,7 @@ impl Session {
                         // starts; the cap matches the actor channel's default bound, so a capped
                         // window still group-commits in at most a couple of batches.
                         if parked.len() >= MAX_PARKED_PRODUCES {
-                            if let Err(e) = drain_parked(&mut parked, out) {
+                            if let Err(e) = drain_parked(engine, member_id, &mut parked, out) {
                                 break Err(e);
                             }
                         }
@@ -387,7 +411,7 @@ impl Session {
                         // actor-side ordering is also preserved: the actor flushes its pending
                         // produce batch before running any job, so an ack/flow/sub still observes
                         // every prior produce durable.
-                        if let Err(e) = drain_parked(&mut parked, out) {
+                        if let Err(e) = drain_parked(engine, member_id, &mut parked, out) {
                             break Err(e);
                         }
                         match self.dispatch(engine, type_tag, body, out) {
@@ -404,7 +428,25 @@ impl Session {
         // runs (those produces already reached the actor and their acks belong on the wire before
         // the close), but the FIRST error wins: a drain error after a loop error is the same fatal
         // engine event and is subsumed by it.
-        let drained = drain_parked(&mut parked, out);
+        let drained = drain_parked(engine, member_id, &mut parked, out);
+        // Drain any READY Level-2 `ProduceConfirm`s for THIS producer connection onto the wire (#497),
+        // so a producer awaiting a confirm receives it on its next pass. A confirm becomes ready when a
+        // consumer in the designated group acks the record (or it dead-letters / force-reaps / times
+        // out). The client's `produce_confirmed` drives these passes (it interleaves Pings while it
+        // waits), so a confirm is delivered without any out-of-band server push (the thread-per-
+        // connection server only writes a connection's socket from that connection's own pass). A no-op
+        // for a connection with no outstanding L2 confirms, so L0/L1 producers and consumers are
+        // byte-for-byte unchanged. Drained even on an error exit: the confirms belong on the wire before
+        // the connection closes, exactly like the parked acks above.
+        //
+        // GATED on `produced_l2`: a connection that has NEVER published a Level-2 produce never routes
+        // the drain through the actor, so a ping-only or pure-consumer connection answers a `Ping`
+        // WITHOUT touching the actor and a stalled produce fsync elsewhere cannot head-of-line-block it
+        // (#177, invariant 4). A connection that DID produce L2 opted into the protocol and its
+        // `produce_confirmed` tolerates the wait, so the head-of-line property holds for everyone else.
+        if self.produced_l2 {
+            drain_produce_confirms(engine, member_id, out);
+        }
         match result {
             Err(e) => Err(e),
             Ok(progress) => drained.map(|()| progress),
@@ -441,9 +483,10 @@ impl Session {
             // intercepts Pub frames before dispatch so it can park them across the pass, #450): a
             // one-entry window, submitted and immediately drained, byte-identical replies.
             Some(FrameType::Pub) => {
+                let member_id = self.member_id;
                 let mut parked = Vec::new();
                 self.handle_pub(engine, body, &mut parked, out)?;
-                drain_parked(&mut parked, out).map(|()| false)
+                drain_parked(engine, member_id, &mut parked, out).map(|()| false)
             }
             Some(FrameType::Ack) => self.handle_ack(engine, body, out).map(|()| true),
             // A cumulative ack commits the broadcast cursor (when accepted), so it returns `true` to
@@ -565,13 +608,16 @@ impl Session {
         parked: &mut Vec<ParkedPub>,
         out: &mut Vec<u8>,
     ) -> Result<(), SessionError> {
+        // Captured up front (it is `Copy`) so the pre-submit error-path drains can register a parked
+        // Level-2 produce's confirm (#497) without re-borrowing `self`.
+        let member_id = self.member_id;
         if !self.connected {
-            drain_parked(parked, out)?;
+            drain_parked(engine, member_id, parked, out)?;
             reply_err(out, "not connected");
             return Ok(());
         }
         let Ok(msg) = decode_pub(body) else {
-            drain_parked(parked, out)?;
+            drain_parked(engine, member_id, parked, out)?;
             reply_err(out, "malformed pub body");
             return Ok(());
         };
@@ -586,10 +632,21 @@ impl Session {
         //   generalization of the historical `PUB_FLAG_FIRE_AND_FORGET` path (an old faf publish IS a
         //   Level-0 publish): it gets NO PubAck, allocates NO reply channel, parks NOTHING, and does not
         //   wait for the fsync. Routed to `produce_no_reply` below.
-        // - LEVEL 2 (`AckLevel::ServerAndClientAck`) FALLS BACK to Level 1 for THIS phase (#495): the
-        //   producer-notify ProduceConfirm is phase 4 (#497), not yet end-to-end. So an L2 publish is
-        //   accepted and acked exactly like L1; the consumer-ack notify is simply not delivered yet.
+        // - LEVEL 2 (`AckLevel::ServerAndClientAck`, #497): accepted and made DURABLE exactly like
+        //   Level 1 (the `PubAck` stays the DURABILITY ack, I2), AND the durable offset is registered
+        //   in the engine's bounded confirm registry so that, when a CONSUMER in the designated group
+        //   later acks it, a server->producer `ProduceConfirm{status = consumed}` fires. The Level-1
+        //   `PubAck` and the Level-2 confirm are TWO acks: durable-then-consumed.
         let ack_level = pub_ack_level(msg.flags);
+        // Whether this publish wants a Level-2 consumer-ack confirmation in addition to its durability
+        // `PubAck` (#497). Only the at-least-once L2 level does; L0 (no reply) and L1 do not.
+        let wants_confirm = matches!(ack_level, AckLevel::ServerAndClientAck);
+        // Mark the connection as having opted into Level 2 (#497) so its passes drain confirms. Set at
+        // parse time, BEFORE the produce is even submitted: it never clears, and it is what keeps the
+        // per-pass confirm drain OFF the actor for an L0/L1-only or ping-only connection (#177).
+        if wants_confirm {
+            self.produced_l2 = true;
+        }
         // A LEVEL-0 publish is the generalized fire-and-forget: it gets no ack and is governed by the
         // fire-and-forget token bucket, REGARDLESS of which Level-0 encoding the producer used (the
         // canonical faf bit, where `msg.fire_and_forget` is already true, OR the level-bit value 1,
@@ -607,14 +664,14 @@ impl Session {
         if let Some(d) = msg.dedup.as_ref() {
             if d.producer_id.len() > MAX_PRODUCER_ID_LEN {
                 if !fire_and_forget {
-                    drain_parked(parked, out)?;
+                    drain_parked(engine, member_id, parked, out)?;
                     reply_err(out, "producer_id too long");
                 }
                 return Ok(());
             }
             if d.msg_id.len() > MAX_MSG_ID_LEN {
                 if !fire_and_forget {
-                    drain_parked(parked, out)?;
+                    drain_parked(engine, member_id, parked, out)?;
                     reply_err(out, "msg_id too long");
                 }
                 return Ok(());
@@ -644,7 +701,7 @@ impl Session {
         if RecordFlags::from_bits(msg.flags).contains(RecordFlags::COMPRESSED) {
             if let Err(e) = validate_descriptor_shape(msg.payload, DEFAULT_MAX_DECOMPRESSED_BYTES) {
                 if !fire_and_forget {
-                    drain_parked(parked, out)?;
+                    drain_parked(engine, member_id, parked, out)?;
                     reply_err(out, &format!("malformed compressed descriptor: {e}"));
                 }
                 return Ok(());
@@ -715,6 +772,7 @@ impl Session {
         parked.push(ParkedPub {
             submission,
             fire_and_forget,
+            wants_confirm,
         });
         Ok(())
     }
@@ -1704,6 +1762,56 @@ fn reply_pub_ack(out: &mut Vec<u8>, frame_type: FrameType, offset: Offset) {
     reply(out, frame_type, &body);
 }
 
+/// Writes one Level-2 `ProduceConfirm` frame (#497) for a ready terminal: the durable offset plus the
+/// terminal status byte, via the shared [`encode_produce_confirm`] codec so the wire body cannot drift
+/// from the proto definition. Maps the core [`ConfirmStatus`] to its wire
+/// [`produce_confirm_status`] byte: `Consumed` -> `CONSUMED`, `TimedOut` -> `TIMED_OUT`, and BOTH
+/// `DeadLettered` and the bounded-registry `Dropped` shed -> `DEAD_LETTERED` (a dropped confirm is a
+/// non-success terminal whose record stayed durable but is no longer tracked, indistinguishable on the
+/// wire from a dead-letter, which is the honest signal: the consumed confirmation will never arrive).
+fn write_produce_confirm(confirm: &ReadyConfirm, out: &mut Vec<u8>) {
+    let status = match confirm.status {
+        ConfirmStatus::Consumed => produce_confirm_status::CONSUMED,
+        ConfirmStatus::TimedOut => produce_confirm_status::TIMED_OUT,
+        ConfirmStatus::DeadLettered | ConfirmStatus::Dropped => {
+            produce_confirm_status::DEAD_LETTERED
+        }
+    };
+    let mut body = Vec::with_capacity(9);
+    encode_produce_confirm(
+        &ProduceConfirmBody {
+            offset: confirm.offset,
+            status,
+        },
+        &mut body,
+    );
+    reply(out, FrameType::ProduceConfirm, &body);
+}
+
+/// Drains every READY Level-2 `ProduceConfirm` for the producer connection `member_id` (#497) and
+/// writes one `ProduceConfirm` frame per terminal onto `out`, FIFO. The terminals are produced
+/// out-of-band by CONSUMER acks (and the dead-letter / force-reap / TTL-timeout failure paths) on
+/// OTHER connection threads, recorded in the engine's bounded registry keyed by this connection's
+/// `member_id`, and drained HERE on this producer's own pass — the only place the blocking
+/// thread-per-connection server may write this socket. A gone actor is a no-op. ADDITIVE: empty for
+/// any connection with no outstanding L2 confirm.
+fn drain_produce_confirms<
+    F: Filesystem + 'static,
+    C: Clock + Clone + 'static,
+    E: EngineAccess<F, C>,
+>(
+    engine: &E,
+    member_id: MemberId,
+    out: &mut Vec<u8>,
+) {
+    let Ok(ready) = engine.with(move |e| e.drain_l2_confirms(member_id)) else {
+        return; // a gone actor: the connection is ending, nothing to deliver
+    };
+    for confirm in ready {
+        write_produce_confirm(&confirm, out);
+    }
+}
+
 /// The safety cap on a single pass's pipelined produce window (#450): how many produces a session
 /// may PARK (submitted to the actor, ack not yet awaited) before it must release the window. It
 /// bounds the parked-reply memory for a buffer packed with tiny PUB frames and matches the actor
@@ -1722,6 +1830,10 @@ struct ParkedPub {
     /// Whether the producer marked this publish fire-and-forget (QoS-0, #11): suppresses every
     /// reply frame for this produce, exactly like the awaited path.
     fire_and_forget: bool,
+    /// Whether this publish is Level 2 (server+client ack, #497): in addition to its durability
+    /// `PubAck`, register the durable offset in the engine's bounded confirm registry so a later
+    /// consumer ack fires a `ProduceConfirm`. `false` for L0/L1, so their paths are unchanged.
+    wants_confirm: bool,
 }
 
 /// Releases a parked produce window (#450): awaits each submission IN SUBMISSION ORDER and appends
@@ -1730,10 +1842,38 @@ struct ParkedPub {
 /// entries are dropped un-replied, which is safe because a batch-covering fsync failure marks EVERY
 /// member of the batch fatal (the actor's `flush_pending`) and the session is closing anyway (the
 /// actor tolerates a dropped reply receiver). After this returns, `parked` is empty.
-fn drain_parked(parked: &mut Vec<ParkedPub>, out: &mut Vec<u8>) -> Result<(), SessionError> {
+///
+/// For a Level-2 publish (#497), AFTER its durability `PubAck` is written (the record is durable
+/// first, I2), the durable offset is REGISTERED in the engine's bounded confirm registry against this
+/// connection's `member_id`, so a later consumer ack in the designated group fires a `ProduceConfirm`
+/// back to this producer. The registration is layered ON TOP of the unchanged Level-1 reply; L0/L1
+/// (`wants_confirm == false`) skip it entirely.
+fn drain_parked<F: Filesystem + 'static, C: Clock + Clone + 'static, E: EngineAccess<F, C>>(
+    engine: &E,
+    member_id: MemberId,
+    parked: &mut Vec<ParkedPub>,
+    out: &mut Vec<u8>,
+) -> Result<(), SessionError> {
     for p in parked.drain(..) {
         let outcome = p.submission.wait()?;
+        // A Level-2 publish whose record became durable registers its offset for the consumer-ack
+        // confirmation, AFTER the durability ack is written below. Only a fresh `Appended` is a new
+        // durable offset to confirm; a dedup hit (`AppendedDuplicate`) returns an ALREADY-confirmed-or-
+        // pending earlier offset, a shed/fence/fatal never became durable, and a fire-and-forget L2 is
+        // not a thing (L2 is at-least-once). So capture the offset to register only on `Appended`.
+        let confirm_offset = match &outcome {
+            ProduceOutcome::Appended(offset) if p.wants_confirm => Some(*offset),
+            _ => None,
+        };
         write_pub_reply(outcome, p.fire_and_forget, out)?;
+        if let Some(offset) = confirm_offset {
+            // Register AFTER the `PubAck` was written: the record is durable (the covering fsync ran
+            // before the actor reported `Appended`) and its durability ack is already on the wire, so
+            // the Level-2 confirm wait is strictly layered on top of the Level-1 durability guarantee.
+            // A gone actor here is a no-op (the connection is ending anyway); the registry is bounded,
+            // so this can never grow without bound.
+            let _ = engine.with(move |e| e.register_l2_confirm(offset, member_id));
+        }
     }
     Ok(())
 }
@@ -6410,5 +6550,239 @@ mod tests {
         s.process(&e, &fetch_frame(10, 0, 0, false), &mut out)
             .expect("the session stays open");
         assert_eq!(one_response(&out).0, FrameType::Err);
+    }
+
+    // -------- Level-2 produce-confirm (#497) --------
+
+    /// Produces ONE message at the given ack level through `s` and returns the `PubAck` offset (`None`
+    /// for a non-acking level). The ack-level field is stamped into the PUB flags exactly as the wire
+    /// carries it, so the server routes it by `pub_ack_level`.
+    fn pub_at_level<C: Clock + Clone + 'static>(
+        s: &mut Session,
+        e: &DirectEngine<InMemoryFs, C>,
+        level: AckLevel,
+        payload: &[u8],
+    ) -> Option<u64> {
+        let flags = match level {
+            AckLevel::NoAck => PUB_FLAG_FIRE_AND_FORGET,
+            AckLevel::ServerAck => 0,
+            AckLevel::ServerAndClientAck => 2 << PUB_FLAG_ACK_LEVEL_SHIFT,
+        };
+        let mut body = Vec::new();
+        encode_pub(
+            &PubBody {
+                flags,
+                timestamp_ms: 0,
+                key: b"",
+                headers: b"",
+                dedup: None,
+                fire_and_forget: false,
+                payload,
+            },
+            &mut body,
+        )
+        .unwrap();
+        let mut out = Vec::new();
+        s.process(e, &frame(FrameType::Pub, &body), &mut out)
+            .unwrap();
+        decode_all(&out)
+            .into_iter()
+            .find(|(ty, _)| *ty == FrameType::PubAck)
+            .map(|(_, b)| decode_pub_ack(&b).unwrap().offset)
+    }
+
+    /// Drives one producer pass on `s` (a Ping) and returns every `ProduceConfirm` (offset, status)
+    /// flushed onto the wire for that connection.
+    fn drain_confirms<C: Clock + Clone + 'static>(
+        s: &mut Session,
+        e: &DirectEngine<InMemoryFs, C>,
+    ) -> Vec<(u64, u8)> {
+        let mut out = Vec::new();
+        s.process(e, &frame(FrameType::Ping, b""), &mut out)
+            .unwrap();
+        decode_all(&out)
+            .into_iter()
+            .filter(|(ty, _)| *ty == FrameType::ProduceConfirm)
+            .map(|(_, b)| {
+                let c = ironbus_proto::message::decode_produce_confirm(&b)
+                    .expect("9-byte confirm body");
+                (c.offset, c.status)
+            })
+            .collect()
+    }
+
+    #[test]
+    fn an_l2_produce_is_confirmed_when_a_consumer_acks_it() {
+        let clock = Arc::new(ManualClock::new());
+        let e = DirectEngine::new(engine_with(Arc::clone(&clock), 5));
+        // Producer and consumer are two sessions over the same engine (distinct member ids).
+        let mut producer = Session::with_member_id(MemberId::new(1));
+        let mut consumer = Session::with_member_id(MemberId::new(2));
+        let mut out = Vec::new();
+        producer
+            .process(&e, &frame(FrameType::Connect, b""), &mut out)
+            .unwrap();
+        consumer
+            .process(&e, &frame(FrameType::Connect, b""), &mut out)
+            .unwrap();
+
+        // L2 produce: the durability PubAck returns the offset.
+        let offset = pub_at_level(&mut producer, &e, AckLevel::ServerAndClientAck, b"l2").unwrap();
+        // No confirm yet (no consumer has acked).
+        assert!(drain_confirms(&mut producer, &e).is_empty());
+
+        // The consumer flows and acks the record in the DESIGNATED (default) group.
+        out.clear();
+        consumer
+            .process(&e, &frame(FrameType::Flow, &4u32.to_le_bytes()), &mut out)
+            .unwrap();
+        let toks = delivered_tokens(&out);
+        let (off, generation) = *toks.iter().find(|(o, _)| *o == offset).expect("delivered");
+        assert_eq!(
+            ack_reply(&mut consumer, &e, AckOp::Ack, off, generation),
+            vec![1]
+        );
+
+        // The producer's next pass carries the CONSUMED ProduceConfirm for the offset.
+        let confirms = drain_confirms(&mut producer, &e);
+        assert_eq!(
+            confirms,
+            vec![(offset, produce_confirm_status::CONSUMED)],
+            "the L2 confirm fires on the consumer ack"
+        );
+        // Drained: a second pass yields nothing.
+        assert!(drain_confirms(&mut producer, &e).is_empty());
+    }
+
+    #[test]
+    fn an_l1_produce_registers_no_confirm() {
+        let clock = Arc::new(ManualClock::new());
+        let e = DirectEngine::new(engine_with(Arc::clone(&clock), 5));
+        let mut producer = Session::with_member_id(MemberId::new(1));
+        let mut consumer = Session::with_member_id(MemberId::new(2));
+        let mut out = Vec::new();
+        producer
+            .process(&e, &frame(FrameType::Connect, b""), &mut out)
+            .unwrap();
+        consumer
+            .process(&e, &frame(FrameType::Connect, b""), &mut out)
+            .unwrap();
+        // A Level-1 produce: the unchanged at-least-once PubAck path, NO confirm registered.
+        let offset = pub_at_level(&mut producer, &e, AckLevel::ServerAck, b"l1").unwrap();
+        out.clear();
+        consumer
+            .process(&e, &frame(FrameType::Flow, &4u32.to_le_bytes()), &mut out)
+            .unwrap();
+        let (off, generation) = *delivered_tokens(&out)
+            .iter()
+            .find(|(o, _)| *o == offset)
+            .expect("delivered");
+        ack_reply(&mut consumer, &e, AckOp::Ack, off, generation);
+        // No ProduceConfirm is ever produced for an L1 publish (L0/L1 byte-for-byte unchanged).
+        assert!(
+            drain_confirms(&mut producer, &e).is_empty(),
+            "L1 never registers an L2 confirm"
+        );
+        assert_eq!(
+            e.engine_mut().confirm_group(),
+            "",
+            "the designated confirm group defaults to the unnamed group"
+        );
+    }
+
+    #[test]
+    fn an_unacked_l2_produce_times_out() {
+        let clock = Arc::new(ManualClock::new());
+        // The default confirm TTL is large; drive a short one directly on the registry semantics by
+        // advancing the clock past the configured TTL. The registry uses DEFAULT_CONFIRM_TTL_NANOS.
+        let e = DirectEngine::new(engine_with(Arc::clone(&clock), 5));
+        let mut producer = Session::with_member_id(MemberId::new(1));
+        let mut out = Vec::new();
+        producer
+            .process(&e, &frame(FrameType::Connect, b""), &mut out)
+            .unwrap();
+        let offset = pub_at_level(&mut producer, &e, AckLevel::ServerAndClientAck, b"l2").unwrap();
+        // Advance well past the default TTL, then drive the produce/commit tick (a fresh L1 produce
+        // by another path) so the timeout sweep runs.
+        clock.advance_monotonic_nanos(ironbus_core::confirm::DEFAULT_CONFIRM_TTL_NANOS + 1);
+        produce(&e, b"tick"); // a commit_batch runs the L2 timeout sweep
+        let confirms = drain_confirms(&mut producer, &e);
+        assert_eq!(
+            confirms,
+            vec![(offset, produce_confirm_status::TIMED_OUT)],
+            "an L2 confirm no consumer acks within the TTL times out"
+        );
+    }
+
+    #[test]
+    fn an_l2_produce_dead_lettered_before_any_ack_is_terminated() {
+        let clock = Arc::new(ManualClock::new());
+        // max_deliver = 1: the first redelivery dead-letters the poison record.
+        let e = DirectEngine::new(engine_with(Arc::clone(&clock), 1));
+        let mut producer = Session::with_member_id(MemberId::new(1));
+        let mut consumer = Session::with_member_id(MemberId::new(2));
+        let mut out = Vec::new();
+        producer
+            .process(&e, &frame(FrameType::Connect, b""), &mut out)
+            .unwrap();
+        consumer
+            .process(&e, &frame(FrameType::Connect, b""), &mut out)
+            .unwrap();
+        let offset =
+            pub_at_level(&mut producer, &e, AckLevel::ServerAndClientAck, b"poison").unwrap();
+
+        // Deliver once (attempt 1), let the lease expire, then re-poll: attempt 2 > max_deliver(1)
+        // dead-letters it WITHOUT any ack.
+        out.clear();
+        consumer
+            .process(&e, &frame(FrameType::Flow, &4u32.to_le_bytes()), &mut out)
+            .unwrap();
+        assert!(delivered_tokens(&out).iter().any(|(o, _)| *o == offset));
+        clock.advance_monotonic_nanos(1_000); // past the visibility window + hard cap
+        out.clear();
+        consumer
+            .process(&e, &frame(FrameType::Flow, &4u32.to_le_bytes()), &mut out)
+            .unwrap();
+        // The dead-letter terminal fires a DEAD_LETTERED confirm to the producer.
+        let confirms = drain_confirms(&mut producer, &e);
+        assert_eq!(
+            confirms,
+            vec![(offset, produce_confirm_status::DEAD_LETTERED)],
+            "a dead-letter before any ack terminates the L2 confirm"
+        );
+    }
+
+    #[test]
+    fn a_producer_disconnect_drops_its_pending_l2_confirms() {
+        let clock = Arc::new(ManualClock::new());
+        let e = DirectEngine::new(engine_with(Arc::clone(&clock), 5));
+        let mut producer = Session::with_member_id(MemberId::new(7));
+        let mut out = Vec::new();
+        producer
+            .process(&e, &frame(FrameType::Connect, b""), &mut out)
+            .unwrap();
+        let offset = pub_at_level(&mut producer, &e, AckLevel::ServerAndClientAck, b"l2").unwrap();
+        assert_eq!(
+            e.engine_mut().drain_l2_confirms(MemberId::new(7)).len(),
+            0,
+            "nothing ready yet (no consumer acked)"
+        );
+        // The producer disconnects: the connection cleanup drops its registry entries.
+        e.engine_mut().drop_l2_confirms(MemberId::new(7));
+        // Even committing past the offset now fires nothing for the gone producer.
+        produce(&e, b"x");
+        e.engine_mut().ack_in(
+            "",
+            &ironbus_core::lease::LeaseToken {
+                offset: Offset::new(offset),
+                generation: 0,
+            },
+        );
+        assert!(
+            e.engine_mut()
+                .drain_l2_confirms(MemberId::new(7))
+                .is_empty(),
+            "a disconnected producer's confirms are dropped, never delivered"
+        );
     }
 }


### PR DESCRIPTION
Closes #497 (Phase 4 of #499, the tunable produce ack-level spectrum).

The FINAL piece of the 0/1/2 ack spectrum: a **Level-2 (server+client-ack)** publish is confirmed only after a **consumer** acks it — durable AND consumed. Builds on #494 (proto: `ProduceConfirm` frame tag 22 + `AckLevel`), #495 (server accept-path, L2-as-L1), #496/#533 (client `produce_with_ack_level` + `ClientConfig.default_ack_level`).

## L2 design

- **Bounded per-offset confirm registry** (new `ironbus-core` module `confirm.rs`): pure, IO-free, clock-seam-driven (mirrors `AckCursor`/`DedupRegistry`). Keys a durable `offset -> (producer MemberId, status)`. Empty until a producer publishes at Level 2, so a no-L2 broker pays nothing.
- **Two acks, in order.** On an L2 produce the server keeps the existing L1-style `PubAck` as the **durability** ack (**I2**: the record is durable first), THEN registers the durable offset for confirmation. The second ack is the `ProduceConfirm{offset, status=consumed}`, fired when a consumer acks.
- **Keyed to ONE designated group** — the default group (operator-redesignable via `set_confirm_group`), NOT *any group* (non-deterministic) nor *all groups* (unbounded). The **cursor-commit hook** fires `Consumed` only when the designated group's `AckCursor` advances past the offset, hooked additively into the existing `ack_in` / `cumulative_ack_in` commit (the consume/ack path is otherwise byte-for-byte unchanged).

## Failure modes (all terminal, all tested)

| Mode | Terminal | Where |
|---|---|---|
| No consumer ever acks | `TimedOut` | TTL sweep on the existing produce/commit tick |
| Dead-lettered before any ack | `DeadLettered` | the dead-letter path |
| Force-reaped (drop-oldest) before any ack | `DeadLettered` | every confirm below the new earliest-retained offset |
| Producer disconnects | dropped (no terminal) | connection cleanup |
| Registry full | `Dropped` (drop-oldest) | a register at the cap |

## Bounded registry

HARD-bounded by a **max-pending cap** (default 65 536) AND a **TTL** (default 5 min) swept on the existing produce/commit tick — so a slow or absent consumer can never grow it without bound (same threat class as the dedup cap #475 and the REJECTED lease-heap leak #485; the ready queue is bounded the same way).

## Client

New additive `produce_confirmed(message, timeout)`: sends an L2 publish, awaits the durability `PubAck`, then awaits the `ProduceConfirm` correlated by offset (with the timeout), returning a `ProduceConfirmation { offset, ConfirmOutcome::{Consumed,TimedOut,DeadLettered,LocalTimeout,Unknown} }`. Kept **separate** from `produce_with_ack_level`. Because the blocking thread-per-connection server has no out-of-band push, the await drives broker passes with interleaved `Ping`s and reads the confirm on the producer's own pass — fully within the existing wire/threading contract (no push, no second socket, no new race).

## Preserved

- **L0/L1 byte-identical**; **I2** (record durable before the L2 confirm wait); the consume/ack/cursor path (the hook is additive); **no unbounded growth**.
- **#177 head-of-line property**: the per-pass confirm drain is gated on whether the connection ever produced L2, so a ping-only / pure-consumer connection still answers a `Ping` WITHOUT touching the actor (a stalled produce fsync elsewhere cannot block it). This was caught by `a_stalled_produce_fsync_does_not_block_another_connections_ping` and is the load-bearing safety gate.

## What to scrutinize

- **The poll-based await.** The server is blocking/request-response with no producer push, so `produce_confirmed` realizes the "await" as a bounded Ping-driven poll. Reviewers should confirm this is the right model vs. a future split read/write push subsystem (out of scope, riskier).
- **The `produced_l2` gate** on the confirm drain (the #177 boundary) and the registration point (post-`PubAck`, durable-first).
- **Session-scoped (not durable) registry**: an L2 wait does not survive a broker restart (the record stayed durable via its `PubAck`; the wait times out, which is the honest signal).

## Gates (all green)

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — clean
- `cargo test --workspace --all-features --locked` — all passed (incl. new L2 tests: confirm-on-ack, each terminal status, producer-disconnect cleanup, registry cap+TTL evict, L0/L1 unchanged, and two client end-to-end tests against the real wire server)

MSRV 1.78 respected (no >=1.80 APIs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)