### PR TITLE
feat(cluster): leader epoch (fencing token) + monotonic leadership lease (#582)

### DIFF
--- a/crates/ironbus-core/src/leader_lease.rs
+++ b/crates/ironbus-core/src/leader_lease.rs
@@ -1,0 +1,570 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! The cluster leader epoch + a time-bounded leadership lease (V2-C1, #582).
+//!
+//! This is the cluster-wide generalization of [`lease.rs`](crate::lease)'s per-consumer
+//! generation fencing. Where a [`LeaseToken`](crate::lease::LeaseToken) fences a stale
+//! message holder by its `generation`, a [`LeaderEpoch`] fences a stale *leader* by its
+//! epoch: Raft's Election Safety gives at most one leader per epoch (per term), so a
+//! strictly-increasing epoch is a cluster-wide fencing token — a leader carrying an old
+//! epoch cannot supersede one carrying a newer epoch.
+//!
+//! On top of the epoch sits a [`LeaderLease`]: a leader holds leadership for only a bounded
+//! lease, measured on the **monotonic** clock (the I6 seam — never the wall clock, so an NTP
+//! step or a backwards wall jump cannot extend or shorten a lease). Once the lease expires a
+//! stale leader is fenced: it must stop acting (and, later in C6, stop serving local reads)
+//! until it renews. This is the cluster analogue of a message lease's visibility deadline.
+//!
+//! The type is PURE and IO-free, exactly like [`lease.rs`](crate::lease) and
+//! [`clock.rs`](crate::clock): the caller supplies the monotonic `now` (in nanoseconds, from
+//! the [`Clock`](crate::clock::Clock) seam) on every call. It holds NO clock and does NO IO,
+//! so it composes with the single-writer actor without coloring the data path and stays
+//! inside `ironbus-core`'s IO-free guarantee. Ordering NEVER consults the wall clock.
+
+use core::cmp::Ordering;
+
+/// The cluster-wide leader epoch: a strictly-increasing fencing token, one per leadership.
+///
+/// It is exactly the Raft term surfaced as a fencing token. Election Safety ("at most one
+/// leader can be elected in a given term") means at most one leader exists per epoch, so a
+/// total order on epochs is a total order on leaderships: a write/commit stamped with an
+/// older epoch is fenced by one stamped with a newer epoch. This generalizes the per-lease
+/// `generation` of [`LeaseToken`](crate::lease::LeaseToken) from one consumer's message to
+/// the whole cluster's leadership.
+///
+/// Epoch `0` is the genesis / "no leadership yet" sentinel: a fresh group that has never
+/// elected a leader is at epoch 0, which is strictly below every real leadership epoch (Raft
+/// terms start at 1 on the first election), so any real leader fences the genesis state.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct LeaderEpoch(u64);
+
+impl LeaderEpoch {
+    /// The genesis epoch: no leadership has been established. Strictly below every real
+    /// leadership epoch, so it is fenced by any elected leader.
+    pub const GENESIS: LeaderEpoch = LeaderEpoch(0);
+
+    /// Wraps a raw term/epoch value (the Raft term) as a [`LeaderEpoch`].
+    #[must_use]
+    pub const fn new(epoch: u64) -> LeaderEpoch {
+        LeaderEpoch(epoch)
+    }
+
+    /// The raw epoch value (the Raft term).
+    #[must_use]
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+
+    /// True if this epoch is at or below `other` — i.e. a write stamped with `self` is
+    /// FENCED by a leadership at `other`. A strictly-greater epoch is never fenced by a
+    /// lesser one; equal epochs are the same leadership (Election Safety: one leader per
+    /// epoch) and so are NOT superseded by each other.
+    #[must_use]
+    pub const fn is_fenced_by(self, other: LeaderEpoch) -> bool {
+        self.0 < other.0
+    }
+}
+
+impl From<u64> for LeaderEpoch {
+    fn from(epoch: u64) -> LeaderEpoch {
+        LeaderEpoch(epoch)
+    }
+}
+
+/// The outcome of observing a (possibly-newer) leadership epoch against the current one.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EpochObservation {
+    /// The observed epoch is strictly newer: leadership advanced. The previous leader (and
+    /// any write it had not yet committed) is now fenced.
+    Advanced {
+        /// The epoch that was current before this observation.
+        previous: LeaderEpoch,
+        /// The new, strictly-greater current epoch.
+        current: LeaderEpoch,
+    },
+    /// The observed epoch equals the current one: the same leadership, no change.
+    Unchanged,
+    /// The observed epoch is strictly OLDER than the current one: a stale leader. It is
+    /// fenced — its observation is rejected and the current epoch is left untouched.
+    Stale {
+        /// The current (newer) epoch that fences the stale observation.
+        current: LeaderEpoch,
+        /// The stale epoch that was observed and rejected.
+        observed: LeaderEpoch,
+    },
+}
+
+/// A time-bounded leadership lease, fenced by a [`LeaderEpoch`] and a MONOTONIC deadline.
+///
+/// A leader establishes a lease at the monotonic time it (re)affirms leadership; the lease
+/// is valid for `lease_nanos` of monotonic time. While valid, the holder may act as leader
+/// (commit metadata, later serve local reads in C6). Once `now` reaches the deadline the
+/// lease is EXPIRED and the holder is fenced: it must renew (which it can only do while still
+/// the Raft leader) before acting again. A leader that lost an election but has not yet
+/// noticed (a partition, a pause) therefore stops acting once its lease lapses, bounding the
+/// stale-leader window without consulting the wall clock.
+///
+/// This is the leadership analogue of a [`Lease`](crate::lease)'s visibility deadline: the
+/// epoch is the cluster fencing token (the `generation`), and the monotonic deadline is the
+/// visibility timeout. Like that table, the deadline is read from the monotonic clock and is
+/// never derived from the wall clock, so an NTP step cannot move it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct LeaderLease {
+    epoch: LeaderEpoch,
+    /// The monotonic time the current lease was granted (its budget is measured from here).
+    granted_at: u64,
+    /// The monotonic deadline at or past which the lease is expired.
+    deadline: u64,
+}
+
+impl LeaderLease {
+    /// Grants a fresh leadership lease at `epoch`, valid from monotonic time `now` for
+    /// `lease_nanos`. The deadline saturates at `u64::MAX` so a huge window cannot wrap.
+    ///
+    /// A `lease_nanos` of zero yields an already-expired lease (the deadline equals `now`),
+    /// which fences immediately; callers use a real, positive window (see [`DEFAULT_LEASE_MS`]).
+    ///
+    /// [`DEFAULT_LEASE_MS`]: LeaderLease::DEFAULT_LEASE_MS
+    #[must_use]
+    pub fn grant(epoch: LeaderEpoch, now: u64, lease_nanos: u64) -> LeaderLease {
+        LeaderLease {
+            epoch,
+            granted_at: now,
+            deadline: now.saturating_add(lease_nanos),
+        }
+    }
+
+    /// The default leadership-lease window, 10 seconds. Comfortably longer than the Raft
+    /// election timeout (so a stable leader renews well before its lease lapses) yet short
+    /// enough to bound the stale-leader window. Callers pass an explicit window in
+    /// nanoseconds; this is the suggested default expressed in milliseconds.
+    pub const DEFAULT_LEASE_MS: u64 = 10_000;
+
+    /// The leadership epoch (fencing token) this lease was granted under.
+    #[must_use]
+    pub const fn epoch(self) -> LeaderEpoch {
+        self.epoch
+    }
+
+    /// The monotonic deadline at or past which the lease is expired.
+    #[must_use]
+    pub const fn deadline(self) -> u64 {
+        self.deadline
+    }
+
+    /// True if the lease is still VALID at monotonic time `now`: `now` is strictly before the
+    /// deadline. At or past the deadline the lease is expired and the holder is fenced. The
+    /// deadline is exclusive, exactly like a message lease's visibility deadline.
+    #[must_use]
+    pub const fn is_valid(self, now: u64) -> bool {
+        now < self.deadline
+    }
+
+    /// True if the lease has EXPIRED at monotonic time `now` (`now` is at or past the
+    /// deadline). A stale leader whose lease has expired is fenced and must not act.
+    #[must_use]
+    pub const fn is_expired(self, now: u64) -> bool {
+        !self.is_valid(now)
+    }
+
+    /// Renews the lease for another `lease_nanos` window from monotonic time `now`, but ONLY
+    /// while it is still the SAME leadership (`epoch` matches) AND the current lease has not
+    /// already expired. A leader renews its own lease on each heartbeat tick while it remains
+    /// leader; once the lease lapses (or leadership changed epoch) renewal is refused and the
+    /// caller must establish a NEW lease via [`grant`] under the new epoch.
+    ///
+    /// Returns `true` and extends the deadline on success; returns `false` (a no-op) if the
+    /// epoch differs or the lease is already expired at `now`. Refusing to renew an expired
+    /// lease keeps the fence one-directional: a leader that fell behind cannot silently
+    /// resurrect a lapsed lease — it must win the next term and grant a fresh one.
+    ///
+    /// [`grant`]: LeaderLease::grant
+    pub fn renew(&mut self, epoch: LeaderEpoch, now: u64, lease_nanos: u64) -> bool {
+        if self.epoch != epoch || self.is_expired(now) {
+            return false;
+        }
+        self.granted_at = now;
+        self.deadline = now.saturating_add(lease_nanos);
+        true
+    }
+
+    /// True if a write/commit stamped with `epoch` is FENCED by this lease's leadership at
+    /// monotonic time `now`. A write is fenced when EITHER its epoch is older than the lease's
+    /// epoch (a superseded leader) OR the lease itself has expired (even the current leader
+    /// must stop acting once its lease lapses). Only a write under the SAME, still-VALID lease
+    /// epoch is allowed through — the cluster analogue of [`LeaseTable::holds_active`].
+    ///
+    /// [`LeaseTable::holds_active`]: crate::lease::LeaseTable::holds_active
+    #[must_use]
+    pub const fn fences(self, epoch: LeaderEpoch, now: u64) -> bool {
+        // Fenced if the writer's epoch is not the current leadership's, or if the lease lapsed.
+        epoch.get() != self.epoch.get() || self.is_expired(now)
+    }
+}
+
+/// Tracks the cluster leader epoch and the local leadership lease for one node, fencing stale
+/// leaders. This is the per-node view the metadata group exposes to the rest of the broker so
+/// later issues (C2 replication, C4 divergence, C6 local reads) can fence with the epoch and
+/// the lease without reaching into raft-rs.
+///
+/// The epoch is the durable fencing token (it IS the Raft term, persisted in the metadata
+/// log's `HardState`, so it survives a restart and is monotonic across leadership changes).
+/// The lease is the volatile, monotonic-clock-bounded grant the LOCAL leader holds; it is not
+/// persisted (a restart starts with no held lease, so a recovered node never acts as a stale
+/// leader until it re-wins leadership and grants a fresh lease).
+///
+/// Pure and IO-free: the caller advances it with `(term, is_leader, now)` observations drawn
+/// from the raft core and the monotonic clock.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct LeadershipTracker {
+    epoch: LeaderEpoch,
+    /// The local leadership lease, present only while this node is (or recently was) leader.
+    lease: Option<LeaderLease>,
+    /// The lease window granted/renewed on each successful observation, in monotonic nanos.
+    lease_nanos: u64,
+}
+
+impl LeadershipTracker {
+    /// A fresh tracker at the genesis epoch with no held lease, granting `lease_nanos`-wide
+    /// leases.
+    #[must_use]
+    pub const fn new(lease_nanos: u64) -> LeadershipTracker {
+        LeadershipTracker {
+            epoch: LeaderEpoch::GENESIS,
+            lease: None,
+            lease_nanos,
+        }
+    }
+
+    /// The current cluster leader epoch (the highest term this node has observed).
+    #[must_use]
+    pub const fn epoch(self) -> LeaderEpoch {
+        self.epoch
+    }
+
+    /// The local leadership lease, if this node currently holds (or recently held) one.
+    #[must_use]
+    pub const fn lease(self) -> Option<LeaderLease> {
+        self.lease
+    }
+
+    /// Records the raft core's current `(term, is_leader)` at monotonic time `now`, advancing
+    /// the epoch monotonically and (re)granting or expiring the local lease.
+    ///
+    /// The epoch only ever moves FORWARD: a higher term advances it (and fences the prior
+    /// leadership); an equal term is the same leadership; a LOWER term is a stale observation
+    /// and is rejected without moving the epoch (the [`EpochObservation::Stale`] arm — the
+    /// monotonicity guarantee).
+    ///
+    /// When this node IS the leader at the (advanced or unchanged) epoch, it grants a fresh
+    /// lease (on an epoch advance) or renews the existing one (on an unchanged epoch) from
+    /// `now`. When it is NOT the leader, any held lease is dropped — it stops acting as
+    /// leader at once (it will also be fenced by its lease lapsing even if this observation
+    /// is missed). Returns the [`EpochObservation`] so the caller can react to a leadership
+    /// change.
+    pub fn observe(&mut self, term: u64, is_leader: bool, now: u64) -> EpochObservation {
+        let observed = LeaderEpoch::new(term);
+        let outcome = match observed.cmp(&self.epoch) {
+            Ordering::Greater => EpochObservation::Advanced {
+                previous: self.epoch,
+                current: observed,
+            },
+            Ordering::Equal => EpochObservation::Unchanged,
+            Ordering::Less => {
+                // A stale, lower term: fence it, do NOT regress the epoch or touch the lease.
+                return EpochObservation::Stale {
+                    current: self.epoch,
+                    observed,
+                };
+            }
+        };
+
+        self.epoch = observed;
+
+        if is_leader {
+            // Renew the existing lease in place if it is the SAME epoch and still live; otherwise
+            // (new epoch, no lease, or a lapsed one) grant a fresh lease under this epoch.
+            let renewed = self
+                .lease
+                .as_mut()
+                .is_some_and(|lease| lease.renew(observed, now, self.lease_nanos));
+            if !renewed {
+                self.lease = Some(LeaderLease::grant(observed, now, self.lease_nanos));
+            }
+        } else {
+            // Not the leader: relinquish any held lease so this node stops acting at once.
+            self.lease = None;
+        }
+
+        outcome
+    }
+
+    /// True if a write/commit stamped with `epoch` is FENCED at monotonic time `now`: either
+    /// its epoch is below the current cluster epoch, or this node does not hold a still-valid
+    /// lease under that epoch. A stale leader (old epoch, or a lapsed lease) cannot commit.
+    #[must_use]
+    pub fn fences(self, epoch: LeaderEpoch, now: u64) -> bool {
+        // Below the known cluster epoch ⇒ fenced regardless of any lease.
+        if epoch.is_fenced_by(self.epoch) {
+            return true;
+        }
+        // At the current epoch: allowed ONLY if this node holds a valid lease under it.
+        match self.lease {
+            Some(lease) => lease.fences(epoch, now),
+            None => true,
+        }
+    }
+
+    /// True if this node may ACT as leader at monotonic time `now`: it holds a lease at the
+    /// current epoch and that lease has not expired. Once the lease lapses this returns false
+    /// even if the node still believes it is leader — the stale-leader fence.
+    #[must_use]
+    pub fn can_act_as_leader(self, now: u64) -> bool {
+        matches!(self.lease, Some(lease) if lease.epoch() == self.epoch && lease.is_valid(now))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const LEASE: u64 = 1_000; // 1_000 ns lease window, so tests advance time in small integers.
+
+    #[test]
+    fn epoch_is_a_total_fencing_order() {
+        let lo = LeaderEpoch::new(3);
+        let hi = LeaderEpoch::new(4);
+        assert!(
+            lo.is_fenced_by(hi),
+            "an older epoch is fenced by a newer one"
+        );
+        assert!(
+            !hi.is_fenced_by(lo),
+            "a newer epoch is never fenced by an older one"
+        );
+        assert!(!lo.is_fenced_by(lo), "the same epoch does not fence itself");
+        assert!(
+            LeaderEpoch::GENESIS.is_fenced_by(LeaderEpoch::new(1)),
+            "genesis is fenced by the first real leadership"
+        );
+        assert_eq!(LeaderEpoch::GENESIS.get(), 0);
+    }
+
+    #[test]
+    fn a_fresh_lease_is_valid_then_expires_on_the_monotonic_clock() {
+        let lease = LeaderLease::grant(LeaderEpoch::new(1), 100, LEASE);
+        assert_eq!(lease.deadline(), 1_100);
+        assert!(lease.is_valid(100), "valid at grant time");
+        assert!(lease.is_valid(1_099), "valid just before the deadline");
+        assert!(!lease.is_valid(1_100), "the deadline is exclusive: expired");
+        assert!(lease.is_expired(1_100));
+        assert!(lease.is_expired(5_000), "stays expired");
+    }
+
+    #[test]
+    fn a_zero_window_lease_is_born_expired() {
+        let lease = LeaderLease::grant(LeaderEpoch::new(1), 42, 0);
+        assert!(lease.is_expired(42), "a zero window fences immediately");
+    }
+
+    #[test]
+    fn grant_deadline_saturates_and_never_wraps() {
+        let lease = LeaderLease::grant(LeaderEpoch::new(1), u64::MAX - 1, u64::MAX);
+        assert_eq!(
+            lease.deadline(),
+            u64::MAX,
+            "saturates, never wraps backwards"
+        );
+        assert!(lease.is_valid(u64::MAX - 1));
+    }
+
+    #[test]
+    fn renew_extends_only_the_same_live_epoch() {
+        let mut lease = LeaderLease::grant(LeaderEpoch::new(2), 0, LEASE); // deadline 1_000
+                                                                           // Renew at 500 under the same epoch: deadline pushed to 1_500.
+        assert!(lease.renew(LeaderEpoch::new(2), 500, LEASE));
+        assert_eq!(lease.deadline(), 1_500);
+        // A different epoch cannot renew (it is a different leadership).
+        assert!(!lease.renew(LeaderEpoch::new(3), 600, LEASE));
+        assert_eq!(lease.deadline(), 1_500, "a foreign-epoch renew is a no-op");
+        // Once expired, even the same epoch cannot renew: must grant fresh under a new term.
+        assert!(!lease.renew(LeaderEpoch::new(2), 1_500, LEASE));
+        assert!(lease.is_expired(1_500));
+    }
+
+    #[test]
+    fn fences_a_stale_or_lapsed_writer() {
+        let lease = LeaderLease::grant(LeaderEpoch::new(5), 0, LEASE); // valid [0, 1_000)
+                                                                       // Same epoch, valid lease: NOT fenced.
+        assert!(
+            !lease.fences(LeaderEpoch::new(5), 500),
+            "current leader within lease acts"
+        );
+        // Older epoch: fenced even while the lease is valid (a superseded leader).
+        assert!(
+            lease.fences(LeaderEpoch::new(4), 500),
+            "an older epoch is fenced"
+        );
+        // Same epoch but the lease lapsed: fenced (even the current leader must stop).
+        assert!(
+            lease.fences(LeaderEpoch::new(5), 1_000),
+            "a lapsed lease fences its own leader"
+        );
+    }
+
+    // --- LeadershipTracker: the per-node epoch + lease seam the metadata group drives. ---
+
+    #[test]
+    fn epoch_is_strictly_monotonic_across_leadership_changes() {
+        // The leader-epoch monotonicity property: across a sequence of (re)elections the epoch
+        // only ever increases, never regresses — even if a stale, lower term is observed.
+        let mut t = LeadershipTracker::new(LEASE);
+        assert_eq!(t.epoch(), LeaderEpoch::GENESIS);
+
+        // Term 1: this node wins. Epoch advances 0 -> 1.
+        assert_eq!(
+            t.observe(1, true, 0),
+            EpochObservation::Advanced {
+                previous: LeaderEpoch::GENESIS,
+                current: LeaderEpoch::new(1),
+            }
+        );
+        assert_eq!(t.epoch(), LeaderEpoch::new(1));
+
+        // Term 2: leadership moves elsewhere (is_leader=false). Epoch advances 1 -> 2.
+        assert_eq!(
+            t.observe(2, false, 10),
+            EpochObservation::Advanced {
+                previous: LeaderEpoch::new(1),
+                current: LeaderEpoch::new(2),
+            }
+        );
+        assert_eq!(t.epoch(), LeaderEpoch::new(2));
+
+        // A STALE observation of an old term 1 is fenced and does NOT regress the epoch.
+        assert_eq!(
+            t.observe(1, true, 20),
+            EpochObservation::Stale {
+                current: LeaderEpoch::new(2),
+                observed: LeaderEpoch::new(1),
+            }
+        );
+        assert_eq!(
+            t.epoch(),
+            LeaderEpoch::new(2),
+            "a stale term never regresses the epoch"
+        );
+
+        // Re-observing the current term is Unchanged (the same leadership, Election Safety).
+        assert_eq!(t.observe(2, false, 30), EpochObservation::Unchanged);
+        assert_eq!(t.epoch(), LeaderEpoch::new(2));
+    }
+
+    #[test]
+    fn at_most_one_leadership_acts_per_epoch_and_a_stale_leader_is_fenced() {
+        // Election Safety surfaced as fencing: at any epoch only the holder of a VALID lease at
+        // that epoch may act; a superseded (older-epoch) leader is always fenced.
+        let mut leader = LeadershipTracker::new(LEASE);
+        leader.observe(7, true, 0); // wins term 7, lease [0, 1_000)
+        assert!(
+            leader.can_act_as_leader(0),
+            "the term-7 leader holds a valid lease"
+        );
+        // A write at the current epoch within the lease is allowed; an older-epoch write is fenced.
+        assert!(
+            !leader.fences(LeaderEpoch::new(7), 500),
+            "the current leader's write commits"
+        );
+        assert!(
+            leader.fences(LeaderEpoch::new(6), 500),
+            "a stale term-6 write is fenced"
+        );
+
+        // Leadership advances to term 8 elsewhere: this node is no longer leader. It drops its
+        // lease and can no longer act, and ANY write it would make is fenced by the new epoch.
+        leader.observe(8, false, 100);
+        assert!(
+            !leader.can_act_as_leader(100),
+            "a superseded node cannot act"
+        );
+        assert!(
+            leader.fences(LeaderEpoch::new(7), 100),
+            "its old-epoch write is fenced"
+        );
+    }
+
+    #[test]
+    fn a_post_expiry_stale_leader_is_fenced_on_the_monotonic_clock() {
+        // The lease-expiry fence: a node that still BELIEVES it is leader (it never saw a newer
+        // term — a partition) stops being able to act once its lease lapses on the monotonic
+        // clock, with no wall-clock involvement and no newer epoch needed to fence it.
+        let mut leader = LeadershipTracker::new(LEASE);
+        leader.observe(3, true, 0); // lease [0, 1_000)
+        assert!(leader.can_act_as_leader(500), "within the lease it may act");
+        assert!(
+            !leader.fences(LeaderEpoch::new(3), 500),
+            "its write commits within the lease"
+        );
+
+        // The monotonic clock crosses the deadline with NO new observation (the partition): the
+        // lease lapses, so the stale leader can no longer act and its write is now fenced.
+        assert!(
+            !leader.can_act_as_leader(1_000),
+            "the lapsed lease fences the stale leader"
+        );
+        assert!(
+            leader.fences(LeaderEpoch::new(3), 1_000),
+            "a post-expiry write by the stale leader cannot commit"
+        );
+    }
+
+    #[test]
+    fn a_leader_renews_its_lease_across_ticks_and_keeps_acting() {
+        // A stable leader re-observes the same term each heartbeat and renews its lease, so it
+        // keeps acting indefinitely without the epoch changing — the steady-state path.
+        let mut leader = LeadershipTracker::new(LEASE);
+        leader.observe(4, true, 0); // lease [0, 1_000)
+                                    // Renew at 800 (still leader, same term): lease extends to [800, 1_800).
+        assert_eq!(leader.observe(4, true, 800), EpochObservation::Unchanged);
+        assert!(
+            leader.can_act_as_leader(1_500),
+            "the renewed lease covers 1_500"
+        );
+        assert_eq!(
+            leader.epoch(),
+            LeaderEpoch::new(4),
+            "renewal never changes the epoch"
+        );
+    }
+
+    #[test]
+    fn losing_leadership_drops_the_lease_at_once() {
+        let mut node = LeadershipTracker::new(LEASE);
+        node.observe(2, true, 0);
+        assert!(node.lease().is_some());
+        // Same term, but no longer the leader: the lease is dropped immediately (a step-down).
+        node.observe(2, false, 100);
+        assert!(
+            node.lease().is_none(),
+            "stepping down relinquishes the lease at once"
+        );
+        assert!(!node.can_act_as_leader(100));
+    }
+
+    #[test]
+    fn the_n1_degenerate_case_grants_a_trivial_lease() {
+        // n=1: the lone voter self-elects at term 1 and trivially holds the only lease at epoch
+        // 1 — there is no other leadership to fence, so the lease/epoch are degenerate but
+        // consistent (the single-node path is unchanged behaviorally; this is pure bookkeeping).
+        let mut solo = LeadershipTracker::new(LEASE);
+        solo.observe(1, true, 0);
+        assert_eq!(solo.epoch(), LeaderEpoch::new(1));
+        assert!(solo.can_act_as_leader(0));
+        assert!(
+            !solo.fences(LeaderEpoch::new(1), 0),
+            "the lone leader is never fenced by itself"
+        );
+        // Re-tick keeps it the sole, unfenced leader.
+        solo.observe(1, true, 1);
+        assert!(solo.can_act_as_leader(1));
+    }
+}

--- a/crates/ironbus-core/src/lib.rs
+++ b/crates/ironbus-core/src/lib.rs
@@ -26,6 +26,7 @@ pub mod delivery;
 pub mod dict;
 pub mod format;
 pub mod keyshared;
+pub mod leader_lease;
 pub mod lease;
 pub mod segment;
 pub mod subject;

--- a/crates/ironbus-server/src/cluster/metadata_group.rs
+++ b/crates/ironbus-server/src/cluster/metadata_group.rs
@@ -25,6 +25,7 @@
 //!   not change the single-node binary's behavior or on-disk layout.
 
 use ironbus_core::clock::Clock;
+use ironbus_core::leader_lease::{EpochObservation, LeaderEpoch, LeaderLease, LeadershipTracker};
 use ironbus_storage::fs::Filesystem;
 use ironbus_storage::log::LogConfig;
 use raft::eraftpb::{Entry, EntryType, Message};
@@ -33,6 +34,14 @@ use slog::{o, Discard, Logger};
 
 use crate::cluster::metadata_storage::{MetadataLogStorage, MetadataStorageError};
 use crate::cluster::state_machine::{DecodeError, MetadataCommand, MetadataStateMachine};
+
+/// The leadership-lease window the metadata group grants, in monotonic nanoseconds.
+///
+/// Derived from the I6 monotonic clock (never the wall clock). It must comfortably exceed the
+/// election window (`election_tick` heartbeats) so a stable leader renews its lease well before
+/// it lapses, yet stay short enough to bound the stale-leader window. We use the core default
+/// (10 s) expressed in nanoseconds.
+const LEADER_LEASE_NANOS: u64 = LeaderLease::DEFAULT_LEASE_MS * 1_000_000;
 
 /// Errors constructing or driving the metadata group.
 #[derive(Debug)]
@@ -101,9 +110,15 @@ const SUPPORTED_VOTER_COUNTS: [usize; 3] = [1, 3, 5];
 pub struct MetadataRaftGroup<F: Filesystem, C: Clock> {
     node: RawNode<MetadataLogStorage<F, C>>,
     state: MetadataStateMachine,
+    /// The monotonic-clock seam (I6), used to time the leadership lease. The SAME logical clock
+    /// the storage was opened with; ordering never consults the wall clock.
+    clock: C,
+    /// The cluster leader epoch + the local leadership lease, advanced from the raft term and the
+    /// monotonic clock on every ready cycle. The epoch is the cluster-wide fencing token (C1-I3).
+    leadership: LeadershipTracker,
 }
 
-impl<F: Filesystem, C: Clock> MetadataRaftGroup<F, C> {
+impl<F: Filesystem, C: Clock + Clone> MetadataRaftGroup<F, C> {
     /// Construct a metadata group for `node_id` over the `voters` set, persisting to a durable
     /// metadata log rooted in the `metaraft/` subdirectory of `parent_fs`.
     ///
@@ -145,15 +160,31 @@ impl<F: Filesystem, C: Clock> MetadataRaftGroup<F, C> {
         raft_config.validate()?;
 
         // Open (or recover) the durable metadata log, seeding the voter ConfState for a fresh
-        // group; the persisted membership wins on a recovered one.
-        let storage = MetadataLogStorage::open(parent_fs, clock, config, voters)?;
+        // group; the persisted membership wins on a recovered one. Keep a clone of the clock for
+        // the leadership lease so the group times leases off the SAME monotonic seam (I6) the
+        // storage uses; the clock is moved into storage and re-read here only for monotonic time.
+        let storage = MetadataLogStorage::open(parent_fs, clock.clone(), config, voters)?;
         // default-logger is disabled; discard raft-rs's own slog output.
         let logger = Logger::root(Discard, o!());
         let node = RawNode::new(&raft_config, storage, &logger)?;
 
+        // Seed the cluster epoch from the recovered durable term (the metadata log's HardState),
+        // so a restarted node never regresses the epoch (#659 durability). No lease is granted at
+        // open: a recovered node holds NO leadership lease until it re-wins leadership and grants a
+        // fresh one, so it can never resume acting as a stale leader across a restart.
+        let mut leadership = LeadershipTracker::new(LEADER_LEASE_NANOS);
+        let recovered_term = node.store().initial_state()?.hard_state.term;
+        if recovered_term > 0 {
+            // Observe as a non-leader so the epoch advances to the durable term without granting
+            // a lease (the node must re-campaign to lead again).
+            leadership.observe(recovered_term, false, clock.now_monotonic_nanos());
+        }
+
         Ok(Self {
             node,
             state: MetadataStateMachine::new(),
+            clock,
+            leadership,
         })
     }
 
@@ -169,11 +200,51 @@ impl<F: Filesystem, C: Clock> MetadataRaftGroup<F, C> {
         self.node.raft.state == StateRole::Leader
     }
 
-    /// The current Raft term (the cluster-wide monotonic leader epoch; exposing it to the
-    /// broker as the per-partition fencing token is C1-I3).
+    /// The current Raft term (the raw consensus term). Prefer [`Self::leader_epoch`] as the
+    /// monotonic cluster fencing token: the term raw off the raft core can briefly read lower
+    /// than the highest epoch this group has observed mid-transition, whereas the epoch never
+    /// regresses (C1-I3).
     #[must_use]
     pub fn term(&self) -> u64 {
         self.node.raft.term
+    }
+
+    /// The cluster-wide monotonic **leader epoch** — the Raft term surfaced as a fencing token
+    /// (C1-I3). It advances strictly on each leadership change and NEVER regresses; Election
+    /// Safety gives at most one leader per epoch, so an old-epoch leader is fenced by a
+    /// newer-epoch one. Later issues (C2 replication, C4 divergence) fence with this so a stale
+    /// leader cannot commit. Durable across a restart (seeded from the metadata log's term, #659).
+    #[must_use]
+    pub fn leader_epoch(&self) -> LeaderEpoch {
+        self.leadership.epoch()
+    }
+
+    /// The local leadership lease, if this node currently holds one (it is the leader and its
+    /// monotonic-clock lease has not lapsed). `None` on a follower, or once a stale leader's
+    /// lease has expired.
+    #[must_use]
+    pub fn leader_lease(&self) -> Option<LeaderLease> {
+        self.leadership.lease()
+    }
+
+    /// Whether this node may ACT as leader **right now** (at the current monotonic time): it
+    /// holds a still-valid lease at the current epoch. Once the lease lapses on the monotonic
+    /// clock this is false even if the raft core still believes it is leader — the stale-leader
+    /// fence that makes safe local leader reads possible later (C6). Reads the I6 monotonic
+    /// clock, never the wall clock.
+    #[must_use]
+    pub fn can_act_as_leader(&self) -> bool {
+        self.leadership
+            .can_act_as_leader(self.clock.now_monotonic_nanos())
+    }
+
+    /// Whether a write/commit stamped with `epoch` is FENCED right now: its epoch is below the
+    /// current cluster epoch, or this node does not hold a valid lease under it. The fencing
+    /// predicate C2/C4 call before letting a (possibly stale) leader commit.
+    #[must_use]
+    pub fn fences(&self, epoch: LeaderEpoch) -> bool {
+        self.leadership
+            .fences(epoch, self.clock.now_monotonic_nanos())
     }
 
     /// The applied view of the replicated control plane.
@@ -182,11 +253,25 @@ impl<F: Filesystem, C: Clock> MetadataRaftGroup<F, C> {
         &self.state
     }
 
+    /// Fold the raft core's current `(term, is_leader)` into the leadership tracker at the
+    /// current monotonic time: advance the epoch monotonically and (re)grant / drop the local
+    /// lease. Called after every state-changing step (tick, ready) so the epoch and lease track
+    /// leadership without the caller reaching into raft-rs. Returns the epoch observation.
+    fn refresh_leadership(&mut self) -> EpochObservation {
+        let term = self.node.raft.term;
+        let is_leader = self.node.raft.state == StateRole::Leader;
+        let now = self.clock.now_monotonic_nanos();
+        self.leadership.observe(term, is_leader, now)
+    }
+
     /// Drive the election timer by one tick. Returns true if the tick produced new work
     /// (a `Ready` to drain). At n=1 a single tick window elapsing makes the lone voter
-    /// elect itself.
+    /// elect itself. The leadership lease is refreshed off the monotonic clock so a leader
+    /// renews (and a stale leader's lapsed lease is observed) on the heartbeat cadence.
     pub fn tick(&mut self) -> bool {
-        self.node.tick()
+        let work = self.node.tick();
+        self.refresh_leadership();
+        work
     }
 
     /// Campaign to become leader immediately (used at n=1 / in tests to avoid waiting out
@@ -197,6 +282,7 @@ impl<F: Filesystem, C: Clock> MetadataRaftGroup<F, C> {
     /// Returns [`GroupError::Raft`] if the core rejects the campaign.
     pub fn campaign(&mut self) -> Result<(), GroupError> {
         self.node.campaign()?;
+        self.refresh_leadership();
         Ok(())
     }
 
@@ -208,6 +294,7 @@ impl<F: Filesystem, C: Clock> MetadataRaftGroup<F, C> {
     /// Returns [`GroupError::Raft`] if the core rejects the message.
     pub fn step(&mut self, msg: Message) -> Result<(), GroupError> {
         self.node.step(msg)?;
+        self.refresh_leadership();
         Ok(())
     }
 
@@ -297,6 +384,12 @@ impl<F: Filesystem, C: Clock> MetadataRaftGroup<F, C> {
         }
         outbound.extend(light.take_messages());
         self.apply_committed(light.take_committed_entries())?;
+
+        // Fold the (possibly-changed) term / leadership into the epoch + lease: an election that
+        // committed this cycle advances the epoch and grants the new leader its monotonic-clock
+        // lease; a step-down drops it. The epoch is durable (it is the persisted term) and the
+        // lease is timed off the I6 monotonic clock — never the wall clock.
+        self.refresh_leadership();
 
         Ok(outbound)
     }
@@ -544,5 +637,211 @@ mod tests {
             }),
             "the committed placement must survive a reopen of the durable group"
         );
+    }
+
+    // --- C1-I3 (#582): leader epoch (fencing token) + monotonic leadership lease. ---
+
+    use std::sync::Arc;
+
+    /// A group whose monotonic clock is a SHARED `Arc<ManualClock>`, so a test can drive the
+    /// very clock the group's leadership lease reads (the storage and the lease share it). The
+    /// returned handle is that clock; advancing it advances the group's monotonic time.
+    fn open_with_shared_clock(
+        fs: &InMemoryFs,
+        node_id: u64,
+        voters: &[u64],
+    ) -> (
+        MetadataRaftGroup<InMemoryFs, Arc<ManualClock>>,
+        Arc<ManualClock>,
+    ) {
+        let clock = Arc::new(ManualClock::new());
+        let group = MetadataRaftGroup::open(node_id, voters, fs, Arc::clone(&clock), log_config())
+            .expect("open shared-clock group");
+        (group, clock)
+    }
+
+    /// Settle a shared-clock group (same bounded drive as `settle`, monomorphized for the
+    /// `Arc<ManualClock>` group).
+    fn settle_shared(group: &mut MetadataRaftGroup<InMemoryFs, Arc<ManualClock>>) {
+        for _ in 0..256 {
+            let _ = group.drive_ready().expect("drive ready");
+            if !group.node.has_ready() {
+                break;
+            }
+        }
+    }
+
+    /// The leader epoch is strictly monotonic across leadership changes and is exposed as the
+    /// cluster fencing token: a fresh group is at genesis (0); winning term T puts it at epoch T;
+    /// it never regresses.
+    #[test]
+    fn leader_epoch_is_monotonic_and_exposed_as_a_fencing_token() {
+        let fs = InMemoryFs::new();
+        let mut group = open_on(&fs, 1, &[1]);
+        // Before any election the epoch is genesis (0), strictly below every real leadership.
+        assert_eq!(group.leader_epoch(), LeaderEpoch::GENESIS);
+        assert!(!group.can_act_as_leader(), "no lease before an election");
+
+        group.campaign().expect("campaign");
+        settle(&mut group);
+        assert!(group.is_leader());
+        let epoch = group.leader_epoch();
+        assert!(
+            epoch.get() >= 1,
+            "winning the first election advances the epoch off genesis"
+        );
+        assert_eq!(
+            epoch.get(),
+            group.term(),
+            "the leader epoch is the raft term surfaced as a fencing token"
+        );
+        // The epoch never regresses: re-driving the settled leader keeps it at the same epoch.
+        settle(&mut group);
+        assert_eq!(
+            group.leader_epoch(),
+            epoch,
+            "a stable leader's epoch does not regress"
+        );
+        // The current leader is not fenced by its own epoch; a strictly-older epoch IS fenced.
+        assert!(
+            !group.fences(epoch),
+            "the current leader's own-epoch write commits"
+        );
+        assert!(
+            group.fences(LeaderEpoch::new(epoch.get() - 1)),
+            "a write at a strictly-older epoch is fenced"
+        );
+    }
+
+    /// Election Safety surfaced through the metadata group: while leading, this node holds a
+    /// valid lease at its epoch and is the only actor at that epoch; a strictly-older-epoch
+    /// write is always fenced (≤ 1 acting leader per epoch).
+    #[test]
+    fn at_most_one_leader_per_epoch_holds_through_the_metadata_group() {
+        let fs = InMemoryFs::new();
+        let (mut group, _clock) = open_with_shared_clock(&fs, 1, &[1]);
+        group.campaign().expect("campaign");
+        settle_shared(&mut group);
+        assert!(group.is_leader());
+        let epoch = group.leader_epoch();
+        assert!(
+            group.can_act_as_leader(),
+            "the elected leader holds a valid lease at its epoch"
+        );
+        // No older-epoch leadership can act: any epoch below the current one is fenced.
+        for older in 0..epoch.get() {
+            assert!(
+                group.fences(LeaderEpoch::new(older)),
+                "epoch {older} is older than the current leadership and must be fenced"
+            );
+        }
+    }
+
+    /// A leadership lease expires on the MONOTONIC clock (not the wall clock), and a post-expiry
+    /// stale leader is fenced: with no newer term observed (a partition), once the lease lapses
+    /// the node can no longer act and its write cannot commit.
+    #[test]
+    fn a_leadership_lease_expires_and_fences_a_stale_leader_on_the_monotonic_clock() {
+        let fs = InMemoryFs::new();
+        let (mut group, clock) = open_with_shared_clock(&fs, 1, &[1]);
+        group.campaign().expect("campaign");
+        settle_shared(&mut group);
+        assert!(group.is_leader());
+        let epoch = group.leader_epoch();
+
+        // The lease was granted at monotonic time 0; it is valid now and the leader may act.
+        let lease = group.leader_lease().expect("leader holds a lease");
+        assert!(
+            group.can_act_as_leader(),
+            "within the lease the leader acts"
+        );
+        assert!(
+            !group.fences(epoch),
+            "its current-epoch write commits within the lease"
+        );
+
+        // WALL-clock motion alone must NOT expire the lease (the lease is monotonic-only): step
+        // the wall clock far forward, leaving the monotonic clock fixed.
+        clock.set_unix_millis(10_000_000_000);
+        assert!(
+            group.can_act_as_leader(),
+            "a wall-clock step does not expire a monotonic lease"
+        );
+
+        // Now advance ONLY the monotonic clock past the lease deadline, observing NO new term
+        // (the partition): the lease lapses and the stale leader is fenced.
+        let past_deadline = lease.deadline() - clock.now_monotonic_nanos() + 1;
+        clock.advance_monotonic_nanos(past_deadline);
+        assert!(
+            !group.can_act_as_leader(),
+            "the lapsed lease fences the stale leader off the monotonic clock"
+        );
+        assert!(
+            group.fences(epoch),
+            "a post-expiry write by the stale leader cannot commit"
+        );
+    }
+
+    /// The n=1 degenerate case: the lone voter self-elects, holds the only (trivial) lease, is
+    /// never fenced by itself, and the epoch/lease are bookkeeping with no behavior change.
+    #[test]
+    fn the_single_node_n1_case_is_trivial_and_degenerate() {
+        let fs = InMemoryFs::new();
+        let mut group = open_on(&fs, 1, &[1]);
+        group.campaign().expect("campaign");
+        settle(&mut group);
+        assert!(group.is_leader(), "the lone voter self-elects");
+        let epoch = group.leader_epoch();
+        assert!(epoch.get() >= 1);
+        assert!(
+            group.can_act_as_leader(),
+            "the sole leader trivially holds the only lease"
+        );
+        // There is no other leadership to fence it; its own-epoch write always commits.
+        assert!(
+            !group.fences(epoch),
+            "the lone leader is never fenced by itself"
+        );
+        assert!(group.leader_lease().is_some());
+    }
+
+    /// The leader epoch SURVIVES the durable metadata-log round-trip (#659): a reopened group
+    /// recovers the epoch from the persisted term and never regresses below it — but holds NO
+    /// lease at open, so a recovered node cannot resume acting as a stale leader.
+    #[test]
+    fn the_leader_epoch_survives_the_metadata_log_roundtrip() {
+        let fs = InMemoryFs::new();
+        let epoch_before = {
+            let mut group = open_on(&fs, 1, &[1]);
+            group.campaign().expect("campaign");
+            settle(&mut group);
+            assert!(group.is_leader());
+            // Commit something so the term is durably checkpointed.
+            group
+                .propose(&MetadataCommand::AssignPartition {
+                    partition: 1,
+                    leader: 1,
+                    epoch: group.leader_epoch().get(),
+                })
+                .expect("propose");
+            settle(&mut group);
+            group.leader_epoch()
+        };
+        assert!(epoch_before.get() >= 1);
+
+        // Reopen over the SAME durable image (a restart): the epoch is recovered from the
+        // persisted term and is at least what it was — it never regresses.
+        let reopened = open_on(&fs, 1, &[1]);
+        assert!(
+            reopened.leader_epoch().get() >= epoch_before.get(),
+            "the recovered epoch never regresses below the durable term"
+        );
+        // A recovered node holds NO lease until it re-wins leadership: it cannot act as a stale
+        // leader across the restart.
+        assert!(
+            !reopened.can_act_as_leader(),
+            "a recovered node holds no leadership lease until it re-campaigns"
+        );
+        assert!(reopened.leader_lease().is_none());
     }
 }

--- a/crates/ironbus-server/src/cluster/mod.rs
+++ b/crates/ironbus-server/src/cluster/mod.rs
@@ -7,26 +7,39 @@
 //! for). Consensus is the production tikv/raft-rs core, wired in here in `ironbus-server`
 //! ONLY (never `ironbus-core`, which stays IO-free and async-free).
 //!
-//! ## Status: C1-I2 (#580) — durable metadata log
+//! ## Status: C1-I3 (#582) — leader epoch (fencing token) + monotonic leadership lease
 //!
 //! C1-I1 (#578) integrated the vendored-codec raft-rs and gave a constructible, in-memory
-//! metadata group; C1-I2 (this) makes the group's storage DURABLE:
+//! metadata group; C1-I2 (#580) made the group's storage DURABLE; C1-I3 (this) surfaces the
+//! Raft term as a cluster-wide leader epoch and bounds leadership with a monotonic-clock lease:
 //!
 //! * [`metadata_group::MetadataRaftGroup`] — a `RawNode<MetadataLogStorage>` for a 1/3/5-voter
 //!   group, driven by the synchronous `tick` / `step` / `propose` / `ready` loop, persisting
-//!   to an IronBus CRC-framed log and fsyncing before it advances;
+//!   to an IronBus CRC-framed log and fsyncing before it advances. It now exposes
+//!   [`leader_epoch`](metadata_group::MetadataRaftGroup::leader_epoch) (the monotonic fencing
+//!   token), a [`leader_lease`](metadata_group::MetadataRaftGroup::leader_lease), and the
+//!   [`fences`](metadata_group::MetadataRaftGroup::fences) /
+//!   [`can_act_as_leader`](metadata_group::MetadataRaftGroup::can_act_as_leader) predicates;
 //! * [`metadata_storage::MetadataLogStorage`] — the durable raft-rs `Storage` over an IronBus
 //!   [`Log`](ironbus_storage::log::Log), so the metadata log IS an IronBus log (its own
 //!   `metaraft/` subdirectory, the dead-letter-sink shape) and inherits I1–I4 (longest-valid-
-//!   prefix recovery, CRC validation, bounded + reported loss / quarantine);
+//!   prefix recovery, CRC validation, bounded + reported loss / quarantine); the epoch is the
+//!   persisted term, so it survives a restart;
 //! * [`state_machine::MetadataStateMachine`] — the deterministic applied control plane
 //!   (membership, placement, leader epoch, config) with a small, zero-dependency,
 //!   hand-rolled command codec.
 //!
+//! The epoch + lease primitive themselves live IO-free in
+//! [`ironbus_core::leader_lease`](ironbus_core::leader_lease) — the cluster-wide generalization
+//! of [`lease.rs`](ironbus_core::lease)'s per-consumer generation fencing — so the metadata
+//! group only WIRES the raft term + the I6 monotonic clock into it.
+//!
 //! ## Deliberately deferred (later C1 issues)
 //!
-//! * **C1-I3** — expose the Raft term as the per-partition leader epoch and pair it with
-//!   the `ironbus-core` lease/clock fencing.
+//! * **PEER TRANSPORT + RUSTSEC-2024-0437** — the wire that parses untrusted peer Raft bytes
+//!   (and the bounding of incoming message size / recursion + removing the deny.toml ignore)
+//!   is a SEPARATE, security-sensitive follow-up; C1-I3 parses NO peer bytes, so the advisory
+//!   stays unreachable and its scoped ignore is unchanged here.
 //! * **C1-I4** — joint-consensus membership changes, learners, and peer-id validation in
 //!   the transport/step seam.
 //! * log COMPACTION / snapshot DATA — physically reclaiming the applied metadata-log prefix
@@ -34,7 +47,7 @@
 //!
 //! This module is NOT yet referenced by the running broker (no `serve`-path wiring), so its
 //! presence does not change the single-node binary's behavior or on-disk layout — the n=1
-//! zero-config path is unaffected.
+//! zero-config path is unaffected (a 1-member group's epoch/lease is trivial / degenerate).
 
 pub mod metadata_group;
 pub mod metadata_storage;


### PR DESCRIPTION
Closes #582 (V2-C1, C1-I3). Builds on the merged C1-I1 (#653, metadata Raft group) + C1-I2 (#659, durable metadata log).

## What this does — the leader-epoch-as-fencing-token + the monotonic leadership lease

Surfaces the metadata Raft **term** as a cluster-wide, strictly-monotonic **leader epoch** — a fencing token. Raft's **Election Safety** gives at most one leader per epoch, so a total order on epochs is a total order on leaderships: a write/commit stamped with an older epoch is fenced by one stamped with a newer epoch. This is the **cluster-wide generalization** of `lease.rs`'s per-consumer `generation` fencing (which IronBus already uses for message leases), lifted from one consumer's message to the whole cluster's leadership.

On top of the epoch sits a **time-bounded leadership lease** derived from the **I6 monotonic clock** (`Clock::now_monotonic_nanos`), **never the wall clock** — so an NTP step or a backwards wall jump cannot extend or shorten a lease. A leader holds leadership only for a bounded lease; once it lapses on the monotonic clock the stale leader is **fenced** and stops acting (even without observing a newer term — e.g. under a partition). This is the basis for safe local leader reads later in C6.

The epoch is exposed so later issues fence with it (a stale/old-epoch leader cannot commit): `leader_epoch()`, `leader_lease()`, `fences(epoch)`, `can_act_as_leader()` on `MetadataRaftGroup`.

### Design
- **`ironbus-core::leader_lease`** (new, pure / IO-free, like `lease.rs` + `clock.rs`): `LeaderEpoch` (the fencing token, = the raft term), `LeaderLease` (a monotonic-deadline grant with renew/expire/fence), and `LeadershipTracker` (the per-node epoch + local lease, advanced from `(term, is_leader, now)`). It **reuses lease.rs's generation-fencing machinery cluster-wide** and reads only the monotonic seam — core stays IO-free.
- **`MetadataRaftGroup`** wires the raft term + the monotonic clock into the tracker on every `tick` / `step` / `campaign` / ready cycle. The epoch is **seeded from the recovered durable term**, so it survives a restart (durable via the metadata log, #659) and never regresses; a recovered node holds **no** lease until it re-wins leadership, so it can never resume acting as a stale leader across a restart.

## Preserved
- The C1-I1/I2 API is additive (the `open` signature gains a `Clone` bound on the clock seam; `SystemClock`/`ManualClock`/`Arc<C>` all satisfy it).
- **Single-node binary unaffected**: the cluster module is still not wired into `serve`; a 1-member `n=1` group's epoch/lease is trivial/degenerate (no behavior change, byte-identical).
- `ironbus-core` stays IO-free (AST + dep-tree guards green); MSRV 1.78; the vendored no-protoc codec untouched.
- **NO untrusted peer bytes are parsed in this PR**, so **RUSTSEC-2024-0437 stays unreachable and its scoped `deny.toml` ignore is unchanged** (no deps changed at all).

## Split out: peer transport + the RUSTSEC-2024-0437 bounding → #667
Per the #582 maintainer gate, the peer **transport** (the thing that parses untrusted peer Raft bytes and so makes the protobuf 2.x advisory reachable) is a large, security-sensitive chunk. It must **bound incoming Raft message size + recursion depth** and then **remove the RUSTSEC-2024-0437 ignore** — too big to bundle cleanly with epoch/lease. Filed as **#667** (separate follow-up). This PR is the deterministic, local epoch+lease core only.

## Scope boundary
Leader-epoch assignment + leadership lease ONLY. Not here: peer transport/replication + RUSTSEC bounding (**#667**); peer-id validation + joint-consensus membership/learners (**C1-I4**); cluster ack levels (**C3**); divergence (**C4**).

## Tests added
- The leader epoch is **strictly monotonic** across leadership changes (a stale lower term never regresses it).
- **<=1 leader per epoch** (Election Safety) holds *through the metadata group* — an older-epoch write is always fenced.
- A leadership lease **expires on the monotonic clock** and a **post-expiry stale leader is fenced** (cannot act/commit); a wall-clock step alone does **not** expire it.
- The **n=1 degenerate** case is trivial (the lone voter trivially holds the only lease, never fenced by itself).
- The **epoch survives the metadata-log round-trip** (durable via #659) and never regresses; a recovered node holds no lease until it re-campaigns.
- (Plus 12 pure unit tests on the core primitive.)

## Gate results
- `cargo fmt --all --check`: clean.
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` (RUSTFLAGS=`-D warnings`), **fresh from `cargo clean`**: clean, zero warnings.
- `cargo test --workspace --all-features --locked`: all suites pass, 0 failures.
- `ironbus-core` IO-free: AST structural check green (21 source files) + the `cargo tree -p ironbus-core` async-runtime guard green.
- MSRV 1.78 build gate (`cargo build --workspace --all-features --locked` on 1.78.0): green.
- No deps changed, so `cargo deny` is unaffected and the RUSTSEC-2024-0437 ignore is unchanged.

## What to scrutinize
- The epoch-seed-on-open path: it observes the recovered durable term as a **non-leader** so the epoch advances without granting a lease — confirm that's the intended "no stale-leader-after-restart" behavior.
- The lease window (`LeaderLease::DEFAULT_LEASE_MS` = 10 s) vs the election-tick ratio (`election_tick: 10`, `heartbeat_tick: 3`): the lease must comfortably exceed the election window so a stable leader always renews before lapsing.
- `fences()` / `can_act_as_leader()` read the live monotonic clock each call (no caching), which is what lets a lapsed lease fence without a new observation — confirm that's the desired contract for C2/C4/C6 callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVWp2H2txnKGru4q2twxM3