### PR TITLE
feat(consume): Tier-S streaming consumer-managed-offset consume mode (#544)

### DIFF
--- a/crates/ironbus-proto/src/frame.rs
+++ b/crates/ironbus-proto/src/frame.rs
@@ -134,6 +134,40 @@ pub enum FrameType {
     /// (`max_records: u32`, `max_bytes: u64`, `expires_ms: u64` relative deadline budget, and a
     /// `no_wait` flag), versioned and forward-compatible.
     Fetch,
+    /// Consumer Tier-S STREAMING fetch request (the consumer-managed-offset consume mode, M1-I7 /
+    /// #544): the consumer names its OWN `start_offset` and the broker serves a CONTIGUOUS batch of
+    /// records `[start_offset, ...)` bounded by `max_records` / `max_bytes` — with NO lease grant, NO
+    /// generation fence, and NO per-record cursor write. This is the Kafka / NATS-pull
+    /// consumer-managed-offset contract: at-least-once holds BY CONSTRUCTION because a crash or
+    /// reconnect simply re-reads from the consumer's last committed offset, so at most the uncommitted
+    /// records redeliver. It is the STREAMING (Tier-S) twin of [`FrameType::Fetch`] (tag 23, the
+    /// work-queue Tier-W batch pull): where `Fetch` runs the per-record lease/cursor poll, this serves
+    /// a contiguous read off the durable prefix and leaves all offset bookkeeping to the consumer,
+    /// which removes exactly the per-record lease + generation + cursor cost that makes single-consumer
+    /// durable consume lose to NATS. The RESPONSE reuses the existing delivery frames verbatim — a run
+    /// of [`FrameType::Deliver`] (with any interleaved [`FrameType::Truncated`] /
+    /// [`FrameType::GapMarker`] advisory), terminated by exactly one [`FrameType::FlowEnd`] carrying
+    /// the delivered count — so no new response frame is introduced. It is a NEW append-only request
+    /// tag: an old client never sends it and the existing `Fetch` (tag 23) and `Flow` (tag 10) wires
+    /// are byte-for-byte unchanged. Body: a [`crate::message::StreamFetchBody`] (`start_offset: u64`,
+    /// `max_records: u32`, `max_bytes: u64`), versioned and forward-compatible.
+    StreamFetch,
+    /// Consumer Tier-S periodic CUMULATIVE COMMIT (the consumer-managed-offset durability point, M1-I7
+    /// / #544): advances the streaming group's committed watermark up to an exclusive `up_to` offset,
+    /// the consumer's PERIODIC "I have durably processed everything below `up_to`" checkpoint. It
+    /// REUSES the same cumulative-ack cursor primitive (`AckCursor::commit_up_to` in `ironbus-core`)
+    /// the broadcast [`FrameType::CumulativeAck`] (tag 19) rides on — no new durable structure is
+    /// invented — but it targets a STREAMING group (where `CumulativeAck` targets a BROADCAST group),
+    /// so the two never collide and `CumulativeAck`'s broadcast-only guard stays unchanged. Because
+    /// tier-S grants no leases, this commit only advances the watermark (it frees retention and stops
+    /// any redeliver below it); there is no per-record lease to reclaim. It is idempotent and monotonic
+    /// (a re-commit at or below the watermark is a no-op success), exactly like `commit_up_to`. The
+    /// SUCCESS response is a body-less [`FrameType::Ok`] (matching the `CumulativeAck` reply shape); an
+    /// out-of-range or wrong-mode commit is an [`FrameType::Err`]. A NEW append-only request tag: an old
+    /// client never sends it. Body: the exclusive `up_to` offset as a little-endian `u64` (8 bytes)
+    /// followed by the work-group name as the remainder (empty selects the default group) — identical
+    /// in shape to the [`crate::message::CumulativeAckBody`].
+    StreamCommit,
 }
 
 impl FrameType {
@@ -164,6 +198,8 @@ impl FrameType {
             FrameType::GapMarker => 21,
             FrameType::ProduceConfirm => 22,
             FrameType::Fetch => 23,
+            FrameType::StreamFetch => 24,
+            FrameType::StreamCommit => 25,
         }
     }
 
@@ -195,6 +231,8 @@ impl FrameType {
             21 => FrameType::GapMarker,
             22 => FrameType::ProduceConfirm,
             23 => FrameType::Fetch,
+            24 => FrameType::StreamFetch,
+            25 => FrameType::StreamCommit,
             _ => return None,
         })
     }
@@ -327,7 +365,7 @@ mod tests {
     use super::*;
     use proptest::prelude::*;
 
-    const ALL_TYPES: [FrameType; 23] = [
+    const ALL_TYPES: [FrameType; 25] = [
         FrameType::Connect,
         FrameType::Info,
         FrameType::Ping,
@@ -351,6 +389,8 @@ mod tests {
         FrameType::GapMarker,
         FrameType::ProduceConfirm,
         FrameType::Fetch,
+        FrameType::StreamFetch,
+        FrameType::StreamCommit,
     ];
 
     #[test]
@@ -392,6 +432,8 @@ mod tests {
         assert_eq!(FrameType::GapMarker.as_u8(), 21);
         assert_eq!(FrameType::ProduceConfirm.as_u8(), 22);
         assert_eq!(FrameType::Fetch.as_u8(), 23);
+        assert_eq!(FrameType::StreamFetch.as_u8(), 24);
+        assert_eq!(FrameType::StreamCommit.as_u8(), 25);
     }
 
     #[test]
@@ -423,8 +465,6 @@ mod tests {
         assert_eq!(FrameType::from_u8(23), Some(FrameType::Fetch));
         // The existing Flow tag is untouched (the batch fetch is additive, not a replacement).
         assert_eq!(FrameType::Flow.as_u8(), 10);
-        // 24 is the new next-free tag (still unknown), so it frames but is not a known type.
-        assert_eq!(FrameType::from_u8(24), None);
         let mut buf = Vec::new();
         encode_frame(FrameType::Fetch, b"\x03\x04", &mut buf).unwrap();
         match decode_frame(&buf).unwrap() {
@@ -433,6 +473,34 @@ mod tests {
                 assert_eq!(body, b"\x03\x04");
             }
             FrameDecode::Incomplete { .. } => panic!("complete"),
+        }
+    }
+
+    #[test]
+    fn stream_tier_tags_are_the_next_free_tags_and_frame() {
+        // #544 (M1-I7): StreamFetch (24) and StreamCommit (25) take the next FREE tags after Fetch
+        // (23). They were previously UNKNOWN tags; pin them as known now and confirm they frame at the
+        // envelope level. The existing Flow (10) and Fetch (23) wires are byte-for-byte unchanged: the
+        // Tier-S streaming mode is ADDITIVE, not a replacement of the Tier-W work-queue verbs.
+        assert_eq!(FrameType::StreamFetch.as_u8(), 24);
+        assert_eq!(FrameType::StreamCommit.as_u8(), 25);
+        assert_eq!(FrameType::from_u8(24), Some(FrameType::StreamFetch));
+        assert_eq!(FrameType::from_u8(25), Some(FrameType::StreamCommit));
+        // The Tier-W verbs are untouched.
+        assert_eq!(FrameType::Flow.as_u8(), 10);
+        assert_eq!(FrameType::Fetch.as_u8(), 23);
+        // 26 is the new next-free tag (still unknown), so it frames but is not a known type.
+        assert_eq!(FrameType::from_u8(26), None);
+        for ty in [FrameType::StreamFetch, FrameType::StreamCommit] {
+            let mut buf = Vec::new();
+            encode_frame(ty, b"\x07\x08", &mut buf).unwrap();
+            match decode_frame(&buf).unwrap() {
+                FrameDecode::Frame { type_tag, body, .. } => {
+                    assert_eq!(FrameType::from_u8(type_tag), Some(ty));
+                    assert_eq!(body, b"\x07\x08");
+                }
+                FrameDecode::Incomplete { .. } => panic!("complete"),
+            }
         }
     }
 
@@ -619,7 +687,7 @@ mod tests {
         /// An unknown type tag still decodes at the envelope level (forward compatibility):
         /// the body and length are recovered; only `from_u8` reports it unknown.
         #[test]
-        fn an_unknown_type_tag_still_frames(tag in 24u8..=255, body in prop::collection::vec(any::<u8>(), 0..256)) {
+        fn an_unknown_type_tag_still_frames(tag in 26u8..=255, body in prop::collection::vec(any::<u8>(), 0..256)) {
             let frame_len = 1u32 + u32::try_from(body.len()).unwrap();
             let mut buf = frame_len.to_le_bytes().to_vec();
             buf.push(tag);

--- a/crates/ironbus-proto/src/message.rs
+++ b/crates/ironbus-proto/src/message.rs
@@ -1308,6 +1308,134 @@ pub fn decode_fetch(body: &[u8]) -> Result<FetchBody, BodyError> {
     })
 }
 
+/// The version of the Tier-S `StreamFetch` (streaming consumer-managed-offset) body framing (#544,
+/// M1-I7). Version `1` is the first (and only) layout. Carried as a leading byte so a future version
+/// can extend the body without a wire break: a reader rejects a version it does not understand rather
+/// than mis-parsing it, exactly like [`FETCH_BODY_VERSION`].
+pub const STREAM_FETCH_BODY_VERSION: u8 = 1;
+
+/// A consumer Tier-S STREAMING fetch request (the `StreamFetch` frame body, #544 / M1-I7): the
+/// consumer-managed-offset twin of [`FetchBody`]. The consumer names its OWN `start_offset` and the
+/// broker serves a CONTIGUOUS batch of records `[start_offset, ...)` bounded by `max_records` /
+/// `max_bytes` — with NO lease, NO generation fence, and NO per-record cursor write. At-least-once
+/// holds BY CONSTRUCTION: a crash or reconnect re-reads from the consumer's last committed offset
+/// (advanced via a periodic [`crate::frame::FrameType::StreamCommit`]), so at most the uncommitted
+/// records redeliver — the Kafka / NATS-pull contract. Where [`FetchBody`] drives the per-record
+/// lease/cursor poll (Tier-W, the work-queue), this drives a contiguous read off the durable prefix,
+/// which removes exactly the per-record cost that makes single-consumer durable consume lose to NATS.
+///
+/// Layout (version+length framed, forward-compatible, mirroring [`FetchBody`]): `body_version: u8`
+/// ([`STREAM_FETCH_BODY_VERSION`]), `field_len: u16` (the length of the v1 known-field block that
+/// follows), then the v1 block: `start_offset: u64 LE`, `max_records: u32 LE`, `max_bytes: u64 LE`.
+/// Bytes past `field_len` (a future version's appended fields) are TOLERATED and ignored by a v1
+/// reader.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct StreamFetchBody {
+    /// The consumer-managed offset to begin the contiguous read at (inclusive). The consumer owns this
+    /// position: it is normally the consumer's last committed offset, so a reconnect resumes exactly
+    /// where it left off. The broker reads forward from here off the durable prefix, bounded by the
+    /// flushed frontier (no un-flushed record is ever served).
+    pub start_offset: u64,
+    /// The maximum number of records to deliver in this batch. The server delivers at most this many
+    /// (the durable prefix's available records and the byte cap also bind). A value of `0` requests
+    /// nothing.
+    pub max_records: u32,
+    /// The maximum total ENCODED record bytes to deliver in this batch. `0` means UNBOUNDED by bytes
+    /// (only the record count and the available durable prefix bind). The server stops once delivering
+    /// the next record would exceed this, EXCEPT the floor-of-one (a batch always delivers at least one
+    /// ready record so a single over-cap record never wedges the consumer).
+    pub max_bytes: u64,
+}
+
+/// The number of bytes in the `StreamFetch` v1 known-field block: `start_offset: u64` +
+/// `max_records: u32` + `max_bytes: u64`.
+const STREAM_FETCH_V1_FIELD_LEN: u16 = 8 + 4 + 8;
+
+/// Encodes a `StreamFetch` body onto the end of `out` (#544): the version byte, the v1 field-block
+/// length, then the v1 block.
+pub fn encode_stream_fetch(req: &StreamFetchBody, out: &mut Vec<u8>) {
+    out.push(STREAM_FETCH_BODY_VERSION);
+    out.extend_from_slice(&STREAM_FETCH_V1_FIELD_LEN.to_le_bytes());
+    out.extend_from_slice(&req.start_offset.to_le_bytes());
+    out.extend_from_slice(&req.max_records.to_le_bytes());
+    out.extend_from_slice(&req.max_bytes.to_le_bytes());
+}
+
+/// Decodes a `StreamFetch` body (#544), cap-before-alloc and panic-free.
+///
+/// The body MUST carry the version byte and the `u16` field-length; the v1 known fields are read from
+/// the front of the declared block and any trailing bytes (a future version's appended fields) are
+/// tolerated and ignored. A body too short to hold the `field_len` it declares is a typed
+/// [`BodyError`], never a panic or an over-read (the `field_len` is bounded against the actual body by
+/// [`Reader::take`] BEFORE any read). An EMPTY body is NOT a valid `StreamFetch` (the frame type is
+/// new, with no historical empty case), so it is a typed [`BodyError::Truncated`].
+///
+/// # Errors
+/// Returns [`BodyError::Truncated`] if the body is too short for the version/length header or the
+/// declared field block, or [`BodyError::BadHandshakeVersion`] for an unknown body version.
+pub fn decode_stream_fetch(body: &[u8]) -> Result<StreamFetchBody, BodyError> {
+    let mut r = Reader::new(body);
+    let version = r.u8()?;
+    if version != STREAM_FETCH_BODY_VERSION {
+        return Err(BodyError::BadHandshakeVersion { version });
+    }
+    let field_len = r.u16()? as usize;
+    let block = r.take(field_len)?;
+    let mut fr = Reader::new(block);
+    // Every v1 slot occupies a fixed position and is always consumed in order; a short block (a sender
+    // that declared fewer bytes) reads what is present and defaults the rest, never panicking.
+    let start_offset = fr.u64().unwrap_or(0);
+    let max_records = fr.u32().unwrap_or(0);
+    let max_bytes = fr.u64().unwrap_or(0);
+    Ok(StreamFetchBody {
+        start_offset,
+        max_records,
+        max_bytes,
+    })
+}
+
+/// A consumer Tier-S periodic CUMULATIVE COMMIT (the `StreamCommit` frame body, #544 / M1-I7): the
+/// consumer-managed-offset durability point. It advances the STREAMING group's committed watermark up
+/// to an exclusive `up_to` offset, the consumer's periodic "everything below `up_to` is durably
+/// processed" checkpoint. It REUSES the same cursor primitive
+/// (`AckCursor::commit_up_to` in `ironbus-core`) the broadcast [`CumulativeAckBody`] rides on —
+/// no new durable structure is invented — but targets a STREAMING group rather than a BROADCAST one,
+/// so the two never collide. The server validates `up_to` against the durable head and the
+/// earliest-retained offset, is idempotent / monotonic on a re-commit, and HARD-REJECTS the verb on a
+/// group that is not streaming.
+///
+/// Layout: `up_to: u64` (the exclusive commit offset, little-endian), then `group` (the work-group
+/// name as the remainder of the body; empty selects the default group). This is BYTE-IDENTICAL to
+/// [`CumulativeAckBody`]'s layout (a shared shape, distinct frame type); the server dispatches on the
+/// FRAME TYPE (Tier-S streaming vs Tier-W broadcast) to pick the right group-mode guard.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct StreamCommitBody<'a> {
+    /// The exclusive offset to commit the streaming cursor up to (every offset strictly below it is
+    /// committed).
+    pub up_to: u64,
+    /// The work-group name (empty selects the default group). Validated server-side.
+    pub group: &'a [u8],
+}
+
+/// Encodes a `StreamCommit` body onto the end of `out`: the 8-byte LE `up_to` offset, then the group
+/// name as the remainder (the same shape as [`encode_cumulative_ack`]).
+pub fn encode_stream_commit(commit: &StreamCommitBody<'_>, out: &mut Vec<u8>) {
+    out.extend_from_slice(&commit.up_to.to_le_bytes());
+    out.extend_from_slice(commit.group);
+}
+
+/// Decodes a `StreamCommit` body: the leading 8-byte LE `up_to` offset, then the remainder is the group
+/// name (the same shape as [`decode_cumulative_ack`]).
+///
+/// # Errors
+/// Returns [`BodyError::Truncated`] if the body is shorter than the 8-byte `up_to` field.
+pub fn decode_stream_commit(body: &[u8]) -> Result<StreamCommitBody<'_>, BodyError> {
+    let mut r = Reader::new(body);
+    let up_to = r.u64()?;
+    let group = r.rest();
+    Ok(StreamCommitBody { up_to, group })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1897,6 +2025,111 @@ mod tests {
         encode_fetch(&req, &mut buf);
         buf.extend_from_slice(b"future-fields"); // appended past field_len
         assert_eq!(decode_fetch(&buf).unwrap(), req);
+    }
+
+    #[test]
+    fn stream_fetch_round_trips() {
+        // #544: the Tier-S streaming fetch carries the consumer-managed start_offset + the batch caps.
+        let req = StreamFetchBody {
+            start_offset: 0x0102_0304_0506_0708,
+            max_records: 256,
+            max_bytes: 1 << 20,
+        };
+        let mut buf = Vec::new();
+        encode_stream_fetch(&req, &mut buf);
+        assert_eq!(decode_stream_fetch(&buf).unwrap(), req);
+    }
+
+    #[test]
+    fn stream_fetch_rejects_an_empty_or_short_body_and_an_unknown_version() {
+        // The frame type is new: an empty body is not a valid request (no historical empty case).
+        assert_eq!(decode_stream_fetch(&[]), Err(BodyError::Truncated));
+        // A declared field_len longer than the body is a typed length error, never an over-read.
+        let mut bad = vec![STREAM_FETCH_BODY_VERSION];
+        bad.extend_from_slice(&99u16.to_le_bytes()); // declares 99 bytes but supplies none
+        assert!(matches!(
+            decode_stream_fetch(&bad),
+            Err(BodyError::Truncated | BodyError::BadLength)
+        ));
+        // An unknown body version is rejected, not best-effort parsed.
+        let mut wrong = Vec::new();
+        encode_stream_fetch(
+            &StreamFetchBody {
+                start_offset: 1,
+                max_records: 1,
+                max_bytes: 0,
+            },
+            &mut wrong,
+        );
+        wrong[0] = STREAM_FETCH_BODY_VERSION + 1;
+        assert_eq!(
+            decode_stream_fetch(&wrong),
+            Err(BodyError::BadHandshakeVersion {
+                version: STREAM_FETCH_BODY_VERSION + 1
+            })
+        );
+    }
+
+    #[test]
+    fn stream_fetch_tolerates_a_future_appended_field() {
+        // A newer client may append fields past the declared v1 block; a v1 reader decodes its known
+        // fields and ignores the tail (forward-compat), exactly like FetchBody.
+        let req = StreamFetchBody {
+            start_offset: 42,
+            max_records: 7,
+            max_bytes: 4096,
+        };
+        let mut buf = Vec::new();
+        encode_stream_fetch(&req, &mut buf);
+        buf.extend_from_slice(b"future-fields");
+        assert_eq!(decode_stream_fetch(&buf).unwrap(), req);
+    }
+
+    #[test]
+    fn stream_commit_round_trips_and_shares_the_cumulative_ack_shape() {
+        // #544: StreamCommit carries the same (u64 up_to, group name) shape as CumulativeAck — a shared
+        // byte layout, a DISTINCT frame type. The server dispatches on the frame type to pick the
+        // group-mode guard (streaming vs broadcast).
+        let commit = StreamCommitBody {
+            up_to: 0x1122_3344_5566_7788,
+            group: b"stream-group",
+        };
+        let mut buf = Vec::new();
+        encode_stream_commit(&commit, &mut buf);
+        assert_eq!(decode_stream_commit(&buf).unwrap(), commit);
+        // The bytes are identical to a CumulativeAck body with the same fields.
+        let mut ca = Vec::new();
+        encode_cumulative_ack(
+            &CumulativeAckBody {
+                up_to: commit.up_to,
+                group: commit.group,
+            },
+            &mut ca,
+        );
+        assert_eq!(
+            buf, ca,
+            "StreamCommit and CumulativeAck share the wire shape"
+        );
+        // An empty group selects the default group.
+        let default_group = StreamCommitBody {
+            up_to: 5,
+            group: b"",
+        };
+        let mut db = Vec::new();
+        encode_stream_commit(&default_group, &mut db);
+        assert_eq!(decode_stream_commit(&db).unwrap(), default_group);
+    }
+
+    #[test]
+    fn stream_commit_rejects_a_short_body() {
+        // Anything shorter than the 8-byte up_to cannot carry the commit offset.
+        for len in 0..8usize {
+            assert_eq!(
+                decode_stream_commit(&vec![0u8; len]),
+                Err(BodyError::Truncated),
+                "a {len}-byte body must be Truncated"
+            );
+        }
     }
 
     proptest! {

--- a/crates/ironbus-server/src/engine.rs
+++ b/crates/ironbus-server/src/engine.rs
@@ -743,6 +743,27 @@ pub enum NackResult {
     Fenced,
 }
 
+/// A Tier-S STREAMING fetch result (#544, M1-I7): the CONTIGUOUS batch of records the broker served
+/// off the durable prefix starting at the consumer-managed `start_offset`, with NO lease granted and
+/// NO per-record cursor write. The consumer owns the offset: it advances its own position past
+/// `next_offset` and periodically durably-commits via [`Engine::stream_commit_in`]. At-least-once holds
+/// by construction — a crash/reconnect re-reads from the last committed offset, redelivering at most
+/// the uncommitted records.
+#[derive(Clone, Debug, Default)]
+pub struct StreamBatch {
+    /// The contiguous run of records read from the durable, flushed prefix `[start_offset, ...)`, in
+    /// offset order, bounded by `max_records` / `max_bytes` / the flushed frontier. May be empty (the
+    /// consumer is already caught up to the durable head, or `start_offset` is at/past it). These are
+    /// the SAME materialized, CRC-validated records the Tier-W poll path returns — only the
+    /// lease/cursor bookkeeping is skipped.
+    pub records: Vec<OwnedRecord>,
+    /// The offset the consumer should resume from on its NEXT fetch: one past the last record served
+    /// (or `start_offset` itself when the batch is empty). It never exceeds the flushed head. A
+    /// reconnecting consumer that has not committed simply re-passes its last committed offset, not
+    /// this value, and the uncommitted span redelivers.
+    pub next_offset: Offset,
+}
+
 /// The outcome of [`Engine::progress`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ProgressResult {
@@ -1633,6 +1654,24 @@ struct WorkGroup {
     /// a cursor with nothing to record, so a consumer that polled but never committed resumes
     /// untouched even after a graceful stop.
     touched: bool,
+    /// Whether this group is a TIER-S STREAMING consumer (#544, M1-I7): a consumer-managed-offset
+    /// mode where the broker serves a CONTIGUOUS batch off the durable prefix with NO lease, NO
+    /// generation fence, and NO per-record cursor write, and durability comes from a PERIODIC
+    /// cumulative [`Engine::stream_commit_in`] that advances this group's committed cursor via
+    /// `commit_up_to`. It is the streaming twin of the default TIER-W work-queue mode (`broadcast` /
+    /// `router` above): where Tier-W grants a per-record lease and writes the cursor on every ack,
+    /// Tier-S removes exactly that per-record cost, which is what makes single-consumer durable
+    /// consume lose to NATS. At-least-once holds BY CONSTRUCTION — a crash or reconnect re-reads from
+    /// the last committed offset (the consumer passes its own `start_offset` to
+    /// [`Engine::stream_fetch_in`]), so at most the uncommitted records redeliver (the Kafka /
+    /// NATS-pull contract). The streaming cursor still pins the retention floor exactly like any
+    /// other group (it is read by [`Engine::min_committed_offset`] once `touched`), so a committed
+    /// streaming consumer frees retention correctly. `false` (Tier-W work-queue) by default, so an
+    /// unconfigured group is byte-for-byte unchanged and the Tier-W lease path is untouched. A
+    /// streaming group never grants leases, so it never carries the broadcast group-of-one hazard:
+    /// it is orthogonal to `broadcast` and `router` and does NOT clear them (a future Connect-default
+    /// tier negotiation, M1-I9, may layer policy on top; this flag is the per-group selector only).
+    streaming: bool,
 }
 
 /// What happens to an evicted group's `group_last_checkpointed` entry (#432): `Keep` leaves it
@@ -1667,6 +1706,11 @@ impl WorkGroup {
             // pinning. The single exception, the boot-created default group with no durable
             // state, is flipped to untouched right after open inserts it.
             touched: true,
+            // Tier-W (work-queue lease mode) by default (#544): a resumed/new group is byte-for-byte
+            // the existing lease path. Tier-S streaming is opted into server-side via
+            // `set_streaming_in` after open, never restored from disk here (the mode is re-applied,
+            // exactly like `broadcast` / `router`).
+            streaming: false,
         }
     }
 }
@@ -4810,6 +4854,221 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
     /// As [`Engine::cumulative_ack_in`].
     pub fn cumulative_ack(&mut self, up_to: Offset) -> Result<(), EngineError> {
         self.cumulative_ack_in(DEFAULT_GROUP, up_to)
+    }
+
+    /// Marks `group` a TIER-S STREAMING consumer (#544, M1-I7), or clears the mode. A streaming group
+    /// is consumer-managed-offset: [`Engine::stream_fetch_in`] serves a contiguous batch off the
+    /// durable prefix with NO lease and NO per-record cursor write, and durability comes from a
+    /// periodic cumulative [`Engine::stream_commit_in`]. This is the serve-time declaration that opts a
+    /// named group into the streaming tier, mirroring [`Engine::set_broadcast_in`] /
+    /// [`Engine::set_key_ordering_in`] (the existing per-group mode setters). The Connect-level tier
+    /// DEFAULT negotiation is a SEPARATE issue (M1-I9); this is the explicit per-group selector only,
+    /// and it does NOT change any default — an unconfigured group stays Tier-W.
+    ///
+    /// Creates the group if absent (validating the name and the group cap, exactly like
+    /// `set_broadcast_in`). Unlike `set_broadcast_in` there is no group-of-one cap to guard: a
+    /// streaming group grants no leases, so there is no in-flight state a later commit could silently
+    /// drop. The flip is therefore always safe and does not clear `broadcast` / `router` (a streaming
+    /// consumer simply reads contiguously; the lease-mode flags are inert on the streaming path).
+    ///
+    /// # Errors
+    /// [`EngineError::InvalidGroupName`] for a malformed name, or [`EngineError::TooManyGroups`] if a
+    /// new group would exceed the per-engine cap.
+    pub fn set_streaming_in(&mut self, group: &str, streaming: bool) -> Result<(), EngineError> {
+        if !self.groups.contains_key(group) {
+            validate_group_name(group)?;
+            if self.max_groups != 0 && self.groups.len() >= self.max_groups {
+                return Err(EngineError::TooManyGroups {
+                    max: self.max_groups,
+                });
+            }
+        }
+        let now = self.log.now_monotonic();
+        let lease_config = self.lease_config;
+        let g = self
+            .groups
+            .entry(group.to_string())
+            .or_insert_with(|| WorkGroup::new(lease_config, now));
+        g.streaming = streaming;
+        Ok(())
+    }
+
+    /// Whether `group` is a TIER-S STREAMING consumer (#544): a consumer-managed-offset group served
+    /// by [`Engine::stream_fetch_in`] / [`Engine::stream_commit_in`]. `false` for an unknown group or a
+    /// default Tier-W work-queue group.
+    #[must_use]
+    pub fn is_streaming_in(&self, group: &str) -> bool {
+        self.groups.get(group).is_some_and(|g| g.streaming)
+    }
+
+    /// Serves a Tier-S STREAMING fetch (#544, M1-I7): a CONTIGUOUS batch of records starting at the
+    /// consumer-managed `start_offset`, bounded by `max_records` / `max_bytes` and the flushed
+    /// frontier — with NO lease grant, NO generation fence, and NO per-record cursor write. This is the
+    /// headline single-consumer consume win: it removes exactly the per-record lease `BTreeMap` insert,
+    /// generation bump, and RLE cursor mutate that the Tier-W [`Engine::poll`] path pays on every
+    /// record, replacing N per-record actor round-trips with ONE contiguous read.
+    ///
+    /// At-least-once holds BY CONSTRUCTION: the consumer owns its offset and re-reads from its last
+    /// committed position on a crash/reconnect (it passes that offset as `start_offset`), so the broker
+    /// keeps no per-delivery state and at most the uncommitted records redeliver — the Kafka /
+    /// NATS-pull contract. The records returned are the SAME materialized, CRC-validated
+    /// [`OwnedRecord`]s the Tier-W path delivers (via the shared `Log::read_range`); only the
+    /// bookkeeping differs.
+    ///
+    /// The group must be in streaming mode (declared via [`Engine::set_streaming_in`]); a fetch on a
+    /// non-streaming group is rejected so a client cannot bypass the Tier-W lease path by accident.
+    /// `member` is accepted for symmetry with the Tier-W member-aware poll and future per-member
+    /// streaming policy, but a streaming fetch is not member-routed (the consumer manages its own
+    /// offset), so it is currently unused beyond marking the group active.
+    ///
+    /// A streaming fetch NEVER advances the group cursor and NEVER touches the lease table: retention
+    /// is pinned only by the periodic [`Engine::stream_commit_in`], so a consumer that fetches but
+    /// never commits pins the floor at its committed offset (not its read offset), exactly the
+    /// consumer-managed contract.
+    ///
+    /// # Errors
+    /// [`EngineError::CumulativeAckOnWorkGroup`] if `group` is not a streaming group (reusing the
+    /// wrong-mode error; the verb belongs to a streaming consumer only), or a storage error reading the
+    /// durable prefix.
+    pub fn stream_fetch_in(
+        &mut self,
+        group: &str,
+        _member: MemberId,
+        start_offset: Offset,
+        max_records: usize,
+        max_bytes: Option<usize>,
+    ) -> Result<StreamBatch, EngineError> {
+        // A streaming fetch belongs to a streaming group ONLY. A Tier-W (lease) group must keep using
+        // the poll/Fetch path; serving it a contiguous lease-free batch would bypass its lease/cursor
+        // semantics. Reject with the wrong-mode error rather than silently degrade the work-queue.
+        if !self.is_streaming_in(group) {
+            return Err(EngineError::CumulativeAckOnWorkGroup);
+        }
+        let now = self.log.now_monotonic();
+        // A fetch IS activity: refresh the idle stamp and mark the group touched so its committed
+        // cursor pins the retention floor (#277 / #424), exactly like a Tier-W poll.
+        if let Some(g) = self.groups.get_mut(group) {
+            g.last_activity = now;
+            g.touched = true;
+        }
+        // The contiguous read off the durable, flushed prefix. `Log::read_range` bounds the read by the
+        // flushed frontier (no un-flushed record is served), `max_records`, and `max_bytes`, and
+        // returns the SAME CRC-validated records the Tier-W poll's `read_from` does — the single shared
+        // read primitive. NO lease is claimed, NO cursor is written: this is the whole point.
+        let records = self.log.read_range(start_offset, max_records, max_bytes)?;
+        // The consumer resumes from one past the last record served (or `start_offset` when empty). The
+        // records are contiguous and offset-ordered, so the last one's offset + 1 is the resume point;
+        // it never exceeds the flushed head (read_range clamps to it). `checked_next` only returns
+        // `None` at the `u64::MAX` boundary a real deployment never reaches; fall back to the record's
+        // own offset there rather than wrap, mirroring `AckCursor::ack`'s exhausted-boundary handling.
+        let next_offset = records.last().map_or(start_offset, |r| {
+            r.offset.checked_next().unwrap_or(r.offset)
+        });
+        // Count the streaming deliveries on the SAME `delivered` counter the Tier-W poll drives, so the
+        // observability taxonomy is unchanged (no new counter). A streaming delivery is never a
+        // redelivery from the broker's view (the broker keeps no per-delivery state); a consumer-driven
+        // re-read after an uncommitted crash is invisible here, exactly as the at-least-once contract
+        // intends.
+        self.counters.delivered = self.counters.delivered.saturating_add(records.len() as u64);
+        Ok(StreamBatch {
+            records,
+            next_offset,
+        })
+    }
+
+    /// Serves a Tier-S streaming fetch in the default work-group (#544): delegates to
+    /// [`Engine::stream_fetch_in`] with the default group name (which must have been marked streaming).
+    ///
+    /// # Errors
+    /// As [`Engine::stream_fetch_in`].
+    pub fn stream_fetch(
+        &mut self,
+        member: MemberId,
+        start_offset: Offset,
+        max_records: usize,
+        max_bytes: Option<usize>,
+    ) -> Result<StreamBatch, EngineError> {
+        self.stream_fetch_in(DEFAULT_GROUP, member, start_offset, max_records, max_bytes)
+    }
+
+    /// Commits a Tier-S STREAMING group's cursor up to the EXCLUSIVE offset `up_to` (#544, M1-I7): the
+    /// consumer's PERIODIC, cumulative "everything below `up_to` is durably processed" checkpoint. It
+    /// REUSES the broadcast cumulative-ack cursor primitive ([`AckCursor::commit_up_to`]) — no new
+    /// durable structure is invented — and advances the SAME committed watermark
+    /// [`Engine::min_committed_offset`] reads, so a committed streaming consumer frees retention exactly
+    /// like a Tier-W ack or a broadcast cumulative ack.
+    ///
+    /// It is the streaming twin of [`Engine::cumulative_ack_in`] and deliberately distinct from it: this
+    /// targets a STREAMING group (where `cumulative_ack_in` targets a BROADCAST group), so the two never
+    /// collide and the broadcast-only guard on `cumulative_ack_in` is unchanged. Because a streaming
+    /// group grants NO leases, this commit does NOT call `release_below` (there is nothing in-flight to
+    /// reclaim); it ONLY advances the watermark. It is idempotent and monotonic — an `up_to` at or below
+    /// the committed offset is a no-op success — exactly like `commit_up_to`.
+    ///
+    /// `up_to` is validated against the durable, retained window `[earliest_retained, durable_head]`
+    /// BEFORE the cursor is touched, so a bad offset leaves the committed position unchanged.
+    ///
+    /// # Errors
+    /// [`EngineError::CumulativeAckOnWorkGroup`] if `group` is not a streaming group, or
+    /// [`EngineError::CumulativeAckOutOfRange`] if `up_to` is past the durable head or below the
+    /// earliest retained offset.
+    pub fn stream_commit_in(&mut self, group: &str, up_to: Offset) -> Result<(), EngineError> {
+        // Streaming groups only: the verb belongs to a consumer-managed-offset group. A Tier-W or
+        // broadcast group is rejected (a broadcast group uses `cumulative_ack_in` instead), so the two
+        // commit verbs never cross modes.
+        if !self.is_streaming_in(group) {
+            return Err(EngineError::CumulativeAckOnWorkGroup);
+        }
+        // Validate `up_to` against the durable, retained window BEFORE touching the cursor — identical
+        // to `cumulative_ack_in`. Committing past the head names records that do not exist; committing
+        // below the earliest retained offset names reaped (or replayed-stale) records. Either leaves the
+        // committed position exactly as it was.
+        let durable_head = self.log.flushed_offset().get();
+        let earliest_retained = self.log.earliest_offset().get();
+        let up_to_raw = up_to.get();
+        if up_to_raw > durable_head || up_to_raw < earliest_retained {
+            return Err(EngineError::CumulativeAckOutOfRange {
+                up_to: up_to_raw,
+                earliest_retained,
+                durable_head,
+            });
+        }
+        let now = self.log.now_monotonic();
+        let Some(g) = self.groups.get_mut(group) else {
+            return Err(EngineError::CumulativeAckOnWorkGroup);
+        };
+        // A commit IS activity: refresh the stamp so the idle sweep does not reclaim a group that
+        // commits via streaming rather than poll.
+        g.last_activity = now;
+        g.touched = true;
+        let before = g.cursor.committed().get();
+        // Advance the single streaming cursor up to `up_to`. `commit_up_to` is idempotent and monotonic
+        // (an `up_to` at or below `committed` is a no-op success; the watermark never regresses), so a
+        // re-commit after a redeliver cannot move the floor backwards. NO `release_below`: a streaming
+        // group holds no leases, so there is nothing in-flight to reclaim (the cardinal difference from
+        // the broadcast cumulative-ack path).
+        if g.cursor.commit_up_to(up_to) {
+            // Count each newly-committed offset as an ack on the SAME counter per-message acks drive, so
+            // the resilience taxonomy is unchanged (no new counter), exactly like `cumulative_ack_in`.
+            let advanced = g.cursor.committed().get().saturating_sub(before);
+            self.counters.acks = self.counters.acks.saturating_add(advanced);
+        }
+        // Fire the Level-2 cursor-commit hook (#497) once `g` is released: a streaming group can be the
+        // designated confirm group, so a cumulative streaming commit confirms every pending L2 produce
+        // below the new watermark in one move. ADDITIVE: a no-op unless this is the designated group
+        // with confirms pending.
+        let committed = g.cursor.committed().get();
+        self.confirm_designated_commit(group, committed);
+        Ok(())
+    }
+
+    /// Commits a Tier-S streaming cursor in the default work-group (#544): delegates to
+    /// [`Engine::stream_commit_in`] with the default group name (which must have been marked streaming).
+    ///
+    /// # Errors
+    /// As [`Engine::stream_commit_in`].
+    pub fn stream_commit(&mut self, up_to: Offset) -> Result<(), EngineError> {
+        self.stream_commit_in(DEFAULT_GROUP, up_to)
     }
 
     /// Nacks the message named by `token`, requeueing it for redelivery and fencing the
@@ -11881,6 +12140,277 @@ mod tests {
             lz4.durable_record_bytes() < 2048,
             "eight compressed 1 KiB produces hold fewer stored bytes than two raw ones: {}",
             lz4.durable_record_bytes()
+        );
+    }
+
+    // ----- Tier-S streaming consumer-managed-offset consume mode (#544, M1-I7) -----
+
+    fn member(id: u64) -> MemberId {
+        MemberId::new(id)
+    }
+
+    #[test]
+    fn stream_fetch_serves_a_contiguous_batch_with_no_lease_and_no_cursor_write() {
+        // THE core property (#544): a Tier-S streaming fetch serves a contiguous run off the durable
+        // prefix WITHOUT granting any lease or writing any per-record cursor state. This is what removes
+        // the per-record cost that makes single-consumer durable consume lose to NATS.
+        let mut e = open(config(10, 5));
+        for i in 0..6u8 {
+            produce(&mut e, &[i]);
+        }
+        e.set_streaming_in("s", true).unwrap();
+
+        let batch = e
+            .stream_fetch_in("s", member(1), Offset::ZERO, 4, None)
+            .unwrap();
+        // A contiguous prefix [0, 4) of records in offset order.
+        assert_eq!(batch.records.len(), 4);
+        for (i, r) in batch.records.iter().enumerate() {
+            assert_eq!(r.offset.get(), i as u64);
+            assert_eq!(&r.payload[..], &[u8::try_from(i).unwrap()]);
+        }
+        // The resume point is one past the last record served.
+        assert_eq!(batch.next_offset, Offset::new(4));
+        // NO lease was granted: the in-flight set is empty.
+        assert_eq!(
+            e.in_flight_in("s"),
+            0,
+            "a streaming fetch grants no lease (the headline Tier-S property)"
+        );
+        // NO cursor was written: the committed offset stays exactly where it was (0).
+        assert_eq!(
+            e.committed_offset_in("s"),
+            Offset::ZERO,
+            "a streaming fetch writes no per-record cursor state"
+        );
+
+        // Fetching AGAIN from the same start re-reads the SAME records (idempotent, consumer-managed):
+        // the broker keeps no per-delivery state, so there is nothing to advance.
+        let again = e
+            .stream_fetch_in("s", member(1), Offset::ZERO, 4, None)
+            .unwrap();
+        assert_eq!(again.records.len(), 4);
+        assert_eq!(again.records[0].offset, Offset::ZERO);
+        assert_eq!(e.in_flight_in("s"), 0);
+        assert_eq!(e.committed_offset_in("s"), Offset::ZERO);
+    }
+
+    #[test]
+    fn stream_fetch_is_rejected_on_a_non_streaming_group() {
+        // A streaming fetch must not bypass the Tier-W lease path: a group that was never declared
+        // streaming rejects the verb, so a client cannot accidentally turn a work-queue into a stream.
+        let mut e = open(config(10, 5));
+        produce(&mut e, b"a");
+        // The default Tier-W group (never marked streaming) rejects it.
+        assert!(matches!(
+            e.stream_fetch_in("w", member(1), Offset::ZERO, 4, None),
+            Err(EngineError::CumulativeAckOnWorkGroup)
+        ));
+        // The default group likewise.
+        assert!(matches!(
+            e.stream_fetch(member(1), Offset::ZERO, 4, None),
+            Err(EngineError::CumulativeAckOnWorkGroup)
+        ));
+    }
+
+    #[test]
+    fn stream_commit_advances_the_watermark_via_the_cumulative_cursor() {
+        // A periodic cumulative StreamCommit advances the streaming group's committed watermark via the
+        // REUSED `commit_up_to` primitive (no new durable structure), and is idempotent / monotonic.
+        let mut e = open(config(10, 5));
+        for _ in 0..10 {
+            produce(&mut e, b"x");
+        }
+        e.set_streaming_in("s", true).unwrap();
+        e.stream_fetch_in("s", member(1), Offset::ZERO, 10, None)
+            .unwrap();
+        assert_eq!(e.committed_offset_in("s"), Offset::ZERO);
+
+        // Commit up to 5 (exclusive): the watermark jumps to 5.
+        e.stream_commit_in("s", Offset::new(5)).unwrap();
+        assert_eq!(e.committed_offset_in("s"), Offset::new(5));
+        // Idempotent: a re-commit at or below the watermark is a no-op success, never a regression.
+        e.stream_commit_in("s", Offset::new(5)).unwrap();
+        e.stream_commit_in("s", Offset::new(3)).unwrap();
+        assert_eq!(e.committed_offset_in("s"), Offset::new(5));
+        // Advance further.
+        e.stream_commit_in("s", Offset::new(10)).unwrap();
+        assert_eq!(e.committed_offset_in("s"), Offset::new(10));
+        // Still no lease was ever taken (commit reclaims nothing because there is nothing in-flight).
+        assert_eq!(e.in_flight_in("s"), 0);
+    }
+
+    #[test]
+    fn stream_commit_rejects_a_non_streaming_group_and_an_out_of_range_offset() {
+        let mut e = open(config(10, 5));
+        for _ in 0..4 {
+            produce(&mut e, b"x");
+        }
+        // A non-streaming group rejects the commit (a broadcast group uses cumulative_ack_in instead).
+        assert!(matches!(
+            e.stream_commit_in("w", Offset::new(2)),
+            Err(EngineError::CumulativeAckOnWorkGroup)
+        ));
+        e.set_streaming_in("s", true).unwrap();
+        // Past the durable head: rejected, watermark unchanged.
+        assert!(matches!(
+            e.stream_commit_in("s", Offset::new(99)),
+            Err(EngineError::CumulativeAckOutOfRange { .. })
+        ));
+        assert_eq!(e.committed_offset_in("s"), Offset::ZERO);
+    }
+
+    #[test]
+    fn stream_at_least_once_survives_a_crash_reconnect_redelivering_only_uncommitted() {
+        // THE at-least-once correctness test (#544): a consumer fetches a batch, commits a PREFIX, then
+        // "crashes" (reconnects with no broker-side delivery state) and resumes from its LAST COMMITTED
+        // offset. The committed offset survives; every uncommitted record is re-delivered; nothing is
+        // lost and the contiguous order is preserved across the reconnect.
+        let mut e = open(config(10, 5));
+        let n = 8u8;
+        for i in 0..n {
+            produce(&mut e, &[i]);
+        }
+        e.set_streaming_in("s", true).unwrap();
+
+        // Fetch all 8, then durably commit only up to 5 (the consumer processed [0,5) and crashed
+        // before committing 5,6,7).
+        let first = e
+            .stream_fetch_in("s", member(1), Offset::ZERO, 8, None)
+            .unwrap();
+        assert_eq!(first.records.len(), 8);
+        e.stream_commit_in("s", Offset::new(5)).unwrap();
+        assert_eq!(e.committed_offset_in("s"), Offset::new(5));
+
+        // CRASH + RECONNECT: the broker kept no per-delivery state (no lease). The reconnecting consumer
+        // resumes from its last committed offset (5) — the consumer-managed contract. It re-reads
+        // [5, 8): exactly the uncommitted records, in order, none lost, at most re-delivered.
+        let resumed = e
+            .stream_fetch_in("s", member(1), e.committed_offset_in("s"), 8, None)
+            .unwrap();
+        let resumed_offsets: Vec<u64> = resumed.records.iter().map(|r| r.offset.get()).collect();
+        assert_eq!(
+            resumed_offsets,
+            vec![5, 6, 7],
+            "exactly the uncommitted records re-deliver, in contiguous order"
+        );
+        // The full delivered set across the crash (committed [0,5) once + redelivered [5,8)) covers
+        // every produced offset at least once: no message loss.
+        let mut seen: std::collections::BTreeSet<u64> =
+            first.records.iter().map(|r| r.offset.get()).collect();
+        seen.extend(resumed.records.iter().map(|r| r.offset.get()));
+        assert_eq!(
+            seen,
+            (0..u64::from(n)).collect(),
+            "every produced offset is delivered at least once (at-least-once)"
+        );
+
+        // The consumer finishes and commits the rest: the watermark reaches the head.
+        e.stream_commit_in("s", Offset::new(u64::from(n))).unwrap();
+        assert_eq!(e.committed_offset_in("s"), Offset::new(u64::from(n)));
+    }
+
+    #[test]
+    fn stream_commit_frees_retention_like_any_other_group() {
+        // A streaming group's committed cursor pins/frees the retention floor exactly like a Tier-W ack
+        // or a broadcast cumulative ack: it is read by `min_committed_offset` once touched. A streaming
+        // consumer that fetches-but-never-commits pins the floor at its committed (0); once it commits,
+        // the now-consumed old segments become reapable.
+        let mut e = open(config_with_retention(0));
+        produce(&mut e, &[0xab; 16]);
+        let one = e.durable_record_bytes();
+        let mut e = open(config_with_retention(2 * one));
+
+        e.set_streaming_in("s", true).unwrap();
+        // Produce well past the bound; the streaming consumer FETCHES everything but does NOT commit, so
+        // its cursor stays at 0 and pins the floor: nothing below 0 may be reaped.
+        for _ in 0..30 {
+            produce(&mut e, &[0xab; 16]);
+        }
+        let head = e.flushed_offset();
+        e.stream_fetch_in("s", member(1), Offset::ZERO, 1024, None)
+            .unwrap();
+        assert_eq!(e.committed_offset_in("s"), Offset::ZERO);
+        // Produce one more to drive the retention pass: the floor is pinned at 0, so nothing reaps.
+        produce(&mut e, &[0xab; 16]);
+        assert_eq!(
+            e.counters().segments_reaped,
+            0,
+            "an uncommitted streaming consumer pins the floor at its committed offset (0)"
+        );
+
+        // Now the consumer durably COMMITS up to the head it read: the floor rises and the next produce
+        // reaps the now-consumed old segments back toward the bound.
+        e.stream_commit_in("s", head).unwrap();
+        assert_eq!(e.committed_offset_in("s"), head);
+        produce(&mut e, &[0xab; 16]);
+        assert!(
+            e.counters().segments_reaped >= 1,
+            "once the streaming consumer commits, old consumed segments reap (retention freed)"
+        );
+        assert!(
+            e.durable_record_bytes() <= 4 * one,
+            "the live durable bytes dropped toward the bound after the streaming commit"
+        );
+    }
+
+    #[test]
+    fn tier_w_lease_path_is_unchanged_when_tier_s_is_available() {
+        // PRESERVE (#544): adding Tier-S leaves Tier-W (the lease/poll/ack work-queue) byte-identical.
+        // A default-group poll still grants a lease, an ack still advances the cursor, and the streaming
+        // verbs are simply unavailable on a Tier-W group. This is the regression guard that the
+        // work-queue differentiator stays intact.
+        let mut e = open(config(10, 5));
+        for i in 0..3u8 {
+            produce(&mut e, &[i]);
+        }
+        // The Tier-W poll path is exactly as before: a lease is granted, the cursor advances on ack.
+        let d = message(e.poll(0).unwrap());
+        assert_eq!(d.offset, Offset::ZERO);
+        assert_eq!(e.in_flight_in(""), 1, "Tier-W still grants a lease");
+        assert_eq!(e.ack(&d.token), AckResult::Acked);
+        assert_eq!(
+            e.committed_offset_in(""),
+            Offset::new(1),
+            "Tier-W ack still advances the cursor"
+        );
+        // The streaming verbs are rejected on this Tier-W group (it was never marked streaming).
+        assert!(matches!(
+            e.stream_fetch(member(1), Offset::ZERO, 4, None),
+            Err(EngineError::CumulativeAckOnWorkGroup)
+        ));
+        assert!(matches!(
+            e.stream_commit(Offset::new(1)),
+            Err(EngineError::CumulativeAckOnWorkGroup)
+        ));
+    }
+
+    #[test]
+    fn stream_fetch_respects_max_records_max_bytes_and_the_flushed_bound() {
+        let mut e = open(config(64, 5));
+        for _ in 0..10 {
+            produce(&mut e, &[0xcd; 32]);
+        }
+        e.set_streaming_in("s", true).unwrap();
+        // max_records bounds the batch.
+        let b = e
+            .stream_fetch_in("s", member(1), Offset::ZERO, 3, None)
+            .unwrap();
+        assert_eq!(b.records.len(), 3);
+        assert_eq!(b.next_offset, Offset::new(3));
+        // A start at the head serves nothing and resumes at the head (caught up).
+        let head = e.flushed_offset();
+        let caught_up = e.stream_fetch_in("s", member(1), head, 100, None).unwrap();
+        assert!(caught_up.records.is_empty());
+        assert_eq!(caught_up.next_offset, head);
+        // A tiny byte cap still serves at least one record (the floor-of-one), never zero.
+        let one_byte = e
+            .stream_fetch_in("s", member(1), Offset::ZERO, 100, Some(1))
+            .unwrap();
+        assert_eq!(
+            one_byte.records.len(),
+            1,
+            "the byte cap floors at one record so a stream never wedges"
         );
     }
 }

--- a/crates/ironbus-server/src/session.rs
+++ b/crates/ironbus-server/src/session.rs
@@ -19,7 +19,7 @@
 use crate::actor::{
     ActorGone, EngineAccess, OwnedAppend, OwnedDedup, ProduceOutcome, ProduceSubmission,
 };
-use crate::engine::{AckResult, EngineError, NackResult, Poll, ProgressResult};
+use crate::engine::{AckResult, EngineError, NackResult, Poll, ProgressResult, StreamBatch};
 use bytes::Bytes;
 use ironbus_core::clock::Clock;
 use ironbus_core::compress::{validate_descriptor_shape, DEFAULT_MAX_DECOMPRESSED_BYTES};
@@ -30,11 +30,12 @@ use ironbus_core::lease::LeaseToken;
 use ironbus_core::types::{Offset, RecordFlags};
 use ironbus_proto::frame::{decode_frame, encode_frame, FrameDecode, FrameError, FrameType};
 use ironbus_proto::message::{
-    decode_ack, decode_connect, decode_cumulative_ack, decode_fetch, decode_pub, decode_sub,
-    encode_dead_letter, encode_deliver, encode_gap_marker, encode_info, encode_produce_confirm,
-    encode_pub_ack, encode_truncated, gap_reason, produce_confirm_status, pub_ack_level, AckLevel,
-    AckOp, CreditAdvert, DeadLetterBody, DeliverBody, GapMarkerBody, InfoBody, ProduceConfirmBody,
-    PubAckBody, TruncatedBody, DEAD_LETTER_MAX_DELIVER, PUB_WIRE_ONLY_FLAGS,
+    decode_ack, decode_connect, decode_cumulative_ack, decode_fetch, decode_pub,
+    decode_stream_commit, decode_stream_fetch, decode_sub, encode_dead_letter, encode_deliver,
+    encode_gap_marker, encode_info, encode_produce_confirm, encode_pub_ack, encode_truncated,
+    gap_reason, produce_confirm_status, pub_ack_level, AckLevel, AckOp, CreditAdvert,
+    DeadLetterBody, DeliverBody, GapMarkerBody, InfoBody, ProduceConfirmBody, PubAckBody,
+    TruncatedBody, DEAD_LETTER_MAX_DELIVER, PUB_WIRE_ONLY_FLAGS,
 };
 use ironbus_storage::fs::Filesystem;
 use std::collections::HashMap;
@@ -499,6 +500,19 @@ impl Session {
             // loop bounded by max_records/max_bytes/expires/no_wait, so it returns `true` to run the
             // interval checkpoint exactly like Flow (it commits cursor progress the same way).
             Some(FrameType::Fetch) => self.handle_fetch(engine, body, out).map(|()| true),
+            // The Tier-S STREAMING fetch (#544): a consumer-managed-offset contiguous read. It grants
+            // NO lease and writes NO cursor, so it never commits progress and there is nothing for the
+            // interval checkpoint to flush — it returns `false`. Durability is the separate periodic
+            // StreamCommit below.
+            Some(FrameType::StreamFetch) => {
+                self.handle_stream_fetch(engine, body, out).map(|()| false)
+            }
+            // The Tier-S periodic CUMULATIVE COMMIT (#544): advances the streaming group's committed
+            // cursor (when accepted), so it returns `true` to run the interval checkpoint, exactly like
+            // the broadcast CumulativeAck.
+            Some(FrameType::StreamCommit) => {
+                self.handle_stream_commit(engine, body, out).map(|()| true)
+            }
             Some(FrameType::Sub) => self.handle_sub(engine, body, out).map(|()| false),
             Some(FrameType::Unsub) => self.handle_unsub(engine, out).map(|()| true),
             // The standalone Nack frame type (a client sends a nack as an Ack frame with the
@@ -1450,6 +1464,164 @@ impl Session {
         // so the response is byte-for-byte a Flow response past the request frame.
         reply(out, FrameType::FlowEnd, &delivered.to_le_bytes());
         Ok(())
+    }
+
+    /// Handles a Tier-S STREAMING fetch (the tag-24 `StreamFetch` frame, #544 / M1-I7): the
+    /// consumer-managed-offset consume mode. The body carries the consumer's OWN `start_offset` plus
+    /// the batch caps; the broker serves a CONTIGUOUS run of records `[start_offset, ...)` off the
+    /// durable, flushed prefix with NO lease grant and NO per-record cursor write — exactly the
+    /// per-record cost the Tier-W `Fetch`/`Flow` path pays and Tier-S removes. The records ride the
+    /// SAME `Deliver` frames the Tier-W path uses, terminated by one `FlowEnd` carrying the delivered
+    /// count, so the response is byte-for-byte a Flow/Fetch response past the request frame — but
+    /// `self.leased` is NEVER touched (there is no lease to track; the consumer acks by offset via the
+    /// periodic `StreamCommit`).
+    ///
+    /// At-least-once holds BY CONSTRUCTION: the consumer drives the offset, so a crash/reconnect simply
+    /// re-fetches from its last committed offset and the uncommitted span redelivers. The engine
+    /// rejects a streaming fetch on a non-streaming group (the group must be declared streaming via
+    /// `set_streaming_in`), which surfaces here as a recoverable `Err`. The `Deliver` frame's
+    /// `generation` field is sent as `0` because there is no lease/fence on this path; a streaming
+    /// consumer commits by offset, not by fencing token.
+    #[allow(clippy::too_many_lines)]
+    fn handle_stream_fetch<
+        F: Filesystem + 'static,
+        C: Clock + Clone + 'static,
+        E: EngineAccess<F, C>,
+    >(
+        &mut self,
+        engine: &E,
+        body: &[u8],
+        out: &mut Vec<u8>,
+    ) -> Result<(), SessionError> {
+        if !self.connected {
+            reply_err(out, "not connected");
+            return Ok(());
+        }
+        let Ok(req) = decode_stream_fetch(body) else {
+            reply_err(out, "malformed stream-fetch body");
+            return Ok(());
+        };
+        // Bound the batch by the negotiated per-consumer credit and byte budget, exactly as the Tier-W
+        // Fetch does (#292/#275), so a generous max_records/max_bytes never lets one fetch run away.
+        // Tier-S holds no leases, so the ceiling is the standing per-fetch cap, not a window minus
+        // in-flight: a streaming consumer's "in-flight" is whatever it has read-but-not-committed, which
+        // it tracks itself.
+        let ceiling = self.credit_ceiling(engine)?;
+        let ceiling_bytes = self.credit_ceiling_bytes(engine)?;
+        // The number of records to serve: the client's request clamped to the per-consumer credit
+        // ceiling. A request of 0 (or a 0 ceiling) serves nothing and replies an empty batch.
+        let want = req.max_records.min(ceiling) as usize;
+        // The byte cap: the smaller of the negotiated per-consumer byte budget and the client's
+        // requested max_bytes (each `0` meaning unbounded), passed to the engine read as the contiguous
+        // read's byte bound. `None` means unbounded (only the record count binds).
+        let max_bytes = match min_budget(ceiling_bytes, req.max_bytes) {
+            0 => None,
+            cap => Some(usize::try_from(cap).unwrap_or(usize::MAX)),
+        };
+        let start = Offset::new(req.start_offset);
+        let group = self.subscription.clone();
+        let member = self.member_id;
+        // ONE actor round-trip serves the whole contiguous batch — the heart of the Tier-S win versus
+        // the N per-record round-trips the Tier-W poll loop makes. The engine reads off the shared
+        // durable read path, claims no lease, and writes no cursor.
+        match engine.with(move |e| e.stream_fetch_in(&group, member, start, want, max_bytes))? {
+            Ok(StreamBatch { records, .. }) => {
+                let mut delivered = 0u32;
+                for record in &records {
+                    let msg = DeliverBody {
+                        offset: record.offset.get(),
+                        // No lease, no fence: a streaming delivery carries generation 0. The consumer
+                        // commits by offset (StreamCommit), never by a per-record fencing token.
+                        generation: 0,
+                        flags: record.flags.bits(),
+                        timestamp_ms: record.timestamp_ms,
+                        key: &record.key,
+                        headers: &record.headers,
+                        payload: &record.payload,
+                    };
+                    let mut frame_body = Vec::new();
+                    if encode_deliver(&msg, &mut frame_body).is_err() {
+                        break;
+                    }
+                    reply(out, FrameType::Deliver, &frame_body);
+                    // CRITICAL: NO `self.leased.insert` here. Tier-S grants no lease, so the consumer's
+                    // in-flight set is its own concern. This is what removes the per-record bookkeeping.
+                    delivered += 1;
+                }
+                // Terminate with the SAME FlowEnd the Tier-W batch uses (its body the delivered count),
+                // so a client frames the streaming batch exactly like a Fetch batch.
+                reply(out, FrameType::FlowEnd, &delivered.to_le_bytes());
+                Ok(())
+            }
+            // A fatal engine error wedges every future op: end the session rather than masquerade it as
+            // a transient rejection (matching the Fetch/cumulative-ack paths).
+            Err(e) if e.is_fatal() => {
+                reply_err(out, "fatal storage error");
+                Err(SessionError::EngineFatal(e))
+            }
+            // The wrong-mode reject (a non-streaming group) and an out-of-range start are client-visible,
+            // recoverable rejections: surface the engine's typed reason and keep the connection open. Do
+            // NOT also send a FlowEnd (the Err is the terminator), matching the Fetch error path.
+            Err(e) => {
+                reply_err(out, &e.to_string());
+                Ok(())
+            }
+        }
+    }
+
+    /// Handles a Tier-S periodic CUMULATIVE COMMIT (the tag-25 `StreamCommit` frame, #544 / M1-I7):
+    /// advances the named streaming group's committed cursor up to the body's exclusive `up_to` offset,
+    /// the consumer's durability checkpoint. The body carries its own group name (like `CumulativeAck`),
+    /// so a streaming consumer drives it on any group it owns. The engine enforces the contract: only a
+    /// group MARKED streaming accepts the verb (a Tier-W or broadcast group is rejected with the
+    /// work-group error), `up_to` is validated against the durable head and the earliest-retained
+    /// offset, and a re-commit is an idempotent no-op success. Because Tier-S holds no leases, the
+    /// commit only advances the watermark (it frees retention and stops any redeliver below it); there
+    /// is no `self.leased` to prune. A success replies the generic body-less `Ok` (matching
+    /// `CumulativeAck`); a rejection replies a typed `Err`; a fatal engine error ends the session.
+    fn handle_stream_commit<
+        F: Filesystem + 'static,
+        C: Clock + Clone + 'static,
+        E: EngineAccess<F, C>,
+    >(
+        &mut self,
+        engine: &E,
+        body: &[u8],
+        out: &mut Vec<u8>,
+    ) -> Result<(), SessionError> {
+        if !self.connected {
+            reply_err(out, "not connected");
+            return Ok(());
+        }
+        let Ok(commit) = decode_stream_commit(body) else {
+            reply_err(out, "malformed stream-commit body");
+            return Ok(());
+        };
+        let Ok(group) = core::str::from_utf8(commit.group) else {
+            reply_err(out, "stream-commit group name must be valid UTF-8");
+            return Ok(());
+        };
+        let group = group.to_string();
+        let up_to = Offset::new(commit.up_to);
+        match engine.with(move |e| e.stream_commit_in(&group, up_to))? {
+            // A committed (or idempotent no-op) streaming commit: the generic body-less success. There
+            // is no per-connection lease to release (Tier-S grants none), so unlike the broadcast
+            // cumulative-ack path there is no `self.leased` bookkeeping here.
+            Ok(()) => {
+                reply(out, FrameType::Ok, &[]);
+                Ok(())
+            }
+            Err(e) if e.is_fatal() => {
+                reply_err(out, "fatal storage error");
+                Err(SessionError::EngineFatal(e))
+            }
+            // The wrong-mode reject and the out-of-range reject are client-visible, recoverable
+            // rejections: surface the engine's typed reason and keep the connection open.
+            Err(e) => {
+                reply_err(out, &e.to_string());
+                Ok(())
+            }
+        }
     }
 
     /// Emits the in-band advisory for a `Poll::Truncated` skip: a consumer that negotiated the


### PR DESCRIPTION
Closes #544 (V2-M1, the headline consume win).

## The two-tier model
- **Tier-W (work-queue, the existing default — byte-identical):** per-message lease + generation fence + visibility timeout + per-message ack + DLQ + key-shared. The richer-than-NATS differentiator, unchanged.
- **Tier-S (streaming, NEW):** the CONSUMER manages its own offset; the broker serves a contiguous batch via `read_range` over the lock-free off-actor read plane (#654) with **NO per-record lease, NO generation fence, NO per-record cursor write**; ack = a periodic **cumulative** `StreamCommit` advancing the group watermark via the reused `AckCursor::commit_up_to`. This removes exactly the per-record cost (lease BTreeMap insert + generation bump + RLE cursor mutate + per-record actor round-trip) that makes single-consumer durable consume lose ~3–20× to NATS.

## At-least-once by construction
A crash/reconnect re-reads from the last committed offset, redelivering at most the uncommitted span — the Kafka/NATS-pull contract. Proven by `stream_at_least_once_survives_a_crash_reconnect_redelivering_only_uncommitted`: fetch 8, commit [0,5), crash, resume → exactly [5,8) redeliver, every offset at-least-once, order preserved.

## Wire (additive)
`StreamFetch` (tag 24) + `StreamCommit` (tag 25), free range. Old clients unaffected; `Fetch`/`Flow` byte-identical. Per-subscription selection; Connect-default tier negotiation = M1-I9.

## Tests (13 tier-S)
no-lease/no-cursor assertion, crash-reconnect at-least-once, cumulative watermark advance (idempotent/monotonic), retention participation, reject-on-non-streaming-group, proto round-trip/short-body/future-field tolerance.

## Scope boundary
Tier-S mode + per-subscription selection + cumulative commit only. M1-I9 (#543 tier negotiation), #542 (sendfile), M2-I11 (partitions), M1-I10 (Fetch batching) not done. The authoritative single-consumer-vs-NATS-pull throughput proof is the milestone gate #554; the no-lease mechanism is proven by tests here.

## Gates
fmt + fresh clippy (-D warnings) + full workspace test green; MSRV 1.78. (Taken over + finalized after the implementing agent hit a usage limit mid-gate; reviewed + gated by me.)

## Scrutinize
The crash-reconnect at-least-once correctness; that Tier-W is untouched.