### PR TITLE
feat(protocol): stream-addressed wire frames — declare/pub/sub by stream id (#588)

### DIFF
--- a/crates/ironbus-cli/src/bench_run.rs
+++ b/crates/ironbus-cli/src/bench_run.rs
@@ -207,11 +207,17 @@ impl IsolatedBroker<EphemeralFs> {
 
 impl<F: Filesystem + 'static> IsolatedBroker<F> {
     /// Hosts an ALREADY-OPENED engine: actor spawn, ephemeral loopback bind, serve thread. The
-    /// shared backend-independent body behind both spawn constructors.
+    /// shared backend-independent body behind both spawn constructors. `F: Clone` because the serve
+    /// thread (`server::serve`) drives `Session::process`, whose stream-addressed verbs (#588) reach
+    /// `StreamSet::declare` (the per-stream log open clones the fs); every opened `Engine<F, _>`
+    /// already carries `F: Clone` (`Engine::open` requires it), so this is no new restriction.
     fn from_engine(
         engine: ironbus_server::engine::Engine<F, ironbus_server::clock::SystemClock>,
         config: &ServeConfig,
-    ) -> Result<IsolatedBroker<F>, CliError> {
+    ) -> Result<IsolatedBroker<F>, CliError>
+    where
+        F: Clone,
+    {
         // Honor the resolved group-commit gather (#454, #472), so the bench broker reflects the
         // SAME default as the real `serve` path (`run_broker` wires `config.commit_gather_us` the
         // same way). Without this the bench would always run the gather-off actor and never measure

--- a/crates/ironbus-cli/src/main.rs
+++ b/crates/ironbus-cli/src/main.rs
@@ -3595,7 +3595,7 @@ fn cmd_serve(
                                  // immutable-config handle + reload, the health server, the accept
                                  // loop, the graceful drain); splitting it further would scatter a
                                  // single concern across helpers.
-fn run_broker<F: Filesystem + 'static>(
+fn run_broker<F: Filesystem + Clone + 'static>(
     engine: Engine<F, SystemClock>,
     addr: &str,
     data_dir: Option<&Path>,
@@ -6639,7 +6639,7 @@ mod tests {
         std::thread::JoinHandle<Engine<F, C>>,
     )
     where
-        F: ironbus_storage::fs::Filesystem + 'static,
+        F: ironbus_storage::fs::Filesystem + Clone + 'static,
         C: ironbus_core::clock::Clock + Clone + Default + 'static,
     {
         let (handle, actor) = spawn_actor(engine, DEFAULT_CHANNEL_BOUND);

--- a/crates/ironbus-client/src/lib.rs
+++ b/crates/ironbus-client/src/lib.rs
@@ -28,11 +28,13 @@ use ironbus_core::types::RecordFlags;
 use ironbus_proto::frame::{decode_frame, encode_frame, FrameDecode, FrameError, FrameType};
 use ironbus_proto::message::{
     decode_dead_letter, decode_deliver, decode_deliver_batch, decode_gap_marker, decode_info,
-    decode_produce_confirm, decode_pub_ack, decode_truncated, encode_ack, encode_connect,
-    encode_cumulative_ack, encode_fetch, encode_pub, encode_stream_commit, encode_stream_fetch,
-    encode_sub, produce_confirm_status, AckBody, AckLevel, AckOp, BodyError, ConnectBody,
-    ConsumeTier, CumulativeAckBody, DeliverBody, FetchBody, PubBody, StreamCommitBody,
-    StreamFetchBody, SubBody, PUB_FLAG_ACK_LEVEL_MASK, PUB_FLAG_ACK_LEVEL_SHIFT,
+    decode_produce_confirm, decode_pub_ack, decode_stream_info_response, decode_truncated,
+    encode_ack, encode_connect, encode_cumulative_ack, encode_fetch, encode_pub, encode_pub_to,
+    encode_stream_commit, encode_stream_declare, encode_stream_fetch, encode_stream_info,
+    encode_sub, encode_sub_to, produce_confirm_status, AckBody, AckLevel, AckOp, BodyError,
+    ConnectBody, ConsumeTier, CumulativeAckBody, DeliverBody, FetchBody, PubBody, PubToBody,
+    StreamCommitBody, StreamDeclareBody, StreamFetchBody, StreamInfoBody, SubBody, SubToBody,
+    PUB_FLAG_ACK_LEVEL_MASK, PUB_FLAG_ACK_LEVEL_SHIFT,
 };
 use std::io::{self, Read, Write};
 use std::net::{TcpStream, ToSocketAddrs};
@@ -127,6 +129,10 @@ impl From<io::Error> for ClientError {
 /// The defaults are conservative but finite, so a misbehaving broker fails the call instead
 /// of hanging the caller indefinitely. Set a field to `None` to block forever on that
 /// operation (the pre-timeout behavior), which is rarely what you want.
+// Each bool advertises a DISTINCT wire CAPABILITY this client understands (gap-marker / streaming /
+// deliver-batch / streams, #346/#543/#541/#588), mapped one-to-one to a `Connect` handshake bit — a
+// documented protocol surface, not internal state a bitfield could replace.
+#[allow(clippy::struct_excessive_bools)]
 #[derive(Clone, Debug)]
 pub struct ClientConfig {
     /// Cap on the initial TCP connect. `None` uses the OS default, which can be minutes.
@@ -186,6 +192,15 @@ pub struct ClientConfig {
     /// checks [`Client::deliver_batch_enabled`] after connecting to learn whether the server confirmed
     /// it. The decoded `Message`s are IDENTICAL either way; this only changes the wire framing.
     pub understands_deliver_batch: bool,
+    /// Whether this client ADVERTISES that it understands the stream-addressed wire verbs
+    /// (`StreamDeclare`/`StreamInfo`/`PubTo`/`SubTo`, tags 28-31, #588, V2-M2-I10): when `true`, the
+    /// `Connect` sets the [`CONNECT_FLAG_UNDERSTANDS_STREAMS`] capability bit, so the server confirms it
+    /// in `Info` and the client may declare / publish-to / subscribe-to NAMED streams by id
+    /// ([`Client::declare_stream`] / [`Client::publish_to`] / [`Client::subscribe_to`]). When `false`
+    /// (the default, backward-compatible) the client uses only the default-stream verbs — byte-for-byte
+    /// today's behavior. A caller checks [`Client::streams_enabled`] after connecting to learn whether
+    /// the server confirmed it.
+    pub understands_streams: bool,
 }
 
 impl Default for ClientConfig {
@@ -219,6 +234,10 @@ impl Default for ClientConfig {
             // always receives per-record `Deliver` frames exactly as before (#541). A caller opts into
             // the raw-framed batch path by setting this (typically alongside `understands_streaming`).
             understands_deliver_batch: false,
+            // Off by default: an unconfigured client does not advertise stream addressing, so it uses
+            // only the default-stream verbs exactly as before (#588). A caller that wants to address
+            // named streams opts in by setting this.
+            understands_streams: false,
         }
     }
 }
@@ -653,6 +672,10 @@ pub struct StreamSummary {
 }
 
 /// A connected IronBus client over one TCP connection.
+// Each bool records a DISTINCT server-CONFIRMED wire capability for this connection (gap-marker /
+// streaming / deliver-batch / streams), each set from its `Info` echo bit — protocol negotiation
+// state, not internal flags a bitfield could replace.
+#[allow(clippy::struct_excessive_bools)]
 #[derive(Debug)]
 pub struct Client {
     stream: TcpStream,
@@ -684,6 +707,12 @@ pub struct Client {
     /// `DeliverBatch` (decoded locally into the same `Message`s); when `false` (an old server, or the
     /// client did not advertise), every delivery is a per-record `Deliver`.
     deliver_batch_enabled: bool,
+    /// Whether the stream-addressed wire verbs (`StreamDeclare`/`StreamInfo`/`PubTo`/`SubTo`, tags
+    /// 28-31) are ACTIVE on this connection (#588, V2-M2-I10): `true` only when this client advertised
+    /// it ([`ClientConfig::understands_streams`]) AND the server confirmed it in `Info`. When `false`
+    /// (an old server, or the client did not advertise), the client may use only the default-stream
+    /// verbs.
+    streams_enabled: bool,
     /// The connection-wide DEFAULT consume tier the SERVER adopted for this connection (#543, V2-M1),
     /// echoed in `Info`, or `None` if the server did not echo one (an old server, or it defaulted to
     /// Tier-W). A subscription that does not pick its own tier consumes at this default server-side.
@@ -728,6 +757,7 @@ impl Client {
             gap_marker_enabled: false,
             streaming_enabled: false,
             deliver_batch_enabled: false,
+            streams_enabled: false,
             negotiated_default_tier: None,
             confirm_cache: Vec::new(),
         };
@@ -755,6 +785,10 @@ impl Client {
                 // the pre-#541 `Connect` and the client receives only per-record `Deliver` frames; a
                 // caller opts in via the config to receive raw-framed batches.
                 understands_deliver_batch: config.understands_deliver_batch,
+                // The stream-addressing capability bit (#588). Off by default, so the body is
+                // byte-for-byte the pre-#588 `Connect` and the client uses only the default-stream
+                // verbs; a caller opts in via the config to address named streams by id.
+                understands_streams: config.understands_streams,
             },
             &mut connect_body,
         );
@@ -781,6 +815,10 @@ impl Client {
                 // when the client advertised it understands the frame), so an old server's empty Info
                 // leaves it off and every delivery is a per-record `Deliver` (#541).
                 client.deliver_batch_enabled = info.deliver_batch;
+                // The stream-addressed verbs are active only when the server CONFIRMED them (it does so
+                // only when the client advertised it understands them), so an old server's empty Info
+                // leaves it off and the client uses only the default-stream verbs (#588).
+                client.streams_enabled = info.streams;
                 Ok(client)
             }
             (FrameType::Err, body) => {
@@ -833,6 +871,16 @@ impl Client {
     #[must_use]
     pub fn deliver_batch_enabled(&self) -> bool {
         self.deliver_batch_enabled
+    }
+
+    /// Whether the stream-addressed wire verbs (`StreamDeclare`/`StreamInfo`/`PubTo`/`SubTo`, tags
+    /// 28-31) are ACTIVE on this connection (#588, V2-M2-I10): `true` only when this client advertised
+    /// it ([`ClientConfig::understands_streams`]) AND the server confirmed it in `Info`. When `false`
+    /// (an old server, or the client did not advertise), the client may use only the default-stream
+    /// verbs ([`Client::produce`] / [`Client::subscribe`] target the default stream).
+    #[must_use]
+    pub fn streams_enabled(&self) -> bool {
+        self.streams_enabled
     }
 
     /// The connection-wide DEFAULT consume tier the server adopted for this connection (#543, V2-M1),
@@ -2137,6 +2185,147 @@ impl Client {
             &mut body,
         );
         self.send(FrameType::CumulativeAck, &body)?;
+        match self.read_frame()? {
+            (FrameType::Ok, _) => Ok(()),
+            (FrameType::Err, body) => {
+                Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
+            }
+            (other, _) => Err(ClientError::Unexpected(other)),
+        }
+    }
+
+    /// CREATE-OR-ENSURE a NAMED stream by id (#588, M2-I10): the `StreamDeclare` verb. Idempotent —
+    /// re-declaring an existing stream is a no-op success — and the broker materializes the stream's
+    /// independent log on the first declare. Requires the connection to have negotiated stream
+    /// addressing ([`ClientConfig::understands_streams`] AND the server confirming it, observable via
+    /// [`Client::streams_enabled`]); a server that did not negotiate it replies an `Err`. The default
+    /// stream (the empty name) is always present and need not be declared.
+    ///
+    /// # Errors
+    /// Returns [`ClientError::Server`] if the server rejects the declare (capability not negotiated, or
+    /// a malformed/over-long name), [`ClientError::Body`] on an over-large field, or a frame/connection
+    /// error.
+    pub fn declare_stream(&mut self, stream: &str) -> Result<(), ClientError> {
+        let mut body = Vec::new();
+        encode_stream_declare(
+            &StreamDeclareBody {
+                stream_id: stream.as_bytes(),
+            },
+            &mut body,
+        )
+        .map_err(ClientError::Body)?;
+        self.send(FrameType::StreamDeclare, &body)?;
+        match self.read_frame()? {
+            (FrameType::Ok, _) => Ok(()),
+            (FrameType::Err, body) => {
+                Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
+            }
+            (other, _) => Err(ClientError::Unexpected(other)),
+        }
+    }
+
+    /// Queries a NAMED stream's existence and durable head (#588, M2-I10): the `StreamInfo` verb.
+    /// Returns `(exists, head)` — `exists = true` and the stream's durable head offset when the stream
+    /// is open, or `(false, 0)` when it does not exist. The default stream (the empty name) always
+    /// reports `exists = true`. Requires the stream-addressing capability (see
+    /// [`Client::declare_stream`]).
+    ///
+    /// # Errors
+    /// Returns [`ClientError::Server`] if the server rejects the query (capability not negotiated, or a
+    /// malformed name), [`ClientError::Body`] on an over-large field, [`ClientError::BadResponse`] on a
+    /// malformed reply, or a frame/connection error.
+    pub fn stream_info(&mut self, stream: &str) -> Result<(bool, u64), ClientError> {
+        let mut body = Vec::new();
+        encode_stream_info(
+            &StreamInfoBody {
+                stream_id: stream.as_bytes(),
+            },
+            &mut body,
+        )
+        .map_err(ClientError::Body)?;
+        self.send(FrameType::StreamInfo, &body)?;
+        match self.read_frame()? {
+            (FrameType::StreamInfo, body) => {
+                let resp = decode_stream_info_response(&body)
+                    .map_err(|_| ClientError::BadResponse("malformed stream-info response"))?;
+                Ok((resp.exists, resp.head))
+            }
+            (FrameType::Err, body) => {
+                Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
+            }
+            (other, _) => Err(ClientError::Unexpected(other)),
+        }
+    }
+
+    /// Publishes a message to a NAMED stream by id (#588, M2-I10): the `PubTo` verb, the stream-
+    /// addressed twin of [`Client::produce`]. The publish body is the SAME [`PubBody`] the default-
+    /// stream produce carries, prefixed with the target stream id, so the broker appends it to that
+    /// named stream's own log and replies a `PubAck` with the assigned offset (ack-implies-durable per
+    /// stream). An EMPTY `stream` targets the default stream (equivalent to [`Client::produce`]). The
+    /// publish is at-least-once (server-ack, Level 1); the fire-and-forget / consumer-ack tiers are the
+    /// default stream's this phase. Requires the stream-addressing capability (see
+    /// [`Client::declare_stream`]).
+    ///
+    /// # Errors
+    /// Returns [`ClientError::Server`] if the server rejects the publish (capability not negotiated, a
+    /// malformed name, or a non-server-ack level), [`ClientError::Body`] on an over-large field,
+    /// [`ClientError::BadResponse`] on a malformed ack, or a frame/connection error.
+    pub fn publish_to(&mut self, stream: &str, message: &PubBody<'_>) -> Result<u64, ClientError> {
+        // Force at-least-once server-ack (Level 1) on the carried body: the named-stream path accepts
+        // only that level this phase, and an old caller never set a level bit, so this is a no-op for
+        // them and a guard against a mismatched method/wire for everyone.
+        let at_least_once = PubBody {
+            fire_and_forget: false,
+            ..*message
+        };
+        let mut pub_body = Vec::new();
+        encode_pub(&at_least_once, &mut pub_body).map_err(ClientError::Body)?;
+        let mut body = Vec::new();
+        encode_pub_to(
+            &PubToBody {
+                stream_id: stream.as_bytes(),
+                pub_body: &pub_body,
+            },
+            &mut body,
+        )
+        .map_err(ClientError::Body)?;
+        self.send(FrameType::PubTo, &body)?;
+        match self.read_frame()? {
+            (FrameType::PubAck, body) => {
+                let ack = decode_pub_ack(&body)
+                    .map_err(|_| ClientError::BadResponse("publish-to reply was not an offset"))?;
+                Ok(ack.offset)
+            }
+            (FrameType::Err, body) => {
+                Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
+            }
+            (other, _) => Err(ClientError::Unexpected(other)),
+        }
+    }
+
+    /// Subscribes this connection's consume path to a NAMED stream's work-group (#588, M2-I10): the
+    /// `SubTo` verb, the stream-addressed twin of [`Client::subscribe`]. Subsequent [`Client::fetch`] /
+    /// [`Client::flow`] and [`Client::ack`] consume from and commit to THAT stream's own competing
+    /// work-group (independent per stream, so the same group name in two streams is two unrelated
+    /// cursors). The stream must already exist (declare or publish to it first); an EMPTY `stream`
+    /// targets the default stream (equivalent to [`Client::subscribe`]). Requires the stream-addressing
+    /// capability (see [`Client::declare_stream`]).
+    ///
+    /// # Errors
+    /// Returns [`ClientError::Server`] if the server rejects the subscription (capability not
+    /// negotiated, an unknown stream, or a malformed name), [`ClientError::Body`] on an over-large
+    /// field, or a frame/connection error.
+    pub fn subscribe_to(&mut self, stream: &str, group: &str) -> Result<(), ClientError> {
+        let mut body = Vec::new();
+        encode_sub_to(
+            &SubToBody {
+                stream_id: stream.as_bytes(),
+                group: group.as_bytes(),
+            },
+            &mut body,
+        )
+        .map_err(ClientError::Body)?;
+        self.send(FrameType::SubTo, &body)?;
         match self.read_frame()? {
             (FrameType::Ok, _) => Ok(()),
             (FrameType::Err, body) => {
@@ -4066,6 +4255,7 @@ mod tests {
                 streaming: false,
                 default_tier: None,
                 deliver_batch: false,
+                streams: false,
             },
             &mut body,
         );
@@ -5298,6 +5488,290 @@ mod tests {
         );
 
         drop(c);
+        shutdown.store(true, Ordering::Release);
+        handle.join().unwrap();
+    }
+
+    // ===== Stream-addressed wire verbs (#588, V2-M2-I10), END-TO-END over the REAL server =====
+
+    /// A client config that advertises the stream-addressing capability (#588).
+    fn config_understanding_streams() -> ClientConfig {
+        ClientConfig {
+            understands_streams: true,
+            ..ClientConfig::default()
+        }
+    }
+
+    #[test]
+    fn streams_capability_negotiates_against_a_real_server() {
+        // #588: a client that advertises `understands_streams` has it CONFIRMED by the server
+        // (`streams_enabled()` true); a client that does NOT advertise it leaves it off, so an old
+        // client is never told it may address named streams. The negotiation is the server->client AND.
+        let (addr, shutdown, handle) = start_server();
+
+        let capable = Client::connect_with(addr, &config_understanding_streams()).unwrap();
+        assert!(
+            capable.streams_enabled(),
+            "the server confirms stream addressing for a client that advertised it"
+        );
+
+        let old = Client::connect(addr).unwrap();
+        assert!(
+            !old.streams_enabled(),
+            "a client that did not advertise stream addressing is never told it may use it"
+        );
+
+        drop(capable);
+        drop(old);
+        shutdown.store(true, Ordering::Release);
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn declare_publish_subscribe_consume_ack_a_named_stream_end_to_end() {
+        // TEETH (#588): the whole named-stream round-trip over the REAL wire server — a streams-capable
+        // client DECLARES a named stream, PUBLISHES to it by id, SUBSCRIBES to its per-stream
+        // work-group, CONSUMES the record via that group, and ACKS it. StreamInfo reports the stream
+        // exists with the right durable head along the way.
+        let (addr, shutdown, handle) = start_server();
+        let mut c = Client::connect_with(addr, &config_understanding_streams()).unwrap();
+        assert!(c.streams_enabled());
+
+        // A query before declare: the named stream does not exist yet.
+        let (exists, _head) = c.stream_info("orders").unwrap();
+        assert!(!exists, "an undeclared named stream does not exist");
+
+        // Declare it (idempotent), then a re-declare is still Ok.
+        c.declare_stream("orders").unwrap();
+        c.declare_stream("orders").unwrap();
+        let (exists, head) = c.stream_info("orders").unwrap();
+        assert!(exists, "the declared named stream now exists");
+        assert_eq!(
+            head, 0,
+            "a freshly declared stream has an empty durable head"
+        );
+
+        // Publish two records to the NAMED stream by id; the offsets are the stream's OWN.
+        let body = |p: &'static [u8]| PubBody {
+            flags: 0,
+            timestamp_ms: 0,
+            key: b"",
+            headers: b"",
+            dedup: None,
+            fire_and_forget: false,
+            payload: p,
+        };
+        let off0 = c.publish_to("orders", &body(b"order-A")).unwrap();
+        let off1 = c.publish_to("orders", &body(b"order-B")).unwrap();
+        assert_eq!(
+            (off0, off1),
+            (0, 1),
+            "the named stream has its own offset space"
+        );
+
+        let (_exists, head) = c.stream_info("orders").unwrap();
+        assert_eq!(
+            head, 2,
+            "the named stream's durable head advanced to two records"
+        );
+
+        // Subscribe to the named stream's work-group, then consume + ack both records via that group.
+        c.subscribe_to("orders", "workers").unwrap();
+        let mut got = Vec::new();
+        for _ in 0..10 {
+            let messages = c.fetch(10).unwrap().messages;
+            for m in &messages {
+                got.push(m.payload.clone());
+                assert!(
+                    c.ack(m.offset, m.generation).unwrap(),
+                    "the named-stream ack commits"
+                );
+            }
+            if got.len() >= 2 {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        assert_eq!(
+            got,
+            vec![b"order-A".to_vec(), b"order-B".to_vec()],
+            "the consumer received exactly the named stream's records, in order"
+        );
+
+        // A re-fetch after acking both delivers nothing: the named stream's cursor advanced.
+        assert!(
+            c.fetch(10).unwrap().messages.is_empty(),
+            "the named stream's committed cursor advanced past both acked records"
+        );
+
+        drop(c);
+        shutdown.store(true, Ordering::Release);
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn cross_stream_isolation_over_the_wire() {
+        // TEETH (#588): a publish to stream A is NEVER seen by a consumer subscribed to stream B — two
+        // named streams are fully independent over the wire (their own logs AND their own per-stream
+        // work-group cursors). The consumer on B sees only B's record; the default stream stays empty.
+        let (addr, shutdown, handle) = start_server();
+        let mut producer = Client::connect_with(addr, &config_understanding_streams()).unwrap();
+        producer.declare_stream("stream-a").unwrap();
+        producer.declare_stream("stream-b").unwrap();
+
+        let body = |p: &'static [u8]| PubBody {
+            flags: 0,
+            timestamp_ms: 0,
+            key: b"",
+            headers: b"",
+            dedup: None,
+            fire_and_forget: false,
+            payload: p,
+        };
+        producer
+            .publish_to("stream-a", &body(b"only-in-a"))
+            .unwrap();
+        producer
+            .publish_to("stream-b", &body(b"only-in-b"))
+            .unwrap();
+
+        // A consumer bound to stream B sees ONLY B's record, never A's.
+        let mut consumer = Client::connect_with(addr, &config_understanding_streams()).unwrap();
+        consumer.subscribe_to("stream-b", "g").unwrap();
+        let mut got = Vec::new();
+        for _ in 0..10 {
+            let messages = consumer.fetch(10).unwrap().messages;
+            for m in &messages {
+                got.push(m.payload.clone());
+                assert!(consumer.ack(m.offset, m.generation).unwrap());
+            }
+            if !got.is_empty() {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        assert_eq!(
+            got,
+            vec![b"only-in-b".to_vec()],
+            "a consumer on stream B sees B's record and NEVER stream A's"
+        );
+
+        // Switch the SAME consumer to stream A and it now sees ONLY A's record (its own cursor).
+        consumer.subscribe_to("stream-a", "g").unwrap();
+        let mut got_a = Vec::new();
+        for _ in 0..10 {
+            let messages = consumer.fetch(10).unwrap().messages;
+            for m in &messages {
+                got_a.push(m.payload.clone());
+                assert!(consumer.ack(m.offset, m.generation).unwrap());
+            }
+            if !got_a.is_empty() {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        assert_eq!(
+            got_a,
+            vec![b"only-in-a".to_vec()],
+            "the same connection on stream A sees ONLY A's record (independent per-stream cursor)"
+        );
+
+        // The DEFAULT stream was never published to, so a default-stream consumer sees nothing.
+        let mut default_consumer = Client::connect(addr).unwrap();
+        assert!(
+            default_consumer.fetch(10).unwrap().messages.is_empty(),
+            "the default stream is untouched by the named-stream publishes"
+        );
+
+        drop(producer);
+        drop(consumer);
+        drop(default_consumer);
+        shutdown.store(true, Ordering::Release);
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn an_old_client_hits_the_default_stream_byte_identically() {
+        // #588 back-compat: a client that did NOT negotiate stream addressing (the capability bit
+        // clear) uses only the default-stream verbs (`produce` / `subscribe` / `fetch` / `ack`), which
+        // target the default stream `""` byte-for-byte today's behavior — a streams-capable client
+        // publishing to the EMPTY stream id (`publish_to("", ...)`) lands in the SAME default stream
+        // and is consumed by the OLD client's plain default subscription, proving the empty-id path is
+        // exactly the default path.
+        let (addr, shutdown, handle) = start_server();
+
+        // The old client produces to the default stream the classic way.
+        let mut old = Client::connect(addr).unwrap();
+        assert!(!old.streams_enabled());
+        let body = |p: &'static [u8]| PubBody {
+            flags: 0,
+            timestamp_ms: 0,
+            key: b"",
+            headers: b"",
+            dedup: None,
+            fire_and_forget: false,
+            payload: p,
+        };
+        let off_old = old.produce(&body(b"classic")).unwrap();
+        assert_eq!(off_old, 0, "the default stream starts at offset 0");
+
+        // A streams-capable client publishes to the EMPTY stream id: it MUST land in the default stream
+        // at the next default offset, indistinguishable from a plain `produce`.
+        let mut capable = Client::connect_with(addr, &config_understanding_streams()).unwrap();
+        let off_empty = capable.publish_to("", &body(b"via-empty-id")).unwrap();
+        assert_eq!(
+            off_empty, 1,
+            "an empty stream id routes to the DEFAULT stream's offset space (byte-identical)"
+        );
+
+        // The old client's plain default subscription consumes BOTH records in order — the empty-id
+        // publish is in the same default stream it always was.
+        old.subscribe("").unwrap();
+        let mut got = Vec::new();
+        for _ in 0..10 {
+            let messages = old.fetch(10).unwrap().messages;
+            for m in &messages {
+                got.push(m.payload.clone());
+                assert!(old.ack(m.offset, m.generation).unwrap());
+            }
+            if got.len() >= 2 {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        assert_eq!(
+            got,
+            vec![b"classic".to_vec(), b"via-empty-id".to_vec()],
+            "the default stream carries both the classic produce and the empty-id publish-to, in order"
+        );
+
+        drop(old);
+        drop(capable);
+        shutdown.store(true, Ordering::Release);
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn the_stream_verbs_are_refused_without_the_negotiated_capability() {
+        // #588 fail-closed: a client that did NOT negotiate stream addressing is REFUSED the
+        // stream-addressed verbs with a typed server error — it can never reach the named-stream path
+        // by accident. (The default-stream verbs stay fully available, exercised above.)
+        let (addr, shutdown, handle) = start_server();
+        let mut old = Client::connect(addr).unwrap();
+        assert!(!old.streams_enabled());
+
+        let declare = old.declare_stream("nope");
+        assert!(
+            matches!(declare, Err(ClientError::Server(_))),
+            "declare without the capability is a typed server error, got {declare:?}"
+        );
+        let info = old.stream_info("nope");
+        assert!(
+            matches!(info, Err(ClientError::Server(_))),
+            "stream_info without the capability is a typed server error, got {info:?}"
+        );
+
+        drop(old);
         shutdown.store(true, Ordering::Release);
         handle.join().unwrap();
     }

--- a/crates/ironbus-proto/src/frame.rs
+++ b/crates/ironbus-proto/src/frame.rs
@@ -203,6 +203,55 @@ pub enum FrameType {
     /// on the peer link, so the client protocol (tags 1-26) is byte-for-byte unchanged and a client
     /// connection never sees it.
     Raft,
+    /// Client request to CREATE-OR-ENSURE a named stream (#588, V2-M2-I10): the explicit-stream-id
+    /// "declare" verb that makes a named stream CLIENT-reachable. The broker `declare`s the stream in
+    /// its [`ironbus_storage::streamset::StreamSet`] (materializing its independent log + recovery) and
+    /// replies a body-less [`FrameType::Ok`] on success or [`FrameType::Err`] on a malformed/over-long
+    /// stream name (fail-closed, never a panic). It is idempotent: re-declaring an existing stream is a
+    /// no-op success. The DEFAULT stream (the empty name `""`) is ALWAYS present and is NOT declared
+    /// this way; a declare of `""` is rejected as a malformed name. Body: a
+    /// [`crate::message::StreamDeclareBody`] (`body_version: u8`, `field_len: u16`, then the
+    /// `stream_id` as a u16-length-prefixed name). It is a NEW append-only request tag: an old client
+    /// never sends it, and the existing tags 1-27 are byte-for-byte unchanged. (See the module doc on
+    /// tag allocation: tags 22-27 were ALREADY taken before this PR, so the streams verbs start at 28,
+    /// NOT the "tags 22+" the originating issue text predates.)
+    StreamDeclare,
+    /// Client query for a named stream's existence and durable head (#588, V2-M2-I10): the
+    /// explicit-stream-id "info" verb. The broker replies a [`FrameType::StreamInfo`] response frame
+    /// (reusing this same tag) carrying whether the stream EXISTS and, if so, its durable head offset,
+    /// or [`FrameType::Err`] on a malformed name. A request and its response share this tag, framed and
+    /// distinguished by their bodies (request = [`crate::message::StreamInfoBody`]; response =
+    /// [`crate::message::StreamInfoResponseBody`]), exactly as `Connect`/`Info` pair across two tags —
+    /// here a single verb round-trips request/response. The default stream `""` always reports
+    /// `exists = true`. A NEW append-only tag; old clients never send it. Body (request): a
+    /// `StreamInfoBody` (`stream_id` as a u16-length name); body (response): a
+    /// `StreamInfoResponseBody` (`exists: u8`, `head: u64 LE`).
+    StreamInfo,
+    /// Producer publish to a NAMED stream (#588, V2-M2-I10): the stream-addressed twin of
+    /// [`FrameType::Pub`] (tag 5). It carries an explicit target `stream_id` followed by a body that is
+    /// BYTE-FOR-BYTE the existing [`crate::message::PubBody`] layout (the same `flags` / timestamp /
+    /// key / headers / opt-in dedup / payload, including the ack-level and fire-and-forget wire bits),
+    /// so the only difference from a plain `Pub` is the stream-id prefix. The broker routes the append
+    /// to the named stream's own log via the engine's id-routed `produce_in_stream` (#676/#679), which
+    /// `declare`s the stream on first produce; the reply is the SAME [`FrameType::PubAck`] (or
+    /// [`FrameType::PubAckDuplicate`]/[`FrameType::Err`]) the default-stream `Pub` returns. A publish to
+    /// the EMPTY stream id is exactly a default-stream publish (it routes through `produce_in_stream("",
+    /// ...)`, byte-for-byte today's behavior). The existing `Pub` (tag 5) wire is UNCHANGED: this is an
+    /// ADDITIVE tag an old client never sends. Body: a [`crate::message::PubToBody`] (`body_version:
+    /// u8`, `field_len: u16` over the `stream_id` u16-length name, then the verbatim `PubBody` bytes as
+    /// the remainder).
+    PubTo,
+    /// Consumer subscribe to a NAMED stream's per-stream work-group (#588, V2-M2-I10): the
+    /// stream-addressed twin of [`FrameType::Sub`] (tag 6). It carries an explicit `stream_id` plus the
+    /// work-`group` name, binding this connection's subsequent stream-scoped `Flow`/`Ack` to that
+    /// stream's OWN competing work-group (independent per stream via the engine's id-routed
+    /// `poll_in_stream`/`ack_in_stream`, #676/#679 — the same group name in two streams is two
+    /// unrelated cursors). The reply is a body-less [`FrameType::Ok`] (the stream must already exist;
+    /// an unknown stream is an [`FrameType::Err`]). A subscribe to the EMPTY stream id targets the
+    /// default stream and is equivalent to a plain `Sub`. The existing `Sub` (tag 6) wire is UNCHANGED:
+    /// this is an ADDITIVE tag an old client never sends. Body: a [`crate::message::SubToBody`]
+    /// (`body_version: u8`, `field_len: u16` over `stream_id` then `group`, each u16-length-prefixed).
+    SubTo,
 }
 
 impl FrameType {
@@ -237,6 +286,10 @@ impl FrameType {
             FrameType::StreamCommit => 25,
             FrameType::DeliverBatch => 26,
             FrameType::Raft => 27,
+            FrameType::StreamDeclare => 28,
+            FrameType::StreamInfo => 29,
+            FrameType::PubTo => 30,
+            FrameType::SubTo => 31,
         }
     }
 
@@ -272,6 +325,10 @@ impl FrameType {
             25 => FrameType::StreamCommit,
             26 => FrameType::DeliverBatch,
             27 => FrameType::Raft,
+            28 => FrameType::StreamDeclare,
+            29 => FrameType::StreamInfo,
+            30 => FrameType::PubTo,
+            31 => FrameType::SubTo,
             _ => return None,
         })
     }
@@ -404,7 +461,7 @@ mod tests {
     use super::*;
     use proptest::prelude::*;
 
-    const ALL_TYPES: [FrameType; 27] = [
+    const ALL_TYPES: [FrameType; 31] = [
         FrameType::Connect,
         FrameType::Info,
         FrameType::Ping,
@@ -432,6 +489,10 @@ mod tests {
         FrameType::StreamCommit,
         FrameType::DeliverBatch,
         FrameType::Raft,
+        FrameType::StreamDeclare,
+        FrameType::StreamInfo,
+        FrameType::PubTo,
+        FrameType::SubTo,
     ];
 
     #[test]
@@ -477,6 +538,46 @@ mod tests {
         assert_eq!(FrameType::StreamCommit.as_u8(), 25);
         assert_eq!(FrameType::DeliverBatch.as_u8(), 26);
         assert_eq!(FrameType::Raft.as_u8(), 27);
+        assert_eq!(FrameType::StreamDeclare.as_u8(), 28);
+        assert_eq!(FrameType::StreamInfo.as_u8(), 29);
+        assert_eq!(FrameType::PubTo.as_u8(), 30);
+        assert_eq!(FrameType::SubTo.as_u8(), 31);
+    }
+
+    #[test]
+    fn stream_wire_tags_are_the_next_free_tags_after_raft_and_frame() {
+        // #588 (M2-I10): the stream-addressed verbs StreamDeclare (28), StreamInfo (29), PubTo (30),
+        // and SubTo (31) take the next FREE tags after the cluster-peer Raft frame (27). The
+        // originating issue text said "tags 22+", but tags 22-27 (ProduceConfirm, Fetch, StreamFetch,
+        // StreamCommit, DeliverBatch, Raft) were ALL allocated before this PR, so the streams verbs
+        // start at 28 — pinned here so a future reorder breaks a test, not a deployed protocol. The
+        // existing client verbs (Pub tag 5, Sub tag 6) are byte-for-byte unchanged: these are ADDITIVE
+        // tags an old client never sends.
+        assert_eq!(FrameType::from_u8(28), Some(FrameType::StreamDeclare));
+        assert_eq!(FrameType::from_u8(29), Some(FrameType::StreamInfo));
+        assert_eq!(FrameType::from_u8(30), Some(FrameType::PubTo));
+        assert_eq!(FrameType::from_u8(31), Some(FrameType::SubTo));
+        // The default-stream verbs are untouched.
+        assert_eq!(FrameType::Pub.as_u8(), 5);
+        assert_eq!(FrameType::Sub.as_u8(), 6);
+        // 32 is the new next-free tag (still unknown), so it frames but is not a known type.
+        assert_eq!(FrameType::from_u8(32), None);
+        for ty in [
+            FrameType::StreamDeclare,
+            FrameType::StreamInfo,
+            FrameType::PubTo,
+            FrameType::SubTo,
+        ] {
+            let mut buf = Vec::new();
+            encode_frame(ty, b"\x0b\x0c", &mut buf).unwrap();
+            match decode_frame(&buf).unwrap() {
+                FrameDecode::Frame { type_tag, body, .. } => {
+                    assert_eq!(FrameType::from_u8(type_tag), Some(ty));
+                    assert_eq!(body, b"\x0b\x0c");
+                }
+                FrameDecode::Incomplete { .. } => panic!("complete"),
+            }
+        }
     }
 
     #[test]
@@ -532,9 +633,9 @@ mod tests {
         // The Tier-W verbs are untouched.
         assert_eq!(FrameType::Flow.as_u8(), 10);
         assert_eq!(FrameType::Fetch.as_u8(), 23);
-        // 28 is the new next-free tag (still unknown), so it frames but is not a known type. (Tag 27
-        // is now the cluster-peer Raft frame, #667.)
-        assert_eq!(FrameType::from_u8(28), None);
+        // 32 is the new next-free tag (still unknown), so it frames but is not a known type. (Tags 27
+        // = cluster-peer Raft #667; 28-31 = the stream-addressed verbs #588.)
+        assert_eq!(FrameType::from_u8(32), None);
         for ty in [FrameType::StreamFetch, FrameType::StreamCommit] {
             let mut buf = Vec::new();
             encode_frame(ty, b"\x07\x08", &mut buf).unwrap();
@@ -558,9 +659,9 @@ mod tests {
         assert_eq!(FrameType::from_u8(26), Some(FrameType::DeliverBatch));
         // The per-record Deliver tag is untouched.
         assert_eq!(FrameType::Deliver.as_u8(), 13);
-        // 28 is the next-free tag (still unknown), so it frames but is not a known type. (Tag 27 is
-        // now the cluster-peer Raft frame, #667.)
-        assert_eq!(FrameType::from_u8(28), None);
+        // 32 is the next-free tag (still unknown), so it frames but is not a known type. (Tags 27 =
+        // cluster-peer Raft #667; 28-31 = the stream-addressed verbs #588.)
+        assert_eq!(FrameType::from_u8(32), None);
         let mut buf = Vec::new();
         encode_frame(FrameType::DeliverBatch, b"\x09\x0a", &mut buf).unwrap();
         match decode_frame(&buf).unwrap() {
@@ -755,7 +856,7 @@ mod tests {
         /// An unknown type tag still decodes at the envelope level (forward compatibility):
         /// the body and length are recovered; only `from_u8` reports it unknown.
         #[test]
-        fn an_unknown_type_tag_still_frames(tag in 28u8..=255, body in prop::collection::vec(any::<u8>(), 0..256)) {
+        fn an_unknown_type_tag_still_frames(tag in 32u8..=255, body in prop::collection::vec(any::<u8>(), 0..256)) {
             let frame_len = 1u32 + u32::try_from(body.len()).unwrap();
             let mut buf = frame_len.to_le_bytes().to_vec();
             buf.push(tag);

--- a/crates/ironbus-proto/src/message.rs
+++ b/crates/ironbus-proto/src/message.rs
@@ -1065,6 +1065,21 @@ pub const CONNECT_FLAG_HAS_DEFAULT_TIER: u8 = 0b0010_0000;
 /// [`CONNECT_FLAG_WANTS_GAP_MARKER`] / [`CONNECT_FLAG_UNDERSTANDS_STREAMING`].
 pub const CONNECT_FLAG_UNDERSTANDS_DELIVER_BATCH: u8 = 0b0100_0000;
 
+/// The `Connect` CAPABILITY bit (#588, V2-M2-I10) by which a client advertises that it UNDERSTANDS
+/// the stream-ADDRESSED wire verbs — `StreamDeclare` (tag 28), `StreamInfo` (tag 29), `PubTo` (tag
+/// 30), and `SubTo` (tag 31) — that make NAMED streams client-reachable. When set, the server
+/// confirms the capability with [`INFO_FLAG_STREAMS`] and the client may declare / publish-to /
+/// subscribe-to a named stream by its explicit id. When CLEAR (an old client, or one that opts out)
+/// the client uses only the default-stream verbs (`Pub`/`Sub`/`Flow`/`Fetch`), which target the
+/// default stream `""` — byte-for-byte today's behavior — and is NEVER sent a streams reply it did
+/// not ask for. Distinct from [`CONNECT_FLAG_UNDERSTANDS_STREAMING`] (the Tier-S consume-tier
+/// capability, #543): that bit names the consume MODE; this bit names multi-stream ADDRESSING. It is
+/// a pure capability flag (no associated value), so it occupies no slot in the v1 field block beyond
+/// this `flags` bit, exactly like [`CONNECT_FLAG_WANTS_GAP_MARKER`]. It is the LAST free bit (bit 7)
+/// of the handshake `flags` byte; a future capability needs an appended flags byte (the version+len
+/// framing already tolerates it).
+pub const CONNECT_FLAG_UNDERSTANDS_STREAMS: u8 = 0b1000_0000;
+
 /// The `Info` presence-flag bit signalling that the server's advertised per-consumer message-credit
 /// fields (`negotiated` + `cap`) are present (#292). A server that does not advertise leaves it clear,
 /// and a client then keeps its own local credit (backward-compat).
@@ -1114,6 +1129,16 @@ pub const INFO_FLAG_HAS_DEFAULT_TIER: u8 = 0b0010_0000;
 /// [`INFO_FLAG_STREAMING`] confirmations.
 pub const INFO_FLAG_DELIVER_BATCH: u8 = 0b0100_0000;
 
+/// The `Info` CAPABILITY bit (#588, V2-M2-I10) by which the server CONFIRMS this connection may use
+/// the stream-addressed wire verbs (`StreamDeclare`/`StreamInfo`/`PubTo`/`SubTo`): `true` only when
+/// the client advertised [`CONNECT_FLAG_UNDERSTANDS_STREAMS`] AND the server supports named streams.
+/// When clear (an old server, or a client that did not advertise) the client knows it will only ever
+/// use the default-stream verbs. The negotiation is AND, the server->client twin of
+/// [`CONNECT_FLAG_UNDERSTANDS_STREAMS`], mirroring the [`INFO_FLAG_GAP_MARKER`] / [`INFO_FLAG_STREAMING`]
+/// / [`INFO_FLAG_DELIVER_BATCH`] confirmations. It is the LAST free bit (bit 7) of the `Info` `flags`
+/// byte.
+pub const INFO_FLAG_STREAMS: u8 = 0b1000_0000;
+
 /// A client's handshake request (the `Connect` frame body, #292). The client MAY request a
 /// per-consumer message credit and/or byte budget; the server clamps each to its own cap and replies
 /// the negotiated value in [`InfoBody`]. A field is REQUESTED only when its presence bit is set in
@@ -1132,6 +1157,10 @@ pub const INFO_FLAG_DELIVER_BATCH: u8 = 0b0100_0000;
 /// neither appended byte is byte-for-byte the historical body. Any bytes past `field_len` (a FUTURE
 /// version's appended fields, e.g. the #71 `wire_protocol_version`) are TOLERATED and ignored by a v1
 /// reader. An empty body is the all-absent default.
+// Each bool is a DISTINCT negotiated wire CAPABILITY flag (gap-marker / streaming / deliver-batch /
+// streams, #346/#543/#541/#588), one bit of the handshake `flags` byte — a documented wire ABI, not
+// internal state a bitfield could replace, so the clippy "more than 3 bools" suggestion does not apply.
+#[allow(clippy::struct_excessive_bools)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct ConnectBody {
     /// The per-consumer message credit the client requests, or `None` to defer to the server default.
@@ -1175,6 +1204,14 @@ pub struct ConnectBody {
     /// new tag, so a pre-batch client is never sent a frame it cannot decode. A pure capability flag, so
     /// it adds no block slot beyond its `flags` bit.
     pub understands_deliver_batch: bool,
+    /// Whether this client UNDERSTANDS the stream-addressed wire verbs (`StreamDeclare`/`StreamInfo`/
+    /// `PubTo`/`SubTo`, tags 28-31, #588, V2-M2-I10): the [`CONNECT_FLAG_UNDERSTANDS_STREAMS`]
+    /// capability bit. When `true`, the client may address NAMED streams by id and the server confirms
+    /// with [`InfoBody::streams`]. When `false` (the default, and an old client) the client uses only
+    /// the default-stream verbs (`Pub`/`Sub`/`Flow`/`Fetch`) — byte-for-byte today's behavior — and is
+    /// never sent a streams reply it did not request. A pure capability flag, so it adds no block slot
+    /// beyond its `flags` bit.
+    pub understands_streams: bool,
 }
 
 /// The number of bytes in the `Connect` v1 known-field block with NO appended bytes (#494, #543):
@@ -1225,6 +1262,9 @@ pub fn encode_connect(req: &ConnectBody, out: &mut Vec<u8>) {
     }
     if req.understands_deliver_batch {
         flags |= CONNECT_FLAG_UNDERSTANDS_DELIVER_BATCH;
+    }
+    if req.understands_streams {
+        flags |= CONNECT_FLAG_UNDERSTANDS_STREAMS;
     }
     out.push(flags);
     out.extend_from_slice(&req.requested_credit.unwrap_or(0).to_le_bytes());
@@ -1295,6 +1335,7 @@ pub fn decode_connect(body: &[u8]) -> Result<ConnectBody, BodyError> {
     let wants_gap_marker = flags & CONNECT_FLAG_WANTS_GAP_MARKER != 0;
     let understands_streaming = flags & CONNECT_FLAG_UNDERSTANDS_STREAMING != 0;
     let understands_deliver_batch = flags & CONNECT_FLAG_UNDERSTANDS_DELIVER_BATCH != 0;
+    let understands_streams = flags & CONNECT_FLAG_UNDERSTANDS_STREAMS != 0;
     Ok(ConnectBody {
         requested_credit,
         requested_credit_bytes,
@@ -1303,6 +1344,7 @@ pub fn decode_connect(body: &[u8]) -> Result<ConnectBody, BodyError> {
         understands_streaming,
         default_tier,
         understands_deliver_batch,
+        understands_streams,
     })
 }
 
@@ -1333,6 +1375,10 @@ pub struct CreditAdvert<T> {
 /// [`INFO_FLAG_HAS_DEFAULT_TIER`]). Each appended byte is OMITTED (and `field_len` shrinks by it) when
 /// absent; an advertisement with neither is byte-for-byte the historical body. Trailing bytes past the
 /// block are a future version's fields, tolerated and ignored. An empty body is the all-absent case.
+// Each bool is a DISTINCT server-confirmed wire CAPABILITY echo (gap-marker / streaming /
+// deliver-batch / streams), one bit of the `Info` `flags` byte — a documented wire ABI, not internal
+// state a bitfield could replace, so the clippy "more than 3 bools" suggestion does not apply.
+#[allow(clippy::struct_excessive_bools)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct InfoBody {
     /// The server's per-consumer message-credit advertisement, or `None` if the server does not
@@ -1371,6 +1417,13 @@ pub struct InfoBody {
     /// advertised it understands the frame AND the server supports it. `false` (an old server, or a
     /// client that did not advertise) tells the client it will only ever see per-record `Deliver` runs.
     pub deliver_batch: bool,
+    /// Whether the server CONFIRMS this connection may use the stream-addressed wire verbs
+    /// (`StreamDeclare`/`StreamInfo`/`PubTo`/`SubTo`, tags 28-31, #588, V2-M2-I10): the
+    /// [`INFO_FLAG_STREAMS`] capability echo, the server->client twin of
+    /// [`ConnectBody::understands_streams`]. `true` only when the client advertised it understands the
+    /// verbs AND the server supports named streams. `false` (an old server, or a client that did not
+    /// advertise) tells the client it will only ever use the default-stream verbs.
+    pub streams: bool,
 }
 
 /// The number of bytes in the `Info` v1 known-field block with NO appended bytes (#494, #543):
@@ -1418,6 +1471,9 @@ pub fn encode_info(info: &InfoBody, out: &mut Vec<u8>) {
     }
     if info.deliver_batch {
         flags |= INFO_FLAG_DELIVER_BATCH;
+    }
+    if info.streams {
+        flags |= INFO_FLAG_STREAMS;
     }
     out.push(flags);
     let credit = info.credit.unwrap_or(CreditAdvert {
@@ -1494,6 +1550,7 @@ pub fn decode_info(body: &[u8]) -> Result<InfoBody, BodyError> {
     let gap_marker = flags & INFO_FLAG_GAP_MARKER != 0;
     let streaming = flags & INFO_FLAG_STREAMING != 0;
     let deliver_batch = flags & INFO_FLAG_DELIVER_BATCH != 0;
+    let streams = flags & INFO_FLAG_STREAMS != 0;
     Ok(InfoBody {
         credit,
         credit_bytes,
@@ -1502,6 +1559,7 @@ pub fn decode_info(body: &[u8]) -> Result<InfoBody, BodyError> {
         streaming,
         default_tier,
         deliver_batch,
+        streams,
     })
 }
 
@@ -1742,6 +1800,317 @@ pub fn decode_stream_commit(body: &[u8]) -> Result<StreamCommitBody<'_>, BodyErr
     Ok(StreamCommitBody { up_to, group })
 }
 
+// ===================================================================================
+// STREAM-ADDRESSED WIRE BODIES (#588, V2-M2-I10): the explicit-stream-id verbs that make NAMED
+// streams CLIENT-reachable — StreamDeclare (tag 28), StreamInfo (tag 29), PubTo (tag 30), SubTo
+// (tag 31). Each rides a `body_version: u8` + `field_len: u16` frame (mirroring `FetchBody` /
+// `StreamFetchBody`) so a future version can append fields without a wire break: a v1 reader reads
+// the known fields from the front of the declared block and TOLERATES (ignores) trailing bytes. The
+// stream id is a `u16`-length-prefixed byte field, capped BEFORE any read by `Reader::take`, so a
+// malformed/oversized id is a typed [`BodyError`], never a panic or over-read (fail-closed). The
+// SUBJECT->stream binding + subject-addressed routing (a `SubTo` resolving a subject/wildcard to a
+// stream) is the SEPARATE M2-I9 (#585) work; THESE bodies carry an EXPLICIT stream id only.
+// ===================================================================================
+
+/// The version of the stream-addressed body framing (#588). Version `1` is the first (and only)
+/// layout. Carried as a leading byte so a future version can extend a body without a wire break: a
+/// reader rejects a version it does not understand rather than mis-parsing it, exactly like
+/// [`FETCH_BODY_VERSION`]. Shared by `StreamDeclare`, `StreamInfo` (request + response), `PubTo`, and
+/// `SubTo`, which all use the same version/length framing.
+pub const STREAM_WIRE_BODY_VERSION: u8 = 1;
+
+/// The hard cap on a stream-id byte length the proto codecs enforce at the wire boundary (#588): the
+/// engine's `StreamId::named` further validates the name's SHAPE (graphic ASCII, non-empty, its own
+/// length bound), but this cap fails a hostile/oversized id closed at decode time BEFORE the name
+/// crosses into the server, so a malformed-id frame is a typed [`BodyError::BadLength`] rather than a
+/// large reservation. It is generous (the engine's own bound is tighter) so it never rejects a name
+/// the engine would accept; it only stops an absurdly long id.
+pub const MAX_STREAM_ID_LEN: usize = 1024;
+
+/// Reads a `u16`-length-prefixed stream-id field, enforcing [`MAX_STREAM_ID_LEN`] (#588). A declared
+/// length over the cap is a typed [`BodyError::BadLength`] (fail-closed) BEFORE the bytes are taken,
+/// so a hostile id cannot force an over-read; a short body is [`BodyError::Truncated`] via
+/// [`Reader::take`]. The returned slice borrows the body (zero-copy).
+fn read_stream_id<'a>(r: &mut Reader<'a>) -> Result<&'a [u8], BodyError> {
+    let len = r.u16()? as usize;
+    if len > MAX_STREAM_ID_LEN {
+        return Err(BodyError::BadLength);
+    }
+    r.take(len)
+}
+
+/// A client's request to CREATE-OR-ENSURE a named stream (the `StreamDeclare` frame body, tag 28,
+/// #588): it carries the explicit `stream_id` to declare. The broker `declare`s it (idempotent) and
+/// replies `Ok`, or `Err` on a malformed/over-long name (the empty name `""` is rejected — the
+/// default stream is always present and is never declared this way).
+///
+/// Layout (version+length framed, forward-compatible): `body_version: u8`
+/// ([`STREAM_WIRE_BODY_VERSION`]), `field_len: u16` (the length of the v1 known-field block), then the
+/// v1 block: `stream_id: u16-len + bytes`. Bytes past `field_len` (a future version's appended fields)
+/// are TOLERATED and ignored.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct StreamDeclareBody<'a> {
+    /// The name of the stream to create-or-ensure (validated server-side by `StreamId::named`).
+    pub stream_id: &'a [u8],
+}
+
+/// Encodes a `StreamDeclare` body onto the end of `out` (#588).
+///
+/// # Errors
+/// Returns [`BodyError::FieldTooLarge`] if the stream id exceeds the `u16` wire limit.
+pub fn encode_stream_declare(
+    req: &StreamDeclareBody<'_>,
+    out: &mut Vec<u8>,
+) -> Result<(), BodyError> {
+    let id_len = u16::try_from(req.stream_id.len()).map_err(|_| BodyError::FieldTooLarge)?;
+    let field_len = u16::try_from(2 + req.stream_id.len()).map_err(|_| BodyError::FieldTooLarge)?;
+    out.push(STREAM_WIRE_BODY_VERSION);
+    out.extend_from_slice(&field_len.to_le_bytes());
+    out.extend_from_slice(&id_len.to_le_bytes());
+    out.extend_from_slice(req.stream_id);
+    Ok(())
+}
+
+/// Decodes a `StreamDeclare` body (#588), cap-before-alloc and panic-free.
+///
+/// The body MUST carry the version byte and `u16` field-length; the v1 `stream_id` is read from the
+/// front of the declared block and trailing block bytes (a future version's fields) are tolerated. A
+/// body too short for its declared block, or a stream id over [`MAX_STREAM_ID_LEN`], is a typed
+/// [`BodyError`] (fail-closed), never a panic or over-read. An EMPTY body is NOT valid (the frame type
+/// is new, with no historical empty case), so it is [`BodyError::Truncated`].
+///
+/// # Errors
+/// [`BodyError::Truncated`] for a short body, [`BodyError::BadLength`] for an over-cap id, or
+/// [`BodyError::BadHandshakeVersion`] for an unknown body version.
+pub fn decode_stream_declare(body: &[u8]) -> Result<StreamDeclareBody<'_>, BodyError> {
+    let mut r = Reader::new(body);
+    let version = r.u8()?;
+    if version != STREAM_WIRE_BODY_VERSION {
+        return Err(BodyError::BadHandshakeVersion { version });
+    }
+    let field_len = r.u16()? as usize;
+    let block = r.take(field_len)?;
+    let mut fr = Reader::new(block);
+    let stream_id = read_stream_id(&mut fr)?;
+    Ok(StreamDeclareBody { stream_id })
+}
+
+/// A client's query for a named stream (the `StreamInfo` REQUEST body, tag 29, #588): it carries the
+/// `stream_id` to query. The broker replies a `StreamInfo` frame whose body is a
+/// [`StreamInfoResponseBody`], or `Err` on a malformed name. Same version/length framing as
+/// [`StreamDeclareBody`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct StreamInfoBody<'a> {
+    /// The name of the stream being queried (validated server-side).
+    pub stream_id: &'a [u8],
+}
+
+/// Encodes a `StreamInfo` REQUEST body onto the end of `out` (#588).
+///
+/// # Errors
+/// Returns [`BodyError::FieldTooLarge`] if the stream id exceeds the `u16` wire limit.
+pub fn encode_stream_info(req: &StreamInfoBody<'_>, out: &mut Vec<u8>) -> Result<(), BodyError> {
+    let id_len = u16::try_from(req.stream_id.len()).map_err(|_| BodyError::FieldTooLarge)?;
+    let field_len = u16::try_from(2 + req.stream_id.len()).map_err(|_| BodyError::FieldTooLarge)?;
+    out.push(STREAM_WIRE_BODY_VERSION);
+    out.extend_from_slice(&field_len.to_le_bytes());
+    out.extend_from_slice(&id_len.to_le_bytes());
+    out.extend_from_slice(req.stream_id);
+    Ok(())
+}
+
+/// Decodes a `StreamInfo` REQUEST body (#588), cap-before-alloc and panic-free (same discipline as
+/// [`decode_stream_declare`]).
+///
+/// # Errors
+/// [`BodyError::Truncated`] for a short body, [`BodyError::BadLength`] for an over-cap id, or
+/// [`BodyError::BadHandshakeVersion`] for an unknown body version.
+pub fn decode_stream_info(body: &[u8]) -> Result<StreamInfoBody<'_>, BodyError> {
+    let mut r = Reader::new(body);
+    let version = r.u8()?;
+    if version != STREAM_WIRE_BODY_VERSION {
+        return Err(BodyError::BadHandshakeVersion { version });
+    }
+    let field_len = r.u16()? as usize;
+    let block = r.take(field_len)?;
+    let mut fr = Reader::new(block);
+    let stream_id = read_stream_id(&mut fr)?;
+    Ok(StreamInfoBody { stream_id })
+}
+
+/// The server's reply to a `StreamInfo` query (the `StreamInfo` RESPONSE body, tag 29, #588): whether
+/// the queried stream EXISTS and, if so, its durable head offset. The default stream `""` always
+/// reports `exists = true`. An unknown future `exists` byte is folded to `false` by the decoder (never
+/// an error), so the field stays forward-compatible.
+///
+/// Layout (version+length framed): `body_version: u8`, `field_len: u16`, then the v1 block:
+/// `exists: u8` (`0` = absent, `1` = present), `head: u64 LE` (the durable head; `0` when absent).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub struct StreamInfoResponseBody {
+    /// Whether the queried stream exists (has been declared / produced-to). The default stream is
+    /// always `true`.
+    pub exists: bool,
+    /// The stream's durable head (flushed) offset; `0` when the stream does not exist.
+    pub head: u64,
+}
+
+/// The number of bytes in the `StreamInfo` RESPONSE v1 known-field block: `exists: u8` + `head: u64`.
+const STREAM_INFO_RESP_V1_FIELD_LEN: u16 = 1 + 8;
+
+/// Encodes a `StreamInfo` RESPONSE body onto the end of `out` (#588): the version byte, the v1
+/// field-block length, then the v1 block.
+pub fn encode_stream_info_response(resp: &StreamInfoResponseBody, out: &mut Vec<u8>) {
+    out.push(STREAM_WIRE_BODY_VERSION);
+    out.extend_from_slice(&STREAM_INFO_RESP_V1_FIELD_LEN.to_le_bytes());
+    out.push(u8::from(resp.exists));
+    out.extend_from_slice(&resp.head.to_le_bytes());
+}
+
+/// Decodes a `StreamInfo` RESPONSE body (#588), cap-before-alloc and panic-free. A short block reads
+/// what is present and defaults the rest (never panicking); a non-`0`/`1` `exists` byte folds to
+/// `false`. An EMPTY body is NOT valid, so it is [`BodyError::Truncated`].
+///
+/// # Errors
+/// [`BodyError::Truncated`] for a short body, or [`BodyError::BadHandshakeVersion`] for an unknown
+/// body version.
+pub fn decode_stream_info_response(body: &[u8]) -> Result<StreamInfoResponseBody, BodyError> {
+    let mut r = Reader::new(body);
+    let version = r.u8()?;
+    if version != STREAM_WIRE_BODY_VERSION {
+        return Err(BodyError::BadHandshakeVersion { version });
+    }
+    let field_len = r.u16()? as usize;
+    let block = r.take(field_len)?;
+    let mut fr = Reader::new(block);
+    let exists = fr.u8().unwrap_or(0) == 1;
+    let head = fr.u64().unwrap_or(0);
+    Ok(StreamInfoResponseBody { exists, head })
+}
+
+/// A producer's publish to a NAMED stream (the `PubTo` frame body, tag 30, #588): an explicit target
+/// `stream_id` followed by a body that IS the verbatim [`PubBody`] bytes (the default-stream `Pub`
+/// body). It deliberately carries the `pub_body` as an opaque borrowed slice rather than a decoded
+/// [`PubBody`], so the stream-addressed publish reuses the EXISTING [`decode_pub`] codec UNCHANGED
+/// (the session decodes the prefix here, then the `pub_body` with `decode_pub`), and the `Pub` (tag 5)
+/// wire stays byte-for-byte identical — the only added bytes are the version/length-framed stream-id
+/// prefix.
+///
+/// Layout (version+length framed): `body_version: u8`, `field_len: u16` (over the `stream_id` field
+/// ONLY), then the v1 block: `stream_id: u16-len + bytes`; then the verbatim `PubBody` bytes as the
+/// REMAINDER after the block. Putting the `PubBody` after the declared block (not inside it) lets a
+/// future version append PubTo-specific fields to the block while the `PubBody` stays the tail.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PubToBody<'a> {
+    /// The target stream name (empty routes to the default stream, byte-for-byte a plain `Pub`).
+    pub stream_id: &'a [u8],
+    /// The verbatim [`PubBody`] bytes, decoded by the caller with [`decode_pub`] (so the publish body
+    /// codec is shared UNCHANGED with the default-stream `Pub`).
+    pub pub_body: &'a [u8],
+}
+
+/// Encodes a `PubTo` body onto the end of `out` (#588): the version byte, the field-block length over
+/// the stream id, the stream id, then the verbatim `pub_body` bytes. The caller produces `pub_body`
+/// with [`encode_pub`].
+///
+/// # Errors
+/// Returns [`BodyError::FieldTooLarge`] if the stream id exceeds the `u16` wire limit.
+pub fn encode_pub_to(req: &PubToBody<'_>, out: &mut Vec<u8>) -> Result<(), BodyError> {
+    let id_len = u16::try_from(req.stream_id.len()).map_err(|_| BodyError::FieldTooLarge)?;
+    let field_len = u16::try_from(2 + req.stream_id.len()).map_err(|_| BodyError::FieldTooLarge)?;
+    out.push(STREAM_WIRE_BODY_VERSION);
+    out.extend_from_slice(&field_len.to_le_bytes());
+    out.extend_from_slice(&id_len.to_le_bytes());
+    out.extend_from_slice(req.stream_id);
+    out.extend_from_slice(req.pub_body);
+    Ok(())
+}
+
+/// Decodes a `PubTo` body (#588) into its `stream_id` and the verbatim `pub_body` tail, cap-before-alloc
+/// and panic-free. The caller decodes `pub_body` with [`decode_pub`]. A body too short for its declared
+/// block, or a stream id over [`MAX_STREAM_ID_LEN`], is a typed [`BodyError`] (fail-closed). An EMPTY
+/// body is NOT valid, so it is [`BodyError::Truncated`].
+///
+/// # Errors
+/// [`BodyError::Truncated`] for a short body, [`BodyError::BadLength`] for an over-cap id, or
+/// [`BodyError::BadHandshakeVersion`] for an unknown body version.
+pub fn decode_pub_to(body: &[u8]) -> Result<PubToBody<'_>, BodyError> {
+    let mut r = Reader::new(body);
+    let version = r.u8()?;
+    if version != STREAM_WIRE_BODY_VERSION {
+        return Err(BodyError::BadHandshakeVersion { version });
+    }
+    let field_len = r.u16()? as usize;
+    let block = r.take(field_len)?;
+    // The PubBody is everything AFTER the declared block (so a future version may grow the block
+    // without disturbing the PubBody tail).
+    let pub_body = r.rest();
+    let mut fr = Reader::new(block);
+    let stream_id = read_stream_id(&mut fr)?;
+    Ok(PubToBody {
+        stream_id,
+        pub_body,
+    })
+}
+
+/// A consumer's subscribe to a NAMED stream's work-group (the `SubTo` frame body, tag 31, #588): an
+/// explicit `stream_id` plus the work-`group` name. It binds the connection's subsequent
+/// stream-scoped `Flow`/`Ack` to that stream's OWN competing work-group (independent per stream). The
+/// EMPTY stream id targets the default stream (equivalent to a plain `Sub`); the empty group selects
+/// the default group.
+///
+/// Layout (version+length framed): `body_version: u8`, `field_len: u16`, then the v1 block:
+/// `stream_id: u16-len + bytes`, `group: u16-len + bytes`. Both fields ride INSIDE the declared block
+/// (each `u16`-length-prefixed), so a future version appends after them. Trailing block bytes are
+/// tolerated.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SubToBody<'a> {
+    /// The target stream name (empty selects the default stream).
+    pub stream_id: &'a [u8],
+    /// The work-group name (empty selects the default group), validated server-side.
+    pub group: &'a [u8],
+}
+
+/// Encodes a `SubTo` body onto the end of `out` (#588): the version byte, the field-block length, then
+/// the stream id and group, each `u16`-length-prefixed.
+///
+/// # Errors
+/// Returns [`BodyError::FieldTooLarge`] if the stream id or group exceeds the `u16` wire limit.
+pub fn encode_sub_to(req: &SubToBody<'_>, out: &mut Vec<u8>) -> Result<(), BodyError> {
+    let id_len = u16::try_from(req.stream_id.len()).map_err(|_| BodyError::FieldTooLarge)?;
+    let group_len = u16::try_from(req.group.len()).map_err(|_| BodyError::FieldTooLarge)?;
+    let field_len = u16::try_from(2 + req.stream_id.len() + 2 + req.group.len())
+        .map_err(|_| BodyError::FieldTooLarge)?;
+    out.push(STREAM_WIRE_BODY_VERSION);
+    out.extend_from_slice(&field_len.to_le_bytes());
+    out.extend_from_slice(&id_len.to_le_bytes());
+    out.extend_from_slice(req.stream_id);
+    out.extend_from_slice(&group_len.to_le_bytes());
+    out.extend_from_slice(req.group);
+    Ok(())
+}
+
+/// Decodes a `SubTo` body (#588), cap-before-alloc and panic-free. The stream id is capped at
+/// [`MAX_STREAM_ID_LEN`]; the group is `u16`-length-prefixed (its SHAPE is validated server-side, as
+/// for a plain `Sub`). A body too short for its declared block is a typed [`BodyError`] (fail-closed).
+/// An EMPTY body is NOT valid, so it is [`BodyError::Truncated`].
+///
+/// # Errors
+/// [`BodyError::Truncated`] for a short body, [`BodyError::BadLength`] for an over-cap id, or
+/// [`BodyError::BadHandshakeVersion`] for an unknown body version.
+pub fn decode_sub_to(body: &[u8]) -> Result<SubToBody<'_>, BodyError> {
+    let mut r = Reader::new(body);
+    let version = r.u8()?;
+    if version != STREAM_WIRE_BODY_VERSION {
+        return Err(BodyError::BadHandshakeVersion { version });
+    }
+    let field_len = r.u16()? as usize;
+    let block = r.take(field_len)?;
+    let mut fr = Reader::new(block);
+    let stream_id = read_stream_id(&mut fr)?;
+    let group = fr.var()?;
+    Ok(SubToBody { stream_id, group })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1847,6 +2216,7 @@ mod tests {
             understands_streaming: false,
             default_tier: None,
             understands_deliver_batch: false,
+            understands_streams: false,
         };
         let mut buf = Vec::new();
         encode_connect(&req, &mut buf);
@@ -1871,6 +2241,7 @@ mod tests {
             streaming: false,
             default_tier: None,
             deliver_batch: false,
+            streams: false,
         };
         let mut buf = Vec::new();
         encode_info(&info, &mut buf);
@@ -2717,8 +3088,9 @@ mod tests {
             understands_streaming in any::<bool>(),
             default_tier in proptest::option::of(any::<u8>()),
             understands_deliver_batch in any::<bool>(),
+            understands_streams in any::<bool>(),
         ) {
-            let req = ConnectBody { requested_credit: credit, requested_credit_bytes: credit_bytes, wants_gap_marker, default_ack_level, understands_streaming, default_tier, understands_deliver_batch };
+            let req = ConnectBody { requested_credit: credit, requested_credit_bytes: credit_bytes, wants_gap_marker, default_ack_level, understands_streaming, default_tier, understands_deliver_batch, understands_streams };
             let mut buf = Vec::new();
             encode_connect(&req, &mut buf);
             prop_assert_eq!(buf[0], HANDSHAKE_BODY_VERSION, "the body leads with its version");
@@ -2738,6 +3110,7 @@ mod tests {
             streaming in any::<bool>(),
             default_tier in proptest::option::of(any::<u8>()),
             deliver_batch in any::<bool>(),
+            streams in any::<bool>(),
         ) {
             let info = InfoBody {
                 credit: credit.map(|(negotiated, cap)| CreditAdvert { negotiated, cap }),
@@ -2747,6 +3120,7 @@ mod tests {
                 streaming,
                 default_tier,
                 deliver_batch,
+                streams,
             };
             let mut buf = Vec::new();
             encode_info(&info, &mut buf);
@@ -2775,7 +3149,7 @@ mod tests {
             credit in proptest::option::of(any::<u32>()),
             trailing in prop::collection::vec(any::<u8>(), 0..64),
         ) {
-            let req = ConnectBody { requested_credit: credit, requested_credit_bytes: None, wants_gap_marker: false, default_ack_level: None, understands_streaming: false, default_tier: None, understands_deliver_batch: false };
+            let req = ConnectBody { requested_credit: credit, requested_credit_bytes: None, wants_gap_marker: false, default_ack_level: None, understands_streaming: false, default_tier: None, understands_deliver_batch: false, understands_streams: false };
             let mut buf = Vec::new();
             encode_connect(&req, &mut buf);
             let mut extended = buf.clone();
@@ -2790,6 +3164,7 @@ mod tests {
                 streaming: false,
                 default_tier: None,
                 deliver_batch: false,
+                streams: false,
             };
             let mut ibuf = Vec::new();
             encode_info(&info, &mut ibuf);
@@ -2864,6 +3239,7 @@ mod tests {
                 understands_streaming: false,
                 default_tier: None,
                 understands_deliver_batch: false,
+                understands_streams: false,
             }
         );
     }
@@ -2883,6 +3259,7 @@ mod tests {
                 streaming: false,
                 default_tier: None,
                 deliver_batch: false,
+                streams: false,
             }
         );
     }
@@ -2897,6 +3274,7 @@ mod tests {
             understands_streaming: false,
             default_tier: None,
             understands_deliver_batch: false,
+            understands_streams: false,
         };
         let mut buf = Vec::new();
         encode_connect(&req, &mut buf);
@@ -2924,6 +3302,7 @@ mod tests {
             streaming: false,
             default_tier: None,
             deliver_batch: false,
+            streams: false,
         };
         let mut buf = Vec::new();
         encode_info(&info, &mut buf);
@@ -3152,6 +3531,7 @@ mod tests {
             understands_streaming: false,
             default_tier: None,
             understands_deliver_batch: false,
+            understands_streams: false,
         };
         let mut pre = Vec::new();
         encode_connect(&no_level, &mut pre);
@@ -3205,6 +3585,7 @@ mod tests {
             streaming: false,
             default_tier: None,
             deliver_batch: false,
+            streams: false,
         };
         let mut pre = Vec::new();
         encode_info(&no_level, &mut pre);
@@ -3243,6 +3624,7 @@ mod tests {
             understands_streaming: false,
             default_tier: None,
             understands_deliver_batch: false,
+            understands_streams: false,
         };
         let mut pre = Vec::new();
         encode_connect(&none, &mut pre);
@@ -3313,6 +3695,7 @@ mod tests {
             streaming: false,
             default_tier: None,
             deliver_batch: false,
+            streams: false,
         };
         let mut pre = Vec::new();
         encode_info(&none, &mut pre);
@@ -3353,6 +3736,7 @@ mod tests {
             understands_streaming: true,
             default_tier: Some(ConsumeTier::Streaming.as_u8()),
             understands_deliver_batch: false,
+            understands_streams: false,
         };
         let mut buf = Vec::new();
         encode_connect(&both, &mut buf);
@@ -3413,6 +3797,7 @@ mod tests {
                 understands_streaming: false,
                 default_tier: None,
                 understands_deliver_batch: false,
+                understands_streams: false,
             }
         );
 
@@ -3433,7 +3818,189 @@ mod tests {
                 streaming: false,
                 default_tier: None,
                 deliver_batch: false,
+                streams: false,
             }
         );
+    }
+
+    // ===== Stream-addressed wire bodies (#588, V2-M2-I10) =====
+
+    #[test]
+    fn connect_and_info_carry_the_streams_capability_bit() {
+        // #588: a streams-capable client sets CONNECT_FLAG_UNDERSTANDS_STREAMS (a pure flags bit, no
+        // block byte); the bit round-trips, appends no byte, and an EMPTY (old-client) Connect never
+        // advertises it. The Info echo (INFO_FLAG_STREAMS) mirrors it.
+        let req = ConnectBody {
+            understands_streams: true,
+            ..ConnectBody::default()
+        };
+        let mut buf = Vec::new();
+        encode_connect(&req, &mut buf);
+        assert_eq!(
+            buf[3] & CONNECT_FLAG_UNDERSTANDS_STREAMS,
+            CONNECT_FLAG_UNDERSTANDS_STREAMS,
+            "the streams capability bit is set in the flags byte"
+        );
+        let mut plain = Vec::new();
+        encode_connect(&ConnectBody::default(), &mut plain);
+        assert_eq!(
+            buf.len(),
+            plain.len(),
+            "the streams capability bit appends no block byte"
+        );
+        assert_eq!(decode_connect(&buf).unwrap(), req);
+        // An EMPTY (old-client) Connect never advertises streams.
+        assert!(!decode_connect(&[]).unwrap().understands_streams);
+
+        let info = InfoBody {
+            streams: true,
+            ..InfoBody::default()
+        };
+        let mut ibuf = Vec::new();
+        encode_info(&info, &mut ibuf);
+        assert_eq!(
+            ibuf[3] & INFO_FLAG_STREAMS,
+            INFO_FLAG_STREAMS,
+            "the Info streams echo bit is set"
+        );
+        assert_eq!(decode_info(&ibuf).unwrap(), info);
+        assert!(!decode_info(&[]).unwrap().streams);
+    }
+
+    #[test]
+    fn stream_declare_and_info_round_trip_with_the_stream_id() {
+        // #588: StreamDeclare / StreamInfo (request) carry the stream id under version+length framing,
+        // round-tripping exactly. The default-stream empty id round-trips too.
+        for id in [b"orders".as_slice(), b"", b"a/b.c-1"] {
+            let mut buf = Vec::new();
+            encode_stream_declare(&StreamDeclareBody { stream_id: id }, &mut buf).unwrap();
+            assert_eq!(
+                buf[0], STREAM_WIRE_BODY_VERSION,
+                "leads with the body version"
+            );
+            assert_eq!(decode_stream_declare(&buf).unwrap().stream_id, id);
+
+            let mut ibuf = Vec::new();
+            encode_stream_info(&StreamInfoBody { stream_id: id }, &mut ibuf).unwrap();
+            assert_eq!(decode_stream_info(&ibuf).unwrap().stream_id, id);
+        }
+    }
+
+    #[test]
+    fn stream_info_response_round_trips_existence_and_head() {
+        // #588: the StreamInfo response carries exists + head; a non-existent stream reports head 0.
+        for (exists, head) in [(true, 42u64), (false, 0), (true, 0)] {
+            let resp = StreamInfoResponseBody { exists, head };
+            let mut buf = Vec::new();
+            encode_stream_info_response(&resp, &mut buf);
+            assert_eq!(decode_stream_info_response(&buf).unwrap(), resp);
+        }
+    }
+
+    #[test]
+    fn pub_to_carries_the_stream_id_and_the_verbatim_pub_body() {
+        // #588: PubTo prefixes a stream id, then carries the EXISTING PubBody bytes verbatim, so the
+        // session reuses decode_pub UNCHANGED. The pub_body round-trips byte-for-byte and decodes back
+        // through the existing codec.
+        let mut pub_body = Vec::new();
+        encode_pub(
+            &PubBody {
+                flags: 0,
+                timestamp_ms: 7,
+                key: b"k",
+                headers: b"h",
+                dedup: None,
+                fire_and_forget: false,
+                payload: b"hello-named-stream",
+            },
+            &mut pub_body,
+        )
+        .unwrap();
+        let mut buf = Vec::new();
+        encode_pub_to(
+            &PubToBody {
+                stream_id: b"orders",
+                pub_body: &pub_body,
+            },
+            &mut buf,
+        )
+        .unwrap();
+        let decoded = decode_pub_to(&buf).unwrap();
+        assert_eq!(decoded.stream_id, b"orders");
+        assert_eq!(decoded.pub_body, pub_body.as_slice());
+        // The carried pub_body decodes through the UNCHANGED PubBody codec.
+        let pb = decode_pub(decoded.pub_body).unwrap();
+        assert_eq!(pb.payload, b"hello-named-stream");
+        assert_eq!(pb.key, b"k");
+    }
+
+    #[test]
+    fn sub_to_round_trips_stream_id_and_group() {
+        // #588: SubTo carries both a stream id and a work-group name, each round-tripping; empty
+        // stream id (default stream) and empty group (default group) both round-trip.
+        for (id, group) in [
+            (b"orders".as_slice(), b"workers".as_slice()),
+            (b"", b""),
+            (b"s", b""),
+            (b"", b"g"),
+        ] {
+            let mut buf = Vec::new();
+            encode_sub_to(
+                &SubToBody {
+                    stream_id: id,
+                    group,
+                },
+                &mut buf,
+            )
+            .unwrap();
+            let decoded = decode_sub_to(&buf).unwrap();
+            assert_eq!(decoded.stream_id, id);
+            assert_eq!(decoded.group, group);
+        }
+    }
+
+    #[test]
+    fn stream_bodies_tolerate_a_future_appended_field() {
+        // #588 forward-compat: a future version may append fields INSIDE the declared block; a v1
+        // reader reads the known fields from the front and TOLERATES (ignores) the trailing bytes,
+        // never erroring. Hand-craft a StreamDeclare body whose field_len is two bytes longer than the
+        // v1 stream-id field and assert the id still decodes.
+        let id = b"future";
+        let mut buf = vec![STREAM_WIRE_BODY_VERSION];
+        let v1_field_len = 2 + id.len();
+        let field_len = u16::try_from(v1_field_len + 2).unwrap(); // two appended future bytes
+        buf.extend_from_slice(&field_len.to_le_bytes());
+        buf.extend_from_slice(&u16::try_from(id.len()).unwrap().to_le_bytes());
+        buf.extend_from_slice(id);
+        buf.extend_from_slice(&[0xaa, 0xbb]); // a future version's appended block bytes
+        assert_eq!(decode_stream_declare(&buf).unwrap().stream_id, id);
+    }
+
+    #[test]
+    fn stream_bodies_fail_closed_on_malformed_input() {
+        // #588 fail-closed: an empty body, an unknown version, a declared field_len past the body, and
+        // an over-cap stream id are each a TYPED BodyError, never a panic or an over-read.
+        // Empty body -> Truncated (no historical empty case for a new frame type).
+        assert_eq!(decode_stream_declare(&[]), Err(BodyError::Truncated));
+        assert_eq!(decode_pub_to(&[]), Err(BodyError::Truncated));
+        assert_eq!(decode_sub_to(&[]), Err(BodyError::Truncated));
+        // Unknown body version -> BadHandshakeVersion.
+        assert_eq!(
+            decode_stream_declare(&[STREAM_WIRE_BODY_VERSION + 1, 0, 0]),
+            Err(BodyError::BadHandshakeVersion {
+                version: STREAM_WIRE_BODY_VERSION + 1
+            })
+        );
+        // A field_len that claims more than the body holds -> Truncated (cap-before-alloc).
+        let mut over = vec![STREAM_WIRE_BODY_VERSION];
+        over.extend_from_slice(&9999u16.to_le_bytes()); // declares 9999 block bytes, has none
+        assert_eq!(decode_stream_declare(&over), Err(BodyError::Truncated));
+        // An over-cap stream id length inside the block -> BadLength, never an over-read.
+        let mut huge = vec![STREAM_WIRE_BODY_VERSION];
+        let claimed_id_len = u16::try_from(MAX_STREAM_ID_LEN + 1).unwrap();
+        let field_len = u16::try_from(2usize).unwrap(); // only room for the 2-byte len prefix
+        huge.extend_from_slice(&field_len.to_le_bytes());
+        huge.extend_from_slice(&claimed_id_len.to_le_bytes());
+        assert_eq!(decode_stream_declare(&huge), Err(BodyError::BadLength));
     }
 }

--- a/crates/ironbus-server/src/engine.rs
+++ b/crates/ironbus-server/src/engine.rs
@@ -2995,6 +2995,56 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         Ok(offset)
     }
 
+    /// CREATE-OR-ENSURE the named stream `stream` WITHOUT producing to it (#588, M2-I10): the
+    /// engine-side of the `StreamDeclare` wire verb. The default stream (the EMPTY name) is always
+    /// present and is a no-op success (`Ok(false)`, "already existed") — it is NEVER materialized via
+    /// the named `streams/` subtree. A NAMED stream is `declare`d in the [`StreamSet`] (materializing
+    /// `streams/<hex(name)>/` and its independent log + recovery) and mirrored in the per-stream
+    /// consumer state, exactly as the declare-on-first-produce in [`Engine::produce_in_stream`] does,
+    /// so a later produce/consume reuses the same open log. Idempotent: re-declaring an open stream is
+    /// `Ok(false)`; a first declare is `Ok(true)`.
+    ///
+    /// # Errors
+    /// [`EngineError::InvalidStreamName`] for a malformed NAMED name (empty is the default, never a
+    /// named-name error here because it short-circuits above; otherwise the graphic-ASCII / length rule
+    /// fails closed at the boundary, before the filesystem), else a storage error from opening the
+    /// stream's log.
+    pub fn declare_stream(&mut self, stream: &str) -> Result<bool, EngineError>
+    where
+        F: Clone,
+    {
+        // The default stream is always open and lives on the root log, NOT in the StreamSet's named
+        // subtree: declaring it is a no-op success, so a `StreamDeclare("")` (which the proto rejects
+        // anyway) never materializes the inert `""` slot.
+        if stream.is_empty() {
+            return Ok(false);
+        }
+        let id = StreamId::named(stream)?;
+        let created = self.streams.declare(&id).map_err(EngineError::Storage)?;
+        // Mirror the per-stream consumer state so a subsequent consume resolves the same way a
+        // produce-declared stream does (idempotent: an existing entry is left untouched).
+        self.named_streams
+            .entry(id)
+            .or_insert_with(NamedStream::new);
+        Ok(created)
+    }
+
+    /// Whether the named stream `stream` EXISTS (is open) (#588): the engine-side of the `StreamInfo`
+    /// wire verb's existence bit. The default stream (the EMPTY name) ALWAYS exists. A named stream
+    /// exists once it has been declared (via [`Engine::declare_stream`] or declare-on-first-produce).
+    /// A malformed named name reports `false` (it can never have been declared), never an error — the
+    /// wire layer fails a malformed id closed before this is reached, so this is a pure existence read.
+    #[must_use]
+    pub fn stream_exists(&self, stream: &str) -> bool {
+        if stream.is_empty() {
+            return true;
+        }
+        let Ok(id) = StreamId::named(stream) else {
+            return false;
+        };
+        self.streams.get(&id).is_some()
+    }
+
     /// Polls the stream named `stream` in work-group `group` (#676): the default stream routes to
     /// today's [`Engine::poll_in`] BYTE-FOR-BYTE; a NAMED stream delivers off its OWN log + its own
     /// per-stream work-group (the same competing lease/cursor machinery, independent per stream, so

--- a/crates/ironbus-server/src/server.rs
+++ b/crates/ironbus-server/src/server.rs
@@ -62,7 +62,7 @@ pub fn serve<F, C>(
     progress: &crate::liveness::LivenessBeacon,
 ) -> std::io::Result<()>
 where
-    F: Filesystem + 'static,
+    F: Filesystem + Clone + 'static,
     C: Clock + Clone + 'static,
 {
     listener.set_nonblocking(true)?;
@@ -118,7 +118,7 @@ fn handle_connection<F, C>(
     member_id: MemberId,
 ) -> std::io::Result<()>
 where
-    F: Filesystem + 'static,
+    F: Filesystem + Clone + 'static,
     C: Clock + Clone + 'static,
 {
     stream.set_nonblocking(false)?; // the handler reads blocking
@@ -178,7 +178,7 @@ fn connection_loop<F, C>(
     session: &mut Session,
 ) -> std::io::Result<()>
 where
-    F: Filesystem + 'static,
+    F: Filesystem + Clone + 'static,
     C: Clock + Clone + 'static,
 {
     let mut inbuf: Vec<u8> = Vec::new();

--- a/crates/ironbus-server/src/session.rs
+++ b/crates/ironbus-server/src/session.rs
@@ -32,15 +32,17 @@ use ironbus_core::lease::LeaseToken;
 use ironbus_core::types::{Offset, RecordFlags};
 use ironbus_proto::frame::{decode_frame, encode_frame, FrameDecode, FrameError, FrameType};
 use ironbus_proto::message::{
-    decode_ack, decode_connect, decode_cumulative_ack, decode_fetch, decode_pub,
-    decode_stream_commit, decode_stream_fetch, decode_sub, encode_dead_letter, encode_deliver,
-    encode_deliver_batch, encode_gap_marker, encode_info, encode_produce_confirm, encode_pub_ack,
-    encode_truncated, gap_reason, produce_confirm_status, pub_ack_level, AckLevel, AckOp,
-    ConsumeTier, CreditAdvert, DeadLetterBody, DeliverBatchHeader, DeliverBody, GapMarkerBody,
-    InfoBody, ProduceConfirmBody, PubAckBody, TruncatedBody, DEAD_LETTER_MAX_DELIVER,
-    PUB_WIRE_ONLY_FLAGS,
+    decode_ack, decode_connect, decode_cumulative_ack, decode_fetch, decode_pub, decode_pub_to,
+    decode_stream_commit, decode_stream_declare, decode_stream_fetch, decode_stream_info,
+    decode_sub, decode_sub_to, encode_dead_letter, encode_deliver, encode_deliver_batch,
+    encode_gap_marker, encode_info, encode_produce_confirm, encode_pub_ack,
+    encode_stream_info_response, encode_truncated, gap_reason, produce_confirm_status,
+    pub_ack_level, AckLevel, AckOp, ConsumeTier, CreditAdvert, DeadLetterBody, DeliverBatchHeader,
+    DeliverBody, GapMarkerBody, InfoBody, ProduceConfirmBody, PubAckBody, StreamInfoResponseBody,
+    TruncatedBody, DEAD_LETTER_MAX_DELIVER, PUB_WIRE_ONLY_FLAGS,
 };
 use ironbus_storage::fs::Filesystem;
+use ironbus_storage::log::Append;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -312,6 +314,26 @@ pub struct Session {
     /// and never sends the new tag, so a pre-batch client is never sent a frame it cannot decode. Default
     /// `false` (backward-compatible).
     deliver_batch_enabled: bool,
+    /// Whether this connection negotiated the stream-ADDRESSED wire verbs (#588, M2-I10): set at
+    /// `Connect` time when the client advertised
+    /// [`ironbus_proto::message::CONNECT_FLAG_UNDERSTANDS_STREAMS`]. When `true`, the connection may
+    /// declare / publish-to / subscribe-to a NAMED stream by id (`StreamDeclare` / `StreamInfo` /
+    /// `PubTo` / `SubTo`, tags 28-31), each routed to the engine's id-routed entry points (#676/#679);
+    /// the server confirms it in `Info` ([`ironbus_proto::message::INFO_FLAG_STREAMS`]). When `false`
+    /// (an old client, or one that opts out) those verbs are REFUSED with a typed `Err` and the
+    /// connection uses ONLY the default-stream verbs (`Pub`/`Sub`/`Flow`/`Fetch`), which target the
+    /// default stream `""` — byte-for-byte today's behavior. Default `false` (backward-compatible).
+    streams_enabled: bool,
+    /// The NAMED stream this connection's consume path is bound to (#588, M2-I10), `""` (the default
+    /// stream) until a `SubTo` binds a named one. A `SubTo` sets BOTH this and `subscription` (the
+    /// work-group within the stream); a plain `Sub`/`Unsub` resets it to the default stream. The Flow
+    /// poll loop and the Ack path route through the engine's id-routed `poll_in_stream` /
+    /// `ack_in_stream` when this is non-empty, and through the unchanged default-stream
+    /// `poll_now_in_member` / `ack_in` when it is empty — so an OLD client (which never sends `SubTo`)
+    /// consumes the default stream byte-for-byte. Held as `Arc<str>` (#487) so handing the name to the
+    /// engine job by value across the actor channel is a refcount bump, not an allocation, exactly like
+    /// `subscription`.
+    stream: GroupName,
     /// Whether this connection has EVER published a Level-2 (server+client-ack) produce (#497): set
     /// when an L2 publish is registered for confirmation, and NEVER cleared. It is the gate that keeps
     /// the per-pass `ProduceConfirm` drain off the actor for a connection that never opted into Level 2
@@ -392,7 +414,11 @@ impl Session {
     /// Returns [`SessionError::BadFrame`] if a frame envelope is malformed (the caller must then
     /// close the connection, a length-prefixed stream cannot resync), [`SessionError::EngineFatal`]
     /// on an unrecoverable engine error, or [`SessionError::ActorGone`] if the append actor exited.
-    pub fn process<F: Filesystem + 'static, C: Clock + Clone + 'static, E: EngineAccess<F, C>>(
+    pub fn process<
+        F: Filesystem + Clone + 'static,
+        C: Clock + Clone + 'static,
+        E: EngineAccess<F, C>,
+    >(
         &mut self,
         engine: &E,
         input: &[u8],
@@ -502,7 +528,11 @@ impl Session {
     /// stalled produce fsync cannot block it, #177); a produce advances the durable head but not a
     /// COMMITTED cursor. An `Ack`/`Flow`/`Unsub` returns `true` (an ack commits, a flow can commit
     /// past a dead-letter, an unsub may evict a caught-up group).
-    fn dispatch<F: Filesystem + 'static, C: Clock + Clone + 'static, E: EngineAccess<F, C>>(
+    fn dispatch<
+        F: Filesystem + Clone + 'static,
+        C: Clock + Clone + 'static,
+        E: EngineAccess<F, C>,
+    >(
         &mut self,
         engine: &E,
         type_tag: u8,
@@ -556,6 +586,20 @@ impl Session {
                 self.handle_stream_commit(engine, body, out).map(|()| true)
             }
             Some(FrameType::Sub) => self.handle_sub(engine, body, out).map(|()| false),
+            // The stream-addressed verbs (#588, M2-I10): each is GATED on the negotiated
+            // `streams_enabled` capability (a client that did not advertise `understands_streams` gets
+            // a typed `Err`, never the new behavior), then routes to the engine's id-routed entry
+            // points (#676/#679). A StreamDeclare/StreamInfo changes no committed cursor (`false`); a
+            // SubTo only binds the subscription (`false`, like Sub); a PubTo never advances a COMMITTED
+            // cursor (`false`, like Pub).
+            Some(FrameType::StreamDeclare) => self
+                .handle_stream_declare(engine, body, out)
+                .map(|()| false),
+            Some(FrameType::StreamInfo) => {
+                self.handle_stream_info(engine, body, out).map(|()| false)
+            }
+            Some(FrameType::PubTo) => self.handle_pub_to(engine, body, out).map(|()| false),
+            Some(FrameType::SubTo) => self.handle_sub_to(engine, body, out).map(|()| false),
             Some(FrameType::Unsub) => self.handle_unsub(engine, out).map(|()| true),
             // The standalone Nack frame type (a client sends a nack as an Ack frame with the
             // Nack op, handled above), or a response-only verb (Info/Pong/Ok/Err/Deliver) a
@@ -637,6 +681,15 @@ impl Session {
         // that did not advertise keeps receiving per-record `Deliver` frames and is never sent the new
         // tag, so an old client that cannot decode the on-disk record layout is never broken.
         self.deliver_batch_enabled = req.understands_deliver_batch;
+        // Negotiate the stream-ADDRESSED wire verbs (#588, M2-I10): the server always SUPPORTS named
+        // streams, so the capability is active exactly when this client advertised it understands the
+        // verbs. A streams-capable client may declare / publish-to / subscribe-to a NAMED stream; one
+        // that did not advertise is REFUSED those verbs (a typed `Err`) and is never sent a streams
+        // reply it did not ask for, so an old client uses only the default-stream verbs unchanged.
+        self.streams_enabled = req.understands_streams;
+        // A repeated Connect re-negotiates idempotently: reset the active named stream to the default
+        // so a re-handshake never leaves a stale named-stream binding from a prior negotiation.
+        self.stream = GroupName::default();
         // The server caps, read LOCALLY off the handle (NO actor round-trip), so the handshake never
         // touches the actor's checkpoint/fsync path and a stalled produce on one connection cannot
         // head-of-line-block this Connect (invariant 4, #177). The caps are static engine config.
@@ -682,6 +735,11 @@ impl Session {
             // client learns whether to expect `DeliverBatch` (tag 26) or only per-record `Deliver`,
             // mirroring the gap-marker / streaming confirmations.
             deliver_batch: self.deliver_batch_enabled,
+            // Confirm the stream-ADDRESSED capability the server activated for this connection (#588),
+            // so the client learns whether it may address named streams by id, mirroring the
+            // gap-marker / streaming / deliver-batch confirmations. The negotiation is AND: this is
+            // `true` only when the client advertised the verbs AND the server supports named streams.
+            streams: self.streams_enabled,
         };
         let mut info_body = Vec::new();
         encode_info(&info, &mut info_body);
@@ -875,7 +933,11 @@ impl Session {
     /// session is fenced (status 0) without touching the engine, so a second connection cannot
     /// commit or requeue a message destined for another consumer. The generation token still
     /// fences a stale op on an own-but-already-redelivered lease.
-    fn handle_ack<F: Filesystem + 'static, C: Clock + Clone + 'static, E: EngineAccess<F, C>>(
+    fn handle_ack<
+        F: Filesystem + Clone + 'static,
+        C: Clock + Clone + 'static,
+        E: EngineAccess<F, C>,
+    >(
         &mut self,
         engine: &E,
         body: &[u8],
@@ -907,6 +969,15 @@ impl Session {
         // reply 2 = cap reached). A status of 0 always means fenced: the token was stale (the message
         // already redelivered or was acked), so the client must NOT drop its state.
         let group = self.subscription.clone();
+        // A NAMED-stream consumer (#588) routes its ACK to the stream's OWN per-stream group cursor via
+        // the engine's id-routed `ack_in_stream` (#676/#679); the nack/term/progress and the egress-AIMD
+        // keep-up are the DEFAULT stream's lease machinery (the named path is plain ack-or-fence this
+        // phase, the #676 scope), so a named-stream consumer that sends one of those gets a fence rather
+        // than a cross-stream effect. The default stream (`self.stream` empty) is byte-for-byte unchanged.
+        let stream = self.stream.clone();
+        if !stream.is_empty() {
+            return self.handle_ack_in_stream(engine, stream, group, ack, &token, out);
+        }
         match ack.op {
             AckOp::Ack => {
                 let status = match engine.with(move |e| e.ack_in(&group, &token))? {
@@ -986,6 +1057,48 @@ impl Session {
                     }
                 };
                 reply(out, FrameType::AckStatus, &[status]);
+                Ok(())
+            }
+        }
+    }
+
+    /// The ACK path for a NAMED-stream consumer (#588, M2-I10): commits the ack `token` in the active
+    /// named stream's OWN per-stream work-group cursor via the engine's id-routed `ack_in_stream`
+    /// (#676/#679), connection-scoped exactly like the default-stream ack (the lease-ownership check ran
+    /// in [`Session::handle_ack`] before this is reached). The named consume path is plain ack-or-fence
+    /// this phase (no nack/term/progress per stream, the #676 scope), so those ops reply FENCED (status
+    /// 0) — a named-stream consumer that re-processes a message simply lets the lease expire and
+    /// redeliver, never crossing into the default stream's lease machinery.
+    fn handle_ack_in_stream<
+        F: Filesystem + Clone + 'static,
+        C: Clock + Clone + 'static,
+        E: EngineAccess<F, C>,
+    >(
+        &mut self,
+        engine: &E,
+        stream: GroupName,
+        group: GroupName,
+        ack: ironbus_proto::message::AckBody,
+        token: &LeaseToken,
+        out: &mut Vec<u8>,
+    ) -> Result<(), SessionError> {
+        match ack.op {
+            AckOp::Ack => {
+                let token = *token;
+                let status = match engine.with(move |e| e.ack_in_stream(&stream, &group, &token))? {
+                    AckResult::Acked => 1u8,
+                    AckResult::Fenced => 0u8,
+                };
+                self.leased.remove(&ack.offset);
+                reply(out, FrameType::AckStatus, &[status]);
+                Ok(())
+            }
+            // Nack/Term/Progress are not on the per-stream consume path this phase (#676 scope): fence
+            // them (status 0) rather than acting on the default stream's lease table. The lease expires
+            // and redelivers on schedule, so at-least-once for the named stream is preserved.
+            AckOp::Nack | AckOp::Term | AckOp::Progress => {
+                self.leased.remove(&ack.offset);
+                reply(out, FrameType::AckStatus, &[0]);
                 Ok(())
             }
         }
@@ -1192,6 +1305,20 @@ impl Session {
         if self.leased.is_empty() {
             return Ok(());
         }
+        // A NAMED-stream consumer (#588) prunes its leases by the stream's COMMITTED cursor rather than
+        // the default stream's per-lease active-lease probe: the #676 named consume path exposes the
+        // per-stream committed offset but not a per-stream `holds_active_lease_in`, so an offset at or
+        // below the named stream's committed watermark is dropped (it was acked), and an expired-but-
+        // not-committed lease stays — it is harmlessly re-leased and overwritten in `leased` on its
+        // redelivery. This keeps `leased` bounded for the named path without the default-stream probe.
+        if !self.stream.is_empty() {
+            let stream = self.stream.clone();
+            let group = self.subscription.clone();
+            let committed =
+                engine.with(move |e| e.committed_offset_in_stream(&stream, &group).get())?;
+            self.leased.retain(|&offset, _| offset >= committed);
+            return Ok(());
+        }
         let group = self.subscription.clone();
         let pairs: Vec<(u64, u64)> = self
             .leased
@@ -1323,9 +1450,25 @@ impl Session {
             // member id; for a plain competing group it is identical to poll_now_in, so the
             // KeyOrdering::None path is unchanged. One poll = one actor round-trip; the actor flushes
             // any pending produce batch first, so each poll sees a consistent durable head.
+            //
+            // A NAMED-stream consumer (#588) routes to the engine's id-routed `poll_in_stream` instead
+            // (its OWN log + per-stream competing work-group, #676/#679), reading the engine's monotonic
+            // `now` inside the job. The named path is plain competing (no key_shared/Tier-S/compaction
+            // this phase, the #676 scope), so it returns only `Poll::Message`/`Poll::Idle`/an error; the
+            // advisory arms below are unreachable for it but cost nothing. The default stream
+            // (`self.stream` empty) is byte-for-byte the existing member-aware poll.
             let group = self.subscription.clone();
             let member = self.member_id;
-            match engine.with(move |e| e.poll_now_in_member(&group, member))? {
+            let stream = self.stream.clone();
+            let poll = engine.with(move |e| {
+                if stream.is_empty() {
+                    e.poll_now_in_member(&group, member)
+                } else {
+                    let now = e.now_monotonic();
+                    e.poll_in_stream(&stream, &group, now)
+                }
+            })?;
+            match poll {
                 Ok(Poll::Message(d)) => {
                     let msg = DeliverBody {
                         offset: d.offset.get(),
@@ -1419,9 +1562,18 @@ impl Session {
             }
         }
         // Drop ownership of any offset now committed (acked here, or committed past on a
-        // dead-letter), keeping `leased` bounded to the in-flight window.
+        // dead-letter), keeping `leased` bounded to the in-flight window. A NAMED-stream consumer
+        // (#588) reads its OWN per-stream committed cursor; the default stream reads the default
+        // cursor byte-for-byte.
         let group = self.subscription.clone();
-        let committed = engine.with(move |e| e.committed_offset_in(&group).get())?;
+        let stream = self.stream.clone();
+        let committed = engine.with(move |e| {
+            if stream.is_empty() {
+                e.committed_offset_in(&group).get()
+            } else {
+                e.committed_offset_in_stream(&stream, &group).get()
+            }
+        })?;
         self.leased.retain(|&offset, _| offset >= committed);
         // CREDIT AUTO-TUNE keep-up (#552): the consumer was COUNT-BOUND by its own window (it asked for
         // at least the whole remaining window) AND drained the full grant it was given (`delivered ==
@@ -2055,6 +2207,11 @@ impl Session {
         // cap are validated by the engine on the first FLOW (#240), surfaced as an Err.
         self.subscription = GroupName::from(group);
         self.registered_subscription = !new_group.is_empty();
+        // A plain `Sub` binds the DEFAULT stream (#588): clear any named-stream binding a prior
+        // `SubTo` set, so this connection's Flow/Ack route to the default stream byte-for-byte. (An old
+        // client never sends `SubTo`, so `self.stream` is already default for it; this only matters for
+        // a streams-capable client switching from a named stream back to a plain default subscribe.)
+        self.stream = GroupName::default();
         self.leased.clear();
         // If the new group is configured key_shared (#64), put it into that mode and join as a
         // member so this connection's keys route to it. A failure to enable the mode (an invalid
@@ -2101,6 +2258,323 @@ impl Session {
         Ok(())
     }
 
+    /// Handles a `StreamDeclare` (#588, M2-I10): CREATE-OR-ENSURE a named stream by id, then reply a
+    /// body-less `Ok`. Routes to the engine's [`Engine::declare_stream`] (which `declare`s the named
+    /// stream in the [`StreamSet`], materializing its independent log + recovery; idempotent). GATED on
+    /// the negotiated streams capability and fail-closed: a client that did not advertise
+    /// `understands_streams` is refused; a malformed/over-long stream id is a typed `Err`; the EMPTY
+    /// name (the default stream, always present) is rejected as a malformed name (the default stream is
+    /// never declared this way). Never panics.
+    fn handle_stream_declare<
+        F: Filesystem + Clone + 'static,
+        C: Clock + Clone + 'static,
+        E: EngineAccess<F, C>,
+    >(
+        &mut self,
+        engine: &E,
+        body: &[u8],
+        out: &mut Vec<u8>,
+    ) -> Result<(), SessionError> {
+        if !self.connected {
+            reply_err(out, "not connected");
+            return Ok(());
+        }
+        if !self.streams_enabled {
+            reply_err(
+                out,
+                "stream addressing not negotiated (set understands_streams)",
+            );
+            return Ok(());
+        }
+        let Ok(decoded) = decode_stream_declare(body) else {
+            reply_err(out, "malformed stream-declare body");
+            return Ok(());
+        };
+        let Ok(stream) = core::str::from_utf8(decoded.stream_id) else {
+            reply_err(out, "stream id must be valid UTF-8");
+            return Ok(());
+        };
+        // The DEFAULT stream is always present and is NEVER declared via the named subtree (#588): an
+        // empty id is a malformed name here, not a silent success, so a client cannot conflate the
+        // default stream with a named one.
+        if stream.is_empty() {
+            reply_err(out, "cannot declare the default stream (empty id)");
+            return Ok(());
+        }
+        let stream = stream.to_string();
+        match engine.with(move |e| e.declare_stream(&stream))? {
+            // Idempotent: a first declare (`true`) and a re-declare (`false`) both reply a body-less Ok.
+            Ok(_) => reply(out, FrameType::Ok, &[]),
+            // A malformed/over-long NAMED name fails closed with the engine's typed reason.
+            Err(e) => reply_err(out, &e.to_string()),
+        }
+        Ok(())
+    }
+
+    /// Handles a `StreamInfo` query (#588, M2-I10): reply a `StreamInfo` RESPONSE frame carrying
+    /// whether the named stream EXISTS and, if so, its durable head offset. The default stream `""`
+    /// always reports `exists = true`. GATED on the negotiated streams capability; a malformed id is a
+    /// typed `Err`. Never panics, never declares (a query is read-only).
+    fn handle_stream_info<
+        F: Filesystem + Clone + 'static,
+        C: Clock + Clone + 'static,
+        E: EngineAccess<F, C>,
+    >(
+        &mut self,
+        engine: &E,
+        body: &[u8],
+        out: &mut Vec<u8>,
+    ) -> Result<(), SessionError> {
+        if !self.connected {
+            reply_err(out, "not connected");
+            return Ok(());
+        }
+        if !self.streams_enabled {
+            reply_err(
+                out,
+                "stream addressing not negotiated (set understands_streams)",
+            );
+            return Ok(());
+        }
+        let Ok(decoded) = decode_stream_info(body) else {
+            reply_err(out, "malformed stream-info body");
+            return Ok(());
+        };
+        let Ok(stream) = core::str::from_utf8(decoded.stream_id) else {
+            reply_err(out, "stream id must be valid UTF-8");
+            return Ok(());
+        };
+        let stream = stream.to_string();
+        // One round-trip reads both the existence bit and the durable head: the head is meaningful only
+        // when the stream exists, and `stream_head` reports `0` for an unknown/malformed stream (which
+        // the response folds with `exists = false`), so the two reads are consistent.
+        let (exists, head) =
+            engine.with(move |e| (e.stream_exists(&stream), e.stream_head(&stream).get()))?;
+        let resp = StreamInfoResponseBody { exists, head };
+        let mut resp_body = Vec::new();
+        encode_stream_info_response(&resp, &mut resp_body);
+        reply(out, FrameType::StreamInfo, &resp_body);
+        Ok(())
+    }
+
+    /// Handles a `PubTo` (#588, M2-I10): publish to a NAMED stream by id. The stream-id prefix is
+    /// stripped here and the verbatim `PubBody` tail is decoded with the UNCHANGED [`decode_pub`] codec,
+    /// so the publish body is shared byte-for-byte with the default-stream `Pub`. An EMPTY stream id is
+    /// exactly a default-stream publish and is routed to the existing [`Session::handle_pub`] path
+    /// (byte-for-byte today's behavior, including the pipelined window). A NAMED stream's append is
+    /// routed through the engine's id-routed [`Engine::produce_in_stream`] (which declares-on-first-
+    /// produce and commits via the cross-stream group-commit tick), via one actor `with` job so the
+    /// covering fsync is the engine's, not a parked window. GATED on the negotiated streams capability;
+    /// fail-closed on a malformed prefix or pub body. Never panics.
+    ///
+    /// SCOPE (#588): this is EXPLICIT-stream-id addressing only. The Level-2 confirm registry, the
+    /// dedup-id-cap pre-check, the CoDel/headroom shed taxonomy, and the pipelined window are the
+    /// DEFAULT stream's; a named-stream publish here is at-least-once Level-1-equivalent (a `PubAck`
+    /// after the named stream's covering fsync) and rejects an unsupported ack level. Per-stream
+    /// dedup / ack-levels / Tier-S are the flagged follow-ups (#681 and the #676 scope notes).
+    fn handle_pub_to<
+        F: Filesystem + Clone + 'static,
+        C: Clock + Clone + 'static,
+        E: EngineAccess<F, C>,
+    >(
+        &mut self,
+        engine: &E,
+        body: &[u8],
+        out: &mut Vec<u8>,
+    ) -> Result<(), SessionError> {
+        if !self.connected {
+            reply_err(out, "not connected");
+            return Ok(());
+        }
+        if !self.streams_enabled {
+            reply_err(
+                out,
+                "stream addressing not negotiated (set understands_streams)",
+            );
+            return Ok(());
+        }
+        let Ok(decoded) = decode_pub_to(body) else {
+            reply_err(out, "malformed pub-to body");
+            return Ok(());
+        };
+        // An EMPTY stream id is a default-stream publish: route the verbatim PubBody tail through the
+        // EXISTING default-stream produce path, byte-for-byte (#588 back-compat — a `PubTo("")` is
+        // indistinguishable from a plain `Pub` downstream).
+        if decoded.stream_id.is_empty() {
+            let mut parked = Vec::new();
+            self.handle_pub(engine, decoded.pub_body, &mut parked, out)?;
+            return drain_parked(engine, self.member_id, &mut parked, out);
+        }
+        let Ok(stream) = core::str::from_utf8(decoded.stream_id) else {
+            reply_err(out, "stream id must be valid UTF-8");
+            return Ok(());
+        };
+        let Ok(msg) = decode_pub(decoded.pub_body) else {
+            reply_err(out, "malformed pub body");
+            return Ok(());
+        };
+        // A named-stream publish is at-least-once Level-1-equivalent this phase: the no-ack (Level-0)
+        // and consumer-ack (Level-2) tiers are the default stream's, so a non-Level-1 ack level on a
+        // PubTo is refused rather than silently downgraded (the producer must use the default stream for
+        // those tiers, or wait for the per-stream ack-level follow-up).
+        if !matches!(pub_ack_level(msg.flags), AckLevel::ServerAck) {
+            reply_err(
+                out,
+                "named-stream publish supports only server-ack (level 1) this phase",
+            );
+            return Ok(());
+        }
+        // The dedup-id wire caps (#33), enforced at the boundary exactly as the default `handle_pub`
+        // does, BEFORE the bytes cross into owned storage.
+        if let Some(d) = msg.dedup.as_ref() {
+            if d.producer_id.len() > MAX_PRODUCER_ID_LEN {
+                reply_err(out, "producer_id too long");
+                return Ok(());
+            }
+            if d.msg_id.len() > MAX_MSG_ID_LEN {
+                reply_err(out, "msg_id too long");
+                return Ok(());
+            }
+        }
+        // Compressed-descriptor SHAPE validation at the wire boundary (#438), same gate as the default
+        // path: a stored compressed object must be decodable by every reader, or a consumer burns
+        // max-deliver cycles on it. A 9-byte header parse, NO decompression.
+        if RecordFlags::from_bits(msg.flags).contains(RecordFlags::COMPRESSED) {
+            if let Err(e) = validate_descriptor_shape(msg.payload, DEFAULT_MAX_DECOMPRESSED_BYTES) {
+                reply_err(out, &format!("malformed compressed descriptor: {e}"));
+                return Ok(());
+            }
+        }
+        // Build the OWNED append (the wire body borrows the connection buffer, which the closure
+        // cannot hold), then route it to the NAMED stream via the engine's id-routed produce in ONE
+        // actor job. `produce_in_stream` declares-on-first-produce and commits the named stream's log
+        // with the cross-stream group-commit tick, so the `PubAck` below is ack-implies-durable for the
+        // named stream (I2 per stream). The default stream's batched/pipelined produce path is entirely
+        // untouched — this is a separate, additive route reached only for a non-empty stream id.
+        let dedup = msg.dedup.map(|d| OwnedDedup {
+            producer_id: Bytes::copy_from_slice(d.producer_id),
+            epoch: d.epoch,
+            msg_id: Bytes::copy_from_slice(d.msg_id),
+        });
+        let append = OwnedAppend {
+            timestamp_ms: msg.timestamp_ms,
+            flags: msg.flags & !PUB_WIRE_ONLY_FLAGS,
+            key: Bytes::copy_from_slice(msg.key),
+            headers: Bytes::copy_from_slice(msg.headers),
+            payload: Bytes::copy_from_slice(msg.payload),
+            dedup,
+            enqueue_monotonic_nanos: engine.now_monotonic_nanos(),
+            fire_and_forget: false,
+        };
+        let stream = stream.to_string();
+        let outcome = engine.with(move |e| {
+            let view = Append {
+                timestamp_ms: append.timestamp_ms,
+                flags: RecordFlags::from_bits(append.flags),
+                key: &append.key,
+                headers: &append.headers,
+                payload: &append.payload,
+            };
+            e.produce_in_stream(&stream, &view)
+        })?;
+        match outcome {
+            Ok(offset) => {
+                let ack = PubAckBody {
+                    offset: offset.get(),
+                };
+                let mut ack_body = Vec::new();
+                encode_pub_ack(&ack, &mut ack_body);
+                reply(out, FrameType::PubAck, &ack_body);
+                Ok(())
+            }
+            // A fatal storage error on the named stream ends the session, exactly like the default
+            // produce path (a frozen writer / broken invariant is unrecoverable).
+            Err(e) if e.is_fatal() => {
+                reply_err(out, "fatal storage error");
+                Err(SessionError::EngineFatal(e))
+            }
+            // A malformed name or a non-fatal storage error (e.g. a byte-cap shed) is a typed,
+            // connection-preserving reject, never a panic.
+            Err(e) => {
+                reply_err(out, &e.to_string());
+                Ok(())
+            }
+        }
+    }
+
+    /// Handles a `SubTo` (#588, M2-I10): subscribe to a NAMED stream's per-stream work-group. Binds
+    /// BOTH `self.stream` (the named stream) and `self.subscription` (the work-group within it), so
+    /// this connection's subsequent `Flow`/`Ack` route to that stream's OWN competing work-group via
+    /// the engine's id-routed `poll_in_stream` / `ack_in_stream` (#676/#679 — the same group name in
+    /// two streams is two unrelated cursors). The named stream must already EXIST (a `StreamDeclare` or
+    /// a prior `PubTo` declared it); an unknown stream is an `Err`. An EMPTY stream id targets the
+    /// default stream and is equivalent to a plain `Sub`. GATED on the negotiated streams capability;
+    /// fail-closed on a malformed body. Never panics.
+    fn handle_sub_to<
+        F: Filesystem + Clone + 'static,
+        C: Clock + Clone + 'static,
+        E: EngineAccess<F, C>,
+    >(
+        &mut self,
+        engine: &E,
+        body: &[u8],
+        out: &mut Vec<u8>,
+    ) -> Result<(), SessionError> {
+        if !self.connected {
+            reply_err(out, "not connected");
+            return Ok(());
+        }
+        if !self.streams_enabled {
+            reply_err(
+                out,
+                "stream addressing not negotiated (set understands_streams)",
+            );
+            return Ok(());
+        }
+        let Ok(decoded) = decode_sub_to(body) else {
+            reply_err(out, "malformed sub-to body");
+            return Ok(());
+        };
+        // An EMPTY stream id is a default-stream subscribe: route through the EXISTING `handle_sub` so
+        // a `SubTo("", group)` is byte-for-byte a plain `Sub` (it also clears any prior named binding).
+        // A `Sub` body IS the raw group-name bytes (see `decode_sub`), so the decoded group slice is
+        // exactly the `Sub` body `handle_sub` expects.
+        if decoded.stream_id.is_empty() {
+            return self.handle_sub(engine, decoded.group, out);
+        }
+        let Ok(stream) = core::str::from_utf8(decoded.stream_id) else {
+            reply_err(out, "stream id must be valid UTF-8");
+            return Ok(());
+        };
+        let Ok(group) = core::str::from_utf8(decoded.group) else {
+            reply_err(out, "group name must be valid UTF-8");
+            return Ok(());
+        };
+        // The named stream must already exist: a SubTo binds a consume cursor, and consuming an
+        // unknown (never-declared) stream is a typed rejection, never a silent empty subscription.
+        let stream_owned = stream.to_string();
+        if !engine.with(move |e| e.stream_exists(&stream_owned))? {
+            reply_err(
+                out,
+                &format!("stream {stream:?} does not exist (declare or publish to it first)"),
+            );
+            return Ok(());
+        }
+        // Switching to a named stream abandons this connection's default-stream leases (they redeliver
+        // there after the visibility timeout); the named subscription starts clean. The per-stream
+        // work-group is created lazily on the first named poll under the per-stream group cap (#676).
+        self.stream = GroupName::from(stream);
+        self.subscription = GroupName::from(group);
+        // A named-stream consume is plain competing (#676): it does not register in the default-stream
+        // key_shared/broadcast subscriber sets, so leave any such default-stream membership/registration
+        // behind (a no-op for a connection that never had one) rather than stranding it.
+        self.registered_subscription = false;
+        self.joined_key_shared = false;
+        self.leased.clear();
+        reply(out, FrameType::Ok, &[]);
+        Ok(())
+    }
+
     fn handle_unsub<F: Filesystem + 'static, C: Clock + Clone + 'static, E: EngineAccess<F, C>>(
         &mut self,
         engine: &E,
@@ -2122,6 +2596,12 @@ impl Session {
         // It is a no-op for the default group, for a group still holding leases (they redeliver or
         // expire first, then the natural idle sweep reclaims it), and when eviction is disabled.
         let leaving = std::mem::take(&mut self.subscription);
+        // Clear any named-stream binding (#588): after an Unsub the connection reverts to the default
+        // stream, so a later Flow with no SubTo polls the default stream byte-for-byte. The named
+        // stream's per-stream work-group is NOT registered in the default-stream key_shared/broadcast/
+        // eviction structures (#676 named consume is plain competing only), so the leave/evict calls
+        // above are no-ops for it; only this local binding needs resetting.
+        self.stream = GroupName::default();
         self.leased.clear();
         if !leaving.is_empty() {
             engine.with(move |e| {
@@ -2778,6 +3258,7 @@ mod tests {
                 understands_streaming: false,
                 default_tier: None,
                 understands_deliver_batch: false,
+                understands_streams: false,
             },
             &mut body,
         );
@@ -3987,6 +4468,7 @@ mod tests {
                 understands_streaming,
                 default_tier: default_tier.map(ConsumeTier::as_u8),
                 understands_deliver_batch: false,
+                understands_streams: false,
             },
             &mut body,
         );
@@ -4143,6 +4625,7 @@ mod tests {
                 understands_streaming,
                 default_tier: None,
                 understands_deliver_batch,
+                understands_streams: false,
             },
             &mut body,
         );
@@ -6499,6 +6982,7 @@ mod tests {
                 understands_streaming: false,
                 default_tier: None,
                 understands_deliver_batch: false,
+                understands_streams: false,
             },
             &mut connect_body,
         );
@@ -7882,6 +8366,7 @@ mod tests {
                 understands_streaming: false,
                 default_tier: None,
                 understands_deliver_batch: false,
+                understands_streams: false,
             },
             &mut connect_body,
         );


### PR DESCRIPTION
Closes #588 (V2-M2, makes named streams client-reachable).

## What this does

Makes NAMED streams reachable from a client by **explicit stream id**, building on the engine's id-routed entry points (#676/#679) and the `StreamSet` substrate (#563). A streams-capable client can now `declare` a named stream, `publish-to` it, `subscribe-to` its per-stream work-group, consume, and ack — each routed to that stream's own log + cursor, fully isolated from every other stream and from the default stream.

## Frame design — new frames vs flag-bit (and why)

**Four NEW additive frame tags**, taking the next-free tags after the cluster-peer `Raft` frame (27):

| tag | frame | role |
|----|-------|------|
| 28 | `StreamDeclare` | create-or-ensure a named stream (idempotent) → `Ok` |
| 29 | `StreamInfo` | query existence + durable head (request/response share the tag) |
| 30 | `PubTo` | publish to a named stream by id (the stream-addressed twin of `Pub`) |
| 31 | `SubTo` | subscribe to a named stream's work-group (the twin of `Sub`) |

**Why new frames, not a flag-bit stream-id on Pub/Sub/Fetch:** the existing `Pub`/`Sub`/`Fetch`/`Deliver`/`StreamFetch`/`StreamCommit`/`DeliverBatch` wires stay **byte-for-byte unchanged** — an old client never sees a new tag, and the default path is not even conditionally re-encoded. `PubTo` carries the **verbatim `PubBody` tail** after its stream-id prefix, so the publish-body codec is shared *unchanged* with the default `Pub` (the session strips the prefix, then decodes the tail with the existing `decode_pub`). Each new body rides a `body_version: u8` + `field_len: u16` frame (the same forward-compat framing as `FetchBody`/`StreamFetchBody`): a v1 reader reads the known fields and **tolerates** a future version's appended bytes.

**Fail-closed decode:** the stream id is a `u16`-length field capped at `MAX_STREAM_ID_LEN` *before* any read, so a malformed/oversized id is a typed `BodyError` (`BadLength`/`Truncated`/`BadHandshakeVersion`), never a panic or over-read.

## Capability negotiation

A new `Connect` `UNDERSTANDS_STREAMS` bit (bit 7 of the handshake flags) with its server→client `Info` `STREAMS` echo. The negotiation is **AND**: `streams_enabled` is true only when the client advertised it *and* the server supports named streams. A client that did not advertise is **refused** the four verbs with a typed `Err` and uses only the default-stream verbs — it is never sent a streams reply it did not ask for. Distinct from `UNDERSTANDS_STREAMING` (the Tier-S consume *mode*, #543): this bit names multi-stream *addressing*.

## Session → engine wiring (#676/#679)

`session.rs` decodes the four frames and dispatches to the engine's id-routed methods (`produce_in_stream` / `poll_in_stream` / `ack_in_stream` / `committed_offset_in_stream`, plus two new `declare_stream` / `stream_exists` engine methods for the declare/info verbs). A `StreamDeclare` ensures the named stream (StreamSet `declare`, materializing its independent log + recovery); a `PubTo` appends to it (declare-on-first-produce, committed via the cross-stream group-commit tick); a `SubTo` binds the connection's consume path to that stream's per-stream `WorkGroup`; the Flow poll loop and the Ack path route through the id-routed engine methods when a named stream is active, and through the unchanged default-stream `poll_now_in_member` / `ack_in` when it is not.

`F: Clone` is threaded through `process`/`dispatch`/`serve` (and a couple of CLI helpers) because `StreamSet::declare` clones the fs to root each stream's log. This is a **no-op in practice**: every concrete filesystem (`StdFs`/`InMemoryFs`/`EphemeralFs`/`FaultFs`) is already `Clone`, exactly as `Engine::open` already requires.

## Back-compat — old client = default stream byte-identical

An OLD client (capability bit clear, plain `Pub`/`Sub`/`Fetch`, no stream-id field) targets the **default stream `""` byte-for-byte today**. A streams-capable client using the **empty stream id** on `PubTo`/`SubTo` routes through the existing default-stream handlers and lands in the same default offset space — proving the empty-id path *is* the default path. The engine default-`""` byte-identity (#679) is preserved.

## Tests

- **end-to-end over a real in-process server:** declare → publish → subscribe + consume via the stream's group → ack, with `StreamInfo` reporting the right existence/head along the way.
- **cross-stream isolation over the WIRE:** a publish to stream A is never seen by a consumer subscribed to stream B; the same connection switched to A then sees only A's record (independent per-stream cursor); the default stream stays empty.
- **old client = default stream byte-identical:** a classic `produce` and a streams-capable `publish_to("", …)` share one default offset space and are both consumed, in order, by the old client's plain default subscription.
- **capability negotiation:** advertised → confirmed; not advertised → off (and the verbs refused with a typed `Err`).
- **proto:** the new frames round-trip, tolerate a future appended field, and fail closed (empty body / unknown version / over-cap id / field-len past the body) — never a panic.

## Scope (explicitly bounded)

Explicit-stream-id addressing **only**:
- subject-addressed routing (by subject/wildcard) is **#585** — flagged, not here;
- partitions are **#586**;
- per-stream durable cursors are **#681**;
- named-stream consume is plain competing this phase (no key_shared / Tier-S / per-stream DLQ — the #676 scope); a named-stream publish is at-least-once server-ack (Level 1), with the Level-0 / Level-2 tiers staying the default stream's.

## Gate results

- `cargo fmt --all --check` — clean
- **FRESH** (post `cargo clean`) `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — clean (the four capability-flag structs carry a justified `allow(clippy::struct_excessive_bools)`: each bool is a distinct documented wire-ABI bit, not internal state)
- `cargo test --workspace --all-features --locked` — all pass. The only failure is a **pre-existing**, macOS-APFS-specific `ironbus-storage` `preallocate` flake (`F_PREALLOCATE` reserves fewer blocks than requested) in a crate this PR does **not** touch (byte-identical to `origin/main`); it passes on Linux CI where `fallocate` reserves exactly.

## What to scrutinize

- The `F: Clone` propagation through `process`/`dispatch`/`serve` — sound because every concrete `F` is `Clone`, but worth a second look.
- Named-stream produce routes through `engine.with(produce_in_stream)` (a direct engine append + its own `commit_tick`) rather than the default stream's batched/pipelined actor window — durable and ordered, but it does not yet share the default path's group-commit amortization (acceptable for initial reachability; per-stream Tier-S is a follow-up).
- The named-stream consumer's stale-lease pruning is by committed cursor (the #676 path exposes no per-stream `holds_active_lease_in`), and nack/term/progress on a named stream fence (the engine offers only ack-or-fence per stream this phase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVWp2H2txnKGru4q2twxM3
