### PR TITLE
feat(consume): DeliverBatch wire frame for contiguous run delivery (#541)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -839,6 +839,7 @@ dependencies = [
 name = "ironbus-proto"
 version = "0.0.0"
 dependencies = [
+ "criterion",
  "proptest",
 ]
 

--- a/crates/ironbus-client/src/lib.rs
+++ b/crates/ironbus-client/src/lib.rs
@@ -27,11 +27,11 @@ use ironbus_core::compress::{
 use ironbus_core::types::RecordFlags;
 use ironbus_proto::frame::{decode_frame, encode_frame, FrameDecode, FrameError, FrameType};
 use ironbus_proto::message::{
-    decode_dead_letter, decode_deliver, decode_gap_marker, decode_info, decode_produce_confirm,
-    decode_pub_ack, decode_truncated, encode_ack, encode_connect, encode_cumulative_ack,
-    encode_fetch, encode_pub, encode_sub, produce_confirm_status, AckBody, AckLevel, AckOp,
-    BodyError, ConnectBody, ConsumeTier, CumulativeAckBody, FetchBody, PubBody, SubBody,
-    PUB_FLAG_ACK_LEVEL_MASK, PUB_FLAG_ACK_LEVEL_SHIFT,
+    decode_dead_letter, decode_deliver, decode_deliver_batch, decode_gap_marker, decode_info,
+    decode_produce_confirm, decode_pub_ack, decode_truncated, encode_ack, encode_connect,
+    encode_cumulative_ack, encode_fetch, encode_pub, encode_sub, produce_confirm_status, AckBody,
+    AckLevel, AckOp, BodyError, ConnectBody, ConsumeTier, CumulativeAckBody, DeliverBody,
+    FetchBody, PubBody, SubBody, PUB_FLAG_ACK_LEVEL_MASK, PUB_FLAG_ACK_LEVEL_SHIFT,
 };
 use std::io::{self, Read, Write};
 use std::net::{TcpStream, ToSocketAddrs};
@@ -176,6 +176,15 @@ pub struct ClientConfig {
     /// backward-compatible) sends no default tier, so the body carries no tier byte and the server
     /// applies Tier-W.
     pub default_consume_tier: Option<ConsumeTier>,
+    /// Whether this client ADVERTISES that it understands the raw-framed `DeliverBatch` frame (tag 26,
+    /// #541, M1-I5): when `true`, the `Connect` sets the [`CONNECT_FLAG_UNDERSTANDS_DELIVER_BATCH`]
+    /// capability bit, so the server MAY deliver a contiguous Tier-S run as ONE `DeliverBatch` (the
+    /// records' on-disk frame bytes, which this client decodes locally) instead of N per-record
+    /// `Deliver` frames. When `false` (the default, backward-compatible) the client does not advertise
+    /// it and ALWAYS receives per-record `Deliver` frames — byte-for-byte today's behavior. A caller
+    /// checks [`Client::deliver_batch_enabled`] after connecting to learn whether the server confirmed
+    /// it. The decoded `Message`s are IDENTICAL either way; this only changes the wire framing.
+    pub understands_deliver_batch: bool,
 }
 
 impl Default for ClientConfig {
@@ -205,6 +214,10 @@ impl Default for ClientConfig {
             // so it sends no tier byte and the server applies Tier-W (#543). A caller opts into a
             // connection default by setting this AND `understands_streaming`.
             default_consume_tier: None,
+            // Off by default: an unconfigured client does not advertise DeliverBatch support, so it
+            // always receives per-record `Deliver` frames exactly as before (#541). A caller opts into
+            // the raw-framed batch path by setting this (typically alongside `understands_streaming`).
+            understands_deliver_batch: false,
         }
     }
 }
@@ -485,6 +498,58 @@ fn with_ack_level_bits(flags: u8, level: AckLevel) -> u8 {
     (flags & !PUB_FLAG_ACK_LEVEL_MASK) | bits
 }
 
+/// Ingests one decoded delivery (`d`) into the fetch result, applying the SAME transparent broker-side
+/// decompression (#430) the per-record path does and pushing the resulting [`Message`] onto `messages`
+/// — UNLESS a prior decompression failure already poisoned the batch (`poison.is_some()`), in which case
+/// the delivery is consumed and dropped un-acked (the broker redelivers it). Shared by the per-record
+/// `Deliver` arm and the `DeliverBatch` arm (#541) so a batched delivery yields byte-for-byte the same
+/// `Message` an equivalent per-record `Deliver` would. The FIRST decompression failure is recorded in
+/// `poison` (carrying the record's offset/generation so the caller can ack/nack-skip it); the rest of
+/// the batch is still drained before the error surfaces.
+fn ingest_delivery(
+    d: &DeliverBody<'_>,
+    messages: &mut Vec<Message>,
+    poison: &mut Option<ClientError>,
+) {
+    // Draining after a decompression failure: the frame is consumed (keeping the connection framed) but
+    // the delivery is dropped un-acked, so the broker redelivers it after its visibility timeout.
+    if poison.is_some() {
+        return;
+    }
+    let flags = RecordFlags::from_bits(d.flags);
+    let (flags, payload) = if flags.contains(RecordFlags::COMPRESSED) {
+        match decompress_payload(
+            flags,
+            d.payload,
+            &NoDictionaries,
+            DEFAULT_MAX_DECOMPRESSED_BYTES,
+        ) {
+            Ok(payload) => (d.flags & !RecordFlags::COMPRESSED.bits(), payload),
+            // The poison record's offset and lease generation travel with the error, so the caller can
+            // ack/nack-skip it; the rest of the batch is drained before the error is returned.
+            Err(source) => {
+                *poison = Some(ClientError::Decompress {
+                    source,
+                    offset: d.offset,
+                    generation: d.generation,
+                });
+                return;
+            }
+        }
+    } else {
+        (d.flags, d.payload.to_vec())
+    };
+    messages.push(Message {
+        offset: d.offset,
+        generation: d.generation,
+        flags,
+        timestamp_ms: d.timestamp_ms,
+        key: d.key.to_vec(),
+        headers: d.headers.to_vec(),
+        payload,
+    });
+}
+
 /// Maps a wire `ProduceConfirm` status byte (#497) to a client [`ConfirmOutcome`]. An unknown future
 /// status decodes to [`ConfirmOutcome::Unknown`] (forward-compatible: the codec already tolerated it),
 /// never an error.
@@ -598,6 +663,12 @@ pub struct Client {
     /// confirmed it in `Info`. When `false` (an old server, or the client did not advertise), this
     /// connection is only ever served Tier-W.
     streaming_enabled: bool,
+    /// Whether the raw-framed `DeliverBatch` frame (tag 26) is ACTIVE on this connection (#541, M1-I5):
+    /// `true` only when this client advertised it ([`ClientConfig::understands_deliver_batch`]) AND the
+    /// server confirmed it in `Info`. When `true`, a contiguous Tier-S run may arrive as ONE
+    /// `DeliverBatch` (decoded locally into the same `Message`s); when `false` (an old server, or the
+    /// client did not advertise), every delivery is a per-record `Deliver`.
+    deliver_batch_enabled: bool,
     /// The connection-wide DEFAULT consume tier the SERVER adopted for this connection (#543, V2-M1),
     /// echoed in `Info`, or `None` if the server did not echo one (an old server, or it defaulted to
     /// Tier-W). A subscription that does not pick its own tier consumes at this default server-side.
@@ -641,6 +712,7 @@ impl Client {
             negotiated_credit_bytes: None,
             gap_marker_enabled: false,
             streaming_enabled: false,
+            deliver_batch_enabled: false,
             negotiated_default_tier: None,
             confirm_cache: Vec::new(),
         };
@@ -664,6 +736,10 @@ impl Client {
                 // (byte-for-byte today's behavior); a caller opts in via the config.
                 understands_streaming: config.understands_streaming,
                 default_tier: config.default_consume_tier.map(ConsumeTier::as_u8),
+                // The DeliverBatch capability bit (#541). Off by default, so the body is byte-for-byte
+                // the pre-#541 `Connect` and the client receives only per-record `Deliver` frames; a
+                // caller opts in via the config to receive raw-framed batches.
+                understands_deliver_batch: config.understands_deliver_batch,
             },
             &mut connect_body,
         );
@@ -686,6 +762,10 @@ impl Client {
                 // the connection default a tier-less subscription consumes at.
                 client.streaming_enabled = info.streaming;
                 client.negotiated_default_tier = info.default_tier.map(ConsumeTier::from_u8);
+                // The DeliverBatch frame is active only when the server CONFIRMED it (it does so only
+                // when the client advertised it understands the frame), so an old server's empty Info
+                // leaves it off and every delivery is a per-record `Deliver` (#541).
+                client.deliver_batch_enabled = info.deliver_batch;
                 Ok(client)
             }
             (FrameType::Err, body) => {
@@ -728,6 +808,16 @@ impl Client {
     #[must_use]
     pub fn streaming_enabled(&self) -> bool {
         self.streaming_enabled
+    }
+
+    /// Whether the raw-framed `DeliverBatch` frame (tag 26) is ACTIVE on this connection (#541, M1-I5):
+    /// `true` only when this client advertised it ([`ClientConfig::understands_deliver_batch`]) AND the
+    /// server confirmed it in `Info`. When `true`, a contiguous Tier-S run may arrive as ONE
+    /// `DeliverBatch` (transparently decoded into the same `Message`s a per-record `Deliver` run would
+    /// yield); when `false`, every delivery is a per-record `Deliver`.
+    #[must_use]
+    pub fn deliver_batch_enabled(&self) -> bool {
+        self.deliver_batch_enabled
     }
 
     /// The connection-wide DEFAULT consume tier the server adopted for this connection (#543, V2-M1),
@@ -1384,51 +1474,70 @@ impl Client {
             match (frame_type, body) {
                 (FrameType::Deliver, body) => {
                     let d = decode_deliver(&body).map_err(ClientError::Body)?;
-                    // Draining after a decompression failure: the frame is consumed (keeping the
-                    // connection framed) but the delivery is dropped un-acked, so the broker
-                    // redelivers it after its visibility timeout.
-                    if poison.is_some() {
-                        continue;
+                    ingest_delivery(&d, &mut messages, &mut poison);
+                }
+                // A raw-framed batch (#541): ONE frame carrying a contiguous run of records as their
+                // ON-DISK frame bytes. Decode the header (the run's first_offset / generation /
+                // record_count), then decode each on-disk frame and reconstruct its offset POSITIONALLY
+                // (first_offset + i, the run being dense and contiguous), feeding each through the SAME
+                // per-record path a `Deliver` takes — so the resulting `Message`s are byte-for-byte what
+                // an equivalent run of per-record `Deliver` frames would yield. Each frame's CRC is
+                // VERIFIED here by `codec::decode` (header and body), so integrity is checked end-to-end;
+                // a corrupt frame is a typed error, never silently accepted. Only seen on a
+                // batch-capable connection; an old server never sends this tag.
+                (FrameType::DeliverBatch, body) => {
+                    let (header, record_bytes) =
+                        decode_deliver_batch(&body).map_err(ClientError::Body)?;
+                    // A batch carries N records but counted as ONE frame at the loop top; charge the
+                    // remaining (N - 1) records against the credit bound so a hostile server cannot
+                    // smuggle an unbounded run of records inside one batch frame. The server bounds a
+                    // real batch by the negotiated credit, so this never trips for a well-behaved peer.
+                    frames = frames
+                        .saturating_add(header.record_count as usize)
+                        .saturating_sub(1);
+                    if frames > limit {
+                        return Err(ClientError::BadResponse(
+                            "server streamed more records than the requested credit",
+                        ));
                     }
-                    // Transparent broker-side decompression (#430): a delivery carrying the
-                    // COMPRESSED bit is decompressed back to the original payload (and the bit
-                    // cleared), so the caller sees exactly the bytes the producer published,
-                    // codec-independent. Bounded by the decompressed-size cap (a bomb guard) and
-                    // dictionary-free (`NoDictionaries`; the lz4 path never references one); a
-                    // payload this build cannot decode is the typed `Decompress` error, no panic.
-                    let flags = RecordFlags::from_bits(d.flags);
-                    let (flags, payload) = if flags.contains(RecordFlags::COMPRESSED) {
-                        match decompress_payload(
-                            flags,
-                            d.payload,
-                            &NoDictionaries,
-                            DEFAULT_MAX_DECOMPRESSED_BYTES,
-                        ) {
-                            Ok(payload) => (d.flags & !RecordFlags::COMPRESSED.bits(), payload),
-                            // The poison record's offset and lease generation travel with the
-                            // error, so the caller can ack/nack-skip it; the rest of the batch
-                            // is drained (see `poison` above) before the error is returned.
-                            Err(source) => {
-                                poison = Some(ClientError::Decompress {
-                                    source,
-                                    offset: d.offset,
-                                    generation: d.generation,
-                                });
-                                continue;
-                            }
-                        }
-                    } else {
-                        (d.flags, d.payload.to_vec())
-                    };
-                    messages.push(Message {
-                        offset: d.offset,
-                        generation: d.generation,
-                        flags,
-                        timestamp_ms: d.timestamp_ms,
-                        key: d.key.to_vec(),
-                        headers: d.headers.to_vec(),
-                        payload,
-                    });
+                    let mut cursor = 0usize;
+                    let mut offset = header.first_offset;
+                    let mut decoded = 0u32;
+                    while cursor < record_bytes.len() {
+                        // CRC-verify and decode ONE on-disk record frame. A bad frame (torn, or a CRC
+                        // mismatch) is a typed `BadResponse`, so the broker never slips a corrupt or
+                        // truncated batch past the client unnoticed.
+                        let (view, consumed) = ironbus_core::codec::decode(&record_bytes[cursor..])
+                            .map_err(|_| {
+                                ClientError::BadResponse("malformed record in DeliverBatch body")
+                            })?;
+                        // Reconstruct the on-wire per-record `Deliver` from the on-disk record: the
+                        // OFFSET is positional (the on-disk frame carries `seq`, not offset), and the
+                        // generation is the batch's (0 for the lease-free Tier-S path). The remaining
+                        // fields (flags/timestamp/key/headers/payload) are the stored record's, so the
+                        // delivery is identical to a per-record `Deliver` for the same record.
+                        let d = DeliverBody {
+                            offset,
+                            generation: header.generation,
+                            flags: view.flags.bits(),
+                            timestamp_ms: view.timestamp_ms,
+                            key: view.key,
+                            headers: view.headers,
+                            payload: view.payload,
+                        };
+                        ingest_delivery(&d, &mut messages, &mut poison);
+                        offset = offset.saturating_add(1);
+                        decoded = decoded.saturating_add(1);
+                        cursor += consumed;
+                    }
+                    // The decoded frame count MUST match the header's record_count and consume the body
+                    // exactly: a mismatch means a malformed batch (a partial frame, or a wrong count),
+                    // which is a typed error rather than a silently short batch.
+                    if cursor != record_bytes.len() || decoded != header.record_count {
+                        return Err(ClientError::BadResponse(
+                            "DeliverBatch record_count or body length mismatch",
+                        ));
+                    }
                 }
                 // An in-band dead-letter advisory for an offset skipped as poison (#63). It is
                 // not a delivery, so it carries its own offset and does not ack.
@@ -3481,6 +3590,7 @@ mod tests {
                 default_ack_level: None,
                 streaming: false,
                 default_tier: None,
+                deliver_batch: false,
             },
             &mut body,
         );
@@ -4112,6 +4222,137 @@ mod tests {
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].payload, original);
         assert_eq!(messages[0].flags & RecordFlags::COMPRESSED.bits(), 0);
+        drop(c);
+        handle.join().unwrap();
+    }
+
+    /// One test record's fields `(flags, key, headers, payload)` for building on-disk batch bytes.
+    type BatchRec<'a> = (u8, &'a [u8], &'a [u8], &'a [u8]);
+
+    /// Builds the contiguous on-disk frame bytes for `records` (seq starting at `base_seq`), the body a
+    /// real broker would splice into a `DeliverBatch` from a stored segment.
+    fn on_disk_record_bytes(base_seq: u64, records: &[BatchRec<'_>]) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        for (i, (flags, key, headers, payload)) in records.iter().enumerate() {
+            ironbus_core::codec::encode(
+                &ironbus_core::codec::RecordView {
+                    seq: ironbus_core::types::Seq::new(base_seq + i as u64),
+                    timestamp_ms: 1000 + i as u64,
+                    flags: RecordFlags::from_bits(*flags),
+                    key,
+                    headers,
+                    payload,
+                },
+                &mut bytes,
+            )
+            .unwrap();
+        }
+        bytes
+    }
+
+    #[test]
+    fn a_scripted_deliver_batch_decodes_to_the_same_messages_as_n_delivers() {
+        // #541 client-side: a scripted server streams ONE DeliverBatch carrying a contiguous run as
+        // on-disk frame bytes; the client decodes it into the SAME `Message`s a per-record `Deliver` run
+        // would yield — offsets reconstructed positionally from the header's first_offset, each record's
+        // CRC verified by the on-disk decode. The decoded messages match a per-record reference exactly.
+        let recs: Vec<BatchRec<'_>> = vec![
+            (0, b"k0", b"h0", b"payload-zero"),
+            (0, b"k1", b"", b"payload-one"),
+            (0, b"", b"h2", b"two"),
+        ];
+        let record_bytes = on_disk_record_bytes(0, &recs);
+        let mut batch_body = Vec::new();
+        ironbus_proto::message::encode_deliver_batch(
+            &ironbus_proto::message::DeliverBatchHeader {
+                first_offset: 100,
+                generation: 0,
+                record_count: 3,
+            },
+            &record_bytes,
+            &mut batch_body,
+        );
+        // The Info advertises the DeliverBatch capability so the client's handshake records it (not
+        // required for decode, but it is the realistic wire). The client decodes the tag regardless.
+        let mut info_body = Vec::new();
+        encode_info(
+            &InfoBody {
+                deliver_batch: true,
+                ..InfoBody::default()
+            },
+            &mut info_body,
+        );
+        let mut script = frame(FrameType::Info, &info_body);
+        script.extend(frame(FrameType::DeliverBatch, &batch_body));
+        script.extend(frame(FrameType::FlowEnd, &3u32.to_le_bytes()));
+        let (addr, handle) = raw_server(script);
+
+        let mut c = Client::connect_with(
+            addr,
+            &ClientConfig {
+                understands_deliver_batch: true,
+                understands_streaming: true,
+                ..ClientConfig::default()
+            },
+        )
+        .unwrap();
+        assert!(c.deliver_batch_enabled(), "the capability is confirmed");
+        let messages = c.fetch(10).unwrap().messages;
+        assert_eq!(messages.len(), 3);
+        // Offsets reconstructed positionally: 100, 101, 102.
+        for (i, m) in messages.iter().enumerate() {
+            assert_eq!(m.offset, 100 + i as u64, "positional offset");
+            assert_eq!(m.generation, 0, "the lease-free streaming generation");
+        }
+        assert_eq!(messages[0].key, b"k0");
+        assert_eq!(messages[0].headers, b"h0");
+        assert_eq!(messages[0].payload, b"payload-zero");
+        assert_eq!(messages[1].key, b"k1");
+        assert_eq!(messages[1].payload, b"payload-one");
+        assert_eq!(messages[2].headers, b"h2");
+        assert_eq!(messages[2].payload, b"two");
+        drop(c);
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn a_scripted_deliver_batch_with_a_corrupt_record_is_a_typed_error_never_a_panic() {
+        // CRC end-to-end: a DeliverBatch body whose on-disk record bytes are corrupted (a flipped byte
+        // breaks the body CRC) is a typed `BadResponse`, never a panic and never a corrupt message handed
+        // to the caller — the client verifies each record's CRC as it decodes the batch.
+        let recs: Vec<BatchRec<'_>> = vec![(0, b"", b"", b"good-record")];
+        let mut record_bytes = on_disk_record_bytes(0, &recs);
+        // Flip a payload byte: the header CRC still passes (the header is untouched), but the body CRC
+        // now mismatches, so `codec::decode` rejects it.
+        let last = record_bytes.len() - ironbus_core::format::RECORD_TRAILER_LEN - 1;
+        record_bytes[last] ^= 0xFF;
+        let mut batch_body = Vec::new();
+        ironbus_proto::message::encode_deliver_batch(
+            &ironbus_proto::message::DeliverBatchHeader {
+                first_offset: 0,
+                generation: 0,
+                record_count: 1,
+            },
+            &record_bytes,
+            &mut batch_body,
+        );
+        let mut script = frame(FrameType::Info, b"");
+        script.extend(frame(FrameType::DeliverBatch, &batch_body));
+        script.extend(frame(FrameType::FlowEnd, &1u32.to_le_bytes()));
+        let (addr, handle) = raw_server(script);
+        let mut c = Client::connect_with(
+            addr,
+            &ClientConfig {
+                understands_deliver_batch: true,
+                ..ClientConfig::default()
+            },
+        )
+        .unwrap();
+        let err = c.fetch(10).unwrap_err();
+        assert!(
+            matches!(err, ClientError::BadResponse(_)),
+            "a corrupt batch record is a typed BadResponse, got {err:?}"
+        );
         drop(c);
         handle.join().unwrap();
     }

--- a/crates/ironbus-proto/Cargo.toml
+++ b/crates/ironbus-proto/Cargo.toml
@@ -10,6 +10,14 @@ authors.workspace = true
 
 [dev-dependencies]
 proptest = "1"
+criterion = "0.5"
 
 [lints]
 workspace = true
+
+# Informational micro-bench (#541): the framing + write overhead a DeliverBatch removes versus N
+# per-record Deliver frames over a contiguous run. Run on demand (`cargo bench -p ironbus-proto`), NOT
+# in per-PR CI; the full consume-vs-NATS leg is #554.
+[[bench]]
+name = "deliver_batch_framing"
+harness = false

--- a/crates/ironbus-proto/benches/deliver_batch_framing.rs
+++ b/crates/ironbus-proto/benches/deliver_batch_framing.rs
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! Informational micro-benchmark for the `DeliverBatch` raw-framed delivery FRAMING + WRITE overhead the
+//! batch frame removes versus N per-record Deliver frames (#541, M1-I5). The local proof for the
+//! batch-framing lever; the full t4g + NATS consume comparison is the milestone gate (#554).
+//!
+//! ## What it isolates: the per-record framing + re-encode the batch removes
+//!
+//! For a Tier-S streaming fetch the broker serves a CONTIGUOUS run of stored records. Two delivery
+//! framings carry the SAME run:
+//!
+//! - PER-RECORD (the BEFORE): N `Deliver` frames. For each record the broker re-encodes the wire body
+//!   (`encode_deliver`: offset, generation, flags, timestamp, length-prefixed key/headers, then the
+//!   payload — a copy of every field) and wraps it in a frame envelope (`encode_frame`: the 4-byte
+//!   length prefix + 1-byte tag). N body re-encodes + N envelopes + N payload copies into the wire
+//!   buffer.
+//! - DELIVERBATCH (this issue): ONE `DeliverBatch` frame. The broker writes the small fixed header
+//!   (`encode_deliver_batch`: version + `field_len` + `first_offset` + generation + `record_count`) ONCE,
+//!   then copies the contiguous run's ON-DISK frame bytes VERBATIM (the bytes it already holds as a
+//!   storage `RawByteRun`, modeled here as a precomputed blob the broker does not re-encode), wrapped
+//!   in ONE frame envelope. ONE header + ONE envelope + ONE bulk copy, zero per-record re-encode.
+//!
+//! The expected result: the batch framing is a clear multiple cheaper, because it does ONE envelope +
+//! ONE header + ONE bulk copy where the per-record path does N envelopes + N body re-encodes + N field
+//! copies. The gap IS the framing/write lever this issue targets, measured at the wire-encode boundary
+//! (the disk `sendfile(2)` that turns the batch's stored-bytes body into a zero-USER-SPACE-copy socket
+//! splice is the deferred follow-up #658, for which the on-disk-bytes batch body is the prerequisite).
+//!
+//! What it measures and what it does NOT: this is the pure wire-encode cost (no IO, no socket). The
+//! on-disk run bytes are precomputed and held as a `bytes::Bytes`-like `Vec` to model the broker
+//! NEVER touching them on the batch path — exactly the zero-re-encode property #658 splices on. Run on
+//! demand (`cargo bench -p ironbus-proto`), NOT in per-PR CI; the full consume-vs-NATS leg is #554.
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use ironbus_proto::frame::{encode_frame, FrameType};
+use ironbus_proto::message::{
+    encode_deliver, encode_deliver_batch, DeliverBatchHeader, DeliverBody,
+};
+
+/// Records per delivered batch (a representative streaming run).
+const BATCH: usize = 64;
+
+/// Payload sizes to sweep: a small record (framing/encode-dominated, where the per-record envelope +
+/// body-field overhead dominates) and larger ones (copy-dominated).
+const PAYLOADS: [usize; 3] = [16, 256, 4096];
+
+/// One record's fields for the bench (the broker holds these as a stored `OwnedRecord`).
+struct Rec {
+    offset: u64,
+    flags: u8,
+    timestamp_ms: u64,
+    key: Vec<u8>,
+    headers: Vec<u8>,
+    payload: Vec<u8>,
+}
+
+fn make_records(payload_len: usize) -> Vec<Rec> {
+    (0..BATCH as u64)
+        .map(|i| Rec {
+            offset: i,
+            flags: 0,
+            timestamp_ms: 1000 + i,
+            key: vec![(i % 7) as u8; 4],
+            headers: vec![(i % 5) as u8; 2],
+            payload: vec![(i % 251) as u8; payload_len],
+        })
+        .collect()
+}
+
+/// Models the contiguous ON-DISK run bytes the broker already holds for the batch path (a
+/// `RawByteRun`), built once OUTSIDE the timed loop so the batch path's cost is the header write + the
+/// ONE bulk copy, NOT a re-encode. The exact on-disk codec lives in `ironbus-storage` (below this
+/// crate), so the blob here is a faithful stand-in of the same total byte count.
+fn on_disk_blob(records: &[Rec]) -> Vec<u8> {
+    // Per the frozen on-disk layout: 36-byte header + body (key+headers+payload) + 8-byte trailer.
+    let mut blob = Vec::new();
+    for r in records {
+        blob.extend_from_slice(&[0u8; 36]);
+        blob.extend_from_slice(&r.key);
+        blob.extend_from_slice(&r.headers);
+        blob.extend_from_slice(&r.payload);
+        blob.extend_from_slice(&[0u8; 8]);
+    }
+    blob
+}
+
+fn bench_framing(c: &mut Criterion) {
+    let mut group = c.benchmark_group("deliver_batch_framing");
+    for payload_len in PAYLOADS {
+        let records = make_records(payload_len);
+        let blob = on_disk_blob(&records);
+
+        // BEFORE: N per-record Deliver frames (re-encode each body + wrap each in a frame envelope).
+        group.bench_with_input(
+            BenchmarkId::new("per_record_deliver", payload_len),
+            &payload_len,
+            |b, _| {
+                b.iter(|| {
+                    let mut out = Vec::new();
+                    for r in &records {
+                        let mut body = Vec::new();
+                        encode_deliver(
+                            &DeliverBody {
+                                offset: r.offset,
+                                generation: 0,
+                                flags: r.flags,
+                                timestamp_ms: r.timestamp_ms,
+                                key: &r.key,
+                                headers: &r.headers,
+                                payload: &r.payload,
+                            },
+                            &mut body,
+                        )
+                        .unwrap();
+                        encode_frame(FrameType::Deliver, &body, &mut out).unwrap();
+                    }
+                    black_box(out.len())
+                });
+            },
+        );
+
+        // AFTER: ONE DeliverBatch frame (one header + one bulk copy of the precomputed on-disk run).
+        group.bench_with_input(
+            BenchmarkId::new("deliver_batch", payload_len),
+            &payload_len,
+            |b, _| {
+                b.iter(|| {
+                    let mut body = Vec::new();
+                    encode_deliver_batch(
+                        &DeliverBatchHeader {
+                            first_offset: 0,
+                            generation: 0,
+                            record_count: u32::try_from(BATCH).unwrap(),
+                        },
+                        &blob,
+                        &mut body,
+                    );
+                    let mut out = Vec::new();
+                    encode_frame(FrameType::DeliverBatch, &body, &mut out).unwrap();
+                    black_box(out.len())
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_framing);
+criterion_main!(benches);

--- a/crates/ironbus-proto/src/frame.rs
+++ b/crates/ironbus-proto/src/frame.rs
@@ -168,6 +168,31 @@ pub enum FrameType {
     /// followed by the work-group name as the remainder (empty selects the default group) — identical
     /// in shape to the [`crate::message::CumulativeAckBody`].
     StreamCommit,
+    /// Server delivers a CONTIGUOUS run of records to a consumer as ONE batch frame (#541, M1-I5): the
+    /// RAW-FRAMED batch delivery whose body carries the records' ON-DISK frame bytes VERBATIM, so a
+    /// contiguous stored run ships in one frame without the broker re-encoding per record. It is the
+    /// BATCH twin of [`FrameType::Deliver`] (tag 13): where `Deliver` carries ONE record re-encoded into
+    /// the on-WIRE layout (offset / generation / u16 lengths), `DeliverBatch` carries N records as the
+    /// concatenation of their on-DISK frames (seq / u32 lengths / header-CRC + body-CRC trailer) plus a
+    /// small fixed header naming the run's `first_offset` and `generation`, so the CLIENT decodes the
+    /// on-disk layout directly and reconstructs each record's offset POSITIONALLY (`first_offset + i`,
+    /// the run being dense and contiguous). Because the body IS the stored bytes, a later disk
+    /// `sendfile(2)`/`splice(2)` path (#658) can splice the segment's page-cache bytes straight into the
+    /// socket after the fixed header — this frame is that path's HARD prerequisite. Each record's own
+    /// CRC32C (header and body) ships inside the body, so the consumer verifies every record end-to-end
+    /// exactly as it does a per-record `Deliver`; integrity is never silently dropped.
+    ///
+    /// It is OPT-IN and ADDITIVE: the server sends it ONLY to a consumer that advertised it understands
+    /// the frame (the [`crate::message::CONNECT_FLAG_UNDERSTANDS_DELIVER_BATCH`] capability bit, confirmed
+    /// by [`crate::message::INFO_FLAG_DELIVER_BATCH`]). An old client that did not advertise it keeps
+    /// receiving the per-record `Deliver` run, byte-for-byte unchanged, and never sees this NEW
+    /// append-only tag. Used today on the Tier-S `StreamFetch` delivery path (the contiguous
+    /// consumer-managed-offset batch from #544); the response is terminated by exactly one
+    /// [`FrameType::FlowEnd`] carrying the delivered count, exactly as the per-record path. Body: a
+    /// [`crate::message::DeliverBatchHeader`] (`body_version: u8`, `field_len: u16`, then `first_offset:
+    /// u64 LE`, `generation: u64 LE`, `record_count: u32 LE`), then the contiguous on-disk record-frame
+    /// bytes as the remainder.
+    DeliverBatch,
 }
 
 impl FrameType {
@@ -200,6 +225,7 @@ impl FrameType {
             FrameType::Fetch => 23,
             FrameType::StreamFetch => 24,
             FrameType::StreamCommit => 25,
+            FrameType::DeliverBatch => 26,
         }
     }
 
@@ -233,6 +259,7 @@ impl FrameType {
             23 => FrameType::Fetch,
             24 => FrameType::StreamFetch,
             25 => FrameType::StreamCommit,
+            26 => FrameType::DeliverBatch,
             _ => return None,
         })
     }
@@ -365,7 +392,7 @@ mod tests {
     use super::*;
     use proptest::prelude::*;
 
-    const ALL_TYPES: [FrameType; 25] = [
+    const ALL_TYPES: [FrameType; 26] = [
         FrameType::Connect,
         FrameType::Info,
         FrameType::Ping,
@@ -391,6 +418,7 @@ mod tests {
         FrameType::Fetch,
         FrameType::StreamFetch,
         FrameType::StreamCommit,
+        FrameType::DeliverBatch,
     ];
 
     #[test]
@@ -434,6 +462,7 @@ mod tests {
         assert_eq!(FrameType::Fetch.as_u8(), 23);
         assert_eq!(FrameType::StreamFetch.as_u8(), 24);
         assert_eq!(FrameType::StreamCommit.as_u8(), 25);
+        assert_eq!(FrameType::DeliverBatch.as_u8(), 26);
     }
 
     #[test]
@@ -489,8 +518,8 @@ mod tests {
         // The Tier-W verbs are untouched.
         assert_eq!(FrameType::Flow.as_u8(), 10);
         assert_eq!(FrameType::Fetch.as_u8(), 23);
-        // 26 is the new next-free tag (still unknown), so it frames but is not a known type.
-        assert_eq!(FrameType::from_u8(26), None);
+        // 27 is the new next-free tag (still unknown), so it frames but is not a known type.
+        assert_eq!(FrameType::from_u8(27), None);
         for ty in [FrameType::StreamFetch, FrameType::StreamCommit] {
             let mut buf = Vec::new();
             encode_frame(ty, b"\x07\x08", &mut buf).unwrap();
@@ -501,6 +530,29 @@ mod tests {
                 }
                 FrameDecode::Incomplete { .. } => panic!("complete"),
             }
+        }
+    }
+
+    #[test]
+    fn deliver_batch_is_the_next_free_tag_and_frames() {
+        // #541 (M1-I5): DeliverBatch takes tag 26, the next FREE tag after StreamCommit (25). It was
+        // previously an UNKNOWN tag; pin it as a known type now and confirm it frames at the envelope
+        // level. The per-record Deliver wire (tag 13) is byte-for-byte unchanged: the batch frame is
+        // ADDITIVE and opt-in, never a replacement of the per-record delivery path.
+        assert_eq!(FrameType::DeliverBatch.as_u8(), 26);
+        assert_eq!(FrameType::from_u8(26), Some(FrameType::DeliverBatch));
+        // The per-record Deliver tag is untouched.
+        assert_eq!(FrameType::Deliver.as_u8(), 13);
+        // 27 is the next-free tag (still unknown), so it frames but is not a known type.
+        assert_eq!(FrameType::from_u8(27), None);
+        let mut buf = Vec::new();
+        encode_frame(FrameType::DeliverBatch, b"\x09\x0a", &mut buf).unwrap();
+        match decode_frame(&buf).unwrap() {
+            FrameDecode::Frame { type_tag, body, .. } => {
+                assert_eq!(FrameType::from_u8(type_tag), Some(FrameType::DeliverBatch));
+                assert_eq!(body, b"\x09\x0a");
+            }
+            FrameDecode::Incomplete { .. } => panic!("complete"),
         }
     }
 
@@ -687,7 +739,7 @@ mod tests {
         /// An unknown type tag still decodes at the envelope level (forward compatibility):
         /// the body and length are recovered; only `from_u8` reports it unknown.
         #[test]
-        fn an_unknown_type_tag_still_frames(tag in 26u8..=255, body in prop::collection::vec(any::<u8>(), 0..256)) {
+        fn an_unknown_type_tag_still_frames(tag in 27u8..=255, body in prop::collection::vec(any::<u8>(), 0..256)) {
             let frame_len = 1u32 + u32::try_from(body.len()).unwrap();
             let mut buf = frame_len.to_le_bytes().to_vec();
             buf.push(tag);

--- a/crates/ironbus-proto/src/message.rs
+++ b/crates/ironbus-proto/src/message.rs
@@ -575,6 +575,119 @@ pub fn decode_deliver(body: &[u8]) -> Result<DeliverBody<'_>, BodyError> {
     })
 }
 
+/// The version of the [`crate::frame::FrameType::DeliverBatch`] (raw-framed batch delivery, tag 26)
+/// HEADER framing (#541, M1-I5). Version `1` is the first (and only) layout. Carried as a leading byte
+/// so a future version can extend the header without a wire break: a reader rejects a version it does
+/// not understand rather than mis-parsing it, exactly like [`STREAM_FETCH_BODY_VERSION`].
+pub const DELIVER_BATCH_HEADER_VERSION: u8 = 1;
+
+/// The FIXED header of a [`crate::frame::FrameType::DeliverBatch`] frame (#541, M1-I5): the small,
+/// length-framed prefix that precedes the contiguous ON-DISK record-frame bytes in the frame body. It
+/// is the RAW-FRAMED batch delivery's only re-encoded part — the records themselves ship as their
+/// stored bytes VERBATIM (the broker never re-encodes per record), so a later disk `sendfile(2)` path
+/// (#658) can splice the segment's page-cache bytes straight in after this header.
+///
+/// ## Why an on-disk body, and how the client reconstructs offsets
+///
+/// The on-disk record frame carries `seq` (its in-segment sequence), NOT the log `offset` the on-wire
+/// [`DeliverBody`] carries. A contiguous run is DENSE and offset-ordered, so the client reconstructs
+/// each record's offset POSITIONALLY: the i-th frame in the body has offset `first_offset + i`. The
+/// header therefore carries only `first_offset` (the run's base) — the client never needs the per-record
+/// seq->offset mapping, it just increments. `generation` is the lease fencing token to carry on an ack;
+/// for the Tier-S streaming path (#544, the first user of this frame) it is `0`, exactly as the
+/// per-record `Deliver` on that path. `record_count` lets the client size its work and validate it
+/// decoded exactly the frames the broker counted.
+///
+/// ## CRC integrity end-to-end
+///
+/// Each on-disk record frame in the body still carries its own header CRC32C and body CRC32C (and the
+/// optional xxh3-64 for a large body). The broker copies the bytes without touching them, so the
+/// consumer verifies every record exactly as it verifies a per-record `Deliver` — integrity is moved to
+/// the only place that still decodes the bytes (the client), never silently dropped.
+///
+/// Layout (version+length framed, forward-compatible, mirroring [`StreamFetchBody`]): `header_version:
+/// u8` ([`DELIVER_BATCH_HEADER_VERSION`]), `field_len: u16` (the length of the v1 known-field block that
+/// follows), then the v1 block: `first_offset: u64 LE`, `generation: u64 LE`, `record_count: u32 LE`.
+/// Bytes past `field_len` (a future version's appended header fields) are TOLERATED and ignored by a v1
+/// reader; everything AFTER the declared block is the contiguous on-disk record-frame bytes (the batch
+/// body), returned to the caller as a borrowed slice so it can be decoded (or spliced) without a copy.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DeliverBatchHeader {
+    /// The log offset of the FIRST record in the batch body. The i-th on-disk frame in the body has
+    /// offset `first_offset + i` (the run is dense and contiguous), which is how the client reconstructs
+    /// per-record offsets without reading each frame's stored `seq`.
+    pub first_offset: u64,
+    /// The lease generation to carry on the ack for these records (the fencing token). `0` on the
+    /// lease-free Tier-S streaming path (#544), matching the per-record `Deliver`'s `generation` there.
+    pub generation: u64,
+    /// How many complete on-disk record frames the batch body carries. The client asserts it decodes
+    /// exactly this many whole frames with no partial tail.
+    pub record_count: u32,
+}
+
+/// The number of bytes in the `DeliverBatch` header v1 known-field block: `first_offset: u64` +
+/// `generation: u64` + `record_count: u32`.
+const DELIVER_BATCH_V1_FIELD_LEN: u16 = 8 + 8 + 4;
+
+/// Encodes a `DeliverBatch` frame body onto the end of `out` (#541): the header version byte, the v1
+/// field-block length, the v1 block, then the contiguous on-disk record-frame bytes VERBATIM. `record_bytes`
+/// is the concatenation of `header.record_count` complete on-disk frames (e.g. an `ironbus-storage`
+/// `RawByteRun`'s bytes), copied through UNCHANGED so each record's CRC ships end-to-end. The fixed header
+/// precedes the variable body, so a future `sendfile(2)` path writes this header then splices the stored
+/// bytes.
+pub fn encode_deliver_batch(header: &DeliverBatchHeader, record_bytes: &[u8], out: &mut Vec<u8>) {
+    out.push(DELIVER_BATCH_HEADER_VERSION);
+    out.extend_from_slice(&DELIVER_BATCH_V1_FIELD_LEN.to_le_bytes());
+    out.extend_from_slice(&header.first_offset.to_le_bytes());
+    out.extend_from_slice(&header.generation.to_le_bytes());
+    out.extend_from_slice(&header.record_count.to_le_bytes());
+    out.extend_from_slice(record_bytes);
+}
+
+/// Decodes a `DeliverBatch` frame body (#541) into its fixed [`DeliverBatchHeader`] and a BORROWED slice
+/// of the contiguous on-disk record-frame bytes that follow it, cap-before-alloc and panic-free.
+///
+/// The body MUST carry the version byte and the `u16` field-length; the v1 known fields are read from the
+/// front of the declared block and any trailing bytes WITHIN the block (a future version's appended header
+/// fields) are tolerated and ignored. Everything AFTER the declared block is the record-bytes slice,
+/// returned by reference so the caller decodes (or splices) it with no copy. A body too short to hold the
+/// `field_len` it declares is a typed [`BodyError`], never a panic or an over-read (the `field_len` is
+/// bounded against the actual body by [`Reader::take`] BEFORE any read). An EMPTY body is NOT a valid
+/// `DeliverBatch` (the frame type is new, with no historical empty case), so it is a typed
+/// [`BodyError::Truncated`].
+///
+/// This decodes ONLY the wire framing; the per-record on-disk frames in `record_bytes` are decoded by the
+/// storage/record codec (`ironbus_core::codec::decode`), kept out of this dependency-light proto crate.
+///
+/// # Errors
+/// Returns [`BodyError::Truncated`] if the body is too short for the version/length header or the declared
+/// field block, or [`BodyError::BadHandshakeVersion`] for an unknown header version.
+pub fn decode_deliver_batch(body: &[u8]) -> Result<(DeliverBatchHeader, &[u8]), BodyError> {
+    let mut r = Reader::new(body);
+    let version = r.u8()?;
+    if version != DELIVER_BATCH_HEADER_VERSION {
+        return Err(BodyError::BadHandshakeVersion { version });
+    }
+    let field_len = r.u16()? as usize;
+    let block = r.take(field_len)?;
+    // Everything after the declared header block is the contiguous on-disk record-frame bytes.
+    let record_bytes = r.rest();
+    let mut fr = Reader::new(block);
+    // Every v1 slot occupies a fixed position and is always consumed in order; a short block (a sender
+    // that declared fewer bytes) reads what is present and defaults the rest, never panicking.
+    let first_offset = fr.u64().unwrap_or(0);
+    let generation = fr.u64().unwrap_or(0);
+    let record_count = fr.u32().unwrap_or(0);
+    Ok((
+        DeliverBatchHeader {
+            first_offset,
+            generation,
+            record_count,
+        },
+        record_bytes,
+    ))
+}
+
 /// A consumer's subscription request (the SUB frame body): the work-group name the consumer
 /// joins for subsequent FLOW fetches and ACKs. The entire body is the name; an empty name
 /// selects the default group (the same one an unsubscribed consumer reads). The server
@@ -941,6 +1054,17 @@ pub const CONNECT_FLAG_UNDERSTANDS_STREAMING: u8 = 0b0001_0000;
 /// a default of Tier-S without the capability bit is ignored (the connection stays Tier-W).
 pub const CONNECT_FLAG_HAS_DEFAULT_TIER: u8 = 0b0010_0000;
 
+/// The `Connect` CAPABILITY bit (#541, M1-I5) by which a consumer advertises that it UNDERSTANDS the
+/// raw-framed [`crate::frame::FrameType::DeliverBatch`] frame (tag 26): when set, the server MAY ship a
+/// contiguous delivery run as ONE `DeliverBatch` whose body carries the records' on-disk frame bytes
+/// verbatim, instead of N per-record [`crate::frame::FrameType::Deliver`] frames. When CLEAR (an old
+/// client, or one that opts out) the server keeps sending the per-record `Deliver` run, byte-for-byte
+/// unchanged, and NEVER sends the new tag — so a consumer that would error on an unknown frame, or that
+/// cannot decode the on-disk record layout, is never broken. It is a pure capability flag (no associated
+/// value), so it occupies no slot in the v1 field block beyond this `flags` bit, exactly like
+/// [`CONNECT_FLAG_WANTS_GAP_MARKER`] / [`CONNECT_FLAG_UNDERSTANDS_STREAMING`].
+pub const CONNECT_FLAG_UNDERSTANDS_DELIVER_BATCH: u8 = 0b0100_0000;
+
 /// The `Info` presence-flag bit signalling that the server's advertised per-consumer message-credit
 /// fields (`negotiated` + `cap`) are present (#292). A server that does not advertise leaves it clear,
 /// and a client then keeps its own local credit (backward-compat).
@@ -980,6 +1104,15 @@ pub const INFO_FLAG_STREAMING: u8 = 0b0001_0000;
 /// folded via [`ConsumeTier::from_u8`]); this presence bit governs only whether it is meaningful,
 /// mirroring [`INFO_FLAG_HAS_DEFAULT_ACK_LEVEL`], so the field is forward+backward compatible.
 pub const INFO_FLAG_HAS_DEFAULT_TIER: u8 = 0b0010_0000;
+
+/// The `Info` CAPABILITY bit (#541, M1-I5) by which the server CONFIRMS it will deliver contiguous runs
+/// as raw-framed [`crate::frame::FrameType::DeliverBatch`] frames for this connection: `true` only when
+/// the client advertised [`CONNECT_FLAG_UNDERSTANDS_DELIVER_BATCH`] AND the server supports the frame.
+/// When clear (an old server, or a client that did not advertise) the client knows it will only ever see
+/// per-record `Deliver` runs and keeps handling them. The negotiation is AND, the server->client twin of
+/// [`CONNECT_FLAG_UNDERSTANDS_DELIVER_BATCH`], mirroring the [`INFO_FLAG_GAP_MARKER`] /
+/// [`INFO_FLAG_STREAMING`] confirmations.
+pub const INFO_FLAG_DELIVER_BATCH: u8 = 0b0100_0000;
 
 /// A client's handshake request (the `Connect` frame body, #292). The client MAY request a
 /// per-consumer message credit and/or byte budget; the server clamps each to its own cap and replies
@@ -1034,6 +1167,14 @@ pub struct ConnectBody {
     /// Tier-S default without the capability is ignored. The value is carried raw as a `u8` so a future
     /// tier the proto does not yet name still round-trips.
     pub default_tier: Option<u8>,
+    /// Whether this consumer UNDERSTANDS the raw-framed `DeliverBatch` frame (tag 26, #541, M1-I5): the
+    /// [`CONNECT_FLAG_UNDERSTANDS_DELIVER_BATCH`] capability bit. When `true`, the server may deliver a
+    /// contiguous run as ONE `DeliverBatch` (the records' on-disk frame bytes, decoded client-side) in
+    /// place of N per-record `Deliver` frames. When `false` (the default, and an old client) the server
+    /// ALWAYS sends per-record `Deliver` frames — byte-for-byte today's behavior — and never sends the
+    /// new tag, so a pre-batch client is never sent a frame it cannot decode. A pure capability flag, so
+    /// it adds no block slot beyond its `flags` bit.
+    pub understands_deliver_batch: bool,
 }
 
 /// The number of bytes in the `Connect` v1 known-field block with NO appended bytes (#494, #543):
@@ -1081,6 +1222,9 @@ pub fn encode_connect(req: &ConnectBody, out: &mut Vec<u8>) {
     }
     if req.default_tier.is_some() {
         flags |= CONNECT_FLAG_HAS_DEFAULT_TIER;
+    }
+    if req.understands_deliver_batch {
+        flags |= CONNECT_FLAG_UNDERSTANDS_DELIVER_BATCH;
     }
     out.push(flags);
     out.extend_from_slice(&req.requested_credit.unwrap_or(0).to_le_bytes());
@@ -1150,6 +1294,7 @@ pub fn decode_connect(body: &[u8]) -> Result<ConnectBody, BodyError> {
         (flags & CONNECT_FLAG_HAS_CREDIT_BYTES != 0).then_some(credit_bytes);
     let wants_gap_marker = flags & CONNECT_FLAG_WANTS_GAP_MARKER != 0;
     let understands_streaming = flags & CONNECT_FLAG_UNDERSTANDS_STREAMING != 0;
+    let understands_deliver_batch = flags & CONNECT_FLAG_UNDERSTANDS_DELIVER_BATCH != 0;
     Ok(ConnectBody {
         requested_credit,
         requested_credit_bytes,
@@ -1157,6 +1302,7 @@ pub fn decode_connect(body: &[u8]) -> Result<ConnectBody, BodyError> {
         default_ack_level,
         understands_streaming,
         default_tier,
+        understands_deliver_batch,
     })
 }
 
@@ -1219,6 +1365,12 @@ pub struct InfoBody {
     /// defaulted to Tier-W) means no echo. APPENDED v1 field mirroring `default_ack_level`: emitted only
     /// when `Some`, so a `None` advertisement is byte-for-byte the body without it.
     pub default_tier: Option<u8>,
+    /// Whether the server CONFIRMS it will deliver contiguous runs as raw-framed `DeliverBatch` frames
+    /// (tag 26) for this connection (#541, M1-I5): the [`INFO_FLAG_DELIVER_BATCH`] capability echo, the
+    /// server->client twin of [`ConnectBody::understands_deliver_batch`]. `true` only when the client
+    /// advertised it understands the frame AND the server supports it. `false` (an old server, or a
+    /// client that did not advertise) tells the client it will only ever see per-record `Deliver` runs.
+    pub deliver_batch: bool,
 }
 
 /// The number of bytes in the `Info` v1 known-field block with NO appended bytes (#494, #543):
@@ -1263,6 +1415,9 @@ pub fn encode_info(info: &InfoBody, out: &mut Vec<u8>) {
     }
     if info.default_tier.is_some() {
         flags |= INFO_FLAG_HAS_DEFAULT_TIER;
+    }
+    if info.deliver_batch {
+        flags |= INFO_FLAG_DELIVER_BATCH;
     }
     out.push(flags);
     let credit = info.credit.unwrap_or(CreditAdvert {
@@ -1338,6 +1493,7 @@ pub fn decode_info(body: &[u8]) -> Result<InfoBody, BodyError> {
     });
     let gap_marker = flags & INFO_FLAG_GAP_MARKER != 0;
     let streaming = flags & INFO_FLAG_STREAMING != 0;
+    let deliver_batch = flags & INFO_FLAG_DELIVER_BATCH != 0;
     Ok(InfoBody {
         credit,
         credit_bytes,
@@ -1345,6 +1501,7 @@ pub fn decode_info(body: &[u8]) -> Result<InfoBody, BodyError> {
         default_ack_level,
         streaming,
         default_tier,
+        deliver_batch,
     })
 }
 
@@ -1689,6 +1846,7 @@ mod tests {
             default_ack_level: None,
             understands_streaming: false,
             default_tier: None,
+            understands_deliver_batch: false,
         };
         let mut buf = Vec::new();
         encode_connect(&req, &mut buf);
@@ -1712,6 +1870,7 @@ mod tests {
             default_ack_level: None,
             streaming: false,
             default_tier: None,
+            deliver_batch: false,
         };
         let mut buf = Vec::new();
         encode_info(&info, &mut buf);
@@ -2239,6 +2398,129 @@ mod tests {
     }
 
     #[test]
+    fn deliver_batch_header_round_trips_with_the_record_bytes_carried_verbatim() {
+        // #541: the DeliverBatch frame body is the fixed header (first_offset / generation /
+        // record_count) followed by the contiguous on-disk record-frame bytes carried VERBATIM. The
+        // header round-trips and the record bytes are returned by reference, byte-for-byte unchanged.
+        let header = DeliverBatchHeader {
+            first_offset: 0x0102_0304_0506_0708,
+            generation: 0,
+            record_count: 3,
+        };
+        let record_bytes = b"on-disk-frame-bytes-here";
+        let mut buf = Vec::new();
+        encode_deliver_batch(&header, record_bytes, &mut buf);
+        let (decoded, decoded_bytes) = decode_deliver_batch(&buf).unwrap();
+        assert_eq!(decoded, header);
+        assert_eq!(decoded_bytes, record_bytes, "record bytes ship verbatim");
+        // An EMPTY record body is valid (a zero-record batch): the header still frames.
+        let empty_header = DeliverBatchHeader {
+            first_offset: 7,
+            generation: 0,
+            record_count: 0,
+        };
+        let mut ebuf = Vec::new();
+        encode_deliver_batch(&empty_header, &[], &mut ebuf);
+        let (eh, eb) = decode_deliver_batch(&ebuf).unwrap();
+        assert_eq!(eh, empty_header);
+        assert!(eb.is_empty());
+    }
+
+    #[test]
+    fn deliver_batch_rejects_an_empty_or_short_body_and_an_unknown_version() {
+        // The frame type is new: an empty body is not a valid frame (no historical empty case).
+        assert_eq!(decode_deliver_batch(&[]), Err(BodyError::Truncated));
+        // A declared field_len longer than the body is a typed length error, never an over-read.
+        let mut bad = vec![DELIVER_BATCH_HEADER_VERSION];
+        bad.extend_from_slice(&99u16.to_le_bytes()); // declares 99 header bytes but supplies none
+        assert!(matches!(
+            decode_deliver_batch(&bad),
+            Err(BodyError::Truncated | BodyError::BadLength)
+        ));
+        // An unknown header version is rejected, not best-effort parsed (so a future layout is never
+        // mis-decoded as v1).
+        let mut wrong = Vec::new();
+        encode_deliver_batch(
+            &DeliverBatchHeader {
+                first_offset: 1,
+                generation: 0,
+                record_count: 0,
+            },
+            &[],
+            &mut wrong,
+        );
+        wrong[0] = DELIVER_BATCH_HEADER_VERSION + 1;
+        assert_eq!(
+            decode_deliver_batch(&wrong),
+            Err(BodyError::BadHandshakeVersion {
+                version: DELIVER_BATCH_HEADER_VERSION + 1
+            })
+        );
+    }
+
+    #[test]
+    fn deliver_batch_tolerates_a_future_appended_header_field() {
+        // FORWARD-COMPAT: a future version may APPEND fields inside the declared header block; a v1
+        // reader reads its known fields and the record bytes still begin right after the declared block,
+        // so a present future header field never bleeds into the record bytes. Hand-build a body whose
+        // header block is one byte longer than v1 (a future field), then a record-bytes tail.
+        let mut buf = vec![DELIVER_BATCH_HEADER_VERSION];
+        let extended_len = DELIVER_BATCH_V1_FIELD_LEN + 1;
+        buf.extend_from_slice(&extended_len.to_le_bytes());
+        buf.extend_from_slice(&123u64.to_le_bytes()); // first_offset
+        buf.extend_from_slice(&0u64.to_le_bytes()); // generation
+        buf.extend_from_slice(&5u32.to_le_bytes()); // record_count
+        buf.push(0xAB); // a FUTURE appended header byte, inside the declared block
+        buf.extend_from_slice(b"record-bytes"); // the body proper begins AFTER the declared block
+        let (header, record_bytes) = decode_deliver_batch(&buf).unwrap();
+        assert_eq!(header.first_offset, 123);
+        assert_eq!(header.record_count, 5);
+        assert_eq!(
+            record_bytes, b"record-bytes",
+            "record bytes begin after the declared header block, not after the v1 fields"
+        );
+    }
+
+    #[test]
+    fn connect_and_info_carry_the_deliver_batch_capability_bit() {
+        // #541: a batch-capable consumer sets the capability bit (a pure flags bit, no block byte); the
+        // bit round-trips and an EMPTY (old-client) Connect never advertises it. The Info echo mirrors it.
+        let req = ConnectBody {
+            understands_deliver_batch: true,
+            ..ConnectBody::default()
+        };
+        let mut buf = Vec::new();
+        encode_connect(&req, &mut buf);
+        assert_eq!(
+            buf[3] & CONNECT_FLAG_UNDERSTANDS_DELIVER_BATCH,
+            CONNECT_FLAG_UNDERSTANDS_DELIVER_BATCH,
+            "the capability bit is set in the flags byte"
+        );
+        // The capability is a PURE flags bit: setting it appends NO byte to the v1 block.
+        let mut plain = Vec::new();
+        encode_connect(&ConnectBody::default(), &mut plain);
+        assert_eq!(buf.len(), plain.len(), "the capability bit appends no byte");
+        assert_eq!(decode_connect(&buf).unwrap(), req);
+        // An EMPTY (old-client) Connect body never advertises the capability.
+        assert!(!decode_connect(&[]).unwrap().understands_deliver_batch);
+
+        let info = InfoBody {
+            deliver_batch: true,
+            ..InfoBody::default()
+        };
+        let mut ibuf = Vec::new();
+        encode_info(&info, &mut ibuf);
+        assert_eq!(
+            ibuf[3] & INFO_FLAG_DELIVER_BATCH,
+            INFO_FLAG_DELIVER_BATCH,
+            "the capability confirmation bit is set in the flags byte"
+        );
+        assert_eq!(decode_info(&ibuf).unwrap(), info);
+        // An EMPTY (old-server) Info body never confirms the capability.
+        assert!(!decode_info(&[]).unwrap().deliver_batch);
+    }
+
+    #[test]
     fn stream_commit_round_trips_and_shares_the_cumulative_ack_shape() {
         // #544: StreamCommit carries the same (u64 up_to, group name) shape as CumulativeAck — a shared
         // byte layout, a DISTINCT frame type. The server dispatches on the frame type to pick the
@@ -2434,8 +2716,9 @@ mod tests {
             default_ack_level in proptest::option::of(any::<u8>()),
             understands_streaming in any::<bool>(),
             default_tier in proptest::option::of(any::<u8>()),
+            understands_deliver_batch in any::<bool>(),
         ) {
-            let req = ConnectBody { requested_credit: credit, requested_credit_bytes: credit_bytes, wants_gap_marker, default_ack_level, understands_streaming, default_tier };
+            let req = ConnectBody { requested_credit: credit, requested_credit_bytes: credit_bytes, wants_gap_marker, default_ack_level, understands_streaming, default_tier, understands_deliver_batch };
             let mut buf = Vec::new();
             encode_connect(&req, &mut buf);
             prop_assert_eq!(buf[0], HANDSHAKE_BODY_VERSION, "the body leads with its version");
@@ -2454,6 +2737,7 @@ mod tests {
             default_ack_level in proptest::option::of(any::<u8>()),
             streaming in any::<bool>(),
             default_tier in proptest::option::of(any::<u8>()),
+            deliver_batch in any::<bool>(),
         ) {
             let info = InfoBody {
                 credit: credit.map(|(negotiated, cap)| CreditAdvert { negotiated, cap }),
@@ -2462,6 +2746,7 @@ mod tests {
                 default_ack_level,
                 streaming,
                 default_tier,
+                deliver_batch,
             };
             let mut buf = Vec::new();
             encode_info(&info, &mut buf);
@@ -2490,7 +2775,7 @@ mod tests {
             credit in proptest::option::of(any::<u32>()),
             trailing in prop::collection::vec(any::<u8>(), 0..64),
         ) {
-            let req = ConnectBody { requested_credit: credit, requested_credit_bytes: None, wants_gap_marker: false, default_ack_level: None, understands_streaming: false, default_tier: None };
+            let req = ConnectBody { requested_credit: credit, requested_credit_bytes: None, wants_gap_marker: false, default_ack_level: None, understands_streaming: false, default_tier: None, understands_deliver_batch: false };
             let mut buf = Vec::new();
             encode_connect(&req, &mut buf);
             let mut extended = buf.clone();
@@ -2504,6 +2789,7 @@ mod tests {
                 default_ack_level: None,
                 streaming: false,
                 default_tier: None,
+                deliver_batch: false,
             };
             let mut ibuf = Vec::new();
             encode_info(&info, &mut ibuf);
@@ -2577,6 +2863,7 @@ mod tests {
                 default_ack_level: None,
                 understands_streaming: false,
                 default_tier: None,
+                understands_deliver_batch: false,
             }
         );
     }
@@ -2595,6 +2882,7 @@ mod tests {
                 default_ack_level: None,
                 streaming: false,
                 default_tier: None,
+                deliver_batch: false,
             }
         );
     }
@@ -2608,6 +2896,7 @@ mod tests {
             default_ack_level: None,
             understands_streaming: false,
             default_tier: None,
+            understands_deliver_batch: false,
         };
         let mut buf = Vec::new();
         encode_connect(&req, &mut buf);
@@ -2634,6 +2923,7 @@ mod tests {
             default_ack_level: None,
             streaming: false,
             default_tier: None,
+            deliver_batch: false,
         };
         let mut buf = Vec::new();
         encode_info(&info, &mut buf);
@@ -2861,6 +3151,7 @@ mod tests {
             default_ack_level: None,
             understands_streaming: false,
             default_tier: None,
+            understands_deliver_batch: false,
         };
         let mut pre = Vec::new();
         encode_connect(&no_level, &mut pre);
@@ -2913,6 +3204,7 @@ mod tests {
             default_ack_level: None,
             streaming: false,
             default_tier: None,
+            deliver_batch: false,
         };
         let mut pre = Vec::new();
         encode_info(&no_level, &mut pre);
@@ -2950,6 +3242,7 @@ mod tests {
             default_ack_level: None,
             understands_streaming: false,
             default_tier: None,
+            understands_deliver_batch: false,
         };
         let mut pre = Vec::new();
         encode_connect(&none, &mut pre);
@@ -3019,6 +3312,7 @@ mod tests {
             default_ack_level: None,
             streaming: false,
             default_tier: None,
+            deliver_batch: false,
         };
         let mut pre = Vec::new();
         encode_info(&none, &mut pre);
@@ -3058,6 +3352,7 @@ mod tests {
             default_ack_level: Some(AckLevel::ServerAndClientAck.as_u8()),
             understands_streaming: true,
             default_tier: Some(ConsumeTier::Streaming.as_u8()),
+            understands_deliver_batch: false,
         };
         let mut buf = Vec::new();
         encode_connect(&both, &mut buf);
@@ -3117,6 +3412,7 @@ mod tests {
                 default_ack_level: None,
                 understands_streaming: false,
                 default_tier: None,
+                understands_deliver_batch: false,
             }
         );
 
@@ -3136,6 +3432,7 @@ mod tests {
                 default_ack_level: None,
                 streaming: false,
                 default_tier: None,
+                deliver_batch: false,
             }
         );
     }

--- a/crates/ironbus-server/src/engine.rs
+++ b/crates/ironbus-server/src/engine.rs
@@ -41,7 +41,7 @@ use ironbus_storage::dlq::{DlqSink, DLQ_SUBDIR};
 use ironbus_storage::fs::Filesystem;
 use ironbus_storage::log::{Append, Log, LogConfig, RetentionBounds};
 use ironbus_storage::loss::LossReport;
-use ironbus_storage::segment::{OwnedRecord, StorageError};
+use ironbus_storage::segment::{OwnedRecord, RawByteRun, StorageError};
 use std::collections::BTreeMap;
 
 /// What the engine does with a produce that would exceed the durable-log byte cap
@@ -761,6 +761,33 @@ pub struct StreamBatch {
     /// (or `start_offset` itself when the batch is empty). It never exceeds the flushed head. A
     /// reconnecting consumer that has not committed simply re-passes its last committed offset, not
     /// this value, and the uncommitted span redelivers.
+    pub next_offset: Offset,
+}
+
+/// A Tier-S STREAMING fetch result served as RAW on-disk frame bytes (#541, M1-I5): the zero-copy twin
+/// of [`StreamBatch`] used to deliver a contiguous run as ONE `DeliverBatch` frame. The contiguous
+/// SEALED prefix of the run comes back as `raw` — the on-disk frame bytes VERBATIM (a refcounted slice
+/// of one segment's resident bytes, the #542 zero-copy primitive), never re-encoded — so a later disk
+/// `sendfile(2)` path (#658) can splice them straight into the socket. Any remainder past the sealed
+/// segment's end (the active tail, which the off-actor raw plane does not serve) is materialized into
+/// `tail` and delivered as ordinary per-record `Deliver` frames; the consumer sees one continuous,
+/// contiguous run regardless of where the sealed/active boundary falls.
+#[derive(Clone, Debug, Default)]
+pub struct StreamRawBatch {
+    /// The contiguous run of records from the SEALED, flushed prefix as raw on-disk frame bytes (#542):
+    /// `raw.bytes` is `raw.record_count` complete on-disk frames in offset order, `raw.first_offset` is
+    /// the first record's log offset, and the i-th frame's offset is `first_offset + i`. Empty
+    /// (`record_count == 0`) when `start_offset` is already in the active tail or at/past the durable
+    /// head. The body CRC of every frame ships verbatim for end-to-end client verification.
+    pub raw: RawByteRun,
+    /// The remainder of the run that fell in the ACTIVE tail (or otherwise could not be served raw),
+    /// materialized as ordinary records and delivered per-record. Contiguous with and immediately
+    /// following `raw` (its first offset is `raw.next_offset`). Empty when the whole run was served raw
+    /// or nothing remained below the flushed head.
+    pub tail: Vec<OwnedRecord>,
+    /// The offset the consumer resumes from on its NEXT fetch: one past the last record served across
+    /// BOTH `raw` and `tail` (or `start_offset` when the whole batch is empty). Never exceeds the
+    /// flushed head.
     pub next_offset: Offset,
 }
 
@@ -4989,6 +5016,89 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         max_bytes: Option<usize>,
     ) -> Result<StreamBatch, EngineError> {
         self.stream_fetch_in(DEFAULT_GROUP, member, start_offset, max_records, max_bytes)
+    }
+
+    /// Serves a Tier-S STREAMING fetch as RAW on-disk frame bytes (#541, M1-I5): the zero-copy twin of
+    /// [`Engine::stream_fetch_in`] used to deliver a contiguous run as ONE `DeliverBatch` frame. It runs
+    /// the IDENTICAL group-mode guard, activity refresh, and `delivered`-counter accounting as
+    /// `stream_fetch_in` (so the two are interchangeable on the wire from the engine's view), but sources
+    /// the contiguous SEALED prefix as the on-disk frame bytes VERBATIM ([`Log::read_range_raw`], the
+    /// #542 zero-copy primitive) instead of materializing every record. Any remainder in the ACTIVE tail
+    /// (which the raw read does not serve) is materialized via the SAME `Log::read_range` the per-record
+    /// path uses, so the consumer always receives one continuous contiguous run.
+    ///
+    /// The records the client reconstructs from `raw` (offset POSITIONALLY as `first_offset + i`) and the
+    /// records in `tail` together are EXACTLY the records `stream_fetch_in` would return for the same
+    /// `[start_offset, ...)` window — the differential test in `engine.rs` pins this. NO lease is
+    /// granted, NO generation is fenced, NO cursor is written, exactly like `stream_fetch_in`.
+    ///
+    /// # Errors
+    /// [`EngineError::CumulativeAckOnWorkGroup`] if `group` is not a streaming group (the same wrong-mode
+    /// guard as `stream_fetch_in`), or a storage error reading the durable prefix.
+    pub fn stream_fetch_raw_in(
+        &mut self,
+        group: &str,
+        _member: MemberId,
+        start_offset: Offset,
+        max_records: usize,
+        max_bytes: Option<usize>,
+    ) -> Result<StreamRawBatch, EngineError> {
+        // The wrong-mode guard and activity refresh are IDENTICAL to `stream_fetch_in`: a raw fetch is
+        // the same Tier-S streaming fetch, only the delivery encoding differs.
+        if !self.is_streaming_in(group) {
+            return Err(EngineError::CumulativeAckOnWorkGroup);
+        }
+        let now = self.log.now_monotonic();
+        if let Some(g) = self.groups.get_mut(group) {
+            g.last_activity = now;
+            g.touched = true;
+        }
+        // The contiguous SEALED prefix as raw on-disk frame bytes (zero-copy, no body decode), plus the
+        // resume point for anything this single-segment raw read did not serve.
+        let (raw, tail_from) = self
+            .log
+            .read_range_raw(start_offset, max_records, max_bytes)?;
+        // Materialize the ACTIVE-tail remainder (if any), bounded by the records the raw run did NOT
+        // already serve and the residual byte budget, so the raw + tail run never exceeds the request.
+        let raw_count = usize::try_from(raw.record_count).unwrap_or(usize::MAX);
+        let tail = match tail_from {
+            Some(from) if raw_count < max_records => {
+                let remaining = max_records - raw_count;
+                // The byte budget the raw run already consumed cannot be cheaply known here; pass the
+                // ORIGINAL `max_bytes` so the tail is bounded by the same cap (the first-frame-always
+                // rule keeps a single over-cap tail record from stalling). The record-count remainder is
+                // the hard bound that keeps raw + tail within the request.
+                self.log.read_range(from, remaining, max_bytes)?
+            }
+            _ => Vec::new(),
+        };
+        // The resume offset is one past the last record across raw and tail (or `start_offset` when
+        // both are empty), mirroring `stream_fetch_in`'s `next_offset`.
+        let next_offset = tail.last().map_or(raw.next_offset, |r| {
+            r.offset.checked_next().unwrap_or(r.offset)
+        });
+        let total = raw.record_count.saturating_add(tail.len() as u64);
+        self.counters.delivered = self.counters.delivered.saturating_add(total);
+        Ok(StreamRawBatch {
+            raw,
+            tail,
+            next_offset,
+        })
+    }
+
+    /// Serves a Tier-S streaming RAW fetch in the default work-group (#541): delegates to
+    /// [`Engine::stream_fetch_raw_in`] with the default group name (which must have been marked streaming).
+    ///
+    /// # Errors
+    /// As [`Engine::stream_fetch_raw_in`].
+    pub fn stream_fetch_raw(
+        &mut self,
+        member: MemberId,
+        start_offset: Offset,
+        max_records: usize,
+        max_bytes: Option<usize>,
+    ) -> Result<StreamRawBatch, EngineError> {
+        self.stream_fetch_raw_in(DEFAULT_GROUP, member, start_offset, max_records, max_bytes)
     }
 
     /// Commits a Tier-S STREAMING group's cursor up to the EXCLUSIVE offset `up_to` (#544, M1-I7): the
@@ -12193,6 +12303,73 @@ mod tests {
         assert_eq!(again.records[0].offset, Offset::ZERO);
         assert_eq!(e.in_flight_in("s"), 0);
         assert_eq!(e.committed_offset_in("s"), Offset::ZERO);
+    }
+
+    #[test]
+    fn stream_fetch_raw_decodes_to_the_same_records_as_stream_fetch() {
+        // #541 DIFFERENTIAL: the RAW batch source (`stream_fetch_raw_in`) decodes — `raw` (positional
+        // offsets) plus the materialized `tail` — to EXACTLY the records `stream_fetch_in` returns for
+        // the same window, with the same offsets, in the same order. This is the core correctness proof
+        // that a DeliverBatch carries the same delivery a per-record Deliver run would.
+        let mut e = open(config(100, 5));
+        for i in 0..40u8 {
+            produce(&mut e, &[i, i.wrapping_add(1)]);
+        }
+        e.set_streaming_in("s", true).unwrap();
+        for start in 0..40u64 {
+            for max in [1usize, 3, 8, 64] {
+                let materialized = e
+                    .stream_fetch_in("s", member(1), Offset::new(start), max, None)
+                    .unwrap();
+                let raw = e
+                    .stream_fetch_raw_in("s", member(1), Offset::new(start), max, None)
+                    .unwrap();
+                // Decode `raw` (positional offsets) then append the materialized tail, the way the
+                // session ships them (DeliverBatch then per-record Deliver).
+                let mut got: Vec<(u64, Vec<u8>)> = Vec::new();
+                let mut cursor = 0usize;
+                let mut off = raw.raw.first_offset.get();
+                while cursor < raw.raw.bytes.len() {
+                    let (view, consumed) =
+                        ironbus_core::codec::decode(&raw.raw.bytes[cursor..]).unwrap();
+                    got.push((off, view.payload.to_vec()));
+                    off += 1;
+                    cursor += consumed;
+                }
+                for r in &raw.tail {
+                    got.push((r.offset.get(), r.payload.to_vec()));
+                }
+                let want: Vec<(u64, Vec<u8>)> = materialized
+                    .records
+                    .iter()
+                    .map(|r| (r.offset.get(), r.payload.to_vec()))
+                    .collect();
+                assert_eq!(
+                    got, want,
+                    "raw batch != materialized at start={start} max={max}"
+                );
+                assert_eq!(
+                    raw.next_offset, materialized.next_offset,
+                    "resume offset mismatch at start={start} max={max}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn stream_fetch_raw_is_rejected_on_a_non_streaming_group_like_stream_fetch() {
+        // The raw path applies the IDENTICAL wrong-mode guard as `stream_fetch_in`, so a client cannot
+        // get a lease-free batch off a Tier-W group by asking for the raw frame.
+        let mut e = open(config(10, 5));
+        produce(&mut e, b"a");
+        assert!(matches!(
+            e.stream_fetch_raw_in("w", member(1), Offset::ZERO, 4, None),
+            Err(EngineError::CumulativeAckOnWorkGroup)
+        ));
+        assert!(matches!(
+            e.stream_fetch_raw(member(1), Offset::ZERO, 4, None),
+            Err(EngineError::CumulativeAckOnWorkGroup)
+        ));
     }
 
     #[test]

--- a/crates/ironbus-server/src/session.rs
+++ b/crates/ironbus-server/src/session.rs
@@ -19,7 +19,9 @@
 use crate::actor::{
     ActorGone, EngineAccess, OwnedAppend, OwnedDedup, ProduceOutcome, ProduceSubmission,
 };
-use crate::engine::{AckResult, EngineError, NackResult, Poll, ProgressResult, StreamBatch};
+use crate::engine::{
+    AckResult, EngineError, NackResult, Poll, ProgressResult, StreamBatch, StreamRawBatch,
+};
 use bytes::Bytes;
 use ironbus_core::clock::Clock;
 use ironbus_core::compress::{validate_descriptor_shape, DEFAULT_MAX_DECOMPRESSED_BYTES};
@@ -32,10 +34,11 @@ use ironbus_proto::frame::{decode_frame, encode_frame, FrameDecode, FrameError, 
 use ironbus_proto::message::{
     decode_ack, decode_connect, decode_cumulative_ack, decode_fetch, decode_pub,
     decode_stream_commit, decode_stream_fetch, decode_sub, encode_dead_letter, encode_deliver,
-    encode_gap_marker, encode_info, encode_produce_confirm, encode_pub_ack, encode_truncated,
-    gap_reason, produce_confirm_status, pub_ack_level, AckLevel, AckOp, ConsumeTier, CreditAdvert,
-    DeadLetterBody, DeliverBody, GapMarkerBody, InfoBody, ProduceConfirmBody, PubAckBody,
-    TruncatedBody, DEAD_LETTER_MAX_DELIVER, PUB_WIRE_ONLY_FLAGS,
+    encode_deliver_batch, encode_gap_marker, encode_info, encode_produce_confirm, encode_pub_ack,
+    encode_truncated, gap_reason, produce_confirm_status, pub_ack_level, AckLevel, AckOp,
+    ConsumeTier, CreditAdvert, DeadLetterBody, DeliverBatchHeader, DeliverBody, GapMarkerBody,
+    InfoBody, ProduceConfirmBody, PubAckBody, TruncatedBody, DEAD_LETTER_MAX_DELIVER,
+    PUB_WIRE_ONLY_FLAGS,
 };
 use ironbus_storage::fs::Filesystem;
 use std::collections::HashMap;
@@ -286,6 +289,15 @@ pub struct Session {
     /// client, or no request), so an unmarked SUB stays on the work-queue tier exactly as before. An
     /// explicit per-subscription tier selection (#544) still overrides this default.
     default_tier: ConsumeTier,
+    /// Whether this connection negotiated the raw-framed `DeliverBatch` frame (tag 26, #541, M1-I5): set
+    /// at `Connect` time when the client advertised
+    /// [`ironbus_proto::message::CONNECT_FLAG_UNDERSTANDS_DELIVER_BATCH`]. When `true`, the server MAY ship
+    /// a contiguous Tier-S run as ONE `DeliverBatch` (the records' on-disk frame bytes, decoded
+    /// client-side) instead of N per-record `Deliver` frames. When `false` (an old client, or one that
+    /// opts out) the server ALWAYS sends per-record `Deliver` frames — byte-for-byte today's behavior —
+    /// and never sends the new tag, so a pre-batch client is never sent a frame it cannot decode. Default
+    /// `false` (backward-compatible).
+    deliver_batch_enabled: bool,
     /// Whether this connection has EVER published a Level-2 (server+client-ack) produce (#497): set
     /// when an L2 publish is registered for confirmation, and NEVER cleared. It is the gate that keeps
     /// the per-pass `ProduceConfirm` drain off the actor for a connection that never opted into Level 2
@@ -605,6 +617,12 @@ impl Session {
         } else {
             ConsumeTier::Work
         };
+        // Negotiate the raw-framed DeliverBatch frame (#541, M1-I5): the server always SUPPORTS it, so
+        // the capability is active exactly when this consumer advertised it understands the frame. A
+        // batch-capable consumer may receive a contiguous Tier-S run as ONE `DeliverBatch` (tag 26); one
+        // that did not advertise keeps receiving per-record `Deliver` frames and is never sent the new
+        // tag, so an old client that cannot decode the on-disk record layout is never broken.
+        self.deliver_batch_enabled = req.understands_deliver_batch;
         // The server caps, read LOCALLY off the handle (NO actor round-trip), so the handshake never
         // touches the actor's checkpoint/fsync path and a stalled produce on one connection cannot
         // head-of-line-block this Connect (invariant 4, #177). The caps are static engine config.
@@ -646,6 +664,10 @@ impl Session {
                 ConsumeTier::Streaming => Some(ConsumeTier::Streaming.as_u8()),
                 ConsumeTier::Work => None,
             },
+            // Confirm the DeliverBatch capability the server activated for this connection (#541), so the
+            // client learns whether to expect `DeliverBatch` (tag 26) or only per-record `Deliver`,
+            // mirroring the gap-marker / streaming confirmations.
+            deliver_batch: self.deliver_batch_enabled,
         };
         let mut info_body = Vec::new();
         encode_info(&info, &mut info_body);
@@ -1563,6 +1585,15 @@ impl Session {
         let start = Offset::new(req.start_offset);
         let group = self.subscription.clone();
         let member = self.member_id;
+        // A consumer that advertised the DeliverBatch capability (#541) takes the RAW-FRAMED batch path:
+        // a contiguous run ships as ONE `DeliverBatch` (the on-disk frame bytes verbatim, sendfile-ready
+        // for #658) instead of N per-record `Deliver` frames, with no broker re-encode of the sealed run.
+        // A consumer that did NOT advertise it takes the byte-for-byte-unchanged per-record path below.
+        if self.deliver_batch_enabled {
+            return Self::serve_stream_fetch_batch(
+                engine, &group, member, start, want, max_bytes, out,
+            );
+        }
         // ONE actor round-trip serves the whole contiguous batch — the heart of the Tier-S win versus
         // the N per-record round-trips the Tier-W poll loop makes. The engine reads off the shared
         // durable read path, claims no lease, and writes no cursor.
@@ -1604,6 +1635,87 @@ impl Session {
             // The wrong-mode reject (a non-streaming group) and an out-of-range start are client-visible,
             // recoverable rejections: surface the engine's typed reason and keep the connection open. Do
             // NOT also send a FlowEnd (the Err is the terminator), matching the Fetch error path.
+            Err(e) => {
+                reply_err(out, &e.to_string());
+                Ok(())
+            }
+        }
+    }
+
+    /// Serves a Tier-S streaming fetch as a RAW-FRAMED `DeliverBatch` (#541, M1-I5), the batch-capable
+    /// half of [`Session::handle_stream_fetch`]. The contiguous SEALED prefix of the run ships as ONE
+    /// `DeliverBatch` frame whose body is the records' on-disk frame bytes VERBATIM (never re-encoded, so
+    /// #658's disk `sendfile(2)` can splice them); any ACTIVE-tail remainder follows as ordinary
+    /// per-record `Deliver` frames, so the consumer always receives one continuous contiguous run. The
+    /// batch is terminated by exactly one `FlowEnd` carrying the TOTAL delivered count, identical to the
+    /// per-record path, so the client frames the response the same way either way.
+    ///
+    /// CRC integrity end-to-end: the broker copies the stored bytes UNTOUCHED into the batch body, so
+    /// each record's header/body CRC ships verbatim for the client to verify exactly as it does a
+    /// per-record `Deliver`. NO lease, NO generation fence, NO cursor write — the same lease-free Tier-S
+    /// contract; the batch header's `generation` is `0`, matching the per-record streaming delivery.
+    #[allow(clippy::too_many_arguments)]
+    fn serve_stream_fetch_batch<
+        F: Filesystem + 'static,
+        C: Clock + Clone + 'static,
+        E: EngineAccess<F, C>,
+    >(
+        engine: &E,
+        group: &GroupName,
+        member: MemberId,
+        start: Offset,
+        want: usize,
+        max_bytes: Option<usize>,
+        out: &mut Vec<u8>,
+    ) -> Result<(), SessionError> {
+        let group = group.clone();
+        match engine.with(move |e| e.stream_fetch_raw_in(&group, member, start, want, max_bytes))? {
+            Ok(StreamRawBatch { raw, tail, .. }) => {
+                let mut delivered: u32 = 0;
+                // The contiguous SEALED prefix as ONE DeliverBatch: the on-disk frame bytes verbatim. A
+                // zero-record run is NOT framed (no empty batch on the wire); the per-record tail and the
+                // FlowEnd still terminate the response.
+                if raw.record_count > 0 {
+                    let header = DeliverBatchHeader {
+                        first_offset: raw.first_offset.get(),
+                        // No lease, no fence: a streaming batch carries generation 0, exactly as the
+                        // per-record streaming `Deliver`. The consumer commits by offset (StreamCommit).
+                        generation: 0,
+                        // The record_count is bounded by `want` (a u32 on the wire), so this conversion
+                        // never truncates a real batch; saturate defensively rather than wrap.
+                        record_count: u32::try_from(raw.record_count).unwrap_or(u32::MAX),
+                    };
+                    let mut frame_body = Vec::new();
+                    encode_deliver_batch(&header, &raw.bytes, &mut frame_body);
+                    reply(out, FrameType::DeliverBatch, &frame_body);
+                    delivered = delivered.saturating_add(header.record_count);
+                }
+                // The ACTIVE-tail remainder (which the raw read does not serve) as ordinary per-record
+                // `Deliver` frames, immediately following the batch — so the run stays contiguous.
+                for record in &tail {
+                    let msg = DeliverBody {
+                        offset: record.offset.get(),
+                        generation: 0,
+                        flags: record.flags.bits(),
+                        timestamp_ms: record.timestamp_ms,
+                        key: &record.key,
+                        headers: &record.headers,
+                        payload: &record.payload,
+                    };
+                    let mut frame_body = Vec::new();
+                    if encode_deliver(&msg, &mut frame_body).is_err() {
+                        break;
+                    }
+                    reply(out, FrameType::Deliver, &frame_body);
+                    delivered = delivered.saturating_add(1);
+                }
+                reply(out, FrameType::FlowEnd, &delivered.to_le_bytes());
+                Ok(())
+            }
+            Err(e) if e.is_fatal() => {
+                reply_err(out, "fatal storage error");
+                Err(SessionError::EngineFatal(e))
+            }
             Err(e) => {
                 reply_err(out, &e.to_string());
                 Ok(())
@@ -2505,6 +2617,7 @@ mod tests {
                 default_ack_level: None,
                 understands_streaming: false,
                 default_tier: None,
+                understands_deliver_batch: false,
             },
             &mut body,
         );
@@ -3493,6 +3606,7 @@ mod tests {
                 default_ack_level: None,
                 understands_streaming,
                 default_tier: default_tier.map(ConsumeTier::as_u8),
+                understands_deliver_batch: false,
             },
             &mut body,
         );
@@ -3632,6 +3746,490 @@ mod tests {
             !e.engine_mut().is_streaming_in("legacy"),
             "an old client's subscription is Tier-W, byte-for-byte today's behavior"
         );
+    }
+
+    // ----- Tier-S DeliverBatch raw-framed delivery (#541, M1-I5) -----
+
+    /// A `Connect` body advertising the streaming and/or `DeliverBatch` capabilities (#541), for the
+    /// batch-delivery session tests.
+    fn batch_connect_body(understands_streaming: bool, understands_deliver_batch: bool) -> Vec<u8> {
+        let mut body = Vec::new();
+        ironbus_proto::message::encode_connect(
+            &ironbus_proto::message::ConnectBody {
+                requested_credit: None,
+                requested_credit_bytes: None,
+                wants_gap_marker: false,
+                default_ack_level: None,
+                understands_streaming,
+                default_tier: None,
+                understands_deliver_batch,
+            },
+            &mut body,
+        );
+        body
+    }
+
+    /// Produces a record with explicit key/headers/payload through the engine, so the batch differential
+    /// exercises non-empty variable fields.
+    fn produce_kh<C: Clock + Clone>(
+        e: &DirectEngine<InMemoryFs, C>,
+        key: &[u8],
+        headers: &[u8],
+        payload: &[u8],
+    ) {
+        e.engine_mut()
+            .produce(&Append {
+                timestamp_ms: 42,
+                flags: RecordFlags::EMPTY,
+                key,
+                headers,
+                payload,
+            })
+            .unwrap();
+    }
+
+    /// Decodes a `DeliverBatch` (tag 26) frame body into the per-record `(offset, DeliverBody-equivalent)`
+    /// the way a batch-capable client does: decode the header, then each on-disk frame (CRC-VERIFIED by
+    /// `codec::decode`), reconstructing the offset POSITIONALLY (`first_offset + i`). Returns
+    /// `(offset, generation, flags, ts, key, headers, payload)` per record. Panics on a CRC/length
+    /// mismatch — exactly the integrity check a real client makes.
+    #[allow(clippy::type_complexity)]
+    fn decode_batch_records(body: &[u8]) -> Vec<(u64, u64, u8, u64, Vec<u8>, Vec<u8>, Vec<u8>)> {
+        let (header, record_bytes) =
+            ironbus_proto::message::decode_deliver_batch(body).expect("batch header decodes");
+        let mut out = Vec::new();
+        let mut cursor = 0usize;
+        let mut offset = header.first_offset;
+        while cursor < record_bytes.len() {
+            // `codec::decode` validates the frame's HEADER and BODY CRC before returning a view, so a
+            // record that decodes here is integrity-verified end-to-end.
+            let (view, consumed) =
+                ironbus_core::codec::decode(&record_bytes[cursor..]).expect("record CRC verifies");
+            out.push((
+                offset,
+                header.generation,
+                view.flags.bits(),
+                view.timestamp_ms,
+                view.key.to_vec(),
+                view.headers.to_vec(),
+                view.payload.to_vec(),
+            ));
+            offset += 1;
+            cursor += consumed;
+        }
+        assert_eq!(
+            cursor,
+            record_bytes.len(),
+            "batch body is exactly whole frames"
+        );
+        assert_eq!(
+            out.len() as u64,
+            u64::from(header.record_count),
+            "count matches"
+        );
+        out
+    }
+
+    /// Connects a batch-capable session, marks `group` streaming, subscribes, and returns the session.
+    fn batch_session(e: &DirectEngine<InMemoryFs, ManualClock>, group: &[u8]) -> Session {
+        e.with({
+            let g = String::from_utf8(group.to_vec()).unwrap();
+            move |eng| eng.set_streaming_in(&g, true).unwrap()
+        })
+        .unwrap();
+        let mut s = Session::new();
+        let mut out = Vec::new();
+        s.process(
+            e,
+            &frame(FrameType::Connect, &batch_connect_body(true, true)),
+            &mut out,
+        )
+        .unwrap();
+        let info = ironbus_proto::message::decode_info(&one_response(&out).1).unwrap();
+        assert!(
+            info.deliver_batch,
+            "the server confirms the DeliverBatch capability"
+        );
+        out.clear();
+        s.process(e, &frame(FrameType::Sub, group), &mut out)
+            .unwrap();
+        assert_eq!(one_response(&out).0, FrameType::Ok);
+        s
+    }
+
+    #[test]
+    #[allow(clippy::too_many_lines)]
+    fn deliver_batch_yields_the_same_records_as_n_per_record_delivers() {
+        // #541 DIFFERENTIAL (the headline correctness proof): a batch-capable consumer's StreamFetch is
+        // answered with a `DeliverBatch` whose decoded records are BYTE-FOR-BYTE the records a per-record
+        // (batch-incapable) consumer gets as N `Deliver` frames — same offsets, generation, flags,
+        // timestamp, key, headers, payload, same order. Variable key/headers/payload exercise the codec.
+        let e = DirectEngine::new(engine());
+        for i in 0..12u8 {
+            produce_kh(&e, &[i, 7], &[i, 9, 9], &[i; 5]);
+        }
+        let mut batch_s = batch_session(&e, b"s");
+        let mut plain_s = {
+            // A batch-INCAPABLE (streaming-only) consumer: it gets per-record Deliver frames.
+            e.with(|eng| eng.set_streaming_in("s", true).unwrap())
+                .unwrap();
+            let mut s = Session::new();
+            let mut out = Vec::new();
+            s.process(
+                &e,
+                &frame(FrameType::Connect, &batch_connect_body(true, false)),
+                &mut out,
+            )
+            .unwrap();
+            let info = ironbus_proto::message::decode_info(&one_response(&out).1).unwrap();
+            assert!(
+                !info.deliver_batch,
+                "a batch-incapable client gets no confirmation"
+            );
+            out.clear();
+            s.process(&e, &frame(FrameType::Sub, b"s"), &mut out)
+                .unwrap();
+            s
+        };
+
+        let req = {
+            let mut b = Vec::new();
+            ironbus_proto::message::encode_stream_fetch(
+                &ironbus_proto::message::StreamFetchBody {
+                    start_offset: 0,
+                    max_records: 100,
+                    max_bytes: 0,
+                },
+                &mut b,
+            );
+            b
+        };
+
+        // The batch-capable response: ONE DeliverBatch (the whole sealed run) then a FlowEnd.
+        let mut batch_out = Vec::new();
+        batch_s
+            .process(&e, &frame(FrameType::StreamFetch, &req), &mut batch_out)
+            .unwrap();
+        let batch_frames = decode_all(&batch_out);
+        assert!(
+            batch_frames
+                .iter()
+                .any(|(ty, _)| *ty == FrameType::DeliverBatch),
+            "a batch-capable consumer is served a DeliverBatch"
+        );
+        assert!(
+            !batch_frames.iter().any(|(ty, _)| *ty == FrameType::Deliver),
+            "the whole sealed run ships as ONE batch, no per-record Deliver"
+        );
+        let batch_body = &batch_frames
+            .iter()
+            .find(|(ty, _)| *ty == FrameType::DeliverBatch)
+            .unwrap()
+            .1;
+        let from_batch = decode_batch_records(batch_body);
+
+        // The per-record response: N Deliver frames then a FlowEnd.
+        let mut plain_out = Vec::new();
+        plain_s
+            .process(&e, &frame(FrameType::StreamFetch, &req), &mut plain_out)
+            .unwrap();
+        let plain_frames = decode_all(&plain_out);
+        assert!(
+            !plain_frames
+                .iter()
+                .any(|(ty, _)| *ty == FrameType::DeliverBatch),
+            "a batch-incapable consumer NEVER gets a DeliverBatch (back-compat)"
+        );
+        let from_plain: Vec<_> = plain_frames
+            .iter()
+            .filter(|(ty, _)| *ty == FrameType::Deliver)
+            .map(|(_, body)| {
+                let d = decode_deliver(body).unwrap();
+                (
+                    d.offset,
+                    d.generation,
+                    d.flags,
+                    d.timestamp_ms,
+                    d.key.to_vec(),
+                    d.headers.to_vec(),
+                    d.payload.to_vec(),
+                )
+            })
+            .collect();
+
+        assert_eq!(from_batch.len(), 12, "all 12 records delivered");
+        assert_eq!(
+            from_batch, from_plain,
+            "the batch decodes to EXACTLY the per-record Deliver run (offsets reconstructed, CRC verified)"
+        );
+        // Both responses terminate with one FlowEnd carrying the same delivered count.
+        let batch_end = batch_frames
+            .iter()
+            .find(|(ty, _)| *ty == FrameType::FlowEnd)
+            .unwrap();
+        let plain_end = plain_frames
+            .iter()
+            .find(|(ty, _)| *ty == FrameType::FlowEnd)
+            .unwrap();
+        assert_eq!(batch_end.1, plain_end.1, "same FlowEnd delivered count");
+        assert_eq!(
+            batch_end.1,
+            12u32.to_le_bytes(),
+            "FlowEnd counts every record"
+        );
+    }
+
+    #[test]
+    fn deliver_batch_reconstructs_offsets_and_resumes_from_a_mid_run_start() {
+        // Per-record offset reconstruction: a batch starting at a non-zero offset reconstructs each
+        // record's offset POSITIONALLY from the header's first_offset, and a bounded batch resumes
+        // exactly where it left off, contiguous with the previous batch (no gap, no overlap).
+        let e = DirectEngine::new(engine());
+        for i in 0..20u8 {
+            produce_kh(&e, b"", b"", &[i]);
+        }
+        let mut s = batch_session(&e, b"s");
+
+        let fetch_from = |s: &mut Session, start: u64, max: u32| -> Vec<u64> {
+            let mut b = Vec::new();
+            ironbus_proto::message::encode_stream_fetch(
+                &ironbus_proto::message::StreamFetchBody {
+                    start_offset: start,
+                    max_records: max,
+                    max_bytes: 0,
+                },
+                &mut b,
+            );
+            let mut out = Vec::new();
+            s.process(&e, &frame(FrameType::StreamFetch, &b), &mut out)
+                .unwrap();
+            let mut offs = Vec::new();
+            for (ty, body) in decode_all(&out) {
+                if ty == FrameType::DeliverBatch {
+                    for r in decode_batch_records(&body) {
+                        offs.push(r.0);
+                    }
+                }
+            }
+            offs
+        };
+
+        // A batch of 5 starting at offset 5 reconstructs offsets [5, 10).
+        assert_eq!(fetch_from(&mut s, 5, 5), vec![5, 6, 7, 8, 9]);
+        // Resuming at 10 with no overlap/gap.
+        assert_eq!(fetch_from(&mut s, 10, 5), vec![10, 11, 12, 13, 14]);
+        // The full run from 0.
+        assert_eq!(fetch_from(&mut s, 0, 100), (0..20).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn deliver_batch_tolerates_a_future_appended_header_field() {
+        // FORWARD-COMPAT: a future server may append fields to the DeliverBatch header; a client decodes
+        // its known fields and the record bytes still begin right after the DECLARED header block. Build a
+        // batch frame whose header block is one byte longer than v1, then assert it decodes correctly.
+        let e = DirectEngine::new(engine());
+        for i in 0..3u8 {
+            produce_kh(&e, b"", b"", &[i]);
+        }
+        let mut s = batch_session(&e, b"s");
+        let mut req = Vec::new();
+        ironbus_proto::message::encode_stream_fetch(
+            &ironbus_proto::message::StreamFetchBody {
+                start_offset: 0,
+                max_records: 100,
+                max_bytes: 0,
+            },
+            &mut req,
+        );
+        let mut out = Vec::new();
+        s.process(&e, &frame(FrameType::StreamFetch, &req), &mut out)
+            .unwrap();
+        let batch_body = decode_all(&out)
+            .into_iter()
+            .find(|(ty, _)| *ty == FrameType::DeliverBatch)
+            .unwrap()
+            .1;
+        // Splice a future header byte INSIDE the declared block: bump field_len, insert a byte after the
+        // v1 fields, and shift the record bytes after it. The header (version, field_len) is the first 3
+        // bytes; the v1 block is the next 20 (first_offset 8 + generation 8 + record_count 4).
+        let mut extended = Vec::new();
+        extended.push(batch_body[0]); // version
+        let new_field_len = (20u16) + 1;
+        extended.extend_from_slice(&new_field_len.to_le_bytes());
+        extended.extend_from_slice(&batch_body[3..3 + 20]); // the v1 block
+        extended.push(0xEE); // a FUTURE appended header byte, inside the declared block
+        extended.extend_from_slice(&batch_body[3 + 20..]); // the record bytes, unchanged
+                                                           // The client decoder recovers the same records despite the future header field.
+        let records = decode_batch_records(&extended);
+        assert_eq!(records.len(), 3);
+        assert_eq!(
+            records.iter().map(|r| r.6.clone()).collect::<Vec<_>>(),
+            vec![vec![0], vec![1], vec![2]]
+        );
+    }
+
+    /// An engine with a SMALL segment cap, so a run of records spans several sealed segments plus the
+    /// active tail — the boundary the raw batch (single-segment) splits on.
+    fn small_segment_engine() -> Engine<InMemoryFs, ManualClock> {
+        Engine::open(
+            InMemoryFs::new(),
+            ManualClock::new(),
+            EngineConfig {
+                log: LogConfig {
+                    max_segment_bytes: 160,
+                    ..LogConfig::default()
+                },
+                ..test_config()
+            },
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn deliver_batch_spans_a_sealed_segment_then_a_per_record_active_tail_partial_batch() {
+        // BOUNDARY / PARTIAL BATCH: with a small segment cap the run spans several sealed segments and the
+        // active tail. The raw batch is bounded to ONE sealed segment, so the response is a SEQUENCE of
+        // DeliverBatch frames (each a sealed segment's run) and per-record Deliver frames (the active
+        // tail), and decoding the whole response in order yields EXACTLY the records — same offsets, same
+        // order — that a per-record-only consumer gets. Integrity (CRC) is verified per record.
+        let e = DirectEngine::new(small_segment_engine());
+        for i in 0..16u8 {
+            produce_kh(&e, &[i], &[i, 1], &[i; 6]);
+        }
+        assert!(
+            e.engine_mut().segment_count() >= 2,
+            "the small cap must have rolled into several segments"
+        );
+        let mut batch_s = batch_session(&e, b"s");
+        let mut plain_s = {
+            e.with(|eng| eng.set_streaming_in("s", true).unwrap())
+                .unwrap();
+            let mut s = Session::new();
+            let mut out = Vec::new();
+            s.process(
+                &e,
+                &frame(FrameType::Connect, &batch_connect_body(true, false)),
+                &mut out,
+            )
+            .unwrap();
+            out.clear();
+            s.process(&e, &frame(FrameType::Sub, b"s"), &mut out)
+                .unwrap();
+            s
+        };
+        let mut req = Vec::new();
+        ironbus_proto::message::encode_stream_fetch(
+            &ironbus_proto::message::StreamFetchBody {
+                start_offset: 0,
+                max_records: 100,
+                max_bytes: 0,
+            },
+            &mut req,
+        );
+
+        // Decode the batch-capable response in order: each DeliverBatch expands to its records, each
+        // Deliver is one record; the concatenation is the whole run.
+        let mut batch_out = Vec::new();
+        batch_s
+            .process(&e, &frame(FrameType::StreamFetch, &req), &mut batch_out)
+            .unwrap();
+        let batch_frames = decode_all(&batch_out);
+        assert!(
+            batch_frames
+                .iter()
+                .any(|(ty, _)| *ty == FrameType::DeliverBatch),
+            "at least one sealed segment ships as a DeliverBatch"
+        );
+        let mut from_batch: Vec<(u64, Vec<u8>)> = Vec::new();
+        for (ty, body) in &batch_frames {
+            match ty {
+                FrameType::DeliverBatch => {
+                    for r in decode_batch_records(body) {
+                        from_batch.push((r.0, r.6));
+                    }
+                }
+                FrameType::Deliver => {
+                    let d = decode_deliver(body).unwrap();
+                    from_batch.push((d.offset, d.payload.to_vec()));
+                }
+                _ => {}
+            }
+        }
+
+        let mut plain_out = Vec::new();
+        plain_s
+            .process(&e, &frame(FrameType::StreamFetch, &req), &mut plain_out)
+            .unwrap();
+        let from_plain: Vec<(u64, Vec<u8>)> = decode_all(&plain_out)
+            .iter()
+            .filter(|(ty, _)| *ty == FrameType::Deliver)
+            .map(|(_, body)| {
+                let d = decode_deliver(body).unwrap();
+                (d.offset, d.payload.to_vec())
+            })
+            .collect();
+
+        assert_eq!(
+            from_batch.len(),
+            16,
+            "every record delivered across the boundary"
+        );
+        assert_eq!(
+            from_batch, from_plain,
+            "batch (sealed segments) + per-record tail == the per-record-only run, in order"
+        );
+        // The offsets are exactly 0..16 with no gap or overlap across the sealed/active boundary.
+        assert_eq!(
+            from_batch.iter().map(|r| r.0).collect::<Vec<_>>(),
+            (0..16).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn an_old_client_never_gets_a_deliver_batch_and_the_wire_is_byte_identical() {
+        // BACK-COMPAT: a batch-INCAPABLE consumer (an old client, or one that did not advertise) is
+        // served the per-record `Deliver` run byte-for-byte the pre-#541 wire, and NEVER the new tag.
+        let e = DirectEngine::new(engine());
+        for i in 0..5u8 {
+            produce_kh(&e, b"", b"", &[i]);
+        }
+        // A streaming-but-NOT-batch consumer.
+        e.with(|eng| eng.set_streaming_in("s", true).unwrap())
+            .unwrap();
+        let mut s = Session::new();
+        let mut out = Vec::new();
+        s.process(
+            &e,
+            &frame(FrameType::Connect, &batch_connect_body(true, false)),
+            &mut out,
+        )
+        .unwrap();
+        out.clear();
+        s.process(&e, &frame(FrameType::Sub, b"s"), &mut out)
+            .unwrap();
+        out.clear();
+        let mut req = Vec::new();
+        ironbus_proto::message::encode_stream_fetch(
+            &ironbus_proto::message::StreamFetchBody {
+                start_offset: 0,
+                max_records: 100,
+                max_bytes: 0,
+            },
+            &mut req,
+        );
+        s.process(&e, &frame(FrameType::StreamFetch, &req), &mut out)
+            .unwrap();
+        let frames = decode_all(&out);
+        assert!(
+            !frames.iter().any(|(ty, _)| *ty == FrameType::DeliverBatch),
+            "an old client is NEVER sent the DeliverBatch tag"
+        );
+        let delivers = frames
+            .iter()
+            .filter(|(ty, _)| *ty == FrameType::Deliver)
+            .count();
+        assert_eq!(delivers, 5, "every record arrives as a per-record Deliver");
+        assert_eq!(frames.last().unwrap().0, FrameType::FlowEnd);
     }
 
     /// Produces a keyed record through the engine, for the `key_shared` session tests.
@@ -5520,6 +6118,7 @@ mod tests {
                 default_ack_level: None,
                 understands_streaming: false,
                 default_tier: None,
+                understands_deliver_batch: false,
             },
             &mut connect_body,
         );
@@ -6902,6 +7501,7 @@ mod tests {
                 default_ack_level: None,
                 understands_streaming: false,
                 default_tier: None,
+                understands_deliver_batch: false,
             },
             &mut connect_body,
         );

--- a/crates/ironbus-storage/src/log.rs
+++ b/crates/ironbus-storage/src/log.rs
@@ -14,7 +14,10 @@ use crate::io::RandomAccessFile;
 use crate::loss::{LossEvent, LossReport, ReasonCode};
 use crate::naming::{segment_file_name, segment_ids};
 use crate::read_plane::{ReadPlane, SealedSegment};
-use crate::segment::{OwnedRecord, RecoveryScan, SegmentReader, SegmentWriter, StorageError};
+use crate::segment::{
+    OwnedRecord, RawByteRun, RecoveryScan, SegmentReader, SegmentWriter, StorageError,
+};
+use bytes::Bytes;
 use ironbus_core::clock::Clock;
 use ironbus_core::codec::RecordView;
 use ironbus_core::format::{
@@ -2270,6 +2273,111 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
         false
     }
 
+    /// Reads a CONTIGUOUS RAW byte run starting at `start`, returning the records' ON-DISK frame bytes
+    /// VERBATIM as one [`RawByteRun`] (the zero-copy read primitive, #542) — the raw, through-actor twin
+    /// of [`Log::read_range`] used by the Tier-S `DeliverBatch` delivery path (#541, M1-I5). Where
+    /// `read_range` decodes every frame into an [`OwnedRecord`], this seeks to the same anchor and hands
+    /// back the contiguous on-disk frame bytes with NO body decode and NO per-record allocation, so a
+    /// later disk `sendfile(2)` path (#658) can splice the segment's bytes straight from page cache.
+    ///
+    /// Bounded to a SINGLE DENSE (v1) segment: a contiguous BYTE range is one slice of one segment file,
+    /// so a run that reaches a segment boundary (or a compacted/active-but-unindexed start) stops there
+    /// and the returned `tail_from` is `Some(off)` — the next offset the caller serves through the
+    /// ordinary materialize path ([`Log::read_range`]). `None` when the read is complete (it hit
+    /// `max_records`, the byte cap, or the flushed frontier within this segment). The seek/clamp logic
+    /// MIRRORS `read_range` exactly, so the run decodes to byte-identical records.
+    ///
+    /// Bounds are identical to `read_range`: `max_records`, the optional `max_bytes` (whole-read cap,
+    /// first-frame always admitted), and the flushed frontier (no record at/past it is served).
+    ///
+    /// # Errors
+    /// Returns [`StorageError::OffsetOutOfRange`] if `start` is older than the oldest retained record,
+    /// or an IO error reading a segment.
+    pub fn read_range_raw(
+        &self,
+        start: Offset,
+        max_records: usize,
+        max_bytes: Option<usize>,
+    ) -> Result<(RawByteRun, Option<Offset>), StorageError> {
+        let start_v = start.get();
+        let flushed = self.flushed_offset.get();
+        let empty = RawByteRun {
+            bytes: Bytes::new(),
+            first_offset: start,
+            record_count: 0,
+            next_offset: start,
+        };
+        if max_records == 0 || start_v >= flushed {
+            // Nothing to serve raw, and nothing remains below the flushed head from `start`.
+            return Ok((empty, None));
+        }
+        let oldest = self
+            .segments
+            .first()
+            .map_or(0, SegmentSlot::covered_base_offset);
+        if start_v < oldest {
+            return Err(StorageError::OffsetOutOfRange {
+                requested: start_v,
+                oldest,
+            });
+        }
+        let slot = &self.segments[self.segment_index_for(start_v)];
+        // A COMPACTED (sparse, v2) slot is NOT served raw (its byte run is non-contiguous): hand the
+        // whole remainder to the materialize path from this segment's covered base (clamped to start).
+        if slot.compacted_covered.is_some() {
+            let tail = start_v.max(slot.covered_base_offset());
+            return Ok((empty, Some(Offset::new(tail))));
+        }
+        let seg_start = start_v.max(slot.base_offset);
+        let Some((anchor_offset, byte_pos, read_end)) = self.seek_in_segment(slot, seg_start)?
+        else {
+            // The dense index does not cover `seg_start` (a not-yet-indexed active tail): serve it
+            // through the materialize path, exactly as `read_slot_into`'s full-scan fallback would.
+            return Ok((empty, Some(start)));
+        };
+        // The anchor may sit a BOUNDED run before `seg_start`; `raw_byte_range` returns frames from the
+        // anchor forward, so trim the leading `gap` records below `seg_start` after the read. We read
+        // `gap + max_records` frames so the wanted count survives the trim, clamped to records below
+        // `flushed` (the per-frame visibility bound the raw read cannot apply itself).
+        let gap = usize::try_from(seg_start.saturating_sub(anchor_offset)).unwrap_or(0);
+        let below_flushed =
+            usize::try_from(flushed.saturating_sub(anchor_offset)).unwrap_or(usize::MAX);
+        let want = max_records.saturating_add(gap).min(below_flushed);
+        let reader = SegmentReader::open(self.fs.open(&segment_file_name(slot.id))?)?;
+        // No byte cap on the raw read when there is a leading gap: the trimmed frames would mis-charge
+        // it. When there is NO gap (`gap == 0`, the common case where the anchor lands exactly on
+        // `seg_start`) the byte cap binds the read directly, identical to `read_range`.
+        let raw_max_bytes = if gap == 0 { max_bytes } else { None };
+        let run = reader.raw_byte_range(
+            byte_pos,
+            Offset::new(anchor_offset),
+            read_end,
+            want,
+            raw_max_bytes,
+        )?;
+        // Trim the leading `gap` frames (the bounded run the anchor preceded `seg_start` by) and apply
+        // the record-count and byte caps to the surviving frames, so the result is byte-identical to the
+        // prefix `read_range` would return over the same single segment.
+        let trimmed = trim_and_bound_raw_run(&run, seg_start, max_records, max_bytes);
+        // Where does the caller resume? If the trimmed run stopped strictly below the flushed head with
+        // records still available in this segment or beyond, the caller continues from `next_offset`
+        // through the materialize path (the next segment, or the active tail). If it reached the flushed
+        // head, the read is complete (`None`).
+        let next = trimmed.next_offset.get();
+        let tail_from = if next < flushed && trimmed.record_count >= max_records as u64 {
+            // Stopped because the record/byte cap bound within this segment: complete (the cap, not the
+            // data, ended it), exactly as `read_range` stops without a fallback.
+            None
+        } else if next < flushed {
+            // More flushed offsets remain past this single-segment raw run (a segment boundary, or a
+            // byte-cap stop with offsets still below flushed): serve the remainder via materialize.
+            Some(Offset::new(next))
+        } else {
+            None
+        };
+        Ok((trimmed, tail_from))
+    }
+
     /// Reclaims disk by deleting whole OLD SEALED segments under any of three composable retention
     /// [`RetentionBounds`] (size, age, count), but NEVER a segment any consumer still needs (the
     /// consumer-safe segment reaper, refs #13, #80). This is the drain side of the overflow policy
@@ -2976,6 +3084,62 @@ impl<F: Filesystem + Clone, C: Clock> Log<F, C> {
         );
         *self.read_plane.borrow_mut() = Some(plane.clone());
         Ok(plane)
+    }
+}
+
+/// Trims a [`RawByteRun`] to begin at `seg_start` (dropping the leading frames a sparse anchor preceded
+/// it by) and re-bounds it to `max_records` / `max_bytes` over the trimmed run — a HEADER-ONLY walk (no
+/// body decode), so it preserves the zero-copy property (the result is a refcount RE-SLICE of the input's
+/// `bytes`, never a copy). The through-actor twin of the read-plane's `trim_raw_run`, used by
+/// [`Log::read_range_raw`] (#541) to make a raw run byte-identical to the prefix [`Log::read_range`] would
+/// return over the same single segment.
+fn trim_and_bound_raw_run(
+    run: &RawByteRun,
+    seg_start: u64,
+    max_records: usize,
+    max_bytes: Option<usize>,
+) -> RawByteRun {
+    let mut cursor = 0usize;
+    let mut offset = run.first_offset.get();
+    let bytes = &run.bytes;
+    // Drop the leading frames below `seg_start` by walking their header lengths.
+    while offset < seg_start && cursor < bytes.len() {
+        let Ok(consumed) = ironbus_core::codec::decoded_len(&bytes[cursor..]) else {
+            break;
+        };
+        if cursor.saturating_add(consumed) > bytes.len() {
+            break;
+        }
+        cursor += consumed;
+        offset = offset.saturating_add(1);
+    }
+    let run_start_byte = cursor;
+    let first_offset = offset;
+    // Admit up to `max_records` / `max_bytes` frames from `seg_start`, "at least one" honored.
+    let mut count = 0usize;
+    let mut byte_total = 0usize;
+    while cursor < bytes.len() && count < max_records {
+        let Ok(consumed) = ironbus_core::codec::decoded_len(&bytes[cursor..]) else {
+            break;
+        };
+        if cursor.saturating_add(consumed) > bytes.len() {
+            break;
+        }
+        if let Some(cap) = max_bytes {
+            if count != 0 && byte_total.saturating_add(consumed) > cap {
+                break;
+            }
+        }
+        byte_total = byte_total.saturating_add(consumed);
+        count += 1;
+        offset = offset.saturating_add(1);
+        cursor += consumed;
+    }
+    RawByteRun {
+        bytes: bytes.slice(run_start_byte..run_start_byte + byte_total),
+        first_offset: Offset::new(first_offset),
+        record_count: count as u64,
+        next_offset: Offset::new(offset),
     }
 }
 
@@ -4384,6 +4548,140 @@ mod tests {
         differential(&log);
         log.clear_segment_indexes();
         differential(&log);
+    }
+
+    /// Decodes a [`RawByteRun`]'s bytes front-to-back into `(RecordView, offset)` pairs the way a
+    /// `DeliverBatch` client does: positional offset reconstruction (`first_offset + i`), each frame
+    /// fully CRC-validated by `codec::decode`. Asserts the run is EXACTLY `record_count` whole frames.
+    fn decode_raw_run(run: &RawByteRun) -> Vec<(RecordView<'_>, u64)> {
+        let mut out = Vec::new();
+        let mut cursor = 0usize;
+        let mut offset = run.first_offset.get();
+        while cursor < run.bytes.len() {
+            let (view, consumed) =
+                ironbus_core::codec::decode(&run.bytes[cursor..]).expect("raw run frame decodes");
+            out.push((view, offset));
+            offset = offset.saturating_add(1);
+            cursor += consumed;
+        }
+        assert_eq!(cursor, run.bytes.len(), "raw run is exactly whole frames");
+        assert_eq!(
+            out.len() as u64,
+            run.record_count,
+            "count matches the frames"
+        );
+        out
+    }
+
+    #[test]
+    fn read_range_raw_is_byte_identical_to_read_range_and_chains_the_whole_prefix() {
+        // #541: the through-actor raw read (the DeliverBatch source) decodes to the SAME records as the
+        // materialize path, with offsets reconstructed POSITIONALLY, and chaining each raw run's
+        // `tail_from` through `read_range` reconstructs the WHOLE flushed prefix with no gaps/overlaps —
+        // across the anchor stride, segment boundaries, and the sealed/active boundary.
+        let n: u64 = 25;
+        let log = rolled_log_unsynced_tail(n);
+        let flushed = log.flushed_offset().get();
+        assert!(log.active_segment_id() >= 2, "must span several segments");
+
+        let differential = |log: &Log<InMemoryFs, ManualClock>| {
+            // Per-window: a single raw run is byte-identical to the prefix `read_range` returns over the
+            // same single segment, and its records start exactly at `start`.
+            for start in 0..flushed {
+                for max in [1usize, 2, 3, 7, 1000] {
+                    let (run, _tail) = log.read_range_raw(Offset::new(start), max, None).unwrap();
+                    let materialized = log.read_range(Offset::new(start), max, None).unwrap();
+                    let decoded = decode_raw_run(&run);
+                    for ((view, off), owned) in decoded.iter().zip(materialized.iter()) {
+                        assert_eq!(*off, owned.offset.get(), "offset at start={start}");
+                        assert_eq!(view.seq, owned.seq, "seq at start={start}");
+                        assert_eq!(view.timestamp_ms, owned.timestamp_ms);
+                        assert_eq!(view.flags, owned.flags);
+                        assert_eq!(view.key, &owned.key[..]);
+                        assert_eq!(view.headers, &owned.headers[..]);
+                        assert_eq!(view.payload, &owned.payload[..]);
+                    }
+                    if let Some((_, off)) = decoded.first() {
+                        assert_eq!(*off, start, "raw run starts at the requested offset");
+                    }
+                }
+            }
+            // Chaining: follow each run's `tail_from` (serving it raw when possible, else materialized)
+            // to walk the whole flushed prefix exactly once, in order.
+            let mut next = 0u64;
+            let mut seen: Vec<u64> = Vec::new();
+            let mut guard = 0u32;
+            while next < flushed {
+                guard += 1;
+                assert!(guard < 10_000, "raw-read chain did not terminate");
+                let (run, tail_from) = log.read_range_raw(Offset::new(next), 1_000, None).unwrap();
+                for (_, off) in decode_raw_run(&run) {
+                    seen.push(off);
+                }
+                match tail_from {
+                    // A raw-served-then-resume boundary (segment edge): continue from the run's end. When
+                    // the raw run was EMPTY (the start landed on the active tail the raw path doesn't
+                    // serve), drain that remainder via the materialize path so the chain advances.
+                    Some(off) => {
+                        if run.record_count == 0 {
+                            for record in log.read_range(off, 1_000, None).unwrap() {
+                                seen.push(record.offset.get());
+                            }
+                            // The active tail is the last region below flushed; the chain ends here.
+                            break;
+                        }
+                        next = off.get();
+                    }
+                    None => break,
+                }
+            }
+            let expected: Vec<u64> = (0..flushed).collect();
+            assert_eq!(
+                seen, expected,
+                "raw chain covers the whole prefix once, in order"
+            );
+        };
+
+        differential(&log);
+        log.clear_segment_indexes();
+        differential(&log);
+    }
+
+    #[test]
+    fn read_range_raw_honors_max_records_and_max_bytes_like_read_range() {
+        // The raw read applies the SAME record-count and byte caps (first-frame-always rule) as
+        // read_range, so a capped raw run decodes to the same records the capped materialize path does.
+        let mut log = open_mem(LogConfig::default());
+        for i in 0..50u32 {
+            log.append(&rec(&i.to_le_bytes())).unwrap();
+        }
+        log.sync().unwrap();
+        let one_frame = log.read_range(Offset::ZERO, 1, None).unwrap()[0].encoded_len();
+        for k in 1..=8usize {
+            let cap = k * one_frame;
+            let (run, _) = log
+                .read_range_raw(Offset::ZERO, usize::MAX, Some(cap))
+                .unwrap();
+            let materialized = log.read_range(Offset::ZERO, usize::MAX, Some(cap)).unwrap();
+            let decoded = decode_raw_run(&run);
+            assert_eq!(
+                decoded.len(),
+                materialized.len(),
+                "raw byte-capped count matches materialize at cap={cap}"
+            );
+            for ((_, off), owned) in decoded.iter().zip(materialized.iter()) {
+                assert_eq!(*off, owned.offset.get());
+            }
+        }
+        // max_records == 0 serves nothing; a start at/past the flushed head serves nothing and resumes
+        // nowhere.
+        let (empty, tail) = log.read_range_raw(Offset::ZERO, 0, None).unwrap();
+        assert_eq!(empty.record_count, 0);
+        assert_eq!(tail, None);
+        let head = log.flushed_offset();
+        let (caught_up, tail) = log.read_range_raw(head, 100, None).unwrap();
+        assert_eq!(caught_up.record_count, 0);
+        assert_eq!(tail, None);
     }
 
     #[test]

--- a/crates/ironbus-storage/src/segment.rs
+++ b/crates/ironbus-storage/src/segment.rs
@@ -296,7 +296,7 @@ pub struct OwnedRecord {
 /// today — the zero-copy path moves the body-CRC check to the only place that still touches the
 /// bytes (the client), it never silently drops integrity. (Verify-once-while-resident is the
 /// separate #540.)
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct RawByteRun {
     /// The raw, contiguous on-disk frame bytes for `[first_offset, next_offset)`, one frame after
     /// another in the frozen on-disk layout. A refcounted [`Bytes`] slice of the shared read buffer


### PR DESCRIPTION
Closes #541 (V2-M1: Consume — beat NATS).

## What & which option

Shipped **Option A** (the on-disk-layout-in-batch path), the one that unlocks disk `sendfile(2)` #658 and the real consume win. A new additive wire frame **`DeliverBatch` (tag 26)** carries a CONTIGUOUS run of records in ONE frame whose body is the records' **on-disk frame bytes VERBATIM** (seq / u32 lengths / header+body CRC). The broker never re-encodes per record; the client decodes the on-disk layout directly. The per-record `Deliver` (tag 13) path is byte-for-byte unchanged.

**Why A over B:** B (concatenated on-wire `Deliver` records) removes per-record framing but the broker still transforms on-disk→on-wire per record, so it is NOT byte-zero-copy and does NOT make sendfile possible. A ships the stored bytes unchanged after a small fixed header, so #658 can write the header then splice the segment's page-cache bytes straight into the socket. A was clean+testable in one PR (the client-side on-disk decoder is just `codec::decode` in a loop, already a tested primitive from #657), so there was no need to fall back to B.

## Frame layout (sendfile-friendly)

Version+length framed, forward-compatible:
```
header_version u8 | field_len u16 | first_offset u64 | generation u64 | record_count u32 | <on-disk record frames…>
```
The fixed header precedes the variable on-disk body, so a future sendfile path writes the header then splices the stored bytes as the batch body.

## Offset/seq reconstruction

The on-disk frame carries `seq`, not the log `offset` the on-wire `Deliver` carries. A contiguous run is **dense**, so the client reconstructs each record's offset **positionally**: the i-th frame's offset is `first_offset + i`. The seq→offset mapping is never needed — only `first_offset` is carried. `generation` is `0` on the lease-free Tier-S path, matching the per-record streaming `Deliver`.

## Wired into tier-S

A batch-capable consumer's `StreamFetch` is answered with ONE `DeliverBatch` for the contiguous **sealed** run (sourced as a zero-copy `RawByteRun` via a new through-actor `Log::read_range_raw` → `Engine::stream_fetch_raw_in`, no re-encode), with any **active-tail** remainder following as per-record `Deliver` frames, terminated by one `FlowEnd` carrying the total count — identical framing to the per-record path.

## Back-compat (opt-in, byte-identical old wire)

Negotiated via a new `Connect` capability bit (`UNDERSTANDS_DELIVER_BATCH`) confirmed by an `Info` bit (`DELIVER_BATCH`), AND-negotiated exactly like gap-marker/streaming. An old client never advertises it, **never** receives the new tag, and gets the per-record `Deliver` run byte-for-byte unchanged. I2/durability and tier-W are untouched.

## CRC end-to-end

The broker copies the stored bytes UNTOUCHED into the batch body, so each record's header+body CRC32C ships verbatim and the client verifies every record (`ironbus_core::codec::decode`) exactly as it does a per-record `Deliver` — integrity is moved to the only place that still decodes the bytes, never silently dropped. A corrupt batch record is a typed client error, never a panic.

## The differential

The headline correctness proof (session-level, on the wire): a batch-capable consumer's `DeliverBatch` decodes to **EXACTLY** the records a per-record (batch-incapable) consumer gets as N `Deliver` frames — same offsets, generation, flags, timestamp, key, headers, payload, same order, same `FlowEnd` count. Mirrored at the engine (`stream_fetch_raw_in` vs `stream_fetch_in`) and storage (`read_range_raw` vs `read_range`) levels, plus a client scripted round-trip.

## Bench

`cargo bench -p ironbus-proto --bench deliver_batch_framing` (DeliverBatch vs N per-record Deliver framing+encode, 64-record run):
- 16B payload: 10.27µs → 0.34µs ≈ **30.6x**
- 256B payload: 13.63µs → 0.83µs ≈ **16.4x**
- 4096B payload: 24.59µs → 11.02µs ≈ **2.2x**

The win is largest for small records (framing-dominated) and shrinks to ~2.2x at 4KiB where the bulk byte copy dominates — and **that residual copy is exactly what #658's sendfile removes** (the batch body is already the stored bytes).

## Sendfile-ready for #658?

**Yes.** The batch body is the contiguous on-disk frame bytes with nothing re-encoded, so #658 drops in the disk `sendfile(2)`/`splice(2)` syscall (write the fixed header, splice the segment byte range) with the materialize+encode path as the always-available fallback.

## Scope boundary

This PR is the `DeliverBatch` frame + encoder/decoder + tier-S wiring + a zero-copy through-actor raw read to source the bytes. The disk `sendfile(2)` **syscall** is **#658** (this is its hard prerequisite). Batched-ack/periodic-ack default = **#550**; credit = **#552**. None of those are touched here.

## Tests added

- proto: `DeliverBatch` round-trip, future-appended-header-field tolerance, empty/short/bad-version rejection, capability bits (Connect/Info), old-client byte-identity.
- storage: `read_range_raw` byte-identical to `read_range` + whole-prefix chaining + record/byte caps.
- engine: `stream_fetch_raw_in` differential vs `stream_fetch_in` + wrong-mode guard.
- session: wire differential (batch == N Delivers), positional offset reconstruction + resume, future header field, old client gets per-record Deliver, sealed+active **boundary/partial batch**.
- client: scripted DeliverBatch round-trip (same Messages as N Delivers) + corrupt-record typed error (CRC end-to-end).

## Gates (all pass, fresh from `cargo clean`)

- `cargo fmt --all --check`: clean.
- `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`: clean.
- `cargo test --workspace --all-features --locked`: all green, 0 failed.

## What to scrutinize

- The `Log::read_range_raw` resume/`tail_from` logic at the sealed/active and segment boundaries (the raw run is single-segment; the active tail materializes) — the boundary/partial-batch test pins it, but it's the subtlest part.
- That the byte-cap accounting across raw + materialized tail never exceeds the request (record-count is the hard bound; `max_bytes` is re-passed to the tail with the first-frame-always rule).