### PR TITLE
feat(storage): versioned data-dir layout marker (reserves streams/, v1=today) (#562)

### DIFF
--- a/crates/ironbus-storage/src/layout.rs
+++ b/crates/ironbus-storage/src/layout.rs
@@ -1,0 +1,357 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! The data-directory LAYOUT version marker (#562, V2-M2 foundation).
+//!
+//! This versions the on-disk DIRECTORY STRUCTURE of a data directory: where the streams,
+//! cursors, and dead-letter subtree live. It is DISTINCT from the per-segment/record
+//! `FORMAT_VERSION` (`ironbus_core::format`), which versions the record and segment
+//! ENCODING. A single data directory therefore carries two orthogonal version axes: the
+//! encoding of each frame, and the shape of the directory that holds the frames.
+//!
+//! ## Why
+//!
+//! V2-M2 introduces N streams, which changes the on-disk shape: named streams will live in
+//! a `streams/<name>/` subtree (generalizing the existing `dlq/` subdir pattern), with the
+//! default stream `""` remaining today's root log. Introducing a new directory shape is a
+//! breaking change to the layout contract, so it must be a VERSIONED, recoverable migration
+//! rather than a silent reinterpretation. This marker reserves that future: it declares the
+//! layout version up front so a newer layout is detected and refused by an older binary
+//! (fail-closed), exactly as an unknown `FORMAT_VERSION` is refused, instead of being
+//! misread.
+//!
+//! ## Layout version 1 (today)
+//!
+//! - The root log IS the default stream `""`: `seg-<hex>.log` segments, `cursor.ckpt` /
+//!   `cursor-<hex>.ckpt`, `counters.ckpt`, and the `quarantine/` forensic subdir at the
+//!   data-dir root.
+//! - The `dlq/` subdirectory holds the dead-letter sink (a second segmented [`crate::log::Log`]).
+//! - The `streams/` subtree is RESERVED for M2-I2 (per-stream logs) and is NOT created here.
+//!
+//! An existing single-log deployment IS, byte for byte, a layout-v1 directory: the marker
+//! only records that fact, it changes no segment, cursor, or DLQ byte.
+//!
+//! ## Durability and recovery (a pure function of durable bytes)
+//!
+//! The marker is stored in `layout.meta`, a [`crate::checkpoint::SlotCheckpoint`]: a
+//! two-slot, CRC32C-protected, alternating-write, fsync'd file. Recovery is the same pure
+//! function of durable bytes the rest of the store obeys:
+//!
+//! - **Absent** (a pre-marker data dir, before this build): treated as layout v1 and the
+//!   marker is WRITTEN. A safe, idempotent upgrade: an existing single-log deployment is
+//!   already byte-for-byte layout v1, so recording v1 reinterprets nothing.
+//! - **Present and v1**: opened unchanged.
+//! - **Present and a FUTURE/unknown version** (a marker that fully decodes — magic and CRC
+//!   valid — but declares a version this build does not understand): FAIL CLOSED with
+//!   [`StorageError::IncompatibleLayoutVersion`]. A newer layout is never silently
+//!   reinterpreted by an older binary.
+//! - **Torn or corrupt** (a slot whose CRC fails, or a payload whose magic is wrong): the
+//!   checkpoint's dual-slot discipline reverts to the other durable slot; if neither slot is
+//!   valid the marker recovers as ABSENT and is re-upgraded to v1. A bad marker therefore
+//!   NEVER bricks an otherwise-valid data dir — it costs at most a re-write of the v1 marker,
+//!   and it never fabricates a future version (only a fully-valid, CRC-checked future marker
+//!   triggers the fail-closed reject). This mirrors how a torn cursor checkpoint regresses to
+//!   its prior durable value rather than inventing one.
+
+use crate::checkpoint::Checkpoint;
+use crate::fs::Filesystem;
+use crate::segment::StorageError;
+
+/// The on-disk data-directory LAYOUT version this build writes and understands. Version 1 is
+/// today's layout: the root log is the default stream `""`, with the `dlq/` subdir and the
+/// `streams/` subtree (the latter reserved, created by M2-I2, not here).
+///
+/// Bumped only by a future layout change (e.g. moving named streams under `streams/<name>/`),
+/// at which point a v1 reader refuses the new value rather than guessing — the same exact-match,
+/// fail-closed discipline as `FORMAT_VERSION`.
+pub const LAYOUT_VERSION: u32 = 1;
+
+/// The reserved data-dir subtree for per-stream logs (M2-I2). NOT created by this module; named
+/// here so the name is reserved by the layout contract and a single source of truth exists once
+/// M2-I2 materializes it.
+pub const STREAMS_SUBDIR: &str = "streams";
+
+/// The on-disk file name of the layout marker. It deliberately does NOT match the `seg-<hex>.log`
+/// or `cursor*.ckpt` naming, so segment enumeration ([`crate::naming::segment_ids`]) and cursor
+/// discovery skip it as a foreign file.
+const LAYOUT_MARKER_FILE: &str = "layout.meta";
+
+/// The magic prefix of the marker payload (IronBus Data-Dir), distinguishing a real layout marker
+/// from an unrelated `layout.meta` a foreign tool might leave: a CRC-valid slot whose magic does
+/// not match is treated as absent, never as a versioned marker.
+const LAYOUT_MAGIC: [u8; 4] = *b"IBDD";
+
+/// The decoded marker payload: magic (4) + layout version (4, little-endian `u32`). The CRC, slot
+/// framing, and dual-slot torn-write tolerance are provided by the [`Checkpoint`] this rides in, so
+/// this struct only encodes the meaningful fields.
+const MARKER_PAYLOAD_LEN: usize = 8;
+
+/// Encodes the marker payload for `version` (magic, then the version little-endian).
+fn encode_marker(version: u32) -> [u8; MARKER_PAYLOAD_LEN] {
+    let mut buf = [0u8; MARKER_PAYLOAD_LEN];
+    buf[0..4].copy_from_slice(&LAYOUT_MAGIC);
+    buf[4..8].copy_from_slice(&version.to_le_bytes());
+    buf
+}
+
+/// Decodes a marker payload to its layout version, returning `None` if the payload is not a
+/// well-formed layout marker (wrong length or wrong magic). A `None` here is treated by the caller
+/// exactly like an absent marker, so a foreign or future-FIELD-LAYOUT payload never masquerades as
+/// a known version.
+fn decode_marker(payload: &[u8]) -> Option<u32> {
+    if payload.len() != MARKER_PAYLOAD_LEN {
+        return None;
+    }
+    if payload[0..4] != LAYOUT_MAGIC {
+        return None;
+    }
+    Some(u32::from_le_bytes(payload[4..8].try_into().ok()?))
+}
+
+/// Checks (and, on a pre-marker dir, best-effort upgrades) the data-directory layout marker,
+/// returning the layout version now in effect.
+///
+/// The ONLY hard failure is a successfully-read, fully-valid marker that declares a version GREATER
+/// than [`LAYOUT_VERSION`]: that is the fail-closed reject ([`StorageError::IncompatibleLayoutVersion`]),
+/// because an older binary must never reinterpret a newer layout. Every other case resolves to a
+/// version with NO error: a present v1 marker returns 1; an ABSENT, torn, corrupt, or foreign marker
+/// is treated as layout v1 (an existing single-log dir is byte-for-byte layout v1) and the v1 marker
+/// is written BEST-EFFORT.
+///
+/// "Best-effort" is deliberate and matches the `counters.ckpt` discipline: the marker is a layout
+/// CONTRACT, not correctness state, so a filesystem that cannot persist it (read-only, out of space,
+/// an injected write fault) must NOT block opening an otherwise-valid data dir. The write is simply
+/// retried on the next open. Persisting the marker therefore never fails `Log::open`; only READING a
+/// valid future marker does.
+///
+/// This must be called by [`crate::log::Log::open`] BEFORE any recovery so a future layout is
+/// refused before its (unknown-shaped) contents are interpreted. It touches only `layout.meta`, so
+/// it never reads or writes a segment, cursor, or DLQ byte: an existing data dir's segments open
+/// exactly as before.
+///
+/// It deliberately does NOT issue its own `sync_dir`: the marker's CONTENT is made durable by
+/// `Checkpoint::write`'s `sync_all`, and its directory entry's durability piggybacks on the next
+/// `sync_dir` the open path already performs (the fresh log's `start_segment`, or a later
+/// produce/seal). A separate `sync_dir` would add a gratuitous fsync to every open and a spurious
+/// failure boundary that a best-effort marker must not introduce.
+///
+/// # Errors
+/// Returns [`StorageError::IncompatibleLayoutVersion`] (and ONLY that) when a valid marker declares
+/// a future version. An IO error reading or writing the marker is swallowed (best-effort), resolving
+/// to layout v1.
+pub fn open_or_upgrade<F: Filesystem>(fs: &F) -> Result<u32, StorageError> {
+    // 1) READ first. Only a fully-valid marker (slot CRC OK, magic OK) declaring a FUTURE version is
+    //    the fail-closed reject; this is the one outcome that propagates an error. A read IO error
+    //    (e.g. an injected fault) is treated as "no readable marker": best-effort, fall through to v1.
+    if let Some(version) = read_marker_version(fs) {
+        if version > LAYOUT_VERSION {
+            return Err(StorageError::IncompatibleLayoutVersion {
+                found: version,
+                supported: LAYOUT_VERSION,
+            });
+        }
+        // A known version (today only v1; a below-current version is reserved for a future explicit
+        // migration step, unreachable now) is accepted as-is, no rewrite.
+        return Ok(version);
+    }
+
+    // 2) Absent / torn / corrupt / foreign / unreadable: this IS layout v1. Write the v1 marker
+    //    BEST-EFFORT (a single-log dir is already byte-for-byte v1, so this records a fact and
+    //    reinterprets nothing); a write failure is swallowed and retried on the next open.
+    let _ = write_v1_marker(fs);
+    Ok(LAYOUT_VERSION)
+}
+
+/// Reads the layout version from `layout.meta`, returning `None` if it is absent, unreadable, torn,
+/// corrupt, or foreign (any case that should be treated as "no valid marker", i.e. layout v1). A
+/// `Some(version)` is a fully-valid, CRC-checked marker payload (the caller decides whether that
+/// version is acceptable). This is read-only and never an error: a bad marker is a `None`, never a
+/// propagated failure, so it can never by itself brick a valid data dir.
+fn read_marker_version<F: Filesystem>(fs: &F) -> Option<u32> {
+    if !fs.exists(LAYOUT_MARKER_FILE).ok()? {
+        return None;
+    }
+    let file = fs.open(LAYOUT_MARKER_FILE).ok()?;
+    let (_checkpoint, recovered) = Checkpoint::open(file).ok()?;
+    decode_marker(recovered.as_deref()?)
+}
+
+/// Best-effort durable write of the v1 marker, creating `layout.meta` if absent. Returns an IO error
+/// to the caller, which swallows it: a filesystem that cannot persist the marker still opens the log.
+fn write_v1_marker<F: Filesystem>(fs: &F) -> Result<(), StorageError> {
+    let file = if fs.exists(LAYOUT_MARKER_FILE).map_err(StorageError::Io)? {
+        fs.open(LAYOUT_MARKER_FILE).map_err(StorageError::Io)?
+    } else {
+        fs.create_new(LAYOUT_MARKER_FILE)
+            .map_err(StorageError::Io)?
+    };
+    let (mut checkpoint, _recovered) = Checkpoint::open(file)?;
+    checkpoint.write(&encode_marker(LAYOUT_VERSION))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fault::FaultFs;
+    use crate::fs::InMemoryFs;
+    use crate::io::RandomAccessFile;
+    use crate::naming::{parse_segment_file_name, segment_file_name, segment_ids};
+
+    /// A fresh data dir gains a durable v1 marker on first open.
+    #[test]
+    fn fresh_dir_writes_v1_marker() {
+        let fs = InMemoryFs::new();
+        assert!(!fs.exists(LAYOUT_MARKER_FILE).unwrap());
+        assert_eq!(open_or_upgrade(&fs).unwrap(), 1);
+        assert!(fs.exists(LAYOUT_MARKER_FILE).unwrap());
+        // The marker is durable across a reopen and stays v1 (idempotent, no second write needed).
+        assert_eq!(open_or_upgrade(&fs).unwrap(), 1);
+    }
+
+    /// An existing pre-marker data dir (segments present, no marker) auto-upgrades to v1 and leaves
+    /// every segment file untouched.
+    #[test]
+    fn pre_marker_dir_auto_upgrades_to_v1_leaving_segments_untouched() {
+        let fs = InMemoryFs::new();
+        // Simulate a pre-marker single-log deployment: a couple of segment files, no marker.
+        for id in [0u64, 1] {
+            let f = fs.create_new(&segment_file_name(id)).unwrap();
+            f.write_all_at(b"segment-bytes", 0).unwrap();
+            f.sync_all().unwrap();
+        }
+        fs.sync_dir().unwrap();
+        let before = fs.open(&segment_file_name(0)).unwrap();
+        let mut before_bytes = vec![0u8; b"segment-bytes".len()];
+        before.read_exact_at(&mut before_bytes, 0).unwrap();
+
+        assert!(!fs.exists(LAYOUT_MARKER_FILE).unwrap());
+        assert_eq!(open_or_upgrade(&fs).unwrap(), 1);
+        assert!(fs.exists(LAYOUT_MARKER_FILE).unwrap());
+
+        // Segments are byte-for-byte unchanged.
+        let after = fs.open(&segment_file_name(0)).unwrap();
+        let mut after_bytes = vec![0u8; b"segment-bytes".len()];
+        after.read_exact_at(&mut after_bytes, 0).unwrap();
+        assert_eq!(before_bytes, after_bytes);
+        // Still exactly the two segments (the marker is not a segment and is not enumerated).
+        assert_eq!(segment_ids(&fs).unwrap(), vec![0, 1]);
+    }
+
+    /// A valid marker declaring a FUTURE version is rejected (fail-closed), never reinterpreted.
+    #[test]
+    fn future_version_is_rejected() {
+        let fs = InMemoryFs::new();
+        // Write a well-formed marker for a version this build does not understand.
+        let file = fs.create_new(LAYOUT_MARKER_FILE).unwrap();
+        file.sync_all().unwrap();
+        fs.sync_dir().unwrap();
+        let (mut cp, _) = Checkpoint::open(file).unwrap();
+        cp.write(&encode_marker(LAYOUT_VERSION + 1)).unwrap();
+
+        let err = open_or_upgrade(&fs).unwrap_err();
+        match err {
+            StorageError::IncompatibleLayoutVersion { found, supported } => {
+                assert_eq!(found, LAYOUT_VERSION + 1);
+                assert_eq!(supported, LAYOUT_VERSION);
+            }
+            other => panic!("expected IncompatibleLayoutVersion, got {other:?}"),
+        }
+        // A far-future version is rejected the same way.
+        let file = fs.open(LAYOUT_MARKER_FILE).unwrap();
+        let (mut cp, _) = Checkpoint::open(file).unwrap();
+        cp.write(&encode_marker(9999)).unwrap();
+        assert!(matches!(
+            open_or_upgrade(&fs).unwrap_err(),
+            StorageError::IncompatibleLayoutVersion { found: 9999, .. }
+        ));
+    }
+
+    /// A corrupted marker (its single durable slot's CRC fails) does NOT brick the dir: it recovers
+    /// as absent and is re-upgraded to v1, bounded to a single marker rewrite.
+    #[test]
+    fn corrupt_marker_recovers_bounded_to_v1_without_bricking() {
+        let fs = InMemoryFs::new();
+        // Establish a v1 marker, then corrupt EVERY byte-region of the file so neither slot's CRC
+        // can validate. The dir's (here, empty) segments must still open fine afterwards.
+        assert_eq!(open_or_upgrade(&fs).unwrap(), 1);
+        let file = fs.open(LAYOUT_MARKER_FILE).unwrap();
+        let len = usize::try_from(file.len().unwrap()).unwrap();
+        let mut bytes = vec![0u8; len];
+        file.read_exact_at(&mut bytes, 0).unwrap();
+        for b in &mut bytes {
+            *b ^= 0xff;
+        }
+        file.write_all_at(&bytes, 0).unwrap();
+        file.sync_all().unwrap();
+
+        // Re-upgrade is idempotent and succeeds (no error, no brick): the marker is rewritten v1.
+        assert_eq!(open_or_upgrade(&fs).unwrap(), 1);
+        // And it is durable + valid again on the next open.
+        assert_eq!(open_or_upgrade(&fs).unwrap(), 1);
+    }
+
+    /// Persisting the marker is BEST-EFFORT: a filesystem whose every write fails still resolves to
+    /// layout v1 with NO error, so a write-erroring (e.g. read-only or full) backing store never
+    /// blocks opening an otherwise-valid data dir. Only READING a valid future marker fails closed.
+    #[test]
+    fn a_marker_write_failure_does_not_fail_the_upgrade() {
+        let (fs, control) = FaultFs::new(InMemoryFs::new());
+        control.set_fail_write(true);
+        // Absent marker + every write failing: still v1, no propagated error.
+        assert_eq!(open_or_upgrade(&fs).unwrap(), 1);
+    }
+
+    /// A valid FUTURE marker still fails closed even when writes are failing: the reject is a READ
+    /// outcome and does not depend on being able to persist anything.
+    #[test]
+    fn a_future_marker_is_rejected_even_when_writes_fail() {
+        let inner = InMemoryFs::new();
+        // Lay down a valid future-version marker on the inner disk.
+        {
+            let file = inner.create_new(LAYOUT_MARKER_FILE).unwrap();
+            file.sync_all().unwrap();
+            inner.sync_dir().unwrap();
+            let (mut cp, _) = Checkpoint::open(file).unwrap();
+            cp.write(&encode_marker(LAYOUT_VERSION + 1)).unwrap();
+        }
+        let (fs, control) = FaultFs::new(inner);
+        control.set_fail_write(true);
+        assert!(matches!(
+            open_or_upgrade(&fs).unwrap_err(),
+            StorageError::IncompatibleLayoutVersion { .. }
+        ));
+    }
+
+    /// A foreign `layout.meta` whose payload is the wrong shape (valid CRC, wrong magic) is treated
+    /// as absent and overwritten with the v1 marker, not mistaken for a versioned marker.
+    #[test]
+    fn foreign_payload_is_treated_as_absent() {
+        let fs = InMemoryFs::new();
+        let file = fs.create_new(LAYOUT_MARKER_FILE).unwrap();
+        file.sync_all().unwrap();
+        fs.sync_dir().unwrap();
+        let (mut cp, _) = Checkpoint::open(file).unwrap();
+        cp.write(b"not-a-layout-marker").unwrap(); // wrong magic, wrong length
+
+        assert_eq!(open_or_upgrade(&fs).unwrap(), 1);
+        // Now a real v1 marker is in place.
+        let file = fs.open(LAYOUT_MARKER_FILE).unwrap();
+        let (_, recovered) = Checkpoint::open(file).unwrap();
+        assert_eq!(decode_marker(recovered.as_deref().unwrap()), Some(1));
+    }
+
+    /// The marker round-trips its version and the encode/decode are inverses for v1.
+    #[test]
+    fn marker_encode_decode_round_trips() {
+        assert_eq!(decode_marker(&encode_marker(1)), Some(1));
+        assert_eq!(decode_marker(&encode_marker(2)), Some(2));
+        assert_eq!(decode_marker(&encode_marker(u32::MAX)), Some(u32::MAX));
+        // Wrong length and wrong magic both decode to None (treated as absent).
+        assert_eq!(decode_marker(b"short"), None);
+        assert_eq!(decode_marker(b"XXXX\x01\x00\x00\x00"), None);
+    }
+
+    /// The marker file name is never mistaken for a segment, so it is invisible to enumeration.
+    #[test]
+    fn marker_file_is_not_a_segment_name() {
+        assert_eq!(parse_segment_file_name(LAYOUT_MARKER_FILE), None);
+    }
+}

--- a/crates/ironbus-storage/src/lib.rs
+++ b/crates/ironbus-storage/src/lib.rs
@@ -14,6 +14,11 @@ pub mod fault;
 pub mod fs;
 pub mod invariants;
 pub mod io;
+/// The data-directory LAYOUT version marker (#562): a small, durable, CRC32C'd `layout.meta` at the
+/// data-dir root that versions the on-disk DIRECTORY structure (where streams/cursors/DLQ live),
+/// distinct from the per-segment `FORMAT_VERSION`. Version 1 is today's layout (root log = default
+/// stream, `dlq/` subdir), and it reserves the `streams/` subtree for per-stream logs (M2-I2).
+pub mod layout;
 pub mod log;
 pub mod loss;
 pub mod naming;

--- a/crates/ironbus-storage/src/log.rs
+++ b/crates/ironbus-storage/src/log.rs
@@ -747,6 +747,13 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
     /// # Errors
     /// Returns [`StorageError`] on an IO error or a structurally invalid segment.
     pub fn open(fs: F, clock: C, config: LogConfig) -> Result<Log<F, C>, StorageError> {
+        // Check (and, on a pre-marker dir, durably write) the data-directory LAYOUT version marker
+        // BEFORE any recovery, so a FUTURE layout is refused fail-closed before its unknown-shaped
+        // contents are interpreted (#562). An absent or torn/corrupt marker recovers as layout v1
+        // and is (re)written idempotently; an existing single-log deployment is byte-for-byte layout
+        // v1, so this records a fact and reinterprets no segment, cursor, or DLQ byte. Recovery below
+        // is unchanged. Reserves the `streams/` subtree for per-stream logs (M2-I2); does not create it.
+        crate::layout::open_or_upgrade(&fs)?;
         let ids = segment_ids(&fs)?;
         match ids.last().copied() {
             None => {

--- a/crates/ironbus-storage/src/segment.rs
+++ b/crates/ironbus-storage/src/segment.rs
@@ -113,6 +113,20 @@ pub enum StorageError {
         /// The configured daily physical write budget the meter met or exceeded.
         budget: u64,
     },
+    /// The data directory's on-disk LAYOUT version (the DIRECTORY structure version in `layout.meta`,
+    /// `crate::layout`) is NEWER than this build understands, so `Log::open` fails CLOSED rather than
+    /// silently reinterpreting a layout it does not know (the same exact-match, refuse-and-report
+    /// discipline as an unknown `FORMAT_VERSION`, #562). DISTINCT from a record/segment version
+    /// mismatch ([`StorageError::Segment`] / [`StorageError::Record`]): this versions where streams,
+    /// cursors, and the DLQ live, not how a frame is encoded. A corrupt or absent marker never
+    /// produces this error (it recovers as layout v1); only a fully-valid, CRC-checked future marker
+    /// does.
+    IncompatibleLayoutVersion {
+        /// The layout version found in the marker.
+        found: u32,
+        /// The highest layout version this build supports ([`crate::layout::LAYOUT_VERSION`]).
+        supported: u32,
+    },
 }
 
 impl core::fmt::Display for StorageError {
@@ -175,6 +189,11 @@ impl core::fmt::Display for StorageError {
                 f,
                 "daily physical write budget reached ({bytes_today} of {budget} bytes today); \
                  produce rejected"
+            ),
+            StorageError::IncompatibleLayoutVersion { found, supported } => write!(
+                f,
+                "data-dir layout version {found} is newer than this build supports ({supported}); \
+                 refusing to open"
             ),
         }
     }

--- a/crates/ironbus-storage/tests/quarantine_recovery.rs
+++ b/crates/ironbus-storage/tests/quarantine_recovery.rs
@@ -141,9 +141,18 @@ fn a_corrupt_segment_is_copied_to_quarantine_while_recovery_recovers_the_prefix(
         "live segment truncated to the prefix"
     );
 
-    // Recovery never scanned the quarantine blob as a live segment: the live directory lists only
-    // the segment file, never the blob.
-    assert_eq!(fs.list().unwrap(), vec![segment_file_name(0)]);
+    // Recovery never scanned the quarantine blob as a live segment: the live directory contains the
+    // segment file (and the data-dir layout marker `layout.meta`, #562) but NEVER the blob, which
+    // lives only in the quarantine/ subdir.
+    let root = fs.list().unwrap();
+    assert!(
+        root.contains(&segment_file_name(0)),
+        "the live segment is present in the root: {root:?}"
+    );
+    assert!(
+        !root.contains(&blob_name),
+        "the quarantine blob is never in the live root listing: {root:?}"
+    );
 }
 
 #[test]

--- a/docs/WAL.md
+++ b/docs/WAL.md
@@ -160,6 +160,32 @@ directory of self-describing files is the authority, no manifest required").
   evidence and must not be shed). It is not on the produce-path retention loop, so in
   the shipped code the DLQ is not auto-reaped.
 
+### 6. The `layout.meta` data-dir layout marker (#562)
+
+- A small, durable, CRC32C-protected file at the data-dir root (`layout.rs`) that
+  declares the on-disk **directory layout version** — where streams, cursors, and the
+  DLQ live — *distinct* from the per-segment/record `FORMAT_VERSION`, which versions the
+  frame ENCODING. The two version axes are orthogonal: one names the shape of the
+  directory, the other the shape of a frame.
+- Format: the same two-slot, CRC32C'd, alternating-write `Checkpoint` file the cursors
+  use (`checkpoint.rs`). Its payload is a 4-byte magic (`IBDD`) plus a little-endian
+  `u32` layout version. A torn slot fails its CRC and is ignored, exactly like a torn
+  cursor.
+- **Layout version 1** is today's layout, described in items 1–5 above: the root log is
+  the default stream `""`, with `cursor*.ckpt`, `counters.ckpt`, the `quarantine/`
+  forensic subdir, and the `dlq/` subdir. The marker also **reserves** a future
+  `streams/` subtree for per-stream logs (M2-I2); that subtree is NOT created here.
+- Created/checked: `Log::open` reads the marker before any recovery. **Absent** (a
+  pre-marker data dir from before #562) is treated as layout v1 and the marker is
+  written — a safe, idempotent upgrade, because an existing single-log deployment is
+  byte-for-byte layout v1 (no segment, cursor, or DLQ byte changes). A **present v1**
+  marker opens unchanged. A **present, fully-valid marker declaring a FUTURE version**
+  fails closed with `StorageError::IncompatibleLayoutVersion` — a newer layout is never
+  silently reinterpreted by an older binary, the same refuse-and-report discipline as an
+  unknown `FORMAT_VERSION`. A **torn or corrupt** marker recovers as absent and is
+  re-upgraded to v1, bounded to a single marker rewrite, so a bad marker never bricks an
+  otherwise-valid data dir and never fabricates a future version.
+
 There is no other on-disk state. In particular there is no index sidecar, no time
 index, no `current` pointer file, and no manifest (all verified absent; see
 [below](#specified-but-not-yet-implemented)).

--- a/docs/compat/versions.md
+++ b/docs/compat/versions.md
@@ -29,6 +29,7 @@ or breaking (a new value means a new layout that an old reader fail-closed refus
 | Id-space | Current value(s) | Defined in (code symbol) | Bump rule | Owner |
 |----------|------------------|--------------------------|-----------|-------|
 | Storage `FORMAT_VERSION` | `1` | `ironbus_core::format::FORMAT_VERSION` | Breaking. A new layout takes a new integer; a v1 reader refuses any other value. | #126, #5 |
+| Data-dir layout version | `1` | `ironbus_storage::layout::LAYOUT_VERSION` (the `layout.meta` marker, CRC32C two-slot checkpoint) | Breaking. Versions the on-disk DIRECTORY structure (where streams/cursors/DLQ live), SEPARATELY from `FORMAT_VERSION` (which versions the frame ENCODING). v1 = today's root-log + `dlq/` layout and reserves a future `streams/` subtree (M2-I2). A v1 reader refuses any higher value; an absent marker auto-upgrades to v1 (an existing single-log dir is byte-for-byte v1); a torn/corrupt marker recovers as v1 and never bricks the dir. | #562, #500 |
 | Record header version | `1` (= `FORMAT_VERSION`) | `format::header_offsets::VERSION` (offset 2), checked in `ironbus_core::codec::decode` | Breaking. Same integer as `FORMAT_VERSION`; stamped per record. | #5 |
 | Segment header version | `1` (= `FORMAT_VERSION`) | `format::segment_header_offsets::VERSION` (offset 8), checked in `ironbus_core::segment::SegmentHeader::decode` | Breaking. Same integer as `FORMAT_VERSION`; stamped per segment. | #4, #5 |
 | Segment footer version | `1` (= `FORMAT_VERSION`) | `format::segment_footer_offsets::VERSION` (offset 2), checked in `ironbus_core::segment::SegmentFooter::decode` | Breaking. Same integer as `FORMAT_VERSION`; stamped per sealed segment. | #4, #5 |
@@ -79,6 +80,7 @@ unknown value. The three actions, consistent with [COMPATIBILITY.md](../COMPATIB
 | Id-space | Action on unknown | Append-only | Owner | Enforcing symbol / status |
 |----------|-------------------|-------------|-------|---------------------------|
 | Storage `FORMAT_VERSION` (record/segment/footer version bytes) | REFUSE | no (breaking) | #126, #5 | `DecodeError::UnsupportedVersion`, `SegmentError::UnsupportedVersion` |
+| Data-dir layout version (`layout.meta` marker) | REFUSE a higher version (fail closed); a torn/corrupt or ABSENT marker recovers as v1 (idempotent upgrade), never refused | no (breaking) | #562, #500 | `StorageError::IncompatibleLayoutVersion`; `ironbus_storage::layout::open_or_upgrade` checked at the top of `Log::open` |
 | Cursor checkpoint snapshot version | REFUSE | no (breaking) | #7 | `SnapshotError::UnsupportedVersion` |
 | `checksum_algo` | REFUSE | yes | #5 | `SegmentError::UnsupportedChecksumAlgo` |
 | `RecordFlags` unknown bits (within a known version) | TOLERATE + PRESERVE | yes | #5, #12 | `RecordFlags::unknown_bits` (kept verbatim, never interpreted) |


### PR DESCRIPTION
Closes #562 (V2-M2 foundation; closes the #500 store-format-migration dependency).

## What

Adds a small, **durable, CRC32C-protected** data-directory **LAYOUT** version marker (`layout.meta` at the data-dir root) that versions the on-disk **DIRECTORY structure** — where streams, cursors, and the DLQ live — **distinct** from the per-segment/record `FORMAT_VERSION`, which versions the frame **ENCODING**. The two version axes are orthogonal.

**Layout version 1 = today's layout**: the root log is the default stream `""`, with the `dlq/` subdir, `cursor*.ckpt` / `counters.ckpt`, and the `quarantine/` forensic subdir. The marker **reserves** a future `streams/` subtree for per-stream logs (M2-I2) **without creating it**, so a later directory-shape change becomes a *versioned, recoverable migration* rather than a silent reinterpretation.

The marker rides the existing **dual-slot CRC32C `Checkpoint`** primitive (the cursor/counters checkpoint), inheriting its torn-write tolerance for free. Its payload is a 4-byte magic (`IBDD`) + a little-endian `u32` version.

## Behavior (checked at the top of `Log::open`, before any recovery)

- **Absent** (a pre-marker data dir): treated as layout v1 and the marker is written. **Idempotent auto-upgrade** — an existing single-log deployment is *byte-for-byte* layout v1, so it records a fact and reinterprets nothing; **segments open byte-identically**.
- **Present v1**: opened unchanged.
- **Present, fully-valid, FUTURE version**: **fail closed** with the typed `StorageError::IncompatibleLayoutVersion` — the same refuse-and-report discipline as an unknown `FORMAT_VERSION`. A newer layout is **never** reinterpreted by an older binary.
- **Torn / corrupt / foreign**: recovers as absent and re-upgrades to v1, **bounded to a single marker rewrite** — a bad marker **never bricks** an otherwise-valid data dir and never fabricates a future version (only a CRC-valid future marker triggers the reject).

Persisting the marker is **best-effort** (the `counters.ckpt` discipline): a read-only / out-of-space / write-erroring filesystem still opens a valid data dir; only **reading** a valid future marker fails closed. The marker file is invisible to segment and cursor enumeration.

**Untouched**: the segment/record `FORMAT_VERSION`, the DLQ subdir, and the wire protocol (this is **on-disk only**). Existing single-log data dirs open unchanged.

## Scope boundary

Marker + reserve `streams/` + absent→v1 upgrade + future-version reject **only**. **No** per-stream logs (M2-I2), **no** CommitCoordinator (M2-I3), **no** `streams/` contents — this RESERVES the path and versions the layout so M2-I2 builds on it.

## Tests

Fresh dir writes the v1 marker; a pre-marker dir (segments present, no marker) auto-upgrades to v1 and leaves segments byte-identical; a future-version marker is rejected (typed, fail-closed); a corrupt marker recovers bounded to v1 without bricking; a foreign payload is treated as absent; a marker write failure does not fail the upgrade; a future marker is rejected even when writes fail; durability across reopen. Docs updated (`WAL.md` on-disk file classes; `compat/versions.md` version registry + classification tables).

## Gates (fresh from `cargo clean`)

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` (RUSTFLAGS `-D warnings`) — clean
- `cargo test --workspace --all-features --locked` — all green (1775 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVWp2H2txnKGru4q2twxM3