### PR TITLE
feat(consume): Connect tier-capability negotiation + connection default tier (#548)

### DIFF
--- a/crates/ironbus-client/src/lib.rs
+++ b/crates/ironbus-client/src/lib.rs
@@ -30,7 +30,7 @@ use ironbus_proto::message::{
     decode_dead_letter, decode_deliver, decode_gap_marker, decode_info, decode_produce_confirm,
     decode_pub_ack, decode_truncated, encode_ack, encode_connect, encode_cumulative_ack,
     encode_fetch, encode_pub, encode_sub, produce_confirm_status, AckBody, AckLevel, AckOp,
-    BodyError, ConnectBody, CumulativeAckBody, FetchBody, PubBody, SubBody,
+    BodyError, ConnectBody, ConsumeTier, CumulativeAckBody, FetchBody, PubBody, SubBody,
     PUB_FLAG_ACK_LEVEL_MASK, PUB_FLAG_ACK_LEVEL_SHIFT,
 };
 use std::io::{self, Read, Write};
@@ -160,6 +160,22 @@ pub struct ClientConfig {
     /// the adopted default in `Info` once that path lands (#497); until then a `Some` request is sent
     /// and decoded by the server but not yet echoed back.
     pub default_ack_level: Option<AckLevel>,
+    /// Whether this client ADVERTISES that it understands the streaming consume tier (Tier-S, #543,
+    /// V2-M1): when `true`, the `Connect` sets the [`CONNECT_FLAG_UNDERSTANDS_STREAMING`] capability
+    /// bit, so the server may serve this connection at Tier-S and honor a Tier-S `default_consume_tier`.
+    /// When `false` (the default, backward-compatible) the client does not advertise it and is ALWAYS
+    /// served Tier-W — byte-for-byte today's behavior — and any Tier-S default it set is ignored. A
+    /// caller checks [`Client::streaming_enabled`] after connecting to learn whether the server
+    /// confirmed it.
+    pub understands_streaming: bool,
+    /// The connection-wide DEFAULT consume tier this client REQUESTS in its `Connect` handshake body
+    /// (#543, V2-M1), or `None` to defer to the server default (Tier-W). When `Some(tier)`,
+    /// `connect_with` sends the raw tier value (see [`ConsumeTier::as_u8`]) so a subscription that does
+    /// not pick its own tier adopts this default server-side. Only HONORED when `understands_streaming`
+    /// is also `true`; a Tier-S default without the capability is ignored. `None` (the default,
+    /// backward-compatible) sends no default tier, so the body carries no tier byte and the server
+    /// applies Tier-W.
+    pub default_consume_tier: Option<ConsumeTier>,
 }
 
 impl Default for ClientConfig {
@@ -181,6 +197,14 @@ impl Default for ClientConfig {
             // it sends a byte-for-byte pre-#494 `Connect` body and the server applies its own default
             // (#494, #496). A caller opts into a connection default by setting this.
             default_ack_level: None,
+            // Off by default: an unconfigured client does not advertise streaming support, so it is
+            // always served Tier-W exactly as before (#543). A caller that wants the streaming tier
+            // opts in by setting this (and typically a Tier-S `default_consume_tier`).
+            understands_streaming: false,
+            // None by default: an unconfigured client requests no connection-wide default consume tier,
+            // so it sends no tier byte and the server applies Tier-W (#543). A caller opts into a
+            // connection default by setting this AND `understands_streaming`.
+            default_consume_tier: None,
         }
     }
 }
@@ -569,6 +593,15 @@ pub struct Client {
     /// (an old server, or the client did not advertise), a skipped span arrives in
     /// [`Fetch::truncations`] as the legacy advisory.
     gap_marker_enabled: bool,
+    /// Whether the streaming consume tier (Tier-S) is ACTIVE on this connection (#543, V2-M1): `true`
+    /// only when this client advertised it ([`ClientConfig::understands_streaming`]) AND the server
+    /// confirmed it in `Info`. When `false` (an old server, or the client did not advertise), this
+    /// connection is only ever served Tier-W.
+    streaming_enabled: bool,
+    /// The connection-wide DEFAULT consume tier the SERVER adopted for this connection (#543, V2-M1),
+    /// echoed in `Info`, or `None` if the server did not echo one (an old server, or it defaulted to
+    /// Tier-W). A subscription that does not pick its own tier consumes at this default server-side.
+    negotiated_default_tier: Option<ConsumeTier>,
     /// Level-2 `ProduceConfirm`s (#497) that arrived for an offset OTHER than the one a
     /// [`Client::produce_confirmed`] call was awaiting, cached so a later call for that offset returns
     /// without re-waiting. Bounded in practice by the number of in-flight L2 produces a single
@@ -607,6 +640,8 @@ impl Client {
             negotiated_credit: None,
             negotiated_credit_bytes: None,
             gap_marker_enabled: false,
+            streaming_enabled: false,
+            negotiated_default_tier: None,
             confirm_cache: Vec::new(),
         };
         // The #292 handshake: send a versioned Connect body carrying any requested credit (an
@@ -624,6 +659,11 @@ impl Client {
                 // the body is byte-for-byte the pre-#494 `Connect`; `Some(level)` negotiates the
                 // connection default a level-less publish then adopts server-side.
                 default_ack_level: config.default_ack_level.map(AckLevel::as_u8),
+                // The streaming-tier capability bit and connection-wide default consume tier (#543).
+                // Off/None by default, so the body carries no tier byte and the connection stays Tier-W
+                // (byte-for-byte today's behavior); a caller opts in via the config.
+                understands_streaming: config.understands_streaming,
+                default_tier: config.default_consume_tier.map(ConsumeTier::as_u8),
             },
             &mut connect_body,
         );
@@ -640,6 +680,12 @@ impl Client {
                 // The gap-marker capability is active only when the server CONFIRMED it (it does so
                 // only when the client advertised it), so an old server's empty Info leaves it off.
                 client.gap_marker_enabled = info.gap_marker;
+                // The streaming tier is active only when the server CONFIRMED it (it does so only when
+                // the client advertised it understands streaming), so an old server's empty Info leaves
+                // it off and the connection stays Tier-W (#543). The echoed default tier is adopted as
+                // the connection default a tier-less subscription consumes at.
+                client.streaming_enabled = info.streaming;
+                client.negotiated_default_tier = info.default_tier.map(ConsumeTier::from_u8);
                 Ok(client)
             }
             (FrameType::Err, body) => {
@@ -673,6 +719,23 @@ impl Client {
     #[must_use]
     pub fn gap_marker_enabled(&self) -> bool {
         self.gap_marker_enabled
+    }
+
+    /// Whether the streaming consume tier (Tier-S) is ACTIVE on this connection (#543, V2-M1): `true`
+    /// only when this client advertised it ([`ClientConfig::understands_streaming`]) AND the server
+    /// confirmed it in `Info`. When `false` (an old server, or the client did not advertise), this
+    /// connection is only ever served Tier-W.
+    #[must_use]
+    pub fn streaming_enabled(&self) -> bool {
+        self.streaming_enabled
+    }
+
+    /// The connection-wide DEFAULT consume tier the server adopted for this connection (#543, V2-M1),
+    /// echoed in `Info`, or `None` if the server did not echo one (an old server, or it defaulted to
+    /// Tier-W). A subscription that does not pick its own tier consumes at this default server-side.
+    #[must_use]
+    pub fn negotiated_default_tier(&self) -> Option<ConsumeTier> {
+        self.negotiated_default_tier
     }
 
     /// Resolves `addr` and connects to the first address that accepts, honoring an optional
@@ -3416,6 +3479,8 @@ mod tests {
                 credit_bytes: None,
                 gap_marker: true,
                 default_ack_level: None,
+                streaming: false,
+                default_tier: None,
             },
             &mut body,
         );

--- a/crates/ironbus-proto/src/message.rs
+++ b/crates/ironbus-proto/src/message.rs
@@ -237,6 +237,52 @@ pub fn pub_ack_level(flags: u8) -> AckLevel {
     }
 }
 
+/// The consume TIER a consumer reads a log at (#543, V2-M1, the consume spine of #544). The storage
+/// log is identical for both tiers; only the per-CONSUMER consume bookkeeping differs, so the tier is
+/// a per-consumer choice the broker honors per subscription, never a per-stream property. It rides the
+/// `Connect`/`Info` handshake as a connection-wide DEFAULT (see [`ConnectBody::default_tier`]) which a
+/// subscription adopts unless it explicitly picks a tier (the #544 per-subscription selection still
+/// overrides). PROTO/CODEC + SELECTION metadata only: it changes no storage and no ack/durability path.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum ConsumeTier {
+    /// Tier-W (work-queue): the existing default — per-message lease + generation fence + visibility
+    /// timeout + per-message ack + DLQ + key-shared. This is today's behavior EXACTLY and the DEFAULT,
+    /// so a connection that negotiates nothing (and an old client) consumes at Tier-W, byte-for-byte
+    /// unchanged.
+    #[default]
+    Work,
+    /// Tier-S (streaming, #544): the CONSUMER manages its own offset; the broker serves a contiguous
+    /// batch with no per-record lease/fence/cursor write, and the ack is a periodic cumulative
+    /// `StreamCommit`. A connection reaches Tier-S only when it advertised it UNDERSTANDS streaming (the
+    /// [`CONNECT_FLAG_UNDERSTANDS_STREAMING`] capability bit), so a pre-streaming client never lands here.
+    Streaming,
+}
+
+impl ConsumeTier {
+    /// The raw `u8` this tier encodes into the appended `default_tier` byte of the handshake bodies
+    /// (`0` = Tier-W, `1` = Tier-S). Carried raw so a FUTURE tier the proto does not yet name still
+    /// round-trips the wire as an opaque byte.
+    #[must_use]
+    pub fn as_u8(self) -> u8 {
+        match self {
+            ConsumeTier::Work => 0,
+            ConsumeTier::Streaming => 1,
+        }
+    }
+
+    /// Folds a raw handshake `default_tier` byte into a [`ConsumeTier`]: `1` is Tier-S; EVERYTHING else
+    /// — `0` (the explicit Tier-W / old-client encoding) and any RESERVED future value — folds to the
+    /// safe Tier-W default rather than erroring, so the field can grow without a wire break and a peer
+    /// that names a tier this build does not understand degrades to today's work-queue behavior.
+    #[must_use]
+    pub fn from_u8(raw: u8) -> ConsumeTier {
+        match raw {
+            1 => ConsumeTier::Streaming,
+            _ => ConsumeTier::Work,
+        }
+    }
+}
+
 /// The opt-in dedup metadata a producer attaches to a PUB to request effectively-once dedup
 /// (#33): a `producer_id` (the dedup identity; empty is the anonymous/session-scoped default),
 /// a monotonic `epoch` (the fencing token; a higher epoch fences an older zombie session), and
@@ -873,6 +919,28 @@ pub const CONNECT_FLAG_WANTS_GAP_MARKER: u8 = 0b0000_0100;
 /// compatible (an old body omits the byte and leaves this bit clear).
 pub const CONNECT_FLAG_HAS_DEFAULT_ACK_LEVEL: u8 = 0b0000_1000;
 
+/// The `Connect` CAPABILITY bit (#543, V2-M1) by which a consumer advertises that it UNDERSTANDS the
+/// streaming consume tier (Tier-S: the `StreamFetch`/`StreamCommit` consumer-managed-offset path, #544).
+/// When set, the server may serve this connection at Tier-S — including honoring a Tier-S
+/// [`ConnectBody::default_tier`] so an unmarked subscription streams. When CLEAR (an old client, or one
+/// that opts out) the connection ALWAYS consumes at Tier-W (the work-queue default), byte-for-byte
+/// today's behavior, and a Tier-S default it might have sent is ignored — a pre-streaming client can
+/// never be silently moved onto a tier it does not understand. Like [`CONNECT_FLAG_WANTS_GAP_MARKER`]
+/// it is a pure capability flag (no associated value), so it occupies no slot in the v1 field block
+/// beyond this `flags` bit.
+pub const CONNECT_FLAG_UNDERSTANDS_STREAMING: u8 = 0b0001_0000;
+
+/// The `Connect` presence-flag bit (#543, V2-M1) signalling that a `default_tier` (the connection-wide
+/// default consume tier a subscription adopts when it does not pick its own) is present and meaningful.
+/// When clear (an old client, or one that defers) the client requests NO default tier and the server
+/// applies Tier-W (the work-queue default). The tier VALUE is an APPENDED v1-block byte (see
+/// [`ConnectBody`], folded via [`ConsumeTier::from_u8`]); this presence bit governs only whether that
+/// byte is meaningful, mirroring [`CONNECT_FLAG_HAS_DEFAULT_ACK_LEVEL`], so the field is
+/// forward+backward compatible (an old body omits the byte and leaves this bit clear). The default is
+/// only HONORED when the streaming capability bit ([`CONNECT_FLAG_UNDERSTANDS_STREAMING`]) is also set;
+/// a default of Tier-S without the capability bit is ignored (the connection stays Tier-W).
+pub const CONNECT_FLAG_HAS_DEFAULT_TIER: u8 = 0b0010_0000;
+
 /// The `Info` presence-flag bit signalling that the server's advertised per-consumer message-credit
 /// fields (`negotiated` + `cap`) are present (#292). A server that does not advertise leaves it clear,
 /// and a client then keeps its own local credit (backward-compat).
@@ -897,6 +965,22 @@ pub const INFO_FLAG_GAP_MARKER: u8 = 0b0000_0100;
 /// only whether it is meaningful, so the field is forward+backward compatible.
 pub const INFO_FLAG_HAS_DEFAULT_ACK_LEVEL: u8 = 0b0000_1000;
 
+/// The `Info` CAPABILITY bit (#543, V2-M1) by which the server CONFIRMS this connection may consume at
+/// the streaming tier (Tier-S): `true` only when the client advertised
+/// [`CONNECT_FLAG_UNDERSTANDS_STREAMING`] AND the server supports the tier. When clear (an old server,
+/// or a client that did not advertise) the client knows it will only ever be served Tier-W and keeps
+/// using the work-queue path. The negotiation is AND, the server->client twin of
+/// [`CONNECT_FLAG_UNDERSTANDS_STREAMING`], mirroring the [`INFO_FLAG_GAP_MARKER`] confirmation.
+pub const INFO_FLAG_STREAMING: u8 = 0b0001_0000;
+
+/// The `Info` presence-flag bit (#543, V2-M1) by which the server ECHOES the connection-wide
+/// `default_tier` it adopted for this connection, the server->client twin of
+/// [`CONNECT_FLAG_HAS_DEFAULT_TIER`]. When clear (an old server, or one that defaulted to Tier-W) the
+/// client reads no default-tier echo. The tier VALUE is an APPENDED v1-block byte (see [`InfoBody`],
+/// folded via [`ConsumeTier::from_u8`]); this presence bit governs only whether it is meaningful,
+/// mirroring [`INFO_FLAG_HAS_DEFAULT_ACK_LEVEL`], so the field is forward+backward compatible.
+pub const INFO_FLAG_HAS_DEFAULT_TIER: u8 = 0b0010_0000;
+
 /// A client's handshake request (the `Connect` frame body, #292). The client MAY request a
 /// per-consumer message credit and/or byte budget; the server clamps each to its own cap and replies
 /// the negotiated value in [`InfoBody`]. A field is REQUESTED only when its presence bit is set in
@@ -907,11 +991,14 @@ pub const INFO_FLAG_HAS_DEFAULT_ACK_LEVEL: u8 = 0b0000_1000;
 /// Layout (version-prefixed, length-prefixed, forward-compatible): `body_version: u8`
 /// ([`HANDSHAKE_BODY_VERSION`]), `field_len: u16` (the length of the v1 known-field block that
 /// follows), then the v1 block: `flags: u8`, `requested_credit: u32 LE`, `requested_credit_bytes:
-/// u64 LE`, and then — ONLY when [`CONNECT_FLAG_HAS_DEFAULT_ACK_LEVEL`] is set — an APPENDED
-/// `default_ack_level: u8` (#494). The ack-level byte is OMITTED (and `field_len` is the historical
-/// length) when the field is absent, so a request without it is byte-for-byte the pre-#494 body. Any
-/// bytes past `field_len` (a FUTURE version's appended fields, e.g. the #71 `wire_protocol_version`)
-/// are TOLERATED and ignored by a v1 reader. An empty body is the all-absent default.
+/// u64 LE`, then — each ONLY when its presence bit is set, in this fixed order — an APPENDED
+/// `default_ack_level: u8` (#494, when [`CONNECT_FLAG_HAS_DEFAULT_ACK_LEVEL`]) and an APPENDED
+/// `default_tier: u8` (#543, when [`CONNECT_FLAG_HAS_DEFAULT_TIER`]). Each appended byte is OMITTED
+/// (and `field_len` shrinks by it) when its field is absent; the encoder and decoder walk them in the
+/// SAME conditional order, so an absent earlier byte never shifts a present later one. A request with
+/// neither appended byte is byte-for-byte the historical body. Any bytes past `field_len` (a FUTURE
+/// version's appended fields, e.g. the #71 `wire_protocol_version`) are TOLERATED and ignored by a v1
+/// reader. An empty body is the all-absent default.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct ConnectBody {
     /// The per-consumer message credit the client requests, or `None` to defer to the server default.
@@ -931,34 +1018,50 @@ pub struct ConnectBody {
     /// the pre-#494 body and an old client (which never sets the presence bit) decodes to `None`. The
     /// value is carried raw as a `u8` so a future level the proto does not yet name still round-trips.
     pub default_ack_level: Option<u8>,
+    /// Whether this consumer UNDERSTANDS the streaming consume tier (#543, V2-M1): the
+    /// [`CONNECT_FLAG_UNDERSTANDS_STREAMING`] capability bit. When `true`, the server may serve the
+    /// connection at Tier-S and may honor a Tier-S `default_tier`. When `false` (the default, and an
+    /// old client) the connection ALWAYS consumes at Tier-W — byte-for-byte today's behavior — and any
+    /// Tier-S `default_tier` is ignored, so a pre-streaming client is never moved onto a tier it cannot
+    /// follow. A pure capability flag, so it adds no block slot beyond its `flags` bit.
+    pub understands_streaming: bool,
+    /// The connection-wide DEFAULT consume tier the client requests (#543, V2-M1): the raw value folded
+    /// via [`ConsumeTier::from_u8`] (`0` = Tier-W, `1` = Tier-S) a SUBSCRIPTION adopts when it does not
+    /// pick its own tier. `None` (an old client, or one that defers) means the server applies Tier-W,
+    /// the work-queue default. APPENDED v1 field mirroring `default_ack_level`: emitted only when
+    /// `Some`, so a `None` request keeps the body byte-for-byte the layout without it, and an old client
+    /// decodes to `None`. The default is only HONORED when `understands_streaming` is also set; a
+    /// Tier-S default without the capability is ignored. The value is carried raw as a `u8` so a future
+    /// tier the proto does not yet name still round-trips.
+    pub default_tier: Option<u8>,
 }
 
-/// The number of bytes in the `Connect` v1 known-field block WITHOUT the appended `default_ack_level`
-/// byte (#494): `flags: u8` + `requested_credit: u32` + `requested_credit_bytes: u64`. This is the
-/// historical, pre-#494 block length, emitted whenever `default_ack_level` is `None` so the body is
-/// byte-for-byte the old one.
+/// The number of bytes in the `Connect` v1 known-field block with NO appended bytes (#494, #543):
+/// `flags: u8` + `requested_credit: u32` + `requested_credit_bytes: u64`. This is the historical,
+/// pre-appended-byte block length; each present appended byte (`default_ack_level`, then
+/// `default_tier`) adds exactly one to it, so an all-absent request is byte-for-byte the old body.
 const CONNECT_V1_FIELD_LEN: u16 = 1 + 4 + 8;
 
-/// The `Connect` v1 block length WITH the appended `default_ack_level` byte (#494): the historical
-/// block plus one byte, emitted only when the field is present.
-const CONNECT_V1_FIELD_LEN_WITH_ACK_LEVEL: u16 = CONNECT_V1_FIELD_LEN + 1;
-
-/// Encodes a `Connect` body onto the end of `out` (#292, #494). The result is the version byte, the v1
-/// field-block length, then the v1 block; an all-`None` request still encodes a well-formed
+/// Encodes a `Connect` body onto the end of `out` (#292, #494, #543). The result is the version byte,
+/// the v1 field-block length, then the v1 block; an all-`None` request still encodes a well-formed
 /// (non-empty) v1 body whose presence flags are clear, which the server reads as "use my defaults".
-/// The `default_ack_level` byte (#494) is APPENDED to the block ONLY when present, and `field_len`
-/// grows by exactly that byte; when absent the body is byte-for-byte the pre-#494 layout. To emit the
-/// historical EMPTY `Connect` body (the old-client case) the caller simply sends an empty body and
-/// does NOT call this; [`decode_connect`] accepts both.
+/// The appended `default_ack_level` (#494) and `default_tier` (#543) bytes are each APPENDED to the
+/// block ONLY when present, in that fixed order, and `field_len` grows by exactly the present bytes;
+/// when both are absent the body is byte-for-byte the historical layout. To emit the historical EMPTY
+/// `Connect` body (the old-client case) the caller simply sends an empty body and does NOT call this;
+/// [`decode_connect`] accepts both.
 pub fn encode_connect(req: &ConnectBody, out: &mut Vec<u8>) {
     out.push(HANDSHAKE_BODY_VERSION);
-    // The block length depends ONLY on whether the appended ack-level byte is present, so a request
-    // without it encodes the historical length and bytes (byte-identity, #494).
-    let field_len = if req.default_ack_level.is_some() {
-        CONNECT_V1_FIELD_LEN_WITH_ACK_LEVEL
-    } else {
-        CONNECT_V1_FIELD_LEN
-    };
+    // The block length is the historical fixed block plus ONE byte for each present appended field, in
+    // declared order (ack-level, then tier). An all-absent request encodes the historical length and
+    // bytes verbatim (byte-identity, #494/#543).
+    let mut field_len = CONNECT_V1_FIELD_LEN;
+    if req.default_ack_level.is_some() {
+        field_len += 1;
+    }
+    if req.default_tier.is_some() {
+        field_len += 1;
+    }
     out.extend_from_slice(&field_len.to_le_bytes());
     let mut flags = 0u8;
     if req.requested_credit.is_some() {
@@ -973,13 +1076,23 @@ pub fn encode_connect(req: &ConnectBody, out: &mut Vec<u8>) {
     if req.default_ack_level.is_some() {
         flags |= CONNECT_FLAG_HAS_DEFAULT_ACK_LEVEL;
     }
+    if req.understands_streaming {
+        flags |= CONNECT_FLAG_UNDERSTANDS_STREAMING;
+    }
+    if req.default_tier.is_some() {
+        flags |= CONNECT_FLAG_HAS_DEFAULT_TIER;
+    }
     out.push(flags);
     out.extend_from_slice(&req.requested_credit.unwrap_or(0).to_le_bytes());
     out.extend_from_slice(&req.requested_credit_bytes.unwrap_or(0).to_le_bytes());
-    // The appended ack-level byte is emitted LAST in the block and ONLY when present, so the historical
-    // fields keep their exact offsets and a `None` request omits the byte entirely (#494).
+    // The appended bytes follow the historical fixed fields, each ONLY when present, in declared order
+    // (ack-level, then tier). The decoder reads them in the SAME conditional order, so an absent earlier
+    // byte never shifts a present later one and the historical fields keep their exact offsets.
     if let Some(level) = req.default_ack_level {
         out.push(level);
+    }
+    if let Some(tier) = req.default_tier {
+        out.push(tier);
     }
 }
 
@@ -1028,15 +1141,22 @@ pub fn decode_connect(body: &[u8]) -> Result<ConnectBody, BodyError> {
     // set the bit but truncated the block.
     let default_ack_level =
         (flags & CONNECT_FLAG_HAS_DEFAULT_ACK_LEVEL != 0).then(|| fr.u8().unwrap_or(0));
+    // The appended tier byte (#543) follows the ack-level byte in the SAME conditional order the
+    // encoder wrote them, so a present tier byte is read from the right offset whether or not the
+    // ack-level byte preceded it. Read AFTER ack-level; a clear bit (or short block) reads no byte.
+    let default_tier = (flags & CONNECT_FLAG_HAS_DEFAULT_TIER != 0).then(|| fr.u8().unwrap_or(0));
     let requested_credit = (flags & CONNECT_FLAG_HAS_CREDIT != 0).then_some(credit);
     let requested_credit_bytes =
         (flags & CONNECT_FLAG_HAS_CREDIT_BYTES != 0).then_some(credit_bytes);
     let wants_gap_marker = flags & CONNECT_FLAG_WANTS_GAP_MARKER != 0;
+    let understands_streaming = flags & CONNECT_FLAG_UNDERSTANDS_STREAMING != 0;
     Ok(ConnectBody {
         requested_credit,
         requested_credit_bytes,
         wants_gap_marker,
         default_ack_level,
+        understands_streaming,
+        default_tier,
     })
 }
 
@@ -1061,11 +1181,12 @@ pub struct CreditAdvert<T> {
 ///
 /// Layout (the same version/length framing as [`ConnectBody`]): `body_version: u8`, `field_len: u16`,
 /// then the v1 block: `flags: u8`, `credit.negotiated: u32 LE`, `credit.cap: u32 LE`,
-/// `credit_bytes.negotiated: u64 LE`, `credit_bytes.cap: u64 LE`, and then — ONLY when
-/// [`INFO_FLAG_HAS_DEFAULT_ACK_LEVEL`] is set — an APPENDED `default_ack_level: u8` (#494). The
-/// ack-level byte is OMITTED (and `field_len` is the historical length) when absent, so an
-/// advertisement without it is byte-for-byte the pre-#494 body. Trailing bytes past the block are a
-/// future version's fields, tolerated and ignored. An empty body is the all-absent case.
+/// `credit_bytes.negotiated: u64 LE`, `credit_bytes.cap: u64 LE`, then — each ONLY when its presence
+/// bit is set, in this fixed order — an APPENDED `default_ack_level: u8` (#494, when
+/// [`INFO_FLAG_HAS_DEFAULT_ACK_LEVEL`]) and an APPENDED `default_tier: u8` (#543, when
+/// [`INFO_FLAG_HAS_DEFAULT_TIER`]). Each appended byte is OMITTED (and `field_len` shrinks by it) when
+/// absent; an advertisement with neither is byte-for-byte the historical body. Trailing bytes past the
+/// block are a future version's fields, tolerated and ignored. An empty body is the all-absent case.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct InfoBody {
     /// The server's per-consumer message-credit advertisement, or `None` if the server does not
@@ -1086,31 +1207,43 @@ pub struct InfoBody {
     /// client keeps whatever default it requested. APPENDED v1 field: emitted only when `Some`, so a
     /// `None` advertisement is byte-for-byte the pre-#494 body and an old server decodes to `None`.
     pub default_ack_level: Option<u8>,
+    /// Whether the server CONFIRMS this connection may consume at the streaming tier (#543, V2-M1): the
+    /// [`INFO_FLAG_STREAMING`] capability echo, the server->client twin of
+    /// [`ConnectBody::understands_streaming`]. `true` only when the client advertised it understands
+    /// streaming AND the server supports the tier. `false` (an old server, or a client that did not
+    /// advertise) tells the client it will only ever be served Tier-W.
+    pub streaming: bool,
+    /// The connection-wide DEFAULT consume tier the server ECHOES for this connection (#543, V2-M1), the
+    /// server->client twin of [`ConnectBody::default_tier`]: the raw value folded via
+    /// [`ConsumeTier::from_u8`] (`0` = Tier-W, `1` = Tier-S). `None` (an old server, or one that
+    /// defaulted to Tier-W) means no echo. APPENDED v1 field mirroring `default_ack_level`: emitted only
+    /// when `Some`, so a `None` advertisement is byte-for-byte the body without it.
+    pub default_tier: Option<u8>,
 }
 
-/// The number of bytes in the `Info` v1 known-field block WITHOUT the appended `default_ack_level`
-/// byte (#494): `flags: u8` + `credit.negotiated: u32` + `credit.cap: u32` + `credit_bytes.negotiated:
-/// u64` + `credit_bytes.cap: u64`. This is the historical, pre-#494 block length.
+/// The number of bytes in the `Info` v1 known-field block with NO appended bytes (#494, #543):
+/// `flags: u8` + `credit.negotiated: u32` + `credit.cap: u32` + `credit_bytes.negotiated: u64` +
+/// `credit_bytes.cap: u64`. This is the historical, pre-appended-byte block length; each present
+/// appended byte (`default_ack_level`, then `default_tier`) adds exactly one to it.
 const INFO_V1_FIELD_LEN: u16 = 1 + 4 + 4 + 8 + 8;
 
-/// The `Info` v1 block length WITH the appended `default_ack_level` byte (#494): the historical block
-/// plus one byte, emitted only when the field is present.
-const INFO_V1_FIELD_LEN_WITH_ACK_LEVEL: u16 = INFO_V1_FIELD_LEN + 1;
-
-/// Encodes an `Info` body onto the end of `out` (#292, #494): the version byte, the v1 field-block
-/// length, then the v1 block. An all-`None` advertisement still encodes a well-formed (non-empty) v1
-/// body whose presence flags are clear, which a client reads as "no advertisement, keep my local
-/// credit". The `default_ack_level` byte (#494) is APPENDED to the block ONLY when present, and
-/// `field_len` grows by exactly that byte; when absent the body is byte-for-byte the pre-#494 layout.
-/// To emit the historical EMPTY `Info` body (the old-server case) the caller sends an empty body and
-/// does NOT call this; [`decode_info`] accepts both.
+/// Encodes an `Info` body onto the end of `out` (#292, #494, #543): the version byte, the v1
+/// field-block length, then the v1 block. An all-`None` advertisement still encodes a well-formed
+/// (non-empty) v1 body whose presence flags are clear, which a client reads as "no advertisement, keep
+/// my local credit". The appended `default_ack_level` (#494) and `default_tier` (#543) bytes are each
+/// APPENDED to the block ONLY when present, in that fixed order, and `field_len` grows by exactly the
+/// present bytes; when both are absent the body is byte-for-byte the historical layout. To emit the
+/// historical EMPTY `Info` body (the old-server case) the caller sends an empty body and does NOT call
+/// this; [`decode_info`] accepts both.
 pub fn encode_info(info: &InfoBody, out: &mut Vec<u8>) {
     out.push(HANDSHAKE_BODY_VERSION);
-    let field_len = if info.default_ack_level.is_some() {
-        INFO_V1_FIELD_LEN_WITH_ACK_LEVEL
-    } else {
-        INFO_V1_FIELD_LEN
-    };
+    let mut field_len = INFO_V1_FIELD_LEN;
+    if info.default_ack_level.is_some() {
+        field_len += 1;
+    }
+    if info.default_tier.is_some() {
+        field_len += 1;
+    }
     out.extend_from_slice(&field_len.to_le_bytes());
     let mut flags = 0u8;
     if info.credit.is_some() {
@@ -1125,6 +1258,12 @@ pub fn encode_info(info: &InfoBody, out: &mut Vec<u8>) {
     if info.default_ack_level.is_some() {
         flags |= INFO_FLAG_HAS_DEFAULT_ACK_LEVEL;
     }
+    if info.streaming {
+        flags |= INFO_FLAG_STREAMING;
+    }
+    if info.default_tier.is_some() {
+        flags |= INFO_FLAG_HAS_DEFAULT_TIER;
+    }
     out.push(flags);
     let credit = info.credit.unwrap_or(CreditAdvert {
         negotiated: 0,
@@ -1138,10 +1277,14 @@ pub fn encode_info(info: &InfoBody, out: &mut Vec<u8>) {
     });
     out.extend_from_slice(&credit_bytes.negotiated.to_le_bytes());
     out.extend_from_slice(&credit_bytes.cap.to_le_bytes());
-    // The appended ack-level byte is emitted LAST in the block and ONLY when present, so the historical
-    // fields keep their exact offsets and a `None` advertisement omits the byte entirely (#494).
+    // The appended bytes follow the historical fixed fields, each ONLY when present, in declared order
+    // (ack-level, then tier), exactly as the decoder reads them, so an absent earlier byte never shifts
+    // a present later one and the historical fields keep their exact offsets.
     if let Some(level) = info.default_ack_level {
         out.push(level);
+    }
+    if let Some(tier) = info.default_tier {
+        out.push(tier);
     }
 }
 
@@ -1182,6 +1325,9 @@ pub fn decode_info(body: &[u8]) -> Result<InfoBody, BodyError> {
     // byte and defaults to `None`.
     let default_ack_level =
         (flags & INFO_FLAG_HAS_DEFAULT_ACK_LEVEL != 0).then(|| fr.u8().unwrap_or(0));
+    // The appended tier byte (#543) follows the ack-level byte in the SAME conditional order the
+    // encoder wrote them, read AFTER ack-level; a clear bit (or short block) reads no byte.
+    let default_tier = (flags & INFO_FLAG_HAS_DEFAULT_TIER != 0).then(|| fr.u8().unwrap_or(0));
     let credit = (flags & INFO_FLAG_HAS_CREDIT != 0).then_some(CreditAdvert {
         negotiated: credit_negotiated,
         cap: credit_cap,
@@ -1191,11 +1337,14 @@ pub fn decode_info(body: &[u8]) -> Result<InfoBody, BodyError> {
         cap: credit_bytes_cap,
     });
     let gap_marker = flags & INFO_FLAG_GAP_MARKER != 0;
+    let streaming = flags & INFO_FLAG_STREAMING != 0;
     Ok(InfoBody {
         credit,
         credit_bytes,
         gap_marker,
         default_ack_level,
+        streaming,
+        default_tier,
     })
 }
 
@@ -1538,6 +1687,8 @@ mod tests {
             requested_credit_bytes: None,
             wants_gap_marker: true,
             default_ack_level: None,
+            understands_streaming: false,
+            default_tier: None,
         };
         let mut buf = Vec::new();
         encode_connect(&req, &mut buf);
@@ -1559,6 +1710,8 @@ mod tests {
             credit_bytes: None,
             gap_marker: true,
             default_ack_level: None,
+            streaming: false,
+            default_tier: None,
         };
         let mut buf = Vec::new();
         encode_info(&info, &mut buf);
@@ -2279,8 +2432,10 @@ mod tests {
             credit_bytes in proptest::option::of(any::<u64>()),
             wants_gap_marker in any::<bool>(),
             default_ack_level in proptest::option::of(any::<u8>()),
+            understands_streaming in any::<bool>(),
+            default_tier in proptest::option::of(any::<u8>()),
         ) {
-            let req = ConnectBody { requested_credit: credit, requested_credit_bytes: credit_bytes, wants_gap_marker, default_ack_level };
+            let req = ConnectBody { requested_credit: credit, requested_credit_bytes: credit_bytes, wants_gap_marker, default_ack_level, understands_streaming, default_tier };
             let mut buf = Vec::new();
             encode_connect(&req, &mut buf);
             prop_assert_eq!(buf[0], HANDSHAKE_BODY_VERSION, "the body leads with its version");
@@ -2288,20 +2443,25 @@ mod tests {
         }
 
         /// An Info body round-trips for any combination of present/absent advertised credit and byte
-        /// budget (#292), the gap-marker capability bit (#346), and the appended `default_ack_level`
-        /// (#494): each survives the round-trip.
+        /// budget (#292), the gap-marker capability bit (#346), the appended `default_ack_level`
+        /// (#494), the streaming capability bit and the appended `default_tier` (#543): each survives
+        /// the round-trip, including BOTH appended bytes present together at independent offsets.
         #[test]
         fn any_info_round_trips(
             credit in proptest::option::of((any::<u32>(), any::<u32>())),
             credit_bytes in proptest::option::of((any::<u64>(), any::<u64>())),
             gap_marker in any::<bool>(),
             default_ack_level in proptest::option::of(any::<u8>()),
+            streaming in any::<bool>(),
+            default_tier in proptest::option::of(any::<u8>()),
         ) {
             let info = InfoBody {
                 credit: credit.map(|(negotiated, cap)| CreditAdvert { negotiated, cap }),
                 credit_bytes: credit_bytes.map(|(negotiated, cap)| CreditAdvert { negotiated, cap }),
                 gap_marker,
                 default_ack_level,
+                streaming,
+                default_tier,
             };
             let mut buf = Vec::new();
             encode_info(&info, &mut buf);
@@ -2330,7 +2490,7 @@ mod tests {
             credit in proptest::option::of(any::<u32>()),
             trailing in prop::collection::vec(any::<u8>(), 0..64),
         ) {
-            let req = ConnectBody { requested_credit: credit, requested_credit_bytes: None, wants_gap_marker: false, default_ack_level: None };
+            let req = ConnectBody { requested_credit: credit, requested_credit_bytes: None, wants_gap_marker: false, default_ack_level: None, understands_streaming: false, default_tier: None };
             let mut buf = Vec::new();
             encode_connect(&req, &mut buf);
             let mut extended = buf.clone();
@@ -2342,6 +2502,8 @@ mod tests {
                 credit_bytes: None,
                 gap_marker: false,
                 default_ack_level: None,
+                streaming: false,
+                default_tier: None,
             };
             let mut ibuf = Vec::new();
             encode_info(&info, &mut ibuf);
@@ -2413,6 +2575,8 @@ mod tests {
                 requested_credit_bytes: None,
                 wants_gap_marker: false,
                 default_ack_level: None,
+                understands_streaming: false,
+                default_tier: None,
             }
         );
     }
@@ -2429,6 +2593,8 @@ mod tests {
                 credit_bytes: None,
                 gap_marker: false,
                 default_ack_level: None,
+                streaming: false,
+                default_tier: None,
             }
         );
     }
@@ -2440,6 +2606,8 @@ mod tests {
             requested_credit_bytes: Some(1024),
             wants_gap_marker: true,
             default_ack_level: None,
+            understands_streaming: false,
+            default_tier: None,
         };
         let mut buf = Vec::new();
         encode_connect(&req, &mut buf);
@@ -2464,6 +2632,8 @@ mod tests {
             }),
             gap_marker: true,
             default_ack_level: None,
+            streaming: false,
+            default_tier: None,
         };
         let mut buf = Vec::new();
         encode_info(&info, &mut buf);
@@ -2689,6 +2859,8 @@ mod tests {
             requested_credit_bytes: None,
             wants_gap_marker: false,
             default_ack_level: None,
+            understands_streaming: false,
+            default_tier: None,
         };
         let mut pre = Vec::new();
         encode_connect(&no_level, &mut pre);
@@ -2720,7 +2892,7 @@ mod tests {
         encode_connect(&with_level, &mut buf);
         assert_eq!(
             &buf[1..3],
-            &CONNECT_V1_FIELD_LEN_WITH_ACK_LEVEL.to_le_bytes(),
+            &(CONNECT_V1_FIELD_LEN + 1).to_le_bytes(),
             "a Some default grows field_len by one byte"
         );
         assert_eq!(
@@ -2739,6 +2911,8 @@ mod tests {
             credit_bytes: None,
             gap_marker: false,
             default_ack_level: None,
+            streaming: false,
+            default_tier: None,
         };
         let mut pre = Vec::new();
         encode_info(&no_level, &mut pre);
@@ -2753,7 +2927,7 @@ mod tests {
         };
         let mut buf = Vec::new();
         encode_info(&with_level, &mut buf);
-        assert_eq!(&buf[1..3], &INFO_V1_FIELD_LEN_WITH_ACK_LEVEL.to_le_bytes());
+        assert_eq!(&buf[1..3], &(INFO_V1_FIELD_LEN + 1).to_le_bytes());
         assert_eq!(
             buf[3] & INFO_FLAG_HAS_DEFAULT_ACK_LEVEL,
             INFO_FLAG_HAS_DEFAULT_ACK_LEVEL
@@ -2761,6 +2935,166 @@ mod tests {
         assert_eq!(buf.len(), pre.len() + 1);
         assert_eq!(*buf.last().unwrap(), 2);
         assert_eq!(decode_info(&buf).unwrap(), with_level);
+    }
+
+    #[test]
+    fn connect_carries_the_streaming_capability_and_default_tier_and_old_client_is_byte_identical()
+    {
+        // #543: a streaming-capable consumer sets the capability bit (a pure flags bit, no block byte)
+        // and MAY append a connection-default tier byte. An old client (or one that defers both) leaves
+        // them clear/None, so the body is byte-for-byte the layout WITHOUT them.
+        let none = ConnectBody {
+            requested_credit: Some(7),
+            requested_credit_bytes: None,
+            wants_gap_marker: false,
+            default_ack_level: None,
+            understands_streaming: false,
+            default_tier: None,
+        };
+        let mut pre = Vec::new();
+        encode_connect(&none, &mut pre);
+        assert_eq!(
+            pre[3] & (CONNECT_FLAG_UNDERSTANDS_STREAMING | CONNECT_FLAG_HAS_DEFAULT_TIER),
+            0,
+            "neither the capability nor the default-tier bit is set"
+        );
+        assert_eq!(
+            pre.len(),
+            3 + usize::from(CONNECT_V1_FIELD_LEN),
+            "no appended tier byte"
+        );
+        assert_eq!(decode_connect(&pre).unwrap(), none);
+
+        // The capability bit is a PURE flags bit: setting it adds NO appended byte, so the body length
+        // is unchanged, only the flags bit flips.
+        let cap_only = ConnectBody {
+            understands_streaming: true,
+            ..none
+        };
+        let mut cap_buf = Vec::new();
+        encode_connect(&cap_only, &mut cap_buf);
+        assert_eq!(
+            cap_buf[3] & CONNECT_FLAG_UNDERSTANDS_STREAMING,
+            CONNECT_FLAG_UNDERSTANDS_STREAMING
+        );
+        assert_eq!(
+            cap_buf.len(),
+            pre.len(),
+            "the capability bit appends no byte"
+        );
+        assert_eq!(decode_connect(&cap_buf).unwrap(), cap_only);
+
+        // A streaming-capable client that ALSO requests a Tier-S default appends exactly one tier byte
+        // and sets the default-tier presence bit; the value round-trips via `ConsumeTier::from_u8`.
+        let with_tier = ConnectBody {
+            understands_streaming: true,
+            default_tier: Some(ConsumeTier::Streaming.as_u8()),
+            ..none
+        };
+        let mut buf = Vec::new();
+        encode_connect(&with_tier, &mut buf);
+        assert_eq!(
+            buf[3] & CONNECT_FLAG_HAS_DEFAULT_TIER,
+            CONNECT_FLAG_HAS_DEFAULT_TIER
+        );
+        assert_eq!(buf.len(), pre.len() + 1, "exactly one appended tier byte");
+        assert_eq!(*buf.last().unwrap(), ConsumeTier::Streaming.as_u8());
+        let decoded = decode_connect(&buf).unwrap();
+        assert_eq!(decoded, with_tier);
+        assert_eq!(
+            decoded.default_tier.map(ConsumeTier::from_u8),
+            Some(ConsumeTier::Streaming)
+        );
+    }
+
+    #[test]
+    fn info_echoes_the_streaming_capability_and_default_tier_and_old_server_is_byte_identical() {
+        // #543: the server->client twin. An old server (or one that confirms neither) is byte-for-byte
+        // the layout without the echo; a confirming server flips the capability bit and may append the
+        // echoed default-tier byte.
+        let none = InfoBody {
+            credit: None,
+            credit_bytes: None,
+            gap_marker: false,
+            default_ack_level: None,
+            streaming: false,
+            default_tier: None,
+        };
+        let mut pre = Vec::new();
+        encode_info(&none, &mut pre);
+        assert_eq!(
+            pre[3] & (INFO_FLAG_STREAMING | INFO_FLAG_HAS_DEFAULT_TIER),
+            0
+        );
+        assert_eq!(pre.len(), 3 + usize::from(INFO_V1_FIELD_LEN));
+        assert_eq!(decode_info(&pre).unwrap(), none);
+
+        let with_tier = InfoBody {
+            streaming: true,
+            default_tier: Some(ConsumeTier::Streaming.as_u8()),
+            ..none
+        };
+        let mut buf = Vec::new();
+        encode_info(&with_tier, &mut buf);
+        assert_eq!(buf[3] & INFO_FLAG_STREAMING, INFO_FLAG_STREAMING);
+        assert_eq!(
+            buf[3] & INFO_FLAG_HAS_DEFAULT_TIER,
+            INFO_FLAG_HAS_DEFAULT_TIER
+        );
+        assert_eq!(buf.len(), pre.len() + 1, "exactly one appended tier byte");
+        assert_eq!(*buf.last().unwrap(), ConsumeTier::Streaming.as_u8());
+        assert_eq!(decode_info(&buf).unwrap(), with_tier);
+    }
+
+    #[test]
+    fn connect_with_both_appended_bytes_keeps_them_at_independent_offsets() {
+        // #494 + #543 together: BOTH appended bytes present. They are written in declared order
+        // (ack-level, then tier) and read in the SAME order, so each lands at its own offset and both
+        // round-trip — the appended-byte discipline composes.
+        let both = ConnectBody {
+            requested_credit: None,
+            requested_credit_bytes: None,
+            wants_gap_marker: false,
+            default_ack_level: Some(AckLevel::ServerAndClientAck.as_u8()),
+            understands_streaming: true,
+            default_tier: Some(ConsumeTier::Streaming.as_u8()),
+        };
+        let mut buf = Vec::new();
+        encode_connect(&both, &mut buf);
+        // field_len = historical + 2 appended bytes; the last two block bytes are ack-level then tier.
+        assert_eq!(&buf[1..3], &(CONNECT_V1_FIELD_LEN + 2).to_le_bytes());
+        assert_eq!(buf[buf.len() - 2], AckLevel::ServerAndClientAck.as_u8());
+        assert_eq!(buf[buf.len() - 1], ConsumeTier::Streaming.as_u8());
+        assert_eq!(decode_connect(&buf).unwrap(), both);
+
+        // FORWARD-COMPAT: a future version appends MORE fields past the declared block; a v1 reader
+        // tolerates the trailing bytes and still recovers every v1 field (including both appended bytes).
+        let mut extended = buf.clone();
+        extended.extend_from_slice(&[0xAA, 0xBB, 0xCC]);
+        assert_eq!(
+            decode_connect(&extended).unwrap(),
+            both,
+            "trailing future bytes are ignored, the appended bytes still decode"
+        );
+    }
+
+    #[test]
+    fn consume_tier_folds_unknown_values_to_work() {
+        // A future tier value the proto does not yet name folds to the safe Tier-W default rather than
+        // erroring, so the field can grow without a wire break (mirrors `pub_ack_level`'s reserved-value
+        // handling). Only the exact value 1 is Tier-S.
+        assert_eq!(ConsumeTier::from_u8(0), ConsumeTier::Work);
+        assert_eq!(ConsumeTier::from_u8(1), ConsumeTier::Streaming);
+        for raw in 2u8..=255 {
+            assert_eq!(
+                ConsumeTier::from_u8(raw),
+                ConsumeTier::Work,
+                "an unknown future tier {raw} degrades to Tier-W"
+            );
+        }
+        assert_eq!(ConsumeTier::Work.as_u8(), 0);
+        assert_eq!(ConsumeTier::Streaming.as_u8(), 1);
+        assert_eq!(ConsumeTier::default(), ConsumeTier::Work);
     }
 
     #[test]
@@ -2781,6 +3115,8 @@ mod tests {
                 requested_credit_bytes: None,
                 wants_gap_marker: false,
                 default_ack_level: None,
+                understands_streaming: false,
+                default_tier: None,
             }
         );
 
@@ -2798,6 +3134,8 @@ mod tests {
                 credit_bytes: None,
                 gap_marker: false,
                 default_ack_level: None,
+                streaming: false,
+                default_tier: None,
             }
         );
     }

--- a/crates/ironbus-server/src/session.rs
+++ b/crates/ironbus-server/src/session.rs
@@ -33,7 +33,7 @@ use ironbus_proto::message::{
     decode_ack, decode_connect, decode_cumulative_ack, decode_fetch, decode_pub,
     decode_stream_commit, decode_stream_fetch, decode_sub, encode_dead_letter, encode_deliver,
     encode_gap_marker, encode_info, encode_produce_confirm, encode_pub_ack, encode_truncated,
-    gap_reason, produce_confirm_status, pub_ack_level, AckLevel, AckOp, CreditAdvert,
+    gap_reason, produce_confirm_status, pub_ack_level, AckLevel, AckOp, ConsumeTier, CreditAdvert,
     DeadLetterBody, DeliverBody, GapMarkerBody, InfoBody, ProduceConfirmBody, PubAckBody,
     TruncatedBody, DEAD_LETTER_MAX_DELIVER, PUB_WIRE_ONLY_FLAGS,
 };
@@ -270,6 +270,22 @@ pub struct Session {
     /// double-signal and an old consumer that would error on an unknown frame is never sent the new
     /// tag. Default `false` (backward-compatible).
     gap_marker_enabled: bool,
+    /// Whether this connection negotiated the streaming consume tier (Tier-S, #543, V2-M1): set at
+    /// `Connect` time when the client advertised
+    /// [`ironbus_proto::message::CONNECT_FLAG_UNDERSTANDS_STREAMING`]. When `true`, the connection may be
+    /// served Tier-S — including honoring a Tier-S `default_tier` so an unmarked SUB streams. When
+    /// `false` (an old client, or one that opts out) the connection is ALWAYS Tier-W and any Tier-S
+    /// default is ignored, so a pre-streaming client is never moved onto a tier it cannot follow.
+    /// Default `false` (backward-compatible).
+    streaming_enabled: bool,
+    /// This connection's negotiated DEFAULT consume tier (#543, V2-M1): the tier a SUBSCRIPTION adopts
+    /// when it does not explicitly pick one. Fixed at `Connect` time from the client's `default_tier`
+    /// request, folded via [`ironbus_proto::message::ConsumeTier::from_u8`], and gated by
+    /// `streaming_enabled` — a Tier-S default is only honored when the capability bit was also set, so it
+    /// is forced back to [`ConsumeTier::Work`] otherwise. [`ConsumeTier::Work`] by default (an old
+    /// client, or no request), so an unmarked SUB stays on the work-queue tier exactly as before. An
+    /// explicit per-subscription tier selection (#544) still overrides this default.
+    default_tier: ConsumeTier,
     /// Whether this connection has EVER published a Level-2 (server+client-ack) produce (#497): set
     /// when an L2 publish is registered for confirmation, and NEVER cleared. It is the gate that keeps
     /// the per-pass `ProduceConfirm` drain off the actor for a connection that never opted into Level 2
@@ -574,6 +590,21 @@ impl Session {
         // gap-marker consumer receives `GapMarker` (tag 21) for a skipped span; one that did not
         // advertise keeps the legacy `Truncated` (tag 18), so an old client is never sent the new tag.
         self.gap_marker_enabled = req.wants_gap_marker;
+        // Negotiate the streaming consume tier (#543, V2-M1): the server always SUPPORTS Tier-S, so the
+        // capability is active exactly when this consumer advertised it understands streaming. The
+        // negotiated connection DEFAULT tier is the client's requested `default_tier` (folded from the
+        // raw byte), but ONLY when the capability is active — a Tier-S default from a client that did
+        // NOT advertise the capability is ignored and the connection stays Tier-W, so a pre-streaming
+        // client can never be moved onto a tier it cannot follow. With the capability clear the default
+        // is forced to Tier-W (today's behavior, byte-for-byte).
+        self.streaming_enabled = req.understands_streaming;
+        self.default_tier = if self.streaming_enabled {
+            req.default_tier
+                .map(ConsumeTier::from_u8)
+                .unwrap_or_default()
+        } else {
+            ConsumeTier::Work
+        };
         // The server caps, read LOCALLY off the handle (NO actor round-trip), so the handshake never
         // touches the actor's checkpoint/fsync path and a stalled produce on one connection cannot
         // head-of-line-block this Connect (invariant 4, #177). The caps are static engine config.
@@ -604,6 +635,17 @@ impl Session {
             // yet (that is phase #497), so this stays `None` and the `Info` body is byte-for-byte the
             // pre-#494 layout.
             default_ack_level: None,
+            // Confirm the streaming-tier capability the server activated for this connection (#543), so
+            // the client learns whether it may consume at Tier-S, mirroring the gap-marker confirmation.
+            streaming: self.streaming_enabled,
+            // Echo the negotiated connection-default tier ONLY when it is Tier-S (the streaming-capable
+            // case): a Tier-W default echoes nothing, so a connection that negotiated nothing keeps the
+            // `Info` body byte-for-byte the pre-#543 layout (no tier byte) and an old/Tier-W client sees
+            // no change. The echo is the value a tier-less subscription consumes at.
+            default_tier: match self.default_tier {
+                ConsumeTier::Streaming => Some(ConsumeTier::Streaming.as_u8()),
+                ConsumeTier::Work => None,
+            },
         };
         let mut info_body = Vec::new();
         encode_info(&info, &mut info_body);
@@ -1760,6 +1802,29 @@ impl Session {
             }
         })?;
         self.joined_key_shared = joined;
+        // Apply the connection's negotiated DEFAULT consume tier (#543, V2-M1) to the newly-subscribed
+        // group, so a subscription that does not explicitly pick a tier consumes at the connection
+        // default. This is ADDITIVE — it marks the group streaming ONLY when the connection default is
+        // Tier-S, and NEVER clears the flag — so:
+        //   - a connection with a Tier-W default (the back-compat case, an old client, or no negotiation)
+        //     leaves the group's tier untouched, so it stays Tier-W exactly as before;
+        //   - an EXPLICIT per-subscription Tier-S selection (#544 `set_streaming_in`) is never undone by a
+        //     Tier-W-default connection, so the explicit selection always OVERRIDES the default;
+        //   - a Tier-S default marks the group streaming, which an explicit selection (made out of band
+        //     via #544) may already have done — the mark is idempotent.
+        // The default tier is already gated by the streaming capability bit at Connect (a Tier-S default
+        // is forced to Tier-W when the client did not advertise the capability), so a pre-streaming
+        // client never reaches this branch and its groups stay Tier-W.
+        if self.default_tier == ConsumeTier::Streaming {
+            let sub = self.subscription.clone();
+            // A failure here is surfaced exactly like the key_shared mode enable above: it is best-effort
+            // at SUB time (the streaming fetch path re-checks the mode and rejects a non-streaming group),
+            // so SUB stays infallible for the tier selection and a transient engine error does not strand
+            // the subscription.
+            engine.with(move |e| {
+                let _ = e.set_streaming_in(&sub, true);
+            })?;
+        }
         reply(out, FrameType::Ok, &[]);
         Ok(())
     }
@@ -2438,6 +2503,8 @@ mod tests {
                 requested_credit_bytes: None,
                 wants_gap_marker: true,
                 default_ack_level: None,
+                understands_streaming: false,
+                default_tier: None,
             },
             &mut body,
         );
@@ -3408,6 +3475,162 @@ mod tests {
             delivered_payloads(&out),
             vec![b"a".to_vec(), b"b".to_vec(), b"c".to_vec()],
             "the freed group still delivers every record to its new lone consumer"
+        );
+    }
+
+    /// Builds a `Connect` frame body advertising the streaming capability (#543) and, optionally, a
+    /// connection-default consume tier. For the tier-negotiation session tests.
+    fn tier_connect_body(
+        understands_streaming: bool,
+        default_tier: Option<ConsumeTier>,
+    ) -> Vec<u8> {
+        let mut body = Vec::new();
+        ironbus_proto::message::encode_connect(
+            &ironbus_proto::message::ConnectBody {
+                requested_credit: None,
+                requested_credit_bytes: None,
+                wants_gap_marker: false,
+                default_ack_level: None,
+                understands_streaming,
+                default_tier: default_tier.map(ConsumeTier::as_u8),
+            },
+            &mut body,
+        );
+        body
+    }
+
+    #[test]
+    fn a_streaming_default_connection_marks_an_unmarked_subscription_tier_s() {
+        // #543, V2-M1: a streaming-CAPABLE client that negotiated a Tier-S connection default has its
+        // unmarked SUB automatically placed on the streaming tier, and the server echoes both the
+        // capability and the default in Info. This is the "one log serves both tiers" wiring: the SUB
+        // never explicitly picked a tier, yet it streams because the connection default says so.
+        let e = DirectEngine::new(engine());
+        let mut s = Session::new();
+        let mut out = Vec::new();
+        s.process(
+            &e,
+            &frame(
+                FrameType::Connect,
+                &tier_connect_body(true, Some(ConsumeTier::Streaming)),
+            ),
+            &mut out,
+        )
+        .unwrap();
+        // Info confirms the capability AND echoes the Tier-S default.
+        let (ty, body) = one_response(&out);
+        assert_eq!(ty, FrameType::Info);
+        let info = ironbus_proto::message::decode_info(&body).unwrap();
+        assert!(
+            info.streaming,
+            "the server confirms the streaming capability"
+        );
+        assert_eq!(
+            info.default_tier.map(ConsumeTier::from_u8),
+            Some(ConsumeTier::Streaming),
+            "the server echoes the negotiated Tier-S default"
+        );
+
+        // SUB to a named group WITHOUT picking a tier: it adopts the connection default (Tier-S).
+        out.clear();
+        s.process(&e, &frame(FrameType::Sub, b"orders"), &mut out)
+            .unwrap();
+        assert_eq!(one_response(&out).0, FrameType::Ok);
+        assert!(
+            e.engine_mut().is_streaming_in("orders"),
+            "the unmarked subscription consumes at the connection's Tier-S default"
+        );
+    }
+
+    #[test]
+    fn an_explicit_per_subscription_tier_overrides_the_connection_default() {
+        // #543 + #544: the explicit per-subscription selection (#544 `set_streaming_in`) OVERRIDES the
+        // connection default. A connection whose default is Tier-W (it advertised the capability but
+        // requested no Tier-S default) never un-marks a group that was explicitly placed on Tier-S, so
+        // the explicit choice wins. Symmetrically, a Tier-S default does not require the explicit call.
+        let e = DirectEngine::new(engine());
+        // The explicit per-subscription Tier-S selection lands FIRST (as #544 exposes it on the engine).
+        e.with(|eng| eng.set_streaming_in("orders", true).unwrap())
+            .unwrap();
+        assert!(e.engine_mut().is_streaming_in("orders"));
+
+        // A streaming-capable client with a Tier-W (default) connection default subscribes to it.
+        let mut s = Session::new();
+        let mut out = Vec::new();
+        s.process(
+            &e,
+            &frame(FrameType::Connect, &tier_connect_body(true, None)),
+            &mut out,
+        )
+        .unwrap();
+        let info = ironbus_proto::message::decode_info(&one_response(&out).1).unwrap();
+        assert!(info.streaming, "the capability is confirmed");
+        assert_eq!(
+            info.default_tier, None,
+            "a Tier-W default echoes no tier byte (byte-identical to before)"
+        );
+        out.clear();
+        s.process(&e, &frame(FrameType::Sub, b"orders"), &mut out)
+            .unwrap();
+        assert_eq!(one_response(&out).0, FrameType::Ok);
+        assert!(
+            e.engine_mut().is_streaming_in("orders"),
+            "the explicit per-subscription Tier-S selection is NOT cleared by a Tier-W-default SUB: \
+             the explicit tier overrides the connection default"
+        );
+    }
+
+    #[test]
+    fn a_pre_streaming_client_always_gets_tier_w_even_with_a_tier_s_default() {
+        // BACK-COMPAT: a client that did NOT advertise the streaming capability is ALWAYS served
+        // Tier-W, byte-for-byte today's behavior, EVEN IF its Connect body carried a Tier-S default —
+        // the server ignores a default it cannot honor, so a pre-streaming client can never be moved
+        // onto a tier it does not understand. An old (empty) Connect and a capability-clear Connect
+        // both leave every subscribed group on the work-queue tier.
+        let e = DirectEngine::new(engine());
+
+        // (a) A capability-CLEAR Connect that nonetheless asks for a Tier-S default: ignored.
+        let mut s = Session::new();
+        let mut out = Vec::new();
+        s.process(
+            &e,
+            &frame(
+                FrameType::Connect,
+                &tier_connect_body(false, Some(ConsumeTier::Streaming)),
+            ),
+            &mut out,
+        )
+        .unwrap();
+        let info = ironbus_proto::message::decode_info(&one_response(&out).1).unwrap();
+        assert!(
+            !info.streaming,
+            "the capability is NOT confirmed for a pre-streaming client"
+        );
+        assert_eq!(
+            info.default_tier, None,
+            "a Tier-S default from a capability-clear client is ignored (no echo)"
+        );
+        out.clear();
+        s.process(&e, &frame(FrameType::Sub, b"orders"), &mut out)
+            .unwrap();
+        assert_eq!(one_response(&out).0, FrameType::Ok);
+        assert!(
+            !e.engine_mut().is_streaming_in("orders"),
+            "a pre-streaming client's subscription stays Tier-W despite the Tier-S default"
+        );
+
+        // (b) An OLD (empty) Connect: the historical case, also Tier-W.
+        let mut old = Session::new();
+        let mut out2 = Vec::new();
+        old.process(&e, &frame(FrameType::Connect, b""), &mut out2)
+            .unwrap();
+        out2.clear();
+        old.process(&e, &frame(FrameType::Sub, b"legacy"), &mut out2)
+            .unwrap();
+        assert_eq!(one_response(&out2).0, FrameType::Ok);
+        assert!(
+            !e.engine_mut().is_streaming_in("legacy"),
+            "an old client's subscription is Tier-W, byte-for-byte today's behavior"
         );
     }
 
@@ -5295,6 +5518,8 @@ mod tests {
                 requested_credit_bytes,
                 wants_gap_marker: false,
                 default_ack_level: None,
+                understands_streaming: false,
+                default_tier: None,
             },
             &mut connect_body,
         );
@@ -6675,6 +6900,8 @@ mod tests {
                 requested_credit_bytes: None,
                 wants_gap_marker: false,
                 default_ack_level: None,
+                understands_streaming: false,
+                default_tier: None,
             },
             &mut connect_body,
         );


### PR DESCRIPTION
Closes #548 (V2-M1, [M1-I9] — "one log serves both tiers").

## What

A clean **Connect-level negotiation layer** that lets a single log serve both consume tiers per-consumer, built on the merged #655 (Tier-S StreamFetch/StreamCommit + `set_streaming_in`). The storage log is identical for both tiers; only per-consumer consume bookkeeping differs, so the tier is a per-consumer choice.

### The capability bit + connection default (mirrors #496 `default_ack_level`)
- A client advertises `CONNECT_FLAG_UNDERSTANDS_STREAMING` — a **pure capability flag bit**, exactly like the existing gap-marker bit (no block slot).
- It OPTIONALLY carries a connection **`default_tier`** — an **appended byte** (Tier-W=0 / Tier-S=1), gated by its own presence bit, mirroring #496's `default_ack_level` appended-byte discipline. New `ConsumeTier` enum (`as_u8`/`from_u8`) folds any unknown future value to the safe Tier-W default.
- The server **echoes** the negotiated capability (`INFO_FLAG_STREAMING`) and default (`INFO_FLAG_HAS_DEFAULT_TIER` + appended byte) in `Info`, the server→client twins.

### Selection wiring
- A SUB that does **not** explicitly pick a tier adopts the connection's negotiated default (via `set_streaming_in` at SUB time). The wiring is **additive** — it only ever marks Tier-S, never clears it.
- An **explicit per-subscription tier** (#655's `set_streaming_in`) therefore still **overrides**: a Tier-W-default connection never un-marks an explicitly-streaming group.
- The Tier-S default is **gated by the capability bit**: a pre-streaming client that sends a Tier-S default has it ignored.

## Back-compat guarantee
- A **pre-streaming client** (capability bit clear, or an old/empty Connect) is **ALWAYS** served Tier-W — byte-for-byte today's behavior — and a Tier-S default it might send is dropped, so it can never be moved onto a tier it cannot follow.
- A Tier-W default (the unset case) echoes **no** tier byte, so the `Connect`/`Info` wires stay **byte-identical** to before. Both appended bytes (`default_ack_level`, then `default_tier`) are written and read in the same conditional order, each at an independent offset.
- **I2 / durability untouched**: this is connection-metadata + selection only — no storage, no ack-path, no consume-mechanics change.

## Scope boundary
Connect capability bit + connection-default tier + Info echo + wiring the SUB default to it, ONLY. Does **not** touch the consume mechanics (#655), zero-copy (#542), batching defaults (#550), or partitions — a clean negotiation layer.

## Tests
- **proto**: capability + default-tier round-trip; both-appended-bytes-at-independent-offsets; future-appended-field tolerance (forward-compat); unknown-tier folds to Tier-W; old-client/old-server byte-identity.
- **session**: a streaming-capable client negotiates a Tier-S default and an unmarked SUB uses it; an explicit per-subscription tier overrides the default; a pre-streaming (bit-clear) client always gets Tier-W (back-compat), incl. the old empty-Connect path.
- proptest round-trips extended to fuzz the new fields.

## Gates (all green)
- `cargo fmt --all --check`: clean
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`: clean **from a fresh `cargo clean`** (not incremental)
- `cargo test --workspace --all-features --locked`: all green

## Scrutinize
- The appended-byte ordering invariant (ack-level then tier) — that an absent earlier byte never shifts a present later one.
- That the SUB-time `set_streaming_in` is additive and never clears an explicit selection.
- That a Tier-S default is correctly suppressed when the capability bit is clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)