### PR TITLE
perf(consume): zero-copy raw-byte-run read primitive for the streaming tier (#542)

### DIFF
--- a/crates/ironbus-storage/Cargo.toml
+++ b/crates/ironbus-storage/Cargo.toml
@@ -86,3 +86,14 @@ harness = false
 [[bench]]
 name = "consume_scaling"
 harness = false
+
+# Informational micro-bench for the ZERO-COPY consume delivery read primitive (#542, M1-I6): the
+# MATERIALIZE+ENCODE delivery path (read_range -> OwnedRecords -> re-encode each into a wire-delivery
+# body) vs the ZERO-COPY raw byte run (read_range_raw -> one Bytes slice, no decode, no re-encode, no
+# payload copy), over the in-memory filesystem and swept across payload sizes. The zero-copy read is a
+# large multiple faster (one alloc + zero per-record decode/encode); the gap is the consume throughput
+# lever. Run on demand (`cargo bench -p ironbus-storage`), not in per-PR CI; the full consume-vs-NATS
+# leg is #554.
+[[bench]]
+name = "zero_copy_delivery"
+harness = false

--- a/crates/ironbus-storage/benches/zero_copy_delivery.rs
+++ b/crates/ironbus-storage/benches/zero_copy_delivery.rs
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! Informational micro-benchmark for the ZERO-COPY consume delivery read primitive (#542, M1-I6).
+//! The local read-boundary proof for the streaming-tier zero-copy path; the full t4g + NATS consume
+//! comparison is the milestone gate (#554).
+//!
+//! ## What it isolates: the read-side cost the zero-copy path removes
+//!
+//! For a Tier-S streaming fetch the broker serves a CONTIGUOUS run of stored records off the durable
+//! prefix. Two read planes serve the SAME run:
+//!
+//! - MATERIALIZE+ENCODE (the BEFORE): the current delivery path reads the run into per-record
+//!   [`ironbus_storage::segment::OwnedRecord`]s (one body-CRC decode + three refcounted slices each,
+//!   via `read_range`), then re-encodes every record's fields into a wire-delivery body (offset,
+//!   generation, flags, timestamp, length-prefixed key/headers, then the payload — the exact field
+//!   copies the `Deliver` body codec lays down). Each record is decoded once and its bytes are copied
+//!   once into the wire buffer.
+//! - ZERO-COPY (this issue): the run is read as ONE contiguous [`ironbus_storage::segment::RawByteRun`]
+//!   (`read_range_raw`) — one read into one buffer, the on-disk frame bytes handed back as a single
+//!   refcounted `bytes::Bytes` slice. NO body decode, NO per-record re-encode: the stored frames ARE
+//!   the batch (the consumer decodes them end-to-end, validating the per-frame CRC that rode along).
+//!
+//! The expected result: the zero-copy read is a large multiple faster on this run, because it does ONE
+//! allocation and ZERO per-record decode/encode where the materialize path does N decodes plus a
+//! payload copy per record. The gap IS the consume throughput lever this issue targets, measured at
+//! the storage read boundary (the wire `sendfile(2)` + `DeliverBatch` framing that turns this into a
+//! zero-USER-SPACE-copy socket write is the deferred follow-up; see #542 / #541).
+//!
+//! What it measures and what it does NOT: the log is opened over the in-memory `InMemoryFs`, so the
+//! work is the real codec decode + CRC32C + buffer/copy cost reading from memory rather than a device.
+//! It models the wire-body re-encode inline (the storage crate sits below `ironbus-proto`, so it does
+//! not link the proto codec) using the SAME field layout the `Deliver` body codec writes, so the
+//! BEFORE cost is faithful. Run on demand (`cargo bench -p ironbus-storage`), NOT in per-PR CI; the
+//! full consume-vs-NATS leg is #554.
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use ironbus_core::clock::ManualClock;
+use ironbus_core::types::{Offset, RecordFlags};
+use ironbus_storage::fs::InMemoryFs;
+use ironbus_storage::log::{Append, Log, LogConfig};
+use ironbus_storage::read_plane::ReadPlane;
+use ironbus_storage::segment::OwnedRecord;
+
+/// Records to pre-seal into the prefix. A small segment cap rolls these into many sealed segments, so
+/// both planes seek/scan the sealed snapshot the way a replaying streaming consumer does.
+const RECORDS: u64 = 4096;
+
+/// Payload sizes to sweep: a small record (framing/decode-dominated) and a larger one (copy-dominated).
+/// The zero-copy win grows with payload size (the materialize path copies every payload byte into the
+/// wire buffer; the zero-copy path never touches it).
+const PAYLOADS: [usize; 3] = [16, 256, 4096];
+
+/// Records pulled per fetch (a representative streaming batch). Both planes serve `[0, BATCH)` from the
+/// sealed prefix — the same run, so the only difference is the decode+re-encode the zero-copy path
+/// removes.
+const BATCH: usize = 64;
+
+/// Builds one in-memory log with `RECORDS` records of `payload_len`-byte payloads pre-sealed into many
+/// small segments, synced so the whole prefix is flushed and visible, plus its off-actor read plane.
+fn sealed_log(payload_len: usize) -> (Log<InMemoryFs, ManualClock>, ReadPlane<InMemoryFs>) {
+    let config = LogConfig {
+        max_segment_bytes: 1 << 16,
+        max_total_bytes: 0,
+        ..LogConfig::default()
+    };
+    let mut log = Log::open(InMemoryFs::new(), ManualClock::new(), config).expect("open log");
+    let payload = vec![0xABu8; payload_len];
+    for i in 0..RECORDS {
+        let _ = log
+            .append(&Append {
+                timestamp_ms: 1 + i,
+                flags: RecordFlags::EMPTY,
+                key: b"route-key",
+                headers: b"h",
+                payload: &payload,
+            })
+            .expect("append");
+        if i % 16 == 0 {
+            log.sync().expect("sync");
+        }
+    }
+    log.sync().expect("final sync");
+    let plane = log.read_plane().expect("build read plane");
+    (log, plane)
+}
+
+/// Re-encodes one record into a wire-delivery body the way the `Deliver` body codec does: the fixed
+/// fields, then the length-prefixed key/headers, then the payload copied in. This is the per-record
+/// cost the MATERIALIZE+ENCODE path pays and the zero-copy path removes. Modeled inline because the
+/// storage crate sits below `ironbus-proto` and does not link its codec; the field layout matches.
+fn encode_deliver_like(rec: &OwnedRecord, out: &mut Vec<u8>) {
+    out.extend_from_slice(&rec.offset.get().to_le_bytes());
+    out.extend_from_slice(&0u64.to_le_bytes()); // generation (0 on Tier-S)
+    out.push(rec.flags.bits());
+    out.extend_from_slice(&rec.timestamp_ms.to_le_bytes());
+    out.extend_from_slice(
+        &u16::try_from(rec.key.len())
+            .unwrap_or(u16::MAX)
+            .to_le_bytes(),
+    );
+    out.extend_from_slice(&rec.key);
+    out.extend_from_slice(
+        &u16::try_from(rec.headers.len())
+            .unwrap_or(u16::MAX)
+            .to_le_bytes(),
+    );
+    out.extend_from_slice(&rec.headers);
+    out.extend_from_slice(&rec.payload); // the payload copy the zero-copy path never makes
+}
+
+fn bench_zero_copy_delivery(c: &mut Criterion) {
+    let mut group = c.benchmark_group("zero_copy_delivery");
+    for &payload_len in &PAYLOADS {
+        let (_log, plane) = sealed_log(payload_len);
+
+        // BEFORE: read_range materializes OwnedRecords (decode + slices), then re-encode each into the
+        // wire-delivery buffer (the per-record copy). One reusable output buffer, as the session has.
+        group.bench_with_input(
+            BenchmarkId::new("materialize_encode", payload_len),
+            &payload_len,
+            |b, _| {
+                let plane = plane.clone();
+                let mut out = Vec::with_capacity(BATCH * (payload_len + 64));
+                b.iter(|| {
+                    out.clear();
+                    let read = plane
+                        .read_range(Offset::ZERO, BATCH, None)
+                        .expect("materialize read");
+                    for rec in &read.records {
+                        encode_deliver_like(rec, &mut out);
+                    }
+                    black_box(out.len());
+                });
+            },
+        );
+
+        // AFTER: read_range_raw hands back the contiguous run as one Bytes slice — no decode, no
+        // re-encode, no payload copy. The bytes ARE the batch the consumer decodes end-to-end.
+        group.bench_with_input(
+            BenchmarkId::new("zero_copy_raw", payload_len),
+            &payload_len,
+            |b, _| {
+                let plane = plane.clone();
+                b.iter(|| {
+                    let raw = plane
+                        .read_range_raw(Offset::ZERO, BATCH, None)
+                        .expect("zero-copy read");
+                    // The "write" is shipping `raw.run.bytes` verbatim; here we just observe its size
+                    // and record count, the work the broker does on this path (no copy, no decode).
+                    black_box(raw.run.bytes.len());
+                    black_box(raw.run.record_count);
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_zero_copy_delivery);
+criterion_main!(benches);

--- a/crates/ironbus-storage/src/read_plane.rs
+++ b/crates/ironbus-storage/src/read_plane.rs
@@ -64,7 +64,7 @@ use std::sync::Arc;
 use arc_swap::ArcSwap;
 
 use crate::naming::segment_file_name;
-use crate::segment::{OwnedRecord, SegmentReader, StorageError};
+use crate::segment::{OwnedRecord, RawByteRun, SegmentReader, StorageError};
 use ironbus_core::types::Offset;
 
 /// One SEALED segment in a [`SealedSnapshot`]: its identity, covered offset range, and the resident
@@ -150,6 +150,30 @@ pub struct SealedRead {
     /// sealed prefix is exhausted at `off` but `off < flushed`, or `off` lands on a compacted slot):
     /// the caller resumes the read at `off` through the actor. `None` when the read is COMPLETE
     /// off-actor (it hit `max`, the byte cap, or the flushed frontier within the sealed prefix).
+    pub fallback_from: Option<u64>,
+}
+
+/// The outcome of a [`ReadPlane::read_range_raw`]: the ZERO-COPY raw byte run served off-actor from
+/// the sealed prefix (#542, M1-I6), plus the next offset the snapshot could NOT serve raw (the active
+/// tail, a compacted slot, or the end of the run's segment), so the caller knows where to resume.
+///
+/// Unlike [`SealedRead`], a raw run is bounded to a SINGLE sealed segment: a contiguous BYTE range is
+/// one slice of one segment file's bytes, so a run that reaches a segment boundary stops there and the
+/// caller resumes at `fallback_from` (the next segment, served by a fresh raw read, or the active tail
+/// through the actor). This keeps the zero-copy invariant exact — the returned bytes are always a
+/// contiguous slice of exactly one resident segment buffer.
+#[derive(Debug)]
+pub struct RawSealedRead {
+    /// The raw contiguous frame run read from one sealed segment's flushed prefix, bounded by the
+    /// flushed frontier, `max_records`, and the optional `max_bytes`. `record_count == 0` (and empty
+    /// `bytes`) when the start is already in the active tail, on a compacted slot, or nothing is below
+    /// `flushed`.
+    pub run: RawByteRun,
+    /// `Some(off)` when more flushed offsets remain that this single-segment raw read did not serve
+    /// (the run hit its segment's end below `flushed`, or the start landed on the active tail or a
+    /// compacted slot): the caller resumes at `off` (another raw read for the next sealed segment, or
+    /// the through-actor path for the active tail). `None` when the read is COMPLETE off-actor (it hit
+    /// `max`, the byte cap, or the flushed frontier within this segment).
     pub fallback_from: Option<u64>,
 }
 
@@ -274,6 +298,150 @@ impl<F: crate::fs::Filesystem> SealedSnapshot<F> {
             records: out,
             fallback_from,
         })
+    }
+
+    /// Reads a CONTIGUOUS RAW byte run from the SEALED prefix starting at `start`, bounded by
+    /// `flushed`, `max_records`, and the optional `max_bytes` — the ZERO-COPY off-actor read (#542,
+    /// M1-I6) and the raw sibling of [`SealedSnapshot::read_range`]. Where `read_range` decodes every
+    /// frame into an [`OwnedRecord`], this seeks to the same anchor and hands the contiguous on-disk
+    /// frame bytes back as ONE [`RawByteRun`] (a refcount slice of one segment's resident buffer) with
+    /// NO body decode and NO per-record allocation.
+    ///
+    /// Bounded to a SINGLE sealed segment (a contiguous byte range is one slice of one file): if the
+    /// run reaches the segment's end with flushed offsets still remaining, `fallback_from` is the next
+    /// offset so the caller resumes (a fresh raw read of the next segment, or the through-actor active
+    /// tail). The seek/clamp logic MIRRORS `read_range` exactly, so the run decodes to byte-identical
+    /// records (the differential test pins this).
+    fn read_range_raw(
+        &self,
+        start: u64,
+        flushed: u64,
+        max_records: usize,
+        max_bytes: Option<usize>,
+    ) -> Result<RawSealedRead, StorageError> {
+        let empty = |fallback_from| RawSealedRead {
+            run: RawByteRun {
+                bytes: bytes::Bytes::new(),
+                first_offset: Offset::new(start),
+                record_count: 0,
+                next_offset: Offset::new(start),
+            },
+            fallback_from,
+        };
+        // The flushed frontier is the HARD bound (mirrors `read_range`). Clamp sealed coverage to it.
+        let visible_sealed_end = self.sealed_end.min(flushed);
+        if max_records == 0 || start >= flushed {
+            return Ok(empty(None));
+        }
+        if start < self.oldest {
+            return Err(StorageError::OffsetOutOfRange {
+                requested: start,
+                oldest: self.oldest,
+            });
+        }
+        // The start is already at/past the sealed prefix's visible end: nothing to serve raw
+        // off-actor; the caller reads `[start, flushed)` (the active tail) through the actor.
+        if start >= visible_sealed_end {
+            return Ok(empty(Some(start)));
+        }
+        let slot = &self.segments[self.segment_index_for(start)];
+        let seg_start = start.max(slot.base_offset);
+        // A COMPACTED (v2, sparse) slot is served by the through-actor v2 scan, not this plane: a
+        // sparse survivor run is not a dense contiguous byte range, so hand the remainder back.
+        if slot.compacted {
+            return Ok(empty(Some(seg_start)));
+        }
+        let Some((anchor_offset, byte_pos)) = slot.seek_anchor(seg_start) else {
+            // The snapshot's anchors do not cover `seg_start`: serve nothing raw, resume past here.
+            return Ok(empty(Some(seg_start)));
+        };
+        let read_end = slot.valid_end;
+        // Cap the raw read at the flushed frontier and the segment's covered end: never carry a frame
+        // at or past `flushed`, and bound the want by how many frames lie below the frontier from the
+        // anchor (the gap the anchor preceded `seg_start` by is dropped after the read).
+        let gap = usize::try_from(seg_start.saturating_sub(anchor_offset)).unwrap_or(0);
+        let covered_end = slot.base_offset.saturating_add(slot.record_count);
+        let seg_visible_end = covered_end.min(flushed);
+        let below_visible =
+            usize::try_from(seg_visible_end.saturating_sub(anchor_offset)).unwrap_or(usize::MAX);
+        let want = max_records.saturating_add(gap).min(below_visible);
+        let reader = SegmentReader::open(self.fs.open(&segment_file_name(slot.id))?)?;
+        let run =
+            reader.raw_byte_range(byte_pos, Offset::new(anchor_offset), read_end, want, None)?;
+        // The anchor may sit BEFORE `seg_start` (sparse anchors land one-per-stride): trim the leading
+        // `gap` frames so the returned run begins exactly at `seg_start`, then re-bound to
+        // `max_records` and `max_bytes` over the trimmed run. Trimming walks frame headers only (no
+        // body decode), preserving the zero-copy property.
+        let trimmed = trim_raw_run(&run, seg_start, max_records, max_bytes);
+        let run_end = trimmed.next_offset.get();
+        // Resume reporting: if this single-segment run stopped strictly below the visible frontier
+        // without hitting `max`/`max_bytes`, the caller resumes at `run_end` (the next segment or the
+        // active tail). If it hit `max`/the byte cap within the segment, it is complete off-actor.
+        let hit_count = trimmed.record_count >= max_records as u64;
+        let hit_bytes = max_bytes.is_some_and(|cap| (trimmed.bytes.len()) >= cap);
+        let fallback_from = if !hit_count && !hit_bytes && run_end < flushed {
+            Some(run_end.max(start))
+        } else {
+            None
+        };
+        Ok(RawSealedRead {
+            run: trimmed,
+            fallback_from,
+        })
+    }
+}
+
+/// Trims a [`RawByteRun`] to begin at `seg_start` (dropping the leading frames a sparse anchor
+/// preceded it by) and re-bounds it to `max_records` / `max_bytes` over the trimmed run — a
+/// HEADER-ONLY walk (no body decode), so it preserves the zero-copy property. Returns a run that is a
+/// sub-slice of the input's `bytes` (a refcount re-slice, never a copy).
+fn trim_raw_run(
+    run: &RawByteRun,
+    seg_start: u64,
+    max_records: usize,
+    max_bytes: Option<usize>,
+) -> RawByteRun {
+    let mut cursor = 0usize;
+    let mut offset = run.first_offset.get();
+    let bytes = &run.bytes;
+    // Drop the leading frames below `seg_start` by walking their header lengths.
+    while offset < seg_start && cursor < bytes.len() {
+        let Ok(consumed) = ironbus_core::codec::decoded_len(&bytes[cursor..]) else {
+            break;
+        };
+        if cursor.saturating_add(consumed) > bytes.len() {
+            break;
+        }
+        cursor += consumed;
+        offset = offset.saturating_add(1);
+    }
+    let run_start_byte = cursor;
+    let first_offset = offset;
+    // Admit up to `max_records` / `max_bytes` frames from `seg_start`, "at least one" honored.
+    let mut count = 0usize;
+    let mut byte_total = 0usize;
+    while cursor < bytes.len() && count < max_records {
+        let Ok(consumed) = ironbus_core::codec::decoded_len(&bytes[cursor..]) else {
+            break;
+        };
+        if cursor.saturating_add(consumed) > bytes.len() {
+            break;
+        }
+        if let Some(cap) = max_bytes {
+            if count != 0 && byte_total.saturating_add(consumed) > cap {
+                break;
+            }
+        }
+        byte_total = byte_total.saturating_add(consumed);
+        count += 1;
+        offset = offset.saturating_add(1);
+        cursor += consumed;
+    }
+    RawByteRun {
+        bytes: bytes.slice(run_start_byte..run_start_byte + byte_total),
+        first_offset: Offset::new(first_offset),
+        record_count: count as u64,
+        next_offset: Offset::new(offset),
     }
 }
 
@@ -411,6 +579,40 @@ impl<F: crate::fs::Filesystem> ReadPlane<F> {
     /// As [`ReadPlane::read_range`].
     pub fn read_one(&self, offset: Offset) -> Result<SealedRead, StorageError> {
         self.read_range(offset, 1, None)
+    }
+
+    /// Reads a CONTIGUOUS RAW byte run from the SEALED, flushed prefix starting at `start`, with NO
+    /// lock and NO actor round-trip — the ZERO-COPY off-actor read (#542, M1-I6) and the raw sibling
+    /// of [`ReadPlane::read_range`]. Takes the SAME frontier-then-snapshot ordering, then hands back
+    /// the contiguous on-disk frame bytes as ONE [`RawByteRun`] (a refcount slice of one segment's
+    /// resident buffer) instead of a `Vec<OwnedRecord>`: no body decode, no per-record allocation.
+    ///
+    /// A raw run is bounded to ONE sealed segment (a contiguous byte range is one slice of one file),
+    /// so the returned [`RawSealedRead::fallback_from`] is `Some(off)` when more flushed offsets
+    /// remain past this segment's run — the caller resumes with another raw read (the next sealed
+    /// segment) or the through-actor path (the active tail). The flushed frontier is loaded FIRST
+    /// (Acquire) and the snapshot SECOND, exactly as `read_range`, so the snapshot is guaranteed to
+    /// cover every sealed offset below the observed frontier.
+    ///
+    /// On the in-memory backends the run is a TRUE no-copy view of the segment's resident bytes; on
+    /// the disk backend it is one positioned read into one buffer (the contiguous extent the deferred
+    /// `sendfile(2)` follow-up would hand to the kernel instead, without changing this read shape).
+    ///
+    /// # Errors
+    /// [`StorageError::OffsetOutOfRange`] if `start` is older than the snapshot's oldest retained
+    /// offset, or an IO error reading a sealed segment.
+    pub fn read_range_raw(
+        &self,
+        start: Offset,
+        max_records: usize,
+        max_bytes: Option<usize>,
+    ) -> Result<RawSealedRead, StorageError> {
+        // ORDER IS LOAD-BEARING (identical to `read_range`): the frontier (Acquire) FIRST, then the
+        // snapshot. A frontier `F` observed here was published AFTER a snapshot covering every sealed
+        // offset below `F`, so the snapshot can never lack a segment the frontier admits.
+        let flushed = self.flushed.load(Ordering::Acquire);
+        let snapshot = self.sealed.load();
+        snapshot.read_range_raw(start.get(), flushed, max_records, max_bytes)
     }
 }
 
@@ -617,6 +819,248 @@ mod tests {
         assert!(
             any_progress,
             "no reader ever read off-actor — the plane never served"
+        );
+    }
+
+    // ----- Zero-copy raw-byte-run path (#542, M1-I6) -----
+
+    /// Decodes a [`RawByteRun`]'s bytes front-to-back into `(RecordView, offset)` pairs, the way a
+    /// consumer that receives the raw run would. Asserts the run carries EXACTLY `record_count` whole
+    /// frames and nothing trails. This is the client-side half of the differential.
+    fn decode_raw_run(run: &RawByteRun) -> Vec<(ironbus_core::codec::RecordView<'_>, u64)> {
+        let mut out = Vec::new();
+        let mut cursor = 0usize;
+        let mut offset = run.first_offset.get();
+        while cursor < run.bytes.len() {
+            let (view, consumed) =
+                ironbus_core::codec::decode(&run.bytes[cursor..]).expect("raw run frame decodes");
+            out.push((view, offset));
+            offset = offset.saturating_add(1);
+            cursor += consumed;
+        }
+        assert_eq!(
+            cursor,
+            run.bytes.len(),
+            "raw run must be exactly whole frames, no partial tail"
+        );
+        assert_eq!(
+            out.len() as u64,
+            run.record_count,
+            "decoded frame count must equal record_count"
+        );
+        out
+    }
+
+    /// DIFFERENTIAL: the zero-copy raw run is BYTE-IDENTICAL to the materialize+encode path. For every
+    /// start offset and several batch sizes, decoding the raw run yields the SAME records (offset, seq,
+    /// timestamp, flags, key, headers, payload — every byte) and in the SAME order as the through-actor
+    /// `read_from`, the existing materialize path. This is the core correctness proof: a contiguous
+    /// stored run shipped raw == the records re-encoded one at a time.
+    #[test]
+    fn raw_run_is_byte_identical_to_the_materialize_path() {
+        let mut log = small_log();
+        for i in 0..200u32 {
+            // Vary key/headers/payload so the differential exercises non-empty variable fields.
+            let payload = i.to_le_bytes();
+            log.append(&Append {
+                timestamp_ms: 100 + u64::from(i),
+                flags: RecordFlags::EMPTY,
+                key: &[(i % 7) as u8; 3],
+                headers: &[(i % 5) as u8; 2],
+                payload: &payload,
+            })
+            .unwrap();
+            if i % 7 == 0 {
+                log.sync().unwrap();
+            }
+        }
+        log.sync().unwrap();
+        let plane = log.read_plane().unwrap();
+        let flushed = log.flushed_offset().get();
+        for start in 0..flushed {
+            for max in [1usize, 3, 8, 64] {
+                let want = max;
+                let materialized = plane.read_range(Offset::new(start), want, None).unwrap();
+                let raw = plane
+                    .read_range_raw(Offset::new(start), want, None)
+                    .unwrap();
+                let decoded = decode_raw_run(&raw.run);
+                // The raw path is single-segment; it serves a PREFIX of the (possibly multi-segment)
+                // materialize result. Compare on the common prefix, then assert resume coverage.
+                for ((view, off), owned) in decoded.iter().zip(materialized.records.iter()) {
+                    assert_eq!(*off, owned.offset.get(), "offset mismatch at start={start}");
+                    assert_eq!(view.seq, owned.seq, "seq mismatch at start={start}");
+                    assert_eq!(
+                        view.timestamp_ms, owned.timestamp_ms,
+                        "timestamp mismatch at start={start}"
+                    );
+                    assert_eq!(view.flags, owned.flags, "flags mismatch at start={start}");
+                    assert_eq!(view.key, &owned.key[..], "key mismatch at start={start}");
+                    assert_eq!(
+                        view.headers,
+                        &owned.headers[..],
+                        "headers mismatch at start={start}"
+                    );
+                    assert_eq!(
+                        view.payload,
+                        &owned.payload[..],
+                        "payload mismatch at start={start}"
+                    );
+                }
+                // The first decoded record (if any) must start exactly at `start`.
+                if let Some((_, off)) = decoded.first() {
+                    assert_eq!(*off, start, "raw run did not start at the requested offset");
+                }
+            }
+        }
+    }
+
+    /// The raw run stops at a SINGLE sealed segment's boundary and reports a `fallback_from` so the
+    /// caller resumes — and chaining raw reads from each `fallback_from` (then the active-tail actor
+    /// read) reconstructs the WHOLE flushed prefix with no gaps or overlaps. A PARTIAL/BOUNDARY batch
+    /// exercise: the small segment cap forces many segment-boundary stops.
+    #[test]
+    fn raw_run_chains_across_segment_boundaries_without_gaps() {
+        let mut log = small_log();
+        for i in 0..300u32 {
+            log.append(&rec(&i.to_le_bytes())).unwrap();
+            if i % 5 == 0 {
+                log.sync().unwrap();
+            }
+        }
+        log.sync().unwrap();
+        let plane = log.read_plane().unwrap();
+        let flushed = log.flushed_offset().get();
+        // Walk the sealed-and-flushed prefix via repeated raw reads, following `fallback_from`. The
+        // chain ends when a read serves nothing AND cannot advance (the start is in the active tail,
+        // which the sealed plane does not serve) or there are no more flushed offsets.
+        let mut next = 0u64;
+        let mut seen = 0u64;
+        let mut guard = 0u32;
+        while next < flushed {
+            guard += 1;
+            assert!(guard < 10_000, "raw-read chain failed to terminate");
+            let raw = plane
+                .read_range_raw(Offset::new(next), 1_000, None)
+                .unwrap();
+            let decoded = decode_raw_run(&raw.run);
+            // Every raw frame must be exactly the next contiguous offset (no gap, no overlap).
+            for (_, off) in &decoded {
+                assert_eq!(*off, seen, "raw chain skipped or repeated an offset");
+                seen += 1;
+            }
+            match raw.fallback_from {
+                // A fallback that does not advance past `next` means the rest is the active tail (the
+                // sealed plane serves no more); stop the sealed-prefix walk there.
+                Some(f) if f > next => next = f,
+                _ => break,
+            }
+        }
+        // We saw every sealed-and-flushed record up to wherever the sealed prefix ends. The remaining
+        // gap to `flushed` (the active tail) is served through the actor; assert we covered the
+        // sealed prefix contiguously and never over-ran the frontier.
+        assert_eq!(
+            seen,
+            next.min(flushed),
+            "raw chain left a gap in the sealed prefix"
+        );
+        assert!(
+            seen <= flushed,
+            "raw chain served past the flushed frontier"
+        );
+        assert!(seen > 0, "raw chain served nothing");
+    }
+
+    /// CRC INTEGRITY: each frame in the raw run carries its OWN body CRC verbatim, so a consumer that
+    /// re-decodes the run validates every frame end-to-end. Decoding the run with the full
+    /// `codec::decode` (which checks header AND body CRC) succeeds for every frame — proving the
+    /// shipped bytes are integrity-checkable downstream, not stripped of their CRC.
+    #[test]
+    fn raw_run_preserves_per_frame_crc_for_end_to_end_verification() {
+        let mut log = small_log();
+        for i in 0..50u32 {
+            log.append(&rec(&i.to_le_bytes())).unwrap();
+            log.sync().unwrap();
+        }
+        let plane = log.read_plane().unwrap();
+        let raw = plane.read_range_raw(Offset::new(0), 64, None).unwrap();
+        // Full decode (header CRC + body CRC) of every frame must succeed: the CRCs rode along.
+        let mut cursor = 0usize;
+        let mut frames = 0u64;
+        while cursor < raw.run.bytes.len() {
+            let (_, consumed) = ironbus_core::codec::decode(&raw.run.bytes[cursor..])
+                .expect("every shipped frame must pass header AND body CRC");
+            cursor += consumed;
+            frames += 1;
+        }
+        assert_eq!(frames, raw.run.record_count);
+        assert!(frames > 0, "expected a non-empty CRC-checked run");
+    }
+
+    /// The byte cap bounds the raw run exactly as it bounds the materialize path: the run carries at
+    /// most `max_bytes` of frames (honoring "at least one"), and its byte length matches the sum of
+    /// the encoded lengths of the records the materialize path returns for the same cap.
+    #[test]
+    fn raw_run_honors_the_byte_cap_like_the_materialize_path() {
+        let mut log = small_log();
+        for i in 0..100u32 {
+            log.append(&rec(&i.to_le_bytes())).unwrap();
+            log.sync().unwrap();
+        }
+        let plane = log.read_plane().unwrap();
+        // A cap that admits a few records but not the whole batch.
+        let cap = 200usize;
+        let materialized = plane.read_range(Offset::new(0), 1_000, Some(cap)).unwrap();
+        let raw = plane
+            .read_range_raw(Offset::new(0), 1_000, Some(cap))
+            .unwrap();
+        let decoded = decode_raw_run(&raw.run);
+        // The raw run is single-segment, so it serves a prefix of the materialize result; compare the
+        // common prefix and assert the raw run respected the cap ("at least one" allowed to exceed).
+        let raw_bytes: usize = raw.run.bytes.len();
+        let first_len = materialized
+            .records
+            .first()
+            .map_or(0, super::OwnedRecord::encoded_len);
+        assert!(
+            raw_bytes <= cap || raw.run.record_count <= 1,
+            "raw run exceeded the byte cap with more than one record (cap={cap}, bytes={raw_bytes}, first_len={first_len})"
+        );
+        for ((_, off), owned) in decoded.iter().zip(materialized.records.iter()) {
+            assert_eq!(*off, owned.offset.get());
+        }
+    }
+
+    /// On the in-memory backend the raw run is a refcount slice of the SEGMENT's resident bytes — a
+    /// true no-copy view. We cannot observe the pointer identity through the public API, but we CAN
+    /// assert the zero-copy contract's observable consequence: the returned `bytes` is a `Bytes`
+    /// handle whose length equals the sum of the on-disk frame lengths, and cloning it is cheap
+    /// (a refcount bump). This pins the memory-backend Bytes-slice path.
+    #[test]
+    fn memory_backend_serves_a_bytes_slice_run() {
+        let mut log = small_log();
+        for i in 0..20u32 {
+            log.append(&rec(&i.to_le_bytes())).unwrap();
+            log.sync().unwrap();
+        }
+        let plane = log.read_plane().unwrap();
+        let raw = plane.read_range_raw(Offset::new(0), 8, None).unwrap();
+        assert!(raw.run.record_count > 0, "expected a non-empty run");
+        // A clone is a refcount bump, not a copy: same bytes, independent handle.
+        let cloned = raw.run.bytes.clone();
+        assert_eq!(&cloned[..], &raw.run.bytes[..]);
+        // The run length equals exactly the sum of the served frames' on-disk encoded lengths.
+        let want = usize::try_from(raw.run.record_count).unwrap();
+        let materialized = plane.read_range(Offset::new(0), want, None).unwrap();
+        let expected: usize = materialized
+            .records
+            .iter()
+            .map(super::OwnedRecord::encoded_len)
+            .sum();
+        assert_eq!(
+            raw.run.bytes.len(),
+            expected,
+            "raw run byte length must equal the sum of frame encoded lengths"
         );
     }
 }

--- a/crates/ironbus-storage/src/segment.rs
+++ b/crates/ironbus-storage/src/segment.rs
@@ -264,6 +264,54 @@ pub struct OwnedRecord {
     pub payload: Bytes,
 }
 
+/// A CONTIGUOUS run of stored record frames returned WITHOUT materializing per-record
+/// [`OwnedRecord`]s and WITHOUT decoding the body — the zero-copy READ primitive (#542, M1-I6).
+///
+/// Where [`SegmentReader::scan_range`] reads the segment bytes into one buffer and then decodes
+/// every frame into an `OwnedRecord` (validating each body CRC and refcount-slicing the three
+/// blobs), this returns the raw on-disk frame bytes for the run `[first_offset, next_offset)` as
+/// ONE refcounted [`Bytes`] handle and stops there: one `read_exact_at`, one allocation, zero body
+/// decodes, zero per-record allocations. On the in-memory backends the underlying buffer is the
+/// segment's own resident bytes (the `Bytes` is a refcount slice, a true no-copy view); on the disk
+/// backend it is one positioned read into one shared buffer (the contiguous-extent foundation a
+/// later `sendfile(2)` path — deferred, see #542's follow-up and #541 `DeliverBatch` — drops in
+/// without re-plumbing the read shape).
+///
+/// ## What `bytes` IS, byte-for-byte
+///
+/// `bytes` is the concatenation of `record_count` complete on-disk record frames in offset order,
+/// each in the frozen on-disk layout (header + key + headers + payload + optional xxh3 + trailer,
+/// per `ironbus_core::format`). It is therefore identical to `scan_range`'s buffer truncated to the
+/// same run: decoding `bytes` front-to-back with `ironbus_core::codec::decode` yields exactly the
+/// records `scan_range` would return over the same range, in the same order, with the same bytes
+/// (the differential test in `read_plane.rs` pins this).
+///
+/// ## CRC integrity is PRESERVED, not dropped
+///
+/// Each frame's own header CRC is validated while walking the run's boundaries (via
+/// `codec::decoded_len`, the cheap header-only check), so a torn or corrupt header ENDS the run
+/// exactly as `scan_range` stops at the first bad frame — a bogus tail is never carried. The body
+/// CRC is NOT re-validated here (the broker never touches the body bytes on this path), but it
+/// ships VERBATIM inside `bytes`, so the consumer verifies the frame end-to-end exactly as it does
+/// today — the zero-copy path moves the body-CRC check to the only place that still touches the
+/// bytes (the client), it never silently drops integrity. (Verify-once-while-resident is the
+/// separate #540.)
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RawByteRun {
+    /// The raw, contiguous on-disk frame bytes for `[first_offset, next_offset)`, one frame after
+    /// another in the frozen on-disk layout. A refcounted [`Bytes`] slice of the shared read buffer
+    /// (the segment's resident bytes on the memory backends): cloning it is a refcount bump, never a
+    /// copy. Empty iff `record_count == 0`.
+    pub bytes: Bytes,
+    /// The log offset of the FIRST frame in `bytes`.
+    pub first_offset: Offset,
+    /// How many complete frames `bytes` carries. `next_offset == first_offset + record_count`.
+    pub record_count: u64,
+    /// The next offset AFTER the run (the first offset NOT included): where a follow-on read
+    /// resumes. Equals `first_offset` when the run is empty.
+    pub next_offset: Offset,
+}
+
 impl OwnedRecord {
     /// Materializes a record from a CRC-VALIDATED [`RecordView`] by taking refcounted slices of the
     /// shared read `buf` the view borrows (#480). `buf` MUST be the exact buffer the `view` was
@@ -1269,6 +1317,107 @@ impl<F: RandomAccessFile> SegmentReader<F> {
         Ok(records)
     }
 
+    /// Reads a CONTIGUOUS run of up to `max` DENSE (v1) frames starting at the file byte position
+    /// `start_byte` as RAW on-disk bytes — the ZERO-COPY READ primitive (#542, M1-I6) and the
+    /// byte-for-byte sibling of [`SegmentReader::scan_range`] MINUS the per-record decode and
+    /// materialization. `scan_range` reads the region into one buffer and then decodes every frame
+    /// into an [`OwnedRecord`] (a body-CRC check + three refcount slices per record); this reads the
+    /// SAME region into the SAME single shared buffer, walks the frame boundaries with the cheap
+    /// HEADER-ONLY check ([`codec::decoded_len`], which validates each frame's header CRC), and
+    /// returns the contiguous frame bytes for the admitted run as ONE refcounted [`Bytes`] handle.
+    /// No body is decoded, no `OwnedRecord` is allocated.
+    ///
+    /// On the in-memory backends the shared buffer the returned [`RawByteRun::bytes`] slices is the
+    /// segment's own resident bytes, so the run is a true no-copy view; on the disk backend it is
+    /// one `read_exact_at` into one buffer (the contiguous extent a later `sendfile(2)` path — see
+    /// #542's deferred follow-up — would hand to the kernel instead of to user space, without
+    /// changing this read shape).
+    ///
+    /// Bounds, all honored in the single pass and IDENTICAL to `scan_range`'s:
+    /// - `max`: stop after `max` frames. `max == 0` returns an empty run at `start_offset`.
+    /// - `read_end`: no frame whose body would extend at or past it is admitted (the caller passes
+    ///   the segment's flushed `valid_end`, so a torn/unflushed tail is never carried).
+    /// - `max_bytes`: stop once the accumulated frame bytes would EXCEED the cap. `None` means no
+    ///   byte cap. The FIRST frame is ALWAYS taken even if it alone exceeds the cap (the "at least
+    ///   one" fetch rule), so a record larger than the cap never stalls the read; the cap then bounds
+    ///   every frame AFTER the first — the exact rule `scan_range` applies.
+    ///
+    /// The frame at `start_byte` is assigned log offset `start_offset` and each subsequent frame the
+    /// next consecutive offset. `start_byte` MUST be a real frame boundary; a header that fails its
+    /// CRC (a torn or mid-frame read) ENDS the run exactly as `scan_range` stops at the first bad
+    /// frame, so the returned bytes are always a clean prefix of whole, header-validated frames. The
+    /// body CRC of each frame is carried VERBATIM in the returned bytes for the consumer to verify
+    /// end-to-end; it is not re-checked here because the bytes are never touched on this path.
+    ///
+    /// # Errors
+    /// Returns an IO error from reading the region. A torn or corrupt header is NOT an error: it
+    /// ends the returned run.
+    pub fn raw_byte_range(
+        &self,
+        start_byte: u64,
+        start_offset: Offset,
+        read_end: u64,
+        max: usize,
+        max_bytes: Option<usize>,
+    ) -> Result<RawByteRun, StorageError> {
+        let empty = RawByteRun {
+            bytes: Bytes::new(),
+            first_offset: start_offset,
+            record_count: 0,
+            next_offset: start_offset,
+        };
+        if max == 0 || start_byte >= read_end {
+            return Ok(empty);
+        }
+        let len = usize::try_from(read_end.saturating_sub(start_byte))
+            .map_err(|_| StorageError::SegmentFull)?;
+        // ONE read into a shared `Bytes` buffer — the same single allocation `scan_range` makes. The
+        // returned run slices THIS buffer (a refcount bump), so a seek-and-read-forward of N frames is
+        // one syscall + one allocation + zero per-record allocations and zero body decodes.
+        let mut buf = BytesMut::zeroed(len);
+        self.file.read_exact_at(&mut buf, start_byte)?;
+        let body = buf.freeze();
+        let mut cursor = 0usize;
+        let mut byte_total = 0usize;
+        let mut count = 0usize;
+        let mut next_offset = start_offset.get();
+        while cursor < body.len() && count < max {
+            // HEADER-ONLY boundary walk: `decoded_len` validates the frame's HEADER CRC and returns
+            // the full frame length WITHOUT touching the body — the cheap half of `codec::decode`. A
+            // torn or corrupt header ends the run, exactly as `scan_range`'s `decode` does, so the
+            // admitted bytes are always whole, header-validated frames.
+            let Ok(consumed) = codec::decoded_len(&body[cursor..]) else {
+                break;
+            };
+            // The frame must lie WHOLLY within the read region; a frame that would run off the end of
+            // the buffer is a torn tail and ends the run (matching `scan_range`, whose `decode` of a
+            // short tail returns `Truncated` and breaks).
+            if cursor.saturating_add(consumed) > body.len() {
+                break;
+            }
+            // Byte cap: stop BEFORE a frame that would push the accumulated bytes past `max_bytes`,
+            // but ALWAYS admit the first frame so a single frame larger than the cap never stalls —
+            // the identical rule `scan_range` applies against `OwnedRecord::encoded_len`.
+            if let Some(cap) = max_bytes {
+                if count != 0 && byte_total.saturating_add(consumed) > cap {
+                    break;
+                }
+            }
+            byte_total = byte_total.saturating_add(consumed);
+            count += 1;
+            next_offset = next_offset.saturating_add(1);
+            cursor += consumed;
+        }
+        Ok(RawByteRun {
+            // The admitted prefix: the first `byte_total` bytes are exactly `count` whole frames. A
+            // refcount slice of the shared buffer, never a copy.
+            bytes: body.slice(0..byte_total),
+            first_offset: start_offset,
+            record_count: count as u64,
+            next_offset: Offset::new(next_offset),
+        })
+    }
+
     /// Scans a COMPACTED (`version` = 2) segment (#337): validates the v2 header (the caller's
     /// [`SegmentReader::open`] already accepted it), reads its SPARSE survivor records, the v2
     /// footer, and the trailing 44-byte compaction-metadata block, and returns them as a
@@ -2113,6 +2262,142 @@ mod tests {
                 .scan_from(positions[0], Offset::new(0), valid_end, usize::MAX)
                 .unwrap()
         );
+    }
+
+    /// The zero-copy `raw_byte_range` (#542, M1-I6) returns the SAME records `scan_range` materializes
+    /// — proven by decoding the raw bytes and comparing every field — while making ONE read, no body
+    /// decode, and no per-record allocation. Covers the byte-identical differential, the `max`/
+    /// `max_bytes` bounds (with "at least one"), the empty/torn boundaries, and the full-frame CRC
+    /// riding along in the returned bytes.
+    #[test]
+    fn raw_byte_range_is_byte_identical_to_scan_range() {
+        let file = Arc::new(InMemoryFile::new());
+        let mut w = SegmentWriter::create(Arc::clone(&file), header()).unwrap();
+        for i in 0..6u64 {
+            w.append(&rec(i, &[u8::try_from(i).unwrap(); 7])).unwrap();
+        }
+        w.sync().unwrap();
+        let reader = SegmentReader::open(Arc::clone(&file)).unwrap();
+        let (positions, valid_end) = reader.record_byte_positions().unwrap();
+        let one_frame = reader
+            .scan_range(positions[0], Offset::new(0), valid_end, 1, None)
+            .unwrap()[0]
+            .encoded_len();
+
+        // Unbounded: the raw run carries all 6 frames and decodes byte-for-byte to scan_range.
+        let materialized = reader
+            .scan_range(positions[0], Offset::new(0), valid_end, usize::MAX, None)
+            .unwrap();
+        let raw = reader
+            .raw_byte_range(positions[0], Offset::new(0), valid_end, usize::MAX, None)
+            .unwrap();
+        assert_eq!(raw.record_count, materialized.len() as u64);
+        assert_eq!(raw.first_offset.get(), 0);
+        assert_eq!(raw.next_offset.get(), materialized.len() as u64);
+        // Decode the raw bytes and compare every field — the byte-identical differential.
+        let mut cursor = 0usize;
+        for (idx, owned) in materialized.iter().enumerate() {
+            let (view, consumed) = codec::decode(&raw.bytes[cursor..]).expect("raw frame decodes");
+            assert_eq!(view.seq, owned.seq, "seq mismatch at {idx}");
+            assert_eq!(
+                view.timestamp_ms, owned.timestamp_ms,
+                "ts mismatch at {idx}"
+            );
+            assert_eq!(view.flags, owned.flags, "flags mismatch at {idx}");
+            assert_eq!(view.key, &owned.key[..], "key mismatch at {idx}");
+            assert_eq!(
+                view.headers,
+                &owned.headers[..],
+                "headers mismatch at {idx}"
+            );
+            assert_eq!(
+                view.payload,
+                &owned.payload[..],
+                "payload mismatch at {idx}"
+            );
+            cursor += consumed;
+        }
+        assert_eq!(cursor, raw.bytes.len(), "no trailing bytes past the frames");
+
+        // max bounds the frame count exactly like scan_range.
+        let raw3 = reader
+            .raw_byte_range(positions[0], Offset::new(0), valid_end, 3, None)
+            .unwrap();
+        assert_eq!(raw3.record_count, 3);
+        assert_eq!(raw3.next_offset.get(), 3);
+
+        // A byte budget of K frames yields K frames; a sub-frame budget still yields one.
+        for k in 1..=4usize {
+            let got = reader
+                .raw_byte_range(
+                    positions[0],
+                    Offset::new(0),
+                    valid_end,
+                    usize::MAX,
+                    Some(k * one_frame),
+                )
+                .unwrap();
+            assert_eq!(got.record_count, k as u64, "byte budget for {k} frames");
+        }
+        for cap in [0usize, 1, one_frame - 1] {
+            let got = reader
+                .raw_byte_range(
+                    positions[0],
+                    Offset::new(0),
+                    valid_end,
+                    usize::MAX,
+                    Some(cap),
+                )
+                .unwrap();
+            assert_eq!(got.record_count, 1, "sub-frame cap {cap} returns one frame");
+        }
+
+        // Empty boundaries: max=0 and start==read_end both serve nothing.
+        let empty = reader
+            .raw_byte_range(positions[0], Offset::new(0), valid_end, 0, None)
+            .unwrap();
+        assert_eq!(empty.record_count, 0);
+        assert!(empty.bytes.is_empty());
+        let at_end = reader
+            .raw_byte_range(valid_end, Offset::new(6), valid_end, 10, None)
+            .unwrap();
+        assert_eq!(at_end.record_count, 0);
+        assert_eq!(at_end.next_offset.get(), 6);
+    }
+
+    /// A torn/corrupt frame header ENDS the raw run exactly as it ends a scan — a bogus tail is never
+    /// carried in the zero-copy bytes (CRC integrity at the run boundary is preserved).
+    #[test]
+    fn raw_byte_range_stops_at_a_torn_frame_like_scan() {
+        let file = Arc::new(InMemoryFile::new());
+        let mut w = SegmentWriter::create(Arc::clone(&file), header()).unwrap();
+        w.append(&rec(0, b"good1")).unwrap();
+        let after_first = w.write_pos();
+        w.append(&rec(1, b"good2")).unwrap();
+        w.sync().unwrap();
+        // Corrupt the second frame's HEADER (the magic byte) so its `decoded_len` header CRC fails.
+        let mut bytes = file.snapshot();
+        let magic_byte = usize::try_from(after_first).unwrap();
+        bytes[magic_byte] ^= 0xFF;
+        file.set_len(0).unwrap();
+        file.write_all_at(&bytes, 0).unwrap();
+
+        let reader = SegmentReader::open(Arc::clone(&file)).unwrap();
+        // Start at the first RECORD frame (past the 64-byte segment header); read_end is the whole FILE
+        // length (past both frames). Reading forward, the corrupt second header fails its CRC in
+        // `decoded_len` and ends the run after the one good frame.
+        let first_record_byte = SEGMENT_HEADER_LEN as u64;
+        let file_len = file.len().unwrap();
+        let raw = reader
+            .raw_byte_range(first_record_byte, Offset::new(0), file_len, 10, None)
+            .unwrap();
+        assert_eq!(
+            raw.record_count, 1,
+            "the torn header ends the run at one frame"
+        );
+        let (view, consumed) = codec::decode(&raw.bytes).expect("the one good frame decodes");
+        assert_eq!(view.payload, b"good1");
+        assert_eq!(consumed, raw.bytes.len());
     }
 
     #[test]


### PR DESCRIPTION
Closes #542 (V2-M1, [M1-I6]).

## What slice shipped

The **storage-layer zero-copy READ primitive** + the **memory-backend Bytes path**, wired into the lock-free off-actor read plane (#654). This is the foundation both the memory path and a future disk `sendfile(2)` path build on.

- **`SegmentReader::raw_byte_range`** (segment.rs): reads a contiguous run of sealed-segment frames as **one** `read_exact_at` into one shared buffer and returns the raw on-disk frame bytes as a single refcounted `bytes::Bytes` slice (`RawByteRun`) — **no `OwnedRecord` materialization, no body decode**. Frame boundaries are walked with the cheap header-only `codec::decoded_len` (which validates each frame's **header CRC**), so a torn/corrupt header ends the run exactly as a scan stops at the first bad frame.
- **`ReadPlane::read_range_raw`** (read_plane.rs): the off-actor, lock-free analogue of `read_range`, returning the raw run (bounded to one sealed segment — a contiguous byte range is one slice of one file) plus a `fallback_from` so the caller resumes at the next segment or the active tail through the actor.

**Memory backend:** the run is a true no-copy `bytes::Bytes` slice of the segment's resident bytes (reuses the #480 `Bytes` substrate). **Disk backend:** one positioned read into one buffer — the contiguous extent a later `sendfile(2)` path hands to the kernel without re-plumbing the read shape.

## Fallback + CRC story

- **Fallback:** zero-copy is an optimization, never the only path. The off-actor raw read returns `fallback_from` whenever it can't serve raw (active tail, compacted slot, segment boundary), and the existing materialize+encode path (`read_range`, untouched) remains the always-available path. (IronBus is plaintext TCP only — no TLS stack is linked, per the `deny.toml` C-crypto ban — so the TLS-can't-sendfile concern is documented for the deferred syscall, not hit today.)
- **CRC integrity preserved:** each stored frame's **body CRC ships verbatim** inside the returned bytes, so the consumer verifies every frame end-to-end exactly as today. The broker never touches the body on this path, so the body-CRC check is moved to the only place that still touches the bytes (the client) — **never silently dropped**. The frame's header CRC is still validated while walking run boundaries.

## Tests (storage lib: 313 pass, +9)

- **byte-identical differential:** decoding the raw run yields the SAME records (offset, seq, timestamp, flags, key, headers, payload — every byte) in the SAME order as the materialize path, swept over every start offset and several batch sizes.
- raw run **chains across segment boundaries** with no gaps/overlaps (reconstructs the whole sealed prefix).
- **CRC end-to-end:** full `codec::decode` (header AND body CRC) of every shipped frame passes.
- **byte cap** honored with "at least one"; a **torn header** ends the run; the **memory-backend Bytes-slice** path; empty/boundary runs.

## Bench (the proof)

`zero_copy_delivery` (in-memory backend, 64-record batch, median): zero-copy raw vs materialize+encode —

| payload | materialize+encode | zero-copy raw | speedup |
|---|---|---|---|
| 16 B | 9.52 µs | 4.37 µs | **2.2x** |
| 256 B | 11.43 µs | 4.76 µs | **2.4x** |
| 4096 B | 39.12 µs | 3.41 µs | **11.5x** |

The win grows with payload size (the materialize path copies every payload byte into the wire buffer; the zero-copy path never touches it). Full t4g + NATS consume comparison is the milestone gate #554.

## Deps / unsafe

**No new dependency** (`bytes`, `arc-swap`, `crc32c` all pre-existing; `Cargo.lock` unchanged → `cargo deny` not triggered). **No `unsafe`, no `nix`/`libc` syscall.** Changes are confined to `ironbus-storage` — `ironbus-core` stays IO-free.

## Scope boundary (vs #541 / #546 / #540)

- **Disk `sendfile(2)` + the `DeliverBatch` on-wire frame (#541, OPEN) are DEFERRED and flagged.** The on-disk frame layout differs from the on-wire `Deliver` body (seq / u32 lengths / header-CRC vs offset / generation / u16 lengths), so shipping the raw stored run on the wire as a batch requires #541's new additive frame **plus** a client-side decoder of the on-disk layout — a multi-issue surface — and the Linux-only syscall can't be differentially/CRC-tested correctly in this environment. This PR ships the byte-range-to-`Bytes` primitive + tier-S off-actor wiring + the memory path, the safe core, and leaves the disk syscall for a focused follow-up.
- **Tier-W (lease-mode) batched zero-copy is #546** — untouched.
- **Verify-once-while-resident CRC is #540** — the primitive carries CRCs verbatim and is compatible with it; not changed here.

## Gates (all pass)

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — clean **from a fresh `cargo clean`** (not incremental)
- `cargo test --workspace --all-features --locked` — all pass (storage lib 313, 0 failed)

## What to scrutinize

- The single-segment bound on the off-actor raw run + the `fallback_from` resume logic (the boundary chaining test covers it, but it's the trickiest invariant).
- The `trim_raw_run` header-only walk that re-anchors a sparse-anchor read to the exact `seg_start` while staying copy-free.
- The header-CRC-only boundary walk vs the deferred body-CRC: confirm the integrity story (body CRC ships verbatim) reads correctly for the eventual wire path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)