### PR TITLE
feat(routing): per-connection generation-guarded subject-resolve cache (#569)

### DIFF
--- a/crates/ironbus-core/Cargo.toml
+++ b/crates/ironbus-core/Cargo.toml
@@ -98,3 +98,11 @@ harness = false
 [[bench]]
 name = "sublist"
 harness = false
+
+# Per-connection resolve cache (#569): the steady-state publish hot path — a cache HIT (a hash
+# lookup + generation-compare, NO trie walk) vs a direct trie walk — and the bind-change cost
+# (a single generation-compare + lazy re-resolve, NOT NATS's per-subject global-cache flush).
+# Backs the "beats NATS results-cache" claim. Run via `cargo bench -p ironbus-core --bench resolve_cache`.
+[[bench]]
+name = "resolve_cache"
+harness = false

--- a/crates/ironbus-core/benches/resolve_cache.rs
+++ b/crates/ironbus-core/benches/resolve_cache.rs
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! Informational micro-benchmarks for the per-connection resolve cache (#569).
+//!
+//! These back the "beats the NATS results-cache" claim with numbers on the two operations
+//! that matter on the publish hot path:
+//!
+//! * a steady-state HIT — a hash lookup + a single generation-compare, NO trie walk —
+//!   measured against a direct `SublistSnapshot::match_into` (a wait-free load + arena walk)
+//!   on the SAME subject, across routing tables of growing size. The HIT cost is flat in the
+//!   table size; the direct walk grows with overlap/depth. That gap is the steady-state win.
+//! * the bind-change cost — what a connection's cache pays when the routing table is
+//!   rebound. On the hot path this is a single `O(1)` generation-compare; the actual
+//!   invalidation is one wholesale `HashMap::clear` of the entries that connection happened
+//!   to hold (freeing `cached` allocations is inherently `O(cached)` — no cache can free N
+//!   entries in `O(1)`), paid LAZILY on the next resolve, OFF any lock, on a PER-CONNECTION
+//!   structure. NATS instead, on every subscription change, flushes a SHARED results cache
+//!   and on a wildcard unsub linear-scans it (`O(slCacheMax = 1024)`) under a GLOBAL write
+//!   lock that contends with every concurrent publisher. The IronBus cost is borne once, by
+//!   the one connection, with no lock and no publisher contention. We bench the IronBus side
+//!   (resolve right after a bind with N entries already cached) to show the SHAPE of that
+//!   cost and that the hot-path guard is the flat generation-compare, not a per-subject scan.
+//!
+//! Run on demand (`cargo bench -p ironbus-core --bench resolve_cache`); not wired into
+//! per-PR CI. Inputs are fixed so a run is deterministic, and `black_box` hides them.
+
+use criterion::{
+    black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput,
+};
+use ironbus_core::resolve_cache::ResolveCache;
+use ironbus_core::subject::Subject;
+use ironbus_core::sublist::{Sublist, SublistBuilder, SublistSnapshot};
+
+/// The routing-table sizes the curves sweep.
+const SIZES: &[usize] = &[16, 256, 4096];
+
+/// A routing table of `n` patterns with genuine literal/`*`/`>` overlap, plus a global
+/// catch-all so the benched subject always matches at least one wildcard target (a realistic
+/// non-trivial match the walk has to assemble).
+fn table(n: usize) -> Sublist<u32> {
+    let mut b = SublistBuilder::new();
+    for i in 0..n {
+        let target = u32::try_from(i).expect("bench table size within u32");
+        match i % 4 {
+            0 => b.insert(&format!("t{i}.svc.req.metric"), target),
+            1 => b.insert(&format!("t{i}.svc.*.metric"), target),
+            2 => b.insert(&format!("t{i}.svc.>"), target),
+            _ => b.insert(&format!("t{i}.evt.click"), target),
+        }
+        .expect("valid bench pattern");
+    }
+    // A catch-all so the hot subject matches a wildcard target regardless of `n`.
+    b.insert(">", u32::MAX).expect("valid catch-all");
+    b.build(0).expect("bench table within fork bound")
+}
+
+/// The hot subject the publisher hammers — present in the table for `i % 4 == 0`.
+const HOT_SUBJECT: &str = "t0.svc.req.metric";
+
+/// Steady-state publish: a cache HIT (hash lookup + generation-compare, NO walk) vs a direct
+/// trie walk on the same subject. The HIT is flat in table size; the direct walk is not.
+fn bench_hit_vs_direct_walk(c: &mut Criterion) {
+    let mut group = c.benchmark_group("resolve_cache/steady_state");
+    group.throughput(Throughput::Elements(1));
+    let subject = Subject::parse_literal(HOT_SUBJECT).expect("valid");
+
+    for &n in SIZES {
+        let snap = SublistSnapshot::new(table(n));
+
+        // Direct walk: the publish path WITHOUT the cache.
+        let mut out = Vec::new();
+        group.bench_with_input(BenchmarkId::new("direct_walk", n), &n, |bch, _| {
+            bch.iter(|| {
+                let gen = snap.match_into(black_box(&subject), &mut out);
+                black_box((gen, out.len()));
+            });
+        });
+
+        // Cache HIT: the publish path WITH the cache, warmed so every iter is a hit.
+        let mut cache = ResolveCache::<u32>::new();
+        cache.resolve(&snap, &subject); // warm
+        group.bench_with_input(BenchmarkId::new("cache_hit", n), &n, |bch, _| {
+            bch.iter(|| {
+                let targets = cache.resolve_with(&snap, black_box(&subject), <[u32]>::len);
+                black_box(targets);
+            });
+        });
+    }
+    group.finish();
+}
+
+/// The number of stale entries a connection's cache holds when a bind invalidates it. This
+/// is the axis NATS's results-cache flush scales on (`O(slCacheMax)`); IronBus must NOT.
+const CACHED_COUNTS: &[usize] = &[16, 256, 1024];
+
+/// The bind-change cost ON THE CACHE, isolated from both the trie rebuild AND the cache
+/// fill: with `cached` stale entries resident, a bind bumps the generation and the next
+/// resolve invalidates the whole cache.
+///
+/// `iter_batched_ref` builds a fresh cache pre-filled with `cached` distinct entries OUTSIDE
+/// the timed region AND drops it outside the timed region (it hands the routine a `&mut`), so
+/// neither the fill nor the cache's Drop is counted. The timed routine is ONLY `store(a tiny
+/// pre-built table) + one resolve`. The `store` is a wait-free swap of an already-built `Arc`
+/// (no per-iter trie rebuild), so the measured cost is exactly the post-bind invalidation:
+/// one generation-compare, one wholesale `HashMap::clear` of the `cached` stale entries, and
+/// one re-walk of a single subject.
+///
+/// The number grows roughly linearly with `cached` — but that growth is the `HashMap::clear`
+/// FREEING the `cached` entries the connection legitimately held, which no cache can do in
+/// `O(1)`. The point the sweep makes is not that the number is constant; it is that the
+/// hot-path GUARD is the flat `O(1)` generation-compare (see the steady-state bench), and the
+/// clear is a single wholesale free OFF ANY LOCK on a per-connection structure — never NATS's
+/// `O(slCacheMax)` scan of a SHARED cache under a GLOBAL write lock that every concurrent
+/// publisher contends on.
+fn bench_bind_invalidation_cost(c: &mut Criterion) {
+    let mut group = c.benchmark_group("resolve_cache/bind_invalidation");
+    group.throughput(Throughput::Elements(1));
+    let subject = Subject::parse_literal(HOT_SUBJECT).expect("valid");
+    // A tiny, PRE-BUILT table; a `store` of it is a constant-cost wait-free swap that just
+    // bumps the generation — never a large trie rebuild inside the timed routine.
+    let snap = SublistSnapshot::new(table(4));
+    let swap_in = || table(4);
+
+    for &cached in CACHED_COUNTS {
+        group.bench_with_input(
+            BenchmarkId::from_parameter(cached),
+            &cached,
+            |bch, &cached| {
+                bch.iter_batched_ref(
+                    || {
+                        // SETUP (untimed, and dropped untimed): a cache pre-filled with `cached`
+                        // distinct stale entries against the current generation.
+                        let mut cache = ResolveCache::<u32>::with_capacity(cached + 16);
+                        for i in 0..cached {
+                            let subj = format!("warm.{i}");
+                            let s = Subject::parse_literal(&subj).expect("valid");
+                            cache.resolve(&snap, &s);
+                        }
+                        cache
+                    },
+                    |cache| {
+                        // TIMED: a wait-free swap (bumps the generation) + one resolve. The resolve
+                        // does ONE generation-compare, drops ALL `cached` stale entries in a single
+                        // clear, and re-walks one subject. This op must not scale with `cached`.
+                        snap.store(swap_in());
+                        let targets = cache.resolve_with(&snap, black_box(&subject), <[u32]>::len);
+                        black_box(targets);
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_hit_vs_direct_walk,
+    bench_bind_invalidation_cost
+);
+criterion_main!(benches);

--- a/crates/ironbus-core/src/lib.rs
+++ b/crates/ironbus-core/src/lib.rs
@@ -27,6 +27,7 @@ pub mod dict;
 pub mod format;
 pub mod keyshared;
 pub mod lease;
+pub mod resolve_cache;
 pub mod segment;
 pub mod subject;
 pub mod sublist;

--- a/crates/ironbus-core/src/resolve_cache.rs
+++ b/crates/ironbus-core/src/resolve_cache.rs
@@ -1,0 +1,552 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! The per-connection, generation-guarded subject-resolve cache (#569, V2-M2).
+//!
+//! A stable publisher hits the **same** literal subject over and over. Resolving that
+//! subject against the routing trie ([`crate::sublist`]) every single time re-walks the
+//! arena on the publish hot path even though the answer has not changed. This module caches
+//! the resolution **per connection**, keyed by the literal subject string, so the trie walk
+//! happens ONCE per `(connection, subject)` and every subsequent publish of that subject is
+//! a hash lookup with no walk.
+//!
+//! Correctness across rebinds is kept by a single integer: the cache remembers the
+//! [`SublistSnapshot`](crate::sublist::SublistSnapshot) **generation** its entries were
+//! resolved against. Every resolve loads the current snapshot once (a wait-free `ArcSwap`
+//! load) and compares its generation to the cache's. If they match, a cached answer is used
+//! directly — no walk. If they differ (a bind changed the routing table, so the snapshot
+//! advanced its generation), the whole cache is dropped and the subject is re-resolved
+//! against the new table. So the hot-path GUARD a bind change adds is a single `O(1)`
+//! generation-compare; the invalidation itself is one wholesale `clear` (freeing the entries
+//! this connection held — inherently `O(entries held)`, but a single off-lock free, not a
+//! per-entry scan) paid LAZILY on the next resolve, plus a per-subject re-resolve on next use.
+//!
+//! # Why this beats the NATS `Sublist` results-cache
+//!
+//! NATS keeps a results cache **inside** its shared `Sublist`:
+//!
+//! * it consults that shared cache on every published message under a `sync.RWMutex`, and
+//! * it FLUSHES the cache on every subscription change, and on a wildcard sub/unsub it
+//!   linear-scans the whole cache (bounded by `slCacheMax = 1024`) under the **write lock**
+//!   to evict stale entries.
+//!
+//! So in NATS a single subscription change does `O(slCacheMax)` work under a global write
+//! lock and contends with every concurrent publisher.
+//!
+//! IronBus moves the cache OFF the shared routing structure and onto the connection:
+//!
+//! * The shared [`SublistSnapshot`](crate::sublist::SublistSnapshot) carries no cache at all
+//!   — a bind change just rebuilds an immutable trie and atomically swaps it in (#568), with
+//!   no cache to flush and no lock.
+//! * Each connection owns a [`ResolveCache`]. A bind change is invisible to it until its
+//!   next resolve, when a single `generation` compare tells it "the table moved, drop my
+//!   cached answers". There is no global flush, no write lock, and the publish hot path
+//!   never blocks on a rebuild.
+//!
+//! The net effect: steady-state publish is `O(1)` (a hash lookup, no walk), and a bind
+//! change is `O(1)` on the hot path (one generation-compare) plus a lazy re-resolve of only
+//! the subjects the connection actually re-publishes.
+//!
+//! # Boundedness (cardinality discipline)
+//!
+//! An unbounded cache is an unbounded memory hazard: a connection that publishes to a
+//! firehose of distinct subjects could grow it without limit, the same cardinality hazard
+//! the bounded subject grammar (#567) and the fail-closed fork bound (#568) guard against. So
+//! the cache is **bounded**: it holds at most [`ResolveCache::capacity`] distinct subjects and
+//! evicts the least-recently-used entry when a new subject would exceed the cap. A connection
+//! with a small working set of hot subjects keeps them all resident; a connection spraying
+//! unbounded distinct subjects is bounded to `capacity` entries and simply re-walks the cold
+//! ones (still correct, just not cached) — it can never grow the cache without bound.
+//!
+//! # IO-free
+//!
+//! This module is pure compute: a `HashMap`, a `Vec`, and integer compares. It touches no
+//! filesystem, network, clock, process, or async runtime, so it stays inside
+//! `ironbus-core`'s IO-free invariant (enforced by `tools/io-free-check`).
+//!
+//! # Where this is wired
+//!
+//! This is the resolve-cache **primitive**: it wraps a
+//! [`SublistSnapshot`](crate::sublist::SublistSnapshot) lookup with the generation guard and
+//! the bound. The subject→stream **binding** that produces the routing table, and the live
+//! publish path that owns one cache per connection, land with the binding policy (#585,
+//! M2-I9); the wire frames are M2-I10. This module ships the cache so #585 can drop it onto
+//! the publish path without re-deriving the generation-guard or the bound.
+
+use std::collections::HashMap;
+
+use crate::subject::Subject;
+use crate::sublist::SublistSnapshot;
+
+/// The default per-connection cache capacity.
+///
+/// `1024` mirrors NATS's `slCacheMax` so the comparison is like-for-like — but here it is a
+/// per-connection LRU bound on a lock-free, per-connection structure, not a shared cache a
+/// wildcard unsub must linear-scan under a global write lock. A connection's hot working set
+/// of distinct publish subjects is almost always far smaller than this; the cap exists only
+/// to fence a pathological publisher that sprays unbounded distinct subjects.
+pub const DEFAULT_CAPACITY: usize = 1024;
+
+/// One cached resolution: the resolved targets for a subject, plus the LRU recency stamp.
+///
+/// The generation is NOT stored per entry: the whole cache shares a single
+/// [`ResolveCache::generation`], so a generation change drops every entry at once (a bind
+/// change invalidates the entire table). Storing it per entry would add a compare per entry
+/// for no gain — the snapshot generation is global to the routing table, not per subject.
+#[derive(Debug, Clone)]
+struct CacheEntry<T> {
+    /// The resolved targets, exactly what a fresh `match()` against the cached generation's
+    /// trie would return (same contents, same order).
+    targets: Vec<T>,
+    /// A monotonically increasing recency stamp; the entry with the smallest stamp is the
+    /// least-recently-used and is the eviction victim. Refreshed on every hit.
+    last_used: u64,
+}
+
+/// A per-connection, generation-guarded, bounded subject→targets resolve cache.
+///
+/// `T` is the routing target — the same opaque, `Clone`-able id the trie carries (a
+/// `StreamId` newtype, a `u64`, …). The cache only stores and returns it.
+///
+/// Each connection owns one `ResolveCache`. It is NOT shared across connections and adds no
+/// lock to the publish path: the only synchronization the resolve touches is the wait-free
+/// `ArcSwap` load inside [`SublistSnapshot`](crate::sublist::SublistSnapshot), exactly as a
+/// direct `match()` would.
+#[derive(Debug)]
+pub struct ResolveCache<T> {
+    /// Subject string -> its resolved targets. Bounded by `capacity`.
+    entries: HashMap<String, CacheEntry<T>>,
+    /// The snapshot generation every entry in `entries` was resolved against. A resolve
+    /// whose loaded snapshot generation differs clears `entries` and adopts the new one.
+    generation: u64,
+    /// The maximum number of distinct subjects the cache retains. When a miss would push the
+    /// count past this, the least-recently-used entry is evicted first.
+    capacity: usize,
+    /// A monotonic counter sourced into each entry's `last_used` to order LRU eviction. It
+    /// only ever increases while the cache is live; it is reset when the cache is cleared.
+    tick: u64,
+    /// Count of resolves that walked the trie (a miss or a generation-invalidation). Exposed
+    /// for tests/metrics so a HIT can be proven NOT to walk; it is not used for routing.
+    walks: u64,
+}
+
+impl<T: Clone> ResolveCache<T> {
+    /// A new, empty cache with [`DEFAULT_CAPACITY`].
+    ///
+    /// The cache starts at generation 0 with no entries; the first resolve adopts whatever
+    /// generation the snapshot it is given is currently at.
+    #[must_use]
+    pub fn new() -> ResolveCache<T> {
+        ResolveCache::with_capacity(DEFAULT_CAPACITY)
+    }
+
+    /// A new, empty cache bounded to at most `capacity` distinct subjects.
+    ///
+    /// A `capacity` of 0 is clamped to 1 so the cache can always hold the single subject it
+    /// is currently resolving (a 0-capacity cache would be a pure pass-through that re-walks
+    /// every publish, which is never what a caller wants).
+    #[must_use]
+    pub fn with_capacity(capacity: usize) -> ResolveCache<T> {
+        ResolveCache {
+            entries: HashMap::new(),
+            generation: 0,
+            capacity: capacity.max(1),
+            tick: 0,
+            walks: 0,
+        }
+    }
+
+    /// The maximum number of distinct subjects this cache retains.
+    #[must_use]
+    pub const fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    /// The number of subjects currently cached.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// `true` if no subject is currently cached.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// The number of resolves that walked the trie (a cold miss, or a re-walk after a bind
+    /// changed the generation). Steady-state hits do NOT advance this, so a test can prove a
+    /// hit took the no-walk path by asserting this stays unchanged across the call.
+    #[must_use]
+    pub const fn walk_count(&self) -> u64 {
+        self.walks
+    }
+
+    /// The generation the currently-cached entries were resolved against.
+    #[must_use]
+    pub const fn generation(&self) -> u64 {
+        self.generation
+    }
+
+    /// Resolves `subject` against `snapshot`, returning its matching targets — from the cache
+    /// on a hit, or by walking the trie once and caching the result on a miss.
+    ///
+    /// # The hot path
+    ///
+    /// 1. Load the current trie snapshot ONCE — a single wait-free `ArcSwap` load (no lock).
+    /// 2. If the snapshot's generation differs from the cache's, a bind changed the routing
+    ///    table: clear the whole cache and adopt the new generation. (This is the only
+    ///    invalidation — no per-entry scan, no shared-cache flush, no lock.)
+    /// 3. If `subject` is present, it is a HIT: refresh its recency and return its targets
+    ///    with NO trie walk.
+    /// 4. Otherwise it is a MISS: walk the trie once against the loaded snapshot, cache the
+    ///    result (evicting the least-recently-used entry first if at capacity), and return it.
+    ///
+    /// The returned `Vec<T>` is a clone of the cached targets, so the caller owns it and the
+    /// cache keeps its copy for the next hit. (Callers that want to avoid the per-call clone
+    /// can use [`ResolveCache::resolve_with`].)
+    ///
+    /// A cache HIT returns EXACTLY what a fresh `snapshot.match_subject(subject)` would return
+    /// against the same generation — same targets, same order — because the cached value IS
+    /// that result, captured at the generation the cache currently holds.
+    pub fn resolve(&mut self, snapshot: &SublistSnapshot<T>, subject: &Subject<'_>) -> Vec<T> {
+        self.resolve_with(snapshot, subject, <[T]>::to_vec)
+    }
+
+    /// Resolves `subject` against `snapshot` and applies `f` to the cached target slice,
+    /// returning `f`'s result. The borrow-returning core of [`ResolveCache::resolve`] for
+    /// callers that want to act on the targets without cloning the whole `Vec` (e.g. fan a
+    /// record out to each target in place).
+    ///
+    /// Same hot path and same generation guard as [`ResolveCache::resolve`]; only the final
+    /// hand-off differs (a projection of the cached slice instead of a clone).
+    pub fn resolve_with<R>(
+        &mut self,
+        snapshot: &SublistSnapshot<T>,
+        subject: &Subject<'_>,
+        f: impl FnOnce(&[T]) -> R,
+    ) -> R {
+        // (1) One wait-free load. The guard pins this exact table version for this resolve.
+        let guard = snapshot.load();
+        let current_gen = guard.generation();
+
+        // (2) Generation guard: a bind moved the table -> drop the whole (now-stale) cache and
+        // adopt the new generation. O(1) on the hot path; the clear only touches THIS
+        // connection's own entries, never a shared structure and never under a lock.
+        if current_gen != self.generation {
+            self.entries.clear();
+            self.generation = current_gen;
+            self.tick = 0;
+        }
+
+        // (3) HIT: the subject is cached at the current generation. Refresh recency and hand
+        // back the cached targets with NO trie walk.
+        let next_tick = self.tick.wrapping_add(1);
+        if let Some(entry) = self.entries.get_mut(subject.as_str()) {
+            self.tick = next_tick;
+            entry.last_used = next_tick;
+            return f(&entry.targets);
+        }
+
+        // (4) MISS: walk the trie ONCE against the loaded snapshot, then cache the result.
+        self.walks += 1;
+        let mut targets = Vec::new();
+        guard.match_into(subject, &mut targets);
+        // Drop the wait-free guard before mutating the map; the targets are already owned.
+        drop(guard);
+
+        self.tick = next_tick;
+        self.evict_if_full();
+        let result = f(&targets);
+        self.entries.insert(
+            subject.as_str().to_owned(),
+            CacheEntry {
+                targets,
+                last_used: next_tick,
+            },
+        );
+        result
+    }
+
+    /// Evicts the least-recently-used entry if inserting one more would exceed `capacity`.
+    ///
+    /// Called only on the MISS path (a cold subject), never on a hit, so the steady-state hot
+    /// path never pays for eviction. The scan is `O(capacity)` and bounded; it runs only when
+    /// the cache is genuinely full and a new distinct subject arrives.
+    fn evict_if_full(&mut self) {
+        if self.entries.len() < self.capacity {
+            return;
+        }
+        // Find the least-recently-used key (smallest `last_used`) and drop it. `capacity >= 1`
+        // and the map is full, so there is always a victim to find.
+        if let Some(victim) = self
+            .entries
+            .iter()
+            .min_by_key(|(_, e)| e.last_used)
+            .map(|(k, _)| k.clone())
+        {
+            self.entries.remove(&victim);
+        }
+    }
+
+    /// Clears every cached entry. The next resolve re-walks. Useful if a caller wants to drop
+    /// the cache's memory without dropping the cache itself (e.g. on a connection idle).
+    pub fn clear(&mut self) {
+        self.entries.clear();
+        self.tick = 0;
+    }
+}
+
+impl<T: Clone> Default for ResolveCache<T> {
+    fn default() -> ResolveCache<T> {
+        ResolveCache::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sublist::{Sublist, SublistBuilder};
+
+    /// Build a trie from `(pattern, target)` pairs (generation 0 from the builder; the
+    /// snapshot restamps on store).
+    fn build(entries: &[(&str, u32)]) -> Sublist<u32> {
+        let mut b = SublistBuilder::new();
+        for (p, t) in entries {
+            b.insert(p, *t).expect("valid test pattern");
+        }
+        b.build(0).expect("test set within fork bound")
+    }
+
+    /// A sorted match straight off the snapshot, the differential oracle a cached answer
+    /// must equal.
+    fn oracle(snap: &SublistSnapshot<u32>, subject: &str) -> Vec<u32> {
+        let s = Subject::parse_literal(subject).expect("valid subject");
+        let mut v = snap.match_subject(&s);
+        v.sort_unstable();
+        v
+    }
+
+    fn resolve_sorted(
+        cache: &mut ResolveCache<u32>,
+        snap: &SublistSnapshot<u32>,
+        subject: &str,
+    ) -> Vec<u32> {
+        let s = Subject::parse_literal(subject).expect("valid subject");
+        let mut v = cache.resolve(snap, &s);
+        v.sort_unstable();
+        v
+    }
+
+    #[test]
+    fn miss_then_hit_returns_same_targets_and_only_one_walk() {
+        let snap = SublistSnapshot::new(build(&[("a.>", 1), ("a.b.c", 2), ("a.*.c", 3)]));
+        let mut cache = ResolveCache::new();
+
+        // First resolve is a MISS: it walks once and matches the trie.
+        assert_eq!(cache.walk_count(), 0);
+        assert_eq!(resolve_sorted(&mut cache, &snap, "a.b.c"), vec![1, 2, 3]);
+        assert_eq!(
+            cache.walk_count(),
+            1,
+            "the cold resolve walked the trie once"
+        );
+        assert_eq!(cache.len(), 1);
+
+        // Subsequent resolves are HITs: NO further walks, identical answer.
+        for _ in 0..100 {
+            assert_eq!(resolve_sorted(&mut cache, &snap, "a.b.c"), vec![1, 2, 3]);
+        }
+        assert_eq!(
+            cache.walk_count(),
+            1,
+            "every repeat was a HIT — the trie was NOT re-walked",
+        );
+    }
+
+    #[test]
+    fn hit_equals_a_fresh_match_differentially() {
+        // A routing table with literal, `*`, and `>` overlap, exercised over many subjects.
+        let snap = SublistSnapshot::new(build(&[
+            ("a.b.c", 1),
+            ("a.*.c", 2),
+            ("a.>", 3),
+            ("a.b.*", 4),
+            ("x.>", 5),
+            ("*", 6),
+        ]));
+        let subjects = [
+            "a.b.c",
+            "a.b.d",
+            "a.q.c",
+            "x.y.z",
+            "lonely",
+            "a",
+            "nomatch.here",
+        ];
+        let mut cache = ResolveCache::new();
+
+        for subj in subjects {
+            let want = oracle(&snap, subj);
+            // First touch (MISS) and a second touch (HIT) must BOTH equal the oracle.
+            assert_eq!(resolve_sorted(&mut cache, &snap, subj), want, "miss {subj}");
+            assert_eq!(resolve_sorted(&mut cache, &snap, subj), want, "hit {subj}");
+        }
+    }
+
+    #[test]
+    fn a_bind_change_invalidates_stale_entries_and_reresolves() {
+        let snap = SublistSnapshot::new(build(&[("a.b", 1)]));
+        let mut cache = ResolveCache::new();
+
+        // Cache `a.b -> [1]` at generation 0.
+        assert_eq!(resolve_sorted(&mut cache, &snap, "a.b"), vec![1]);
+        assert_eq!(cache.generation(), 0);
+        assert_eq!(cache.walk_count(), 1);
+
+        // A bind changes the routing table: now `a.b -> [99]`. The snapshot generation
+        // advances on store.
+        let g = snap.store(build(&[("a.b", 99)]));
+        assert_eq!(g, 1);
+
+        // The very next resolve sees the new generation, drops the stale entry, and
+        // re-walks: it must return the NEW result, never the stale `[1]`.
+        assert_eq!(
+            resolve_sorted(&mut cache, &snap, "a.b"),
+            vec![99],
+            "no stale routing after a bind",
+        );
+        assert_eq!(cache.generation(), 1, "cache adopted the new generation");
+        assert_eq!(cache.walk_count(), 2, "the bind change forced one re-walk");
+        // And the re-resolved entry is itself cached again (a follow-up is a HIT).
+        assert_eq!(resolve_sorted(&mut cache, &snap, "a.b"), vec![99]);
+        assert_eq!(cache.walk_count(), 2);
+    }
+
+    #[test]
+    fn a_bind_change_costs_one_compare_not_a_per_subject_scan() {
+        // Cache MANY distinct subjects, then bump the generation ONCE. The invalidation is a
+        // single O(1) generation-compare that detects the change, then one wholesale clear,
+        // NOT a per-subject scan/flush. We assert the post-bind state: the cache is empty
+        // (dropped wholesale on the next resolve), and exactly ONE re-walk happens for the one
+        // subject re-touched — the others are simply gone, never individually flushed.
+        let snap = SublistSnapshot::new(build(&[("t.>", 1)]));
+        let mut cache = ResolveCache::with_capacity(4096);
+        for i in 0..1000u32 {
+            let subj = format!("t.{i}");
+            let s = Subject::parse_literal(&subj).unwrap();
+            cache.resolve(&snap, &s);
+        }
+        assert_eq!(cache.len(), 1000);
+        let walks_before = cache.walk_count();
+
+        // One bind change.
+        snap.store(build(&[("t.>", 2)]));
+
+        // The next resolve clears the WHOLE cache via one generation-compare and re-walks
+        // only the single subject it touches. The other 999 are dropped wholesale, not
+        // scanned or flushed one by one.
+        let s = Subject::parse_literal("t.0").unwrap();
+        let got = cache.resolve(&snap, &s);
+        assert_eq!(got, vec![2]);
+        assert_eq!(cache.len(), 1, "the whole stale cache was dropped");
+        assert_eq!(
+            cache.walk_count(),
+            walks_before + 1,
+            "exactly ONE re-walk, not one per previously-cached subject",
+        );
+    }
+
+    #[test]
+    fn cache_is_bounded_and_evicts_lru() {
+        let snap = SublistSnapshot::new(build(&[("s.>", 1)]));
+        let mut cache = ResolveCache::with_capacity(3);
+
+        // Fill to capacity with three distinct subjects.
+        for subj in ["s.a", "s.b", "s.c"] {
+            let s = Subject::parse_literal(subj).unwrap();
+            cache.resolve(&snap, &s);
+        }
+        assert_eq!(cache.len(), 3);
+        assert_eq!(cache.capacity(), 3);
+
+        // Touch `s.a` so `s.b` becomes the least-recently-used.
+        let sa = Subject::parse_literal("s.a").unwrap();
+        cache.resolve(&snap, &sa);
+
+        // A fourth distinct subject evicts the LRU (`s.b`), staying at capacity.
+        let sd = Subject::parse_literal("s.d").unwrap();
+        cache.resolve(&snap, &sd);
+        assert_eq!(cache.len(), 3, "cache stayed bounded at capacity");
+
+        let walks_before = cache.walk_count();
+        // `s.a`, `s.c`, `s.d` are resident -> HITs (no walk). `s.b` was evicted -> a MISS.
+        for subj in ["s.a", "s.c", "s.d"] {
+            let s = Subject::parse_literal(subj).unwrap();
+            cache.resolve(&snap, &s);
+        }
+        assert_eq!(
+            cache.walk_count(),
+            walks_before,
+            "resident subjects all HIT"
+        );
+
+        let sb = Subject::parse_literal("s.b").unwrap();
+        cache.resolve(&snap, &sb);
+        assert_eq!(
+            cache.walk_count(),
+            walks_before + 1,
+            "the evicted subject re-walked (proving it was actually evicted)",
+        );
+    }
+
+    #[test]
+    fn unbounded_distinct_subjects_cannot_grow_the_cache() {
+        // A firehose of distinct subjects can never push the cache past its capacity.
+        let snap = SublistSnapshot::new(build(&[(">", 1)]));
+        let mut cache = ResolveCache::with_capacity(8);
+        for i in 0..10_000u32 {
+            let subj = format!("spray.{i}");
+            let s = Subject::parse_literal(&subj).unwrap();
+            let got = cache.resolve(&snap, &s);
+            assert_eq!(got, vec![1]); // still correct, just not cached
+            assert!(cache.len() <= 8, "never exceeds capacity");
+        }
+        assert_eq!(cache.len(), 8);
+    }
+
+    #[test]
+    fn zero_capacity_is_clamped_to_one() {
+        let snap = SublistSnapshot::new(build(&[("a", 1)]));
+        let mut cache = ResolveCache::with_capacity(0);
+        assert_eq!(cache.capacity(), 1, "a 0 capacity is clamped to 1");
+        let s = Subject::parse_literal("a").unwrap();
+        assert_eq!(cache.resolve(&snap, &s), vec![1]);
+        assert_eq!(cache.len(), 1);
+    }
+
+    #[test]
+    fn resolve_with_avoids_the_clone_but_sees_the_same_targets() {
+        let snap = SublistSnapshot::new(build(&[("a.>", 1), ("a.b", 2)]));
+        let mut cache = ResolveCache::new();
+        let s = Subject::parse_literal("a.b").unwrap();
+
+        // `resolve_with` projects the cached slice without cloning the whole Vec.
+        let count_miss = cache.resolve_with(&snap, &s, <[u32]>::len);
+        assert_eq!(count_miss, 2);
+        let sum_hit = cache.resolve_with(&snap, &s, |t| t.iter().sum::<u32>());
+        assert_eq!(sum_hit, 3);
+        assert_eq!(cache.walk_count(), 1, "the second call was a HIT");
+    }
+
+    #[test]
+    fn empty_match_is_cached_too() {
+        // A subject that matches NOTHING is a legitimate (empty) result and must be cached,
+        // so a hot publisher to an unbound subject doesn't re-walk every time.
+        let snap = SublistSnapshot::new(build(&[("a.b", 1)]));
+        let mut cache = ResolveCache::new();
+        let s = Subject::parse_literal("z.z.z").unwrap();
+        assert_eq!(cache.resolve(&snap, &s), Vec::<u32>::new());
+        assert_eq!(cache.walk_count(), 1);
+        assert_eq!(cache.resolve(&snap, &s), Vec::<u32>::new());
+        assert_eq!(cache.walk_count(), 1, "the empty result was cached (HIT)");
+    }
+}

--- a/crates/ironbus-core/tests/resolve_cache.rs
+++ b/crates/ironbus-core/tests/resolve_cache.rs
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! Differential + property tests for the per-connection resolve cache (#569, V2-M2).
+//!
+//! The central guarantee is DIFFERENTIAL: a cached resolve must return EXACTLY what a fresh
+//! `SublistSnapshot::match_subject` would return against the live routing table — including
+//! across bind changes, where the cache's generation guard must drop stale entries and
+//! re-resolve. The cache is just a per-connection fast path over the trie; proving the two
+//! agree over randomized tables, subjects, and interleaved binds proves the cache never
+//! routes stale.
+//!
+//! Layered like the trie tests (#568):
+//!
+//! 1. A GOLDEN sequence pins miss/hit/invalidate behavior on hand-picked cases.
+//! 2. A PROPTEST differential oracle interleaves random resolves and random binds and
+//!    asserts cache-resolve == fresh-match on every draw, and that the cache stays bounded.
+
+use std::collections::BTreeSet;
+
+use ironbus_core::resolve_cache::ResolveCache;
+use ironbus_core::subject::Subject;
+use ironbus_core::sublist::{Sublist, SublistBuilder, SublistSnapshot};
+
+/// Build a trie at generation 0 from `(pattern, target)` pairs. The test sets are
+/// small/shallow, so their worst-case fork frontier is far under the cap and the build
+/// always succeeds here.
+fn build(entries: &[(&str, u32)]) -> Sublist<u32> {
+    let mut b = SublistBuilder::new();
+    for (p, t) in entries {
+        b.insert(p, *t).expect("valid test pattern");
+    }
+    b.build(0).expect("test set within fork bound")
+}
+
+/// The authoritative reference: a fresh match straight off the live snapshot, sorted.
+fn fresh_match(snap: &SublistSnapshot<u32>, subject: &str) -> BTreeSet<u32> {
+    let s = Subject::parse_literal(subject).expect("valid subject");
+    snap.match_subject(&s).into_iter().collect()
+}
+
+/// What the cache returns for `subject`, sorted, for an order-independent comparison.
+fn cache_match(
+    cache: &mut ResolveCache<u32>,
+    snap: &SublistSnapshot<u32>,
+    subject: &str,
+) -> BTreeSet<u32> {
+    let s = Subject::parse_literal(subject).expect("valid subject");
+    cache.resolve(snap, &s).into_iter().collect()
+}
+
+// ---------------------------------------------------------------------------
+// 1. Golden sequence: miss -> hit -> bind -> re-resolve.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn golden_cache_sequence_never_routes_stale() {
+    let snap = SublistSnapshot::new(build(&[("a.b.c", 1), ("a.*.c", 2), ("a.>", 3)]));
+    let mut cache = ResolveCache::new();
+
+    // Cold MISS then warm HIT both equal the fresh match.
+    let want0 = fresh_match(&snap, "a.b.c");
+    assert_eq!(cache_match(&mut cache, &snap, "a.b.c"), want0);
+    assert_eq!(cache.walk_count(), 1);
+    assert_eq!(cache_match(&mut cache, &snap, "a.b.c"), want0);
+    assert_eq!(cache.walk_count(), 1, "second touch was a HIT, no walk");
+
+    // A bind changes the table. The very next resolve must reflect the NEW table.
+    snap.store(build(&[("a.b.c", 7), ("a.>", 3)]));
+    let want1 = fresh_match(&snap, "a.b.c");
+    assert_ne!(want0, want1, "the bind actually changed the routing answer");
+    assert_eq!(
+        cache_match(&mut cache, &snap, "a.b.c"),
+        want1,
+        "no stale routing after the bind",
+    );
+    assert_eq!(cache.walk_count(), 2, "the bind forced exactly one re-walk");
+}
+
+// ---------------------------------------------------------------------------
+// 2. Property: cache-resolve == fresh-match under interleaved binds; bounded.
+// ---------------------------------------------------------------------------
+
+use proptest::prelude::*;
+
+/// A legal literal token from a SMALL alphabet so random patterns and subjects collide
+/// often (forcing real matches, not just empty sets).
+const LITERAL_TOKEN: &str = "[ab][12]?";
+
+/// One pattern token: mostly literals, sometimes a `*`.
+fn pattern_token() -> impl Strategy<Value = String> {
+    prop_oneof![
+        8 => LITERAL_TOKEN.prop_map(String::from),
+        2 => Just("*".to_string()),
+    ]
+}
+
+/// A syntactically-valid pattern: 1..=4 literal-or-`*` tokens, optionally a trailing `>`.
+fn arb_pattern() -> impl Strategy<Value = String> {
+    (
+        proptest::collection::vec(pattern_token(), 1..=4),
+        any::<bool>(),
+    )
+        .prop_map(|(mut toks, tail)| {
+            if tail {
+                toks.push(">".to_string());
+            }
+            toks.join(".")
+        })
+}
+
+/// A valid literal subject: 1..=5 literal tokens (no wildcards).
+fn arb_subject() -> impl Strategy<Value = String> {
+    proptest::collection::vec(LITERAL_TOKEN.prop_map(String::from), 1..=5)
+        .prop_map(|toks| toks.join("."))
+}
+
+/// A pattern set -> `(pattern, target)` entries with distinct targets, offset by `base` so
+/// successive tables are distinguishable.
+fn entries(patterns: &[String], base: u32) -> Vec<(&str, u32)> {
+    patterns
+        .iter()
+        .enumerate()
+        .map(|(i, p)| (p.as_str(), base + u32::try_from(i).unwrap()))
+        .collect()
+}
+
+/// One step in the randomized interleaving: resolve a subject, or rebind the whole table.
+#[derive(Clone, Debug)]
+enum Step {
+    Resolve(String),
+    Rebind(Vec<String>),
+}
+
+fn arb_step() -> impl Strategy<Value = Step> {
+    prop_oneof![
+        7 => arb_subject().prop_map(Step::Resolve),
+        3 => proptest::collection::vec(arb_pattern(), 1..=6).prop_map(Step::Rebind),
+    ]
+}
+
+proptest! {
+    /// THE differential property: against a cache and a live snapshot, an arbitrary
+    /// interleaving of resolves and rebinds always yields, for every resolve, EXACTLY the
+    /// set a fresh match against the then-current snapshot yields. This proves the
+    /// generation guard never serves a stale answer no matter how binds interleave with
+    /// publishes — the property #569 exists to guarantee.
+    #[test]
+    fn cache_resolve_equals_fresh_match_under_interleaved_binds(
+        initial in proptest::collection::vec(arb_pattern(), 1..=6),
+        steps in proptest::collection::vec(arb_step(), 1..=40),
+    ) {
+        let snap = SublistSnapshot::<u32>::new(build(&entries(&initial, 0)));
+        // A small capacity so eviction is exercised within a run.
+        let mut cache = ResolveCache::<u32>::with_capacity(8);
+        let mut base = 1000u32;
+
+        for step in steps {
+            match step {
+                Step::Resolve(subj) => {
+                    let want = fresh_match(&snap, &subj);
+                    let got = cache_match(&mut cache, &snap, &subj);
+                    prop_assert_eq!(got, want, "subject={:?}", subj);
+                    // The cache is ALWAYS bounded, no matter the resolve history.
+                    prop_assert!(cache.len() <= cache.capacity());
+                }
+                Step::Rebind(pats) => {
+                    snap.store(build(&entries(&pats, base)));
+                    base += 1000;
+                }
+            }
+        }
+    }
+
+    /// A HIT is byte-identical to a fresh match for the SAME generation: resolve once
+    /// (miss, caches), then resolve again (hit) without an intervening bind; the hit must
+    /// equal a fresh match taken at that same generation.
+    #[test]
+    fn hit_is_identical_to_fresh_match_at_same_generation(
+        patterns in proptest::collection::vec(arb_pattern(), 1..=8),
+        subject in arb_subject(),
+    ) {
+        let snap = SublistSnapshot::<u32>::new(build(&entries(&patterns, 0)));
+        let mut cache = ResolveCache::<u32>::new();
+
+        let miss = cache_match(&mut cache, &snap, &subject); // walks, caches
+        let fresh = fresh_match(&snap, &subject);
+        let hit = cache_match(&mut cache, &snap, &subject); // no walk
+        prop_assert_eq!(&miss, &fresh, "miss == fresh");
+        prop_assert_eq!(&hit, &fresh, "hit == fresh (no stale)");
+        prop_assert_eq!(cache.walk_count(), 1, "exactly one walk for the miss");
+    }
+}


### PR DESCRIPTION
Closes #569 (V2-M2 routing, [M2-I8]).

## What

A per-connection, generation-guarded subject-resolve cache: a small cache mapping a publish subject string -> its resolved target(s) (the Sublist match result), tagged with the `SublistSnapshot` `generation` it was resolved against. It makes steady-state publish **O(1)** (a hash lookup, no trie walk) while staying correct across rebinds.

Builds on merged #649 (subject parser, `crates/ironbus-core/src/subject.rs`) and #651 (wait-free arena trie + `ArcSwap` snapshot + monotonic `generation`, `crates/ironbus-core/src/sublist.rs` — the `generation` counter was exposed there *for exactly this cache*).

## The cache + generation-guard

On a publish (`ResolveCache::resolve` / `resolve_with`):

1. **One wait-free `ArcSwap` load** of the current `SublistSnapshot` (no lock — the same load a direct `match()` does).
2. **Generation guard**: compare the loaded snapshot's `generation` to the cache's. If they differ (a bind changed the trie, so the snapshot advanced its generation), drop the whole cache and adopt the new generation. This is the *only* invalidation.
3. **HIT** (generations match and the subject is present): return the cached targets directly — **no trie walk**.
4. **MISS** (absent, or just invalidated): walk the trie **once** against the loaded snapshot and re-cache.

So the trie walk happens **once per (connection, subject) until a bind change**, not once per message.

## Beat-NATS angle

NATS consults a **shared** `Sublist` results-cache on **every published message under a `RWMutex`**, and **flushes that global cache on every subscription change** — on a wildcard sub/unsub it linear-scans the whole cache (`O(slCacheMax = 1024)`) under the **write lock**, contending with every concurrent publisher.

IronBus moves the cache **off the shared routing structure and onto the connection**:

- The shared `SublistSnapshot` carries **no cache at all** — a bind just rebuilds an immutable trie and atomically swaps it in (#651), nothing to flush, no lock.
- Each connection owns its own `ResolveCache`. The hot-path cost a bind adds is a **single O(1) generation-compare**; the invalidation is **one wholesale `clear`** paid **lazily on the next resolve, off any lock**, with **no global flush** and **no publisher contention**. Only the subjects the connection actually re-publishes get re-resolved (lazily).

## The bound (cardinality discipline)

The cache is **bounded** to at most `ResolveCache::capacity` distinct subjects (default `DEFAULT_CAPACITY = 1024`, mirroring NATS's `slCacheMax` for a like-for-like comparison), with **LRU eviction** when a cold subject would overflow it. A connection with a small hot working set keeps it all resident; a connection spraying unbounded distinct subjects is fenced to `capacity` entries (the cold ones are still resolved correctly, just re-walked) and **cannot grow the cache without bound** — the same cardinality posture as the bounded subject grammar (#567) and the fail-closed fork bound (#651). Eviction runs only on the MISS path, never on a hit, so the steady-state hot path never pays for it.

## Preserved invariants

- **Correctness == calling `match()` directly.** A HIT returns *exactly* what a fresh trie walk would — proven by a differential test (unit + proptest).
- **Wait-free read (#651) intact.** The cache adds **no lock** to the publish path; its only synchronization is the same wait-free `ArcSwap` load a direct match does.
- **`ironbus-core` stays IO-free** (the cache lives there): `HashMap` + `Vec` + integer compares only. `io-free-check` passes.
- **No wire/storage change.**

## Scope boundary

This PR ships the resolve **CACHE primitive** + its generation-guard + its bound, **only**. The trie itself (#651) is done. The subject->stream **binding** + single-home/ambiguous policy is **#585 (M2-I9)**; the wire frames are **M2-I10**.

**FLAG:** the live publish path does **not** resolve a subject->stream yet — the trie/binding is not wired into publish (verified: no `Sublist`/`SublistSnapshot`/`match_*` references anywhere in `ironbus-server`), because multi-stream storage/binding lands in M2-I2/M2-I9. So per the issue's instruction this is implemented as a **reusable, tested primitive** that wraps `Sublist` + generation, with a unit- and integration-level harness. **#585 (M2-I9) wires it onto the publish path** (one `ResolveCache` per connection); it can drop this in without re-deriving the generation-guard or the bound.

## Tests (all green)

Unit (`src/resolve_cache.rs`) + integration (`tests/resolve_cache.rs`):

- **Differential (HIT == `match()`)**: a HIT returns identical targets to a fresh snapshot match — golden cases, plus a proptest over random pattern sets, random subjects, and random interleavings of resolves and binds (`cache_resolve_equals_fresh_match_under_interleaved_binds`).
- **Invalidation on bind**: a bind change (generation advance) invalidates stale entries; the next resolve re-walks and returns the **NEW** result — proves no stale routing after a bind.
- **Bounded**: LRU eviction works; a firehose of 10k distinct subjects never grows the cache past `capacity`.
- **A HIT does NOT walk the trie**: asserted via a `walk_count()` counter (a hit leaves it unchanged).

## Bench (`cargo bench -p ironbus-core --bench resolve_cache`)

Steady-state publish — cache HIT vs a direct trie walk, on the same subject, across routing-table sizes:

| table size | direct walk | cache HIT |
|---|---|---|
| 16   | ~106 ns | ~22.2 ns |
| 256  | ~109 ns | ~22.1 ns |
| 4096 | ~120 ns | ~22.3 ns |

The HIT is **~22 ns and FLAT** regardless of table size; the direct walk is ~106-120 ns and grows with table size/overlap. That's the steady-state win (**~5x**, and constant vs. growing).

Bind-change cost: the hot-path **guard** is the flat O(1) generation-compare above; the invalidation itself is one wholesale `HashMap::clear` (freeing the entries the connection held is inherently O(entries-held) — no cache frees N entries in O(1)), paid **lazily, off any lock, on a per-connection structure** — never NATS's `O(slCacheMax)` scan of a **shared** cache under a **global write lock**. The bench (`resolve_cache/bind_invalidation`) shows that cost shape (~2.5/7.7/24 us at 16/256/1024 held entries) — the linear part is just the wholesale free, not a per-subject locked scan.

## Gates (fresh clippy from `cargo clean`, MSRV 1.78, `RUSTFLAGS -D warnings`)

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` (after `cargo clean`) — clean (pedantic on)
- `cargo test --workspace --all-features --locked` — all pass (9 unit + 3 integration new tests)
- `cargo run -p io-free-check -- crates/ironbus-core/src` — **ok: 21 source file(s) ... structurally IO-free**

## What to scrutinize

- **Invalidation = whole-cache clear-on-generation-change** (not per-entry generation tags). Chosen because a bind invalidates the *entire* table, so per-entry generations would only add a compare per entry for no gain; the trade-off is a connection re-resolves its working set after *any* bind (lazily). If a future binding policy makes most binds touch a small subtree, a finer-grained scheme could re-validate surviving entries — out of scope here.
- **LRU eviction is an O(capacity) min-scan on the MISS path** (never on a hit). Fine for `capacity = 1024`; if a much larger cap is ever wanted, swap for an intrusive LRU list.
- The differential proptest is the load-bearing correctness proof — worth a careful read of its oracle (`fresh_match` straight off the live snapshot).
