### PR TITLE
feat(routing): subject->stream binding + fail-closed single-home resolution (#585)

### DIFF
--- a/crates/ironbus-core/src/binding.rs
+++ b/crates/ironbus-core/src/binding.rs
@@ -1,0 +1,292 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! Subject->stream binding + fail-closed single-home resolution (#585, V2-M2-I9).
+//!
+//! This is the routing POLICY that sits on top of the wait-free trie ([`crate::sublist`]) and the
+//! per-connection resolve cache ([`crate::resolve_cache`]): given a literal [`Subject`], it answers the
+//! ONE question a publish needs — *which single stream stores this record?* — as a TOTAL function with
+//! explicit, typed outcomes.
+//!
+//! # The binding
+//!
+//! A *binding* is a `(SubjectPattern -> target)` registration in the trie: a stream that BINDS
+//! `order.>` and `payment.*.done` registers those two patterns with its own id as the target. The
+//! binding table IS a [`Sublist`](crate::sublist::Sublist): `target = T` is the stream id (the trie is
+//! generic, so `ironbus-core` stays IO-free and never names a storage type). Adding or removing a
+//! binding rebuilds the immutable trie and swaps a fresh [`SublistSnapshot`](crate::sublist) generation
+//! in — which is exactly the signal the per-connection [`ResolveCache`](crate::resolve_cache) watches to
+//! drop a stale routing answer, so a bind change can never leave a connection routing to the old stream.
+//!
+//! # Single-home resolution (the default, fail-closed)
+//!
+//! A publish to a literal subject resolves to the *set* of bound streams (the trie match), then this
+//! module reduces that set to a single destination under the SINGLE-HOME default:
+//!
+//! * **exactly one** bound stream -> [`Resolution::Routed`] (route the record there);
+//! * **zero** bound streams -> [`Resolution::NoStream`] — a typed, FAIL-CLOSED reject, NOT a silent
+//!   drop. This is the explicit beat over NATS, which silently discards a publish to a subject with no
+//!   matching interest while still returning a successful `PubAck`: the producer believes the message
+//!   landed when it vanished. IronBus refuses the publish with a typed error so the producer learns
+//!   immediately that the subject is unbound;
+//! * **two or more** bound streams -> [`Resolution::Ambiguous`] — also a typed reject under the
+//!   single-home default, because storing one record requires ONE unambiguous destination log. The
+//!   `overlap_ok` opt-in FAN-OUT (publish the record to every bound stream) is a SEPARATE, later issue;
+//!   the single-home default refuses rather than guessing or silently fanning out.
+//!
+//! Resolution is therefore a total function: every literal subject maps to exactly one of the three
+//! outcomes, none of which is a silent drop or a panic. That totality is the first-principles reason the
+//! primitive lives here, beside the grammar ([`crate::subject`]) and the trie it reduces.
+//!
+//! # IO-free
+//!
+//! This module is pure compute: it inspects a borrowed target slice (or a trie match) and returns a
+//! decision. It touches no filesystem, network, clock, process, or async runtime, so it stays inside
+//! `ironbus-core`'s IO-free invariant (enforced by `tools/io-free-check`). The wire framing and the
+//! storage-side wiring (mapping the resolved `T` to a real stream log) land in `ironbus-server`.
+
+use crate::resolve_cache::ResolveCache;
+use crate::subject::Subject;
+use crate::sublist::SublistSnapshot;
+
+/// The outcome of resolving a literal [`Subject`] to a single bound stream under the single-home
+/// default. A TOTAL function: a subject is always exactly one of these, never a silent drop or a panic.
+///
+/// `T` is the routing target the trie carries (the stream id; a `Clone`-able opaque value here). The
+/// `Routed` variant hands back the single resolved target; the two reject variants are the fail-closed
+/// beat over NATS's silent-drop — a publish that resolves to zero or many streams is REFUSED with a
+/// typed reason, never accepted-and-discarded.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Resolution<T> {
+    /// EXACTLY ONE bound stream matched: route the record to `target`.
+    Routed(T),
+    /// ZERO bound streams matched: a fail-closed reject (`NoStreamForSubject` on the wire). The publish
+    /// is REFUSED, not silently dropped — the explicit beat over NATS, which would discard it while
+    /// acking success. The producer must bind the subject to a stream first.
+    NoStream,
+    /// TWO OR MORE bound streams matched: a fail-closed reject (`AmbiguousSubject` on the wire) under the
+    /// single-home default, because one record needs one unambiguous destination log. Carries the number
+    /// of streams that matched so a caller (and an operator) can see HOW ambiguous the binding set is.
+    /// The opt-in `overlap_ok` fan-out is a separate, later feature; until then an ambiguous subject is
+    /// refused rather than fanned out or guessed.
+    Ambiguous {
+        /// How many bound streams matched the subject (always `>= 2` for this variant).
+        matched: usize,
+    },
+}
+
+impl<T> Resolution<T> {
+    /// The single routed target, or `None` for either reject. A convenience for a caller that only
+    /// cares about the happy path.
+    #[must_use]
+    pub fn routed(self) -> Option<T> {
+        match self {
+            Resolution::Routed(t) => Some(t),
+            Resolution::NoStream | Resolution::Ambiguous { .. } => None,
+        }
+    }
+
+    /// Whether this resolution is the happy-path single route.
+    #[must_use]
+    pub const fn is_routed(&self) -> bool {
+        matches!(self, Resolution::Routed(_))
+    }
+}
+
+/// Reduces a slice of matched targets to a single-home [`Resolution`], the FAIL-CLOSED core decision:
+/// zero matches -> [`Resolution::NoStream`], exactly one -> [`Resolution::Routed`], two or more ->
+/// [`Resolution::Ambiguous`]. This is the one place the single-home policy lives, shared by the cached
+/// and uncached resolve paths so they can never disagree.
+///
+/// The slice is the trie's match result for a literal subject (every bound stream whose pattern matched).
+/// It is reduced WITHOUT allocating and without inspecting target identity beyond counting — two
+/// DISTINCT streams binding the same subject is ambiguous, and so is one stream that (pathologically)
+/// registered two patterns both matching the subject; either way a single record cannot pick one
+/// destination, so both are refused under the single-home default. (Deduplicating a single stream that
+/// matched via two of its own patterns into one route is a refinement the binding API avoids by not
+/// registering a stream's overlapping patterns; it is called out in the #585 scope, not silently
+/// collapsed here.)
+#[must_use]
+pub fn single_home<T: Clone>(matched: &[T]) -> Resolution<T> {
+    match matched {
+        [] => Resolution::NoStream,
+        [one] => Resolution::Routed(one.clone()),
+        many => Resolution::Ambiguous {
+            matched: many.len(),
+        },
+    }
+}
+
+/// Resolves `subject` to a single-home [`Resolution`] DIRECTLY against `snapshot` (no cache): one
+/// wait-free trie walk, then the single-home reduction. Use this for a cold or one-shot resolve; a hot
+/// publisher should use [`resolve_single_home_cached`] so the steady-state resolve is O(1).
+///
+/// This is the uncached twin of [`resolve_single_home_cached`] and shares the exact [`single_home`]
+/// reduction, so the two return identical outcomes for the same subject + routing table.
+#[must_use]
+pub fn resolve_single_home<T: Clone>(
+    snapshot: &SublistSnapshot<T>,
+    subject: &Subject<'_>,
+) -> Resolution<T> {
+    let mut matched = Vec::new();
+    snapshot.match_into(subject, &mut matched);
+    single_home(&matched)
+}
+
+/// Resolves `subject` to a single-home [`Resolution`] THROUGH the per-connection resolve cache: a cache
+/// HIT is an O(1) hash lookup with NO trie walk (and no global cache flush on a bind change), a MISS
+/// walks the trie once and caches the targets. The single-home reduction runs over the cached target
+/// slice WITHOUT cloning the whole `Vec` (the reduction clones only the ONE routed target on the happy
+/// path), via [`ResolveCache::resolve_with`].
+///
+/// # Why this beats NATS's per-publish global Sublist walk
+///
+/// NATS resolves EVERY publish through its shared `Sublist` (under a read lock) and flushes a global
+/// results cache on every subscription change. Here the trie is wait-free and carries NO shared cache;
+/// the cache is per-connection and generation-guarded, so steady-state resolution is O(1) and a bind
+/// change costs a single generation-compare on the next publish (the cache drops its stale answers
+/// lazily) rather than a global flush. A bind change therefore NEVER leaves this connection routing to a
+/// stale stream: the next resolve sees the advanced [`SublistSnapshot`](crate::sublist) generation, drops
+/// the cached answer, and re-resolves against the new table.
+#[must_use]
+pub fn resolve_single_home_cached<T: Clone>(
+    cache: &mut ResolveCache<T>,
+    snapshot: &SublistSnapshot<T>,
+    subject: &Subject<'_>,
+) -> Resolution<T> {
+    cache.resolve_with(snapshot, subject, single_home)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sublist::{Sublist, SublistBuilder};
+
+    /// Build a binding trie from `(pattern, stream-id)` pairs. `T` here is a `u32` stand-in for a stream
+    /// id (the server wires the real `StreamId`); the trie is generic, so the policy is identical.
+    fn bindings(entries: &[(&str, u32)]) -> Sublist<u32> {
+        let mut b = SublistBuilder::new();
+        for (p, t) in entries {
+            b.insert(p, *t).expect("valid binding pattern");
+        }
+        b.build(0).expect("binding set within fork bound")
+    }
+
+    fn subject(s: &str) -> Subject<'_> {
+        Subject::parse_literal(s).expect("valid literal subject")
+    }
+
+    #[test]
+    fn single_bound_stream_routes() {
+        // "orders" binds "order.>"; a publish to "order.us.created" routes to exactly that stream.
+        let snap = SublistSnapshot::new(bindings(&[("order.>", 42)]));
+        assert_eq!(
+            resolve_single_home(&snap, &subject("order.us.created")),
+            Resolution::Routed(42)
+        );
+    }
+
+    #[test]
+    fn unbound_subject_is_no_stream_not_a_silent_drop() {
+        // No binding matches: a FAIL-CLOSED NoStream reject, never a silent drop (the beat over NATS).
+        let snap = SublistSnapshot::new(bindings(&[("order.>", 42)]));
+        assert_eq!(
+            resolve_single_home(&snap, &subject("telemetry.cpu")),
+            Resolution::NoStream
+        );
+        // An EMPTY binding table refuses everything fail-closed (nothing is bound yet).
+        let empty = SublistSnapshot::<u32>::empty();
+        assert_eq!(
+            resolve_single_home(&empty, &subject("anything")),
+            Resolution::NoStream
+        );
+    }
+
+    #[test]
+    fn subject_bound_to_two_streams_is_ambiguous() {
+        // TWO distinct streams both bind a pattern matching the subject: single-home refuses with the
+        // typed AmbiguousSubject, carrying the match count.
+        let snap = SublistSnapshot::new(bindings(&[("order.>", 1), ("order.us.*", 2)]));
+        assert_eq!(
+            resolve_single_home(&snap, &subject("order.us.created")),
+            Resolution::Ambiguous { matched: 2 }
+        );
+        // A subject only the first pattern covers is unambiguous again.
+        assert_eq!(
+            resolve_single_home(&snap, &subject("order.eu.created")),
+            Resolution::Routed(1)
+        );
+    }
+
+    #[test]
+    fn single_home_reduction_is_total() {
+        assert_eq!(single_home::<u32>(&[]), Resolution::NoStream);
+        assert_eq!(single_home(&[7u32]), Resolution::Routed(7));
+        assert_eq!(
+            single_home(&[7u32, 8, 9]),
+            Resolution::Ambiguous { matched: 3 }
+        );
+    }
+
+    #[test]
+    fn cached_resolution_equals_uncached_and_hits_without_walking() {
+        let snap = SublistSnapshot::new(bindings(&[
+            ("order.>", 1),
+            ("payment.*.done", 2),
+            ("metric.cpu", 3),
+        ]));
+        let mut cache = ResolveCache::new();
+        for s in [
+            "order.us.created",
+            "payment.visa.done",
+            "metric.cpu",
+            "unbound.subject",
+        ] {
+            let subj = subject(s);
+            let want = resolve_single_home(&snap, &subj);
+            // MISS then HIT both equal the uncached oracle.
+            assert_eq!(resolve_single_home_cached(&mut cache, &snap, &subj), want);
+            assert_eq!(resolve_single_home_cached(&mut cache, &snap, &subj), want);
+        }
+        // Every subject was walked exactly once (the second touch HIT without a walk).
+        assert_eq!(cache.walk_count(), 4);
+    }
+
+    #[test]
+    fn a_bind_change_invalidates_the_cache_no_stale_routing() {
+        // Bind "order.>" -> stream 1, cache the route, then REBIND "order.>" -> stream 2. The next
+        // resolve must route to the NEW stream, never the stale 1 (the generation guard drops it).
+        let snap = SublistSnapshot::new(bindings(&[("order.>", 1)]));
+        let mut cache = ResolveCache::new();
+        let subj = subject("order.us.created");
+        assert_eq!(
+            resolve_single_home_cached(&mut cache, &snap, &subj),
+            Resolution::Routed(1)
+        );
+        assert_eq!(cache.walk_count(), 1);
+
+        // A bind change: rebuild the trie so "order.>" now targets stream 2, swap it in (the snapshot
+        // advances its generation on store).
+        snap.store(bindings(&[("order.>", 2)]));
+        assert_eq!(
+            resolve_single_home_cached(&mut cache, &snap, &subj),
+            Resolution::Routed(2),
+            "no stale routing after a rebind"
+        );
+        assert_eq!(cache.walk_count(), 2, "the bind change forced one re-walk");
+
+        // Add a SECOND binding for the same subject: it becomes ambiguous, and the cache reflects it.
+        snap.store(bindings(&[("order.>", 2), ("order.us.created", 3)]));
+        assert_eq!(
+            resolve_single_home_cached(&mut cache, &snap, &subj),
+            Resolution::Ambiguous { matched: 2 }
+        );
+    }
+
+    #[test]
+    fn resolution_accessors() {
+        assert_eq!(Resolution::Routed(5u32).routed(), Some(5));
+        assert!(Resolution::Routed(5u32).is_routed());
+        assert_eq!(Resolution::<u32>::NoStream.routed(), None);
+        assert!(!Resolution::<u32>::NoStream.is_routed());
+        assert_eq!(Resolution::<u32>::Ambiguous { matched: 2 }.routed(), None);
+    }
+}

--- a/crates/ironbus-core/src/lib.rs
+++ b/crates/ironbus-core/src/lib.rs
@@ -11,6 +11,7 @@ pub(crate) mod raw;
 
 pub mod attempt;
 pub mod backpressure;
+pub mod binding;
 pub mod clock;
 pub mod codec;
 pub mod compress;

--- a/crates/ironbus-proto/src/frame.rs
+++ b/crates/ironbus-proto/src/frame.rs
@@ -252,6 +252,43 @@ pub enum FrameType {
     /// this is an ADDITIVE tag an old client never sends. Body: a [`crate::message::SubToBody`]
     /// (`body_version: u8`, `field_len: u16` over `stream_id` then `group`, each u16-length-prefixed).
     SubTo,
+    /// Client request to BIND a subject PATTERN to a stream (#585, V2-M2-I9): the subject-routing
+    /// "bind" verb that completes the subjects story. The broker registers `(pattern -> stream)` in its
+    /// wait-free routing trie (rebuilding it and advancing the routing generation, which invalidates
+    /// every connection's resolve cache) and `declare`s the target stream, replying a body-less
+    /// [`FrameType::Ok`] on success or [`FrameType::Err`] on a malformed pattern / stream name or a
+    /// fork-bound rejection (fail-closed, never a panic). Idempotent: re-binding the same
+    /// `(pattern, stream)` pair is a no-op success. The `pattern` is a #567 PATTERN (wildcards `*`/`>`
+    /// allowed); the `stream` is the bound stream (the empty name binds the DEFAULT stream). It is a NEW
+    /// append-only request tag: an old client never sends it, and tags 1-31 are byte-for-byte unchanged.
+    /// Body: a [`crate::message::BindSubjectBody`] (`body_version: u8`, `field_len: u16`, then
+    /// `stream_id` and `pattern`, each u16-length-prefixed).
+    BindSubject,
+    /// Producer publish BY SUBJECT (#585, V2-M2-I9): the subject-ADDRESSED twin of [`FrameType::PubTo`]
+    /// (tag 30). It carries a literal `subject` followed by the verbatim [`crate::message::PubBody`]
+    /// bytes (so the publish body codec is shared UNCHANGED with `Pub`/`PubTo`). The broker resolves the
+    /// subject through the binding trie under the FAIL-CLOSED single-home default — EXACTLY ONE bound
+    /// stream routes the append there (via the id-routed `produce_in_stream`), ZERO is an
+    /// `ERR_NO_STREAM_FOR_SUBJECT` reject (the explicit beat over NATS's silent drop), two-or-more is an
+    /// `ERR_AMBIGUOUS_SUBJECT` reject — and replies the SAME [`FrameType::PubAck`] (or [`FrameType::Err`])
+    /// a `PubTo` returns. Resolution rides the connection's generation-guarded resolve cache, so
+    /// steady-state routing is O(1). It is a NEW append-only tag an old client never sends; the existing
+    /// `Pub` (tag 5) / `PubTo` (tag 30) wires are unchanged. Body: a [`crate::message::PubSubjectBody`]
+    /// (`body_version: u8`, `field_len: u16` over the `subject` u16-length name, then the verbatim
+    /// `PubBody` bytes as the remainder).
+    PubSubject,
+    /// Consumer subscribe BY SUBJECT (#585, V2-M2-I9): the subject-ADDRESSED twin of [`FrameType::SubTo`]
+    /// (tag 31). It carries a `subject` (literal or WILDCARD pattern) plus the work-`group` name. The
+    /// broker resolves the subject through the binding trie: a LITERAL subject resolves single-home to
+    /// ONE bound stream and binds this connection's subsequent `Flow`/`Ack` to that stream's own
+    /// competing work-group (via the id-routed `poll_in_stream`/`ack_in_stream`); an unbound subject is
+    /// an `ERR_NO_STREAM_FOR_SUBJECT` reject and an ambiguous one an `ERR_AMBIGUOUS_SUBJECT` reject
+    /// (single-home — fanning a wildcard sub over multiple streams is the flagged follow-up). The reply
+    /// is a body-less [`FrameType::Ok`] on a resolved bind, else [`FrameType::Err`]. It is a NEW
+    /// append-only tag an old client never sends; the existing `Sub` (tag 6) / `SubTo` (tag 31) wires
+    /// are unchanged. Body: a [`crate::message::SubSubjectBody`] (`body_version: u8`, `field_len: u16`
+    /// over `subject` then `group`, each u16-length-prefixed).
+    SubSubject,
 }
 
 impl FrameType {
@@ -290,6 +327,9 @@ impl FrameType {
             FrameType::StreamInfo => 29,
             FrameType::PubTo => 30,
             FrameType::SubTo => 31,
+            FrameType::BindSubject => 32,
+            FrameType::PubSubject => 33,
+            FrameType::SubSubject => 34,
         }
     }
 
@@ -329,6 +369,9 @@ impl FrameType {
             29 => FrameType::StreamInfo,
             30 => FrameType::PubTo,
             31 => FrameType::SubTo,
+            32 => FrameType::BindSubject,
+            33 => FrameType::PubSubject,
+            34 => FrameType::SubSubject,
             _ => return None,
         })
     }
@@ -461,7 +504,7 @@ mod tests {
     use super::*;
     use proptest::prelude::*;
 
-    const ALL_TYPES: [FrameType; 31] = [
+    const ALL_TYPES: [FrameType; 34] = [
         FrameType::Connect,
         FrameType::Info,
         FrameType::Ping,
@@ -493,6 +536,9 @@ mod tests {
         FrameType::StreamInfo,
         FrameType::PubTo,
         FrameType::SubTo,
+        FrameType::BindSubject,
+        FrameType::PubSubject,
+        FrameType::SubSubject,
     ];
 
     #[test]
@@ -542,6 +588,36 @@ mod tests {
         assert_eq!(FrameType::StreamInfo.as_u8(), 29);
         assert_eq!(FrameType::PubTo.as_u8(), 30);
         assert_eq!(FrameType::SubTo.as_u8(), 31);
+        assert_eq!(FrameType::BindSubject.as_u8(), 32);
+        assert_eq!(FrameType::PubSubject.as_u8(), 33);
+        assert_eq!(FrameType::SubSubject.as_u8(), 34);
+    }
+
+    #[test]
+    fn subject_routing_tags_are_the_next_free_tags_after_subto() {
+        // #585 (M2-I9): the subject-addressed verbs BindSubject (32), PubSubject (33), and SubSubject
+        // (34) take the next FREE tags after the explicit-stream-id SubTo (31). Pinned here so a future
+        // reorder breaks a test, not a deployed protocol. They are ADDITIVE: tags 1-31 are unchanged.
+        assert_eq!(FrameType::from_u8(32), Some(FrameType::BindSubject));
+        assert_eq!(FrameType::from_u8(33), Some(FrameType::PubSubject));
+        assert_eq!(FrameType::from_u8(34), Some(FrameType::SubSubject));
+        // 35 is the new next-free tag (still unknown), so it frames but is not a known type.
+        assert_eq!(FrameType::from_u8(35), None);
+        for ty in [
+            FrameType::BindSubject,
+            FrameType::PubSubject,
+            FrameType::SubSubject,
+        ] {
+            let mut buf = Vec::new();
+            encode_frame(ty, b"\x0b\x0c", &mut buf).unwrap();
+            match decode_frame(&buf).unwrap() {
+                FrameDecode::Frame { type_tag, body, .. } => {
+                    assert_eq!(FrameType::from_u8(type_tag), Some(ty));
+                    assert_eq!(body, b"\x0b\x0c");
+                }
+                FrameDecode::Incomplete { .. } => panic!("complete"),
+            }
+        }
     }
 
     #[test]
@@ -560,8 +636,9 @@ mod tests {
         // The default-stream verbs are untouched.
         assert_eq!(FrameType::Pub.as_u8(), 5);
         assert_eq!(FrameType::Sub.as_u8(), 6);
-        // 32 is the new next-free tag (still unknown), so it frames but is not a known type.
-        assert_eq!(FrameType::from_u8(32), None);
+        // Tags 32-34 are now the subject-routing verbs (#585); 35 is the next-free unknown tag.
+        assert_eq!(FrameType::from_u8(32), Some(FrameType::BindSubject));
+        assert_eq!(FrameType::from_u8(35), None);
         for ty in [
             FrameType::StreamDeclare,
             FrameType::StreamInfo,
@@ -633,9 +710,10 @@ mod tests {
         // The Tier-W verbs are untouched.
         assert_eq!(FrameType::Flow.as_u8(), 10);
         assert_eq!(FrameType::Fetch.as_u8(), 23);
-        // 32 is the new next-free tag (still unknown), so it frames but is not a known type. (Tags 27
-        // = cluster-peer Raft #667; 28-31 = the stream-addressed verbs #588.)
-        assert_eq!(FrameType::from_u8(32), None);
+        // 35 is the next-free tag (still unknown), so it frames but is not a known type. (Tags 27 =
+        // cluster-peer Raft #667; 28-31 = the stream-addressed verbs #588; 32-34 = the subject-routing
+        // verbs #585.)
+        assert_eq!(FrameType::from_u8(35), None);
         for ty in [FrameType::StreamFetch, FrameType::StreamCommit] {
             let mut buf = Vec::new();
             encode_frame(ty, b"\x07\x08", &mut buf).unwrap();
@@ -659,9 +737,10 @@ mod tests {
         assert_eq!(FrameType::from_u8(26), Some(FrameType::DeliverBatch));
         // The per-record Deliver tag is untouched.
         assert_eq!(FrameType::Deliver.as_u8(), 13);
-        // 32 is the next-free tag (still unknown), so it frames but is not a known type. (Tags 27 =
-        // cluster-peer Raft #667; 28-31 = the stream-addressed verbs #588.)
-        assert_eq!(FrameType::from_u8(32), None);
+        // 35 is the next-free tag (still unknown), so it frames but is not a known type. (Tags 27 =
+        // cluster-peer Raft #667; 28-31 = the stream-addressed verbs #588; 32-34 = the subject-routing
+        // verbs #585.)
+        assert_eq!(FrameType::from_u8(35), None);
         let mut buf = Vec::new();
         encode_frame(FrameType::DeliverBatch, b"\x09\x0a", &mut buf).unwrap();
         match decode_frame(&buf).unwrap() {
@@ -856,7 +935,7 @@ mod tests {
         /// An unknown type tag still decodes at the envelope level (forward compatibility):
         /// the body and length are recovered; only `from_u8` reports it unknown.
         #[test]
-        fn an_unknown_type_tag_still_frames(tag in 32u8..=255, body in prop::collection::vec(any::<u8>(), 0..256)) {
+        fn an_unknown_type_tag_still_frames(tag in 35u8..=255, body in prop::collection::vec(any::<u8>(), 0..256)) {
             let frame_len = 1u32 + u32::try_from(body.len()).unwrap();
             let mut buf = frame_len.to_le_bytes().to_vec();
             buf.push(tag);

--- a/crates/ironbus-proto/src/message.rs
+++ b/crates/ironbus-proto/src/message.rs
@@ -2111,6 +2111,188 @@ pub fn decode_sub_to(body: &[u8]) -> Result<SubToBody<'_>, BodyError> {
     Ok(SubToBody { stream_id, group })
 }
 
+// ===================================================================================
+// SUBJECT-ADDRESSED WIRE BODIES (#585, V2-M2-I9): the subject->stream binding + subject-addressed
+// pub/sub verbs that complete the SUBJECTS story — BindSubject (tag 32), PubSubject (tag 33), SubSubject
+// (tag 34). Each rides the SAME `body_version: u8` + `field_len: u16` frame as the explicit-stream-id
+// verbs (#588), so a future version appends fields without a wire break. A subject/pattern field is a
+// `u16`-length-prefixed byte field capped at [`MAX_STREAM_ID_LEN`] BEFORE any read (fail-closed): a
+// malformed/oversized subject is a typed [`BodyError`], never a panic or over-read. The server further
+// validates a subject through the #567 grammar; the wire cap only stops an absurdly long field. These are
+// ADDITIVE tags an old client never sends; the explicit-stream-id verbs (tags 28-31) are unchanged.
+// ===================================================================================
+
+/// Reads a `u16`-length-prefixed subject/pattern field, reusing [`MAX_STREAM_ID_LEN`] as the wire cap
+/// (#585). A declared length over the cap is a typed [`BodyError::BadLength`] (fail-closed) BEFORE the
+/// bytes are taken; a short body is [`BodyError::Truncated`] via [`Reader::take`]. The slice borrows the
+/// body (zero-copy). The server's #567 grammar is the real validator; this only fails a hostile length.
+fn read_subject<'a>(r: &mut Reader<'a>) -> Result<&'a [u8], BodyError> {
+    let len = r.u16()? as usize;
+    if len > MAX_STREAM_ID_LEN {
+        return Err(BodyError::BadLength);
+    }
+    r.take(len)
+}
+
+/// A client's request to BIND a subject PATTERN to a stream (the `BindSubject` frame body, tag 32,
+/// #585): an explicit `stream_id` (the empty name binds the DEFAULT stream) and a `pattern` (#567
+/// pattern, wildcards allowed). The broker registers `(pattern -> stream)` and replies `Ok`, or `Err`
+/// on a malformed pattern / stream name or a fork-bound rejection.
+///
+/// Layout (version+length framed): `body_version: u8`, `field_len: u16`, then the v1 block:
+/// `stream_id: u16-len + bytes`, `pattern: u16-len + bytes`. Trailing block bytes are tolerated.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct BindSubjectBody<'a> {
+    /// The bound stream's name (empty binds the default stream), validated server-side.
+    pub stream_id: &'a [u8],
+    /// The subject PATTERN to bind (#567 pattern, validated server-side).
+    pub pattern: &'a [u8],
+}
+
+/// Encodes a `BindSubject` body onto the end of `out` (#585).
+///
+/// # Errors
+/// Returns [`BodyError::FieldTooLarge`] if the stream id or pattern exceeds the `u16` wire limit.
+pub fn encode_bind_subject(req: &BindSubjectBody<'_>, out: &mut Vec<u8>) -> Result<(), BodyError> {
+    let id_len = u16::try_from(req.stream_id.len()).map_err(|_| BodyError::FieldTooLarge)?;
+    let pat_len = u16::try_from(req.pattern.len()).map_err(|_| BodyError::FieldTooLarge)?;
+    let field_len = u16::try_from(2 + req.stream_id.len() + 2 + req.pattern.len())
+        .map_err(|_| BodyError::FieldTooLarge)?;
+    out.push(STREAM_WIRE_BODY_VERSION);
+    out.extend_from_slice(&field_len.to_le_bytes());
+    out.extend_from_slice(&id_len.to_le_bytes());
+    out.extend_from_slice(req.stream_id);
+    out.extend_from_slice(&pat_len.to_le_bytes());
+    out.extend_from_slice(req.pattern);
+    Ok(())
+}
+
+/// Decodes a `BindSubject` body (#585), cap-before-alloc and panic-free. A short body or an over-cap
+/// field is a typed [`BodyError`]; an EMPTY body is [`BodyError::Truncated`].
+///
+/// # Errors
+/// [`BodyError::Truncated`] for a short body, [`BodyError::BadLength`] for an over-cap field, or
+/// [`BodyError::BadHandshakeVersion`] for an unknown body version.
+pub fn decode_bind_subject(body: &[u8]) -> Result<BindSubjectBody<'_>, BodyError> {
+    let mut r = Reader::new(body);
+    let version = r.u8()?;
+    if version != STREAM_WIRE_BODY_VERSION {
+        return Err(BodyError::BadHandshakeVersion { version });
+    }
+    let field_len = r.u16()? as usize;
+    let block = r.take(field_len)?;
+    let mut fr = Reader::new(block);
+    let stream_id = read_stream_id(&mut fr)?;
+    let pattern = read_subject(&mut fr)?;
+    Ok(BindSubjectBody { stream_id, pattern })
+}
+
+/// A producer's publish BY SUBJECT (the `PubSubject` frame body, tag 33, #585): a literal `subject`
+/// followed by the verbatim [`PubBody`] bytes (decoded by the caller with [`decode_pub`], so the publish
+/// body codec is shared UNCHANGED with `Pub`/`PubTo`). The broker resolves the subject single-home to one
+/// bound stream and routes the append there (or rejects unbound/ambiguous, fail-closed).
+///
+/// Layout (version+length framed): `body_version: u8`, `field_len: u16` (over the `subject` field ONLY),
+/// then the v1 block: `subject: u16-len + bytes`; then the verbatim `PubBody` bytes as the REMAINDER.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PubSubjectBody<'a> {
+    /// The literal subject to publish on (validated #567 literal server-side).
+    pub subject: &'a [u8],
+    /// The verbatim [`PubBody`] bytes, decoded by the caller with [`decode_pub`].
+    pub pub_body: &'a [u8],
+}
+
+/// Encodes a `PubSubject` body onto the end of `out` (#585): the version byte, the field-block length
+/// over the subject, the subject, then the verbatim `pub_body` bytes.
+///
+/// # Errors
+/// Returns [`BodyError::FieldTooLarge`] if the subject exceeds the `u16` wire limit.
+pub fn encode_pub_subject(req: &PubSubjectBody<'_>, out: &mut Vec<u8>) -> Result<(), BodyError> {
+    let subj_len = u16::try_from(req.subject.len()).map_err(|_| BodyError::FieldTooLarge)?;
+    let field_len = u16::try_from(2 + req.subject.len()).map_err(|_| BodyError::FieldTooLarge)?;
+    out.push(STREAM_WIRE_BODY_VERSION);
+    out.extend_from_slice(&field_len.to_le_bytes());
+    out.extend_from_slice(&subj_len.to_le_bytes());
+    out.extend_from_slice(req.subject);
+    out.extend_from_slice(req.pub_body);
+    Ok(())
+}
+
+/// Decodes a `PubSubject` body (#585) into its `subject` and the verbatim `pub_body` tail,
+/// cap-before-alloc and panic-free. A short body or an over-cap subject is a typed [`BodyError`]; an
+/// EMPTY body is [`BodyError::Truncated`].
+///
+/// # Errors
+/// [`BodyError::Truncated`] for a short body, [`BodyError::BadLength`] for an over-cap subject, or
+/// [`BodyError::BadHandshakeVersion`] for an unknown body version.
+pub fn decode_pub_subject(body: &[u8]) -> Result<PubSubjectBody<'_>, BodyError> {
+    let mut r = Reader::new(body);
+    let version = r.u8()?;
+    if version != STREAM_WIRE_BODY_VERSION {
+        return Err(BodyError::BadHandshakeVersion { version });
+    }
+    let field_len = r.u16()? as usize;
+    let block = r.take(field_len)?;
+    let pub_body = r.rest();
+    let mut fr = Reader::new(block);
+    let subject = read_subject(&mut fr)?;
+    Ok(PubSubjectBody { subject, pub_body })
+}
+
+/// A consumer's subscribe BY SUBJECT (the `SubSubject` frame body, tag 34, #585): a `subject` (literal
+/// or wildcard) plus the work-`group` name. The broker resolves the subject single-home to one bound
+/// stream and binds the connection's subsequent `Flow`/`Ack` to that stream's competing work-group (or
+/// rejects unbound/ambiguous, fail-closed).
+///
+/// Layout (version+length framed): `body_version: u8`, `field_len: u16`, then the v1 block:
+/// `subject: u16-len + bytes`, `group: u16-len + bytes`. Trailing block bytes are tolerated.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SubSubjectBody<'a> {
+    /// The subject to subscribe on (a literal or wildcard pattern, validated server-side).
+    pub subject: &'a [u8],
+    /// The work-group name (empty selects the default group), validated server-side.
+    pub group: &'a [u8],
+}
+
+/// Encodes a `SubSubject` body onto the end of `out` (#585): the version byte, the field-block length,
+/// then the subject and group, each `u16`-length-prefixed.
+///
+/// # Errors
+/// Returns [`BodyError::FieldTooLarge`] if the subject or group exceeds the `u16` wire limit.
+pub fn encode_sub_subject(req: &SubSubjectBody<'_>, out: &mut Vec<u8>) -> Result<(), BodyError> {
+    let subj_len = u16::try_from(req.subject.len()).map_err(|_| BodyError::FieldTooLarge)?;
+    let group_len = u16::try_from(req.group.len()).map_err(|_| BodyError::FieldTooLarge)?;
+    let field_len = u16::try_from(2 + req.subject.len() + 2 + req.group.len())
+        .map_err(|_| BodyError::FieldTooLarge)?;
+    out.push(STREAM_WIRE_BODY_VERSION);
+    out.extend_from_slice(&field_len.to_le_bytes());
+    out.extend_from_slice(&subj_len.to_le_bytes());
+    out.extend_from_slice(req.subject);
+    out.extend_from_slice(&group_len.to_le_bytes());
+    out.extend_from_slice(req.group);
+    Ok(())
+}
+
+/// Decodes a `SubSubject` body (#585), cap-before-alloc and panic-free. A short body or an over-cap
+/// subject is a typed [`BodyError`]; an EMPTY body is [`BodyError::Truncated`].
+///
+/// # Errors
+/// [`BodyError::Truncated`] for a short body, [`BodyError::BadLength`] for an over-cap subject, or
+/// [`BodyError::BadHandshakeVersion`] for an unknown body version.
+pub fn decode_sub_subject(body: &[u8]) -> Result<SubSubjectBody<'_>, BodyError> {
+    let mut r = Reader::new(body);
+    let version = r.u8()?;
+    if version != STREAM_WIRE_BODY_VERSION {
+        return Err(BodyError::BadHandshakeVersion { version });
+    }
+    let field_len = r.u16()? as usize;
+    let block = r.take(field_len)?;
+    let mut fr = Reader::new(block);
+    let subject = read_subject(&mut fr)?;
+    let group = fr.var()?;
+    Ok(SubSubjectBody { subject, group })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -4002,5 +4184,100 @@ mod tests {
         huge.extend_from_slice(&field_len.to_le_bytes());
         huge.extend_from_slice(&claimed_id_len.to_le_bytes());
         assert_eq!(decode_stream_declare(&huge), Err(BodyError::BadLength));
+    }
+
+    // ---- #585 (M2-I9): subject-addressed bodies ----
+
+    #[test]
+    fn bind_subject_round_trips_stream_and_pattern() {
+        // BindSubject carries both a stream id and a subject PATTERN, each round-tripping (wildcards
+        // are part of the pattern bytes; the proto does not validate the grammar — the server does).
+        for (stream, pattern) in [
+            (&b"orders"[..], &b"order.>"[..]),
+            (&b""[..], &b"payment.*.done"[..]), // empty stream binds the default stream
+            (&b"metrics"[..], &b">"[..]),
+        ] {
+            let mut buf = Vec::new();
+            encode_bind_subject(
+                &BindSubjectBody {
+                    stream_id: stream,
+                    pattern,
+                },
+                &mut buf,
+            )
+            .unwrap();
+            let decoded = decode_bind_subject(&buf).unwrap();
+            assert_eq!(decoded.stream_id, stream);
+            assert_eq!(decoded.pattern, pattern);
+        }
+    }
+
+    #[test]
+    fn pub_subject_round_trips_subject_and_verbatim_pub_body() {
+        // PubSubject prefixes a literal subject, then carries the EXISTING PubBody bytes VERBATIM, so the
+        // publish body codec is shared byte-for-byte with Pub/PubTo.
+        let mut pub_body = Vec::new();
+        encode_pub(
+            &PubBody {
+                flags: 0,
+                timestamp_ms: 99,
+                key: b"k",
+                headers: b"h",
+                payload: b"payload-bytes",
+                dedup: None,
+                fire_and_forget: false,
+            },
+            &mut pub_body,
+        )
+        .unwrap();
+        let mut buf = Vec::new();
+        encode_pub_subject(
+            &PubSubjectBody {
+                subject: b"order.us.created",
+                pub_body: &pub_body,
+            },
+            &mut buf,
+        )
+        .unwrap();
+        let decoded = decode_pub_subject(&buf).unwrap();
+        assert_eq!(decoded.subject, b"order.us.created");
+        // The verbatim tail decodes with the UNCHANGED decode_pub codec.
+        assert_eq!(decoded.pub_body, pub_body.as_slice());
+        let msg = decode_pub(decoded.pub_body).unwrap();
+        assert_eq!(msg.payload, b"payload-bytes");
+    }
+
+    #[test]
+    fn sub_subject_round_trips_subject_and_group() {
+        for (subject, group) in [
+            (&b"order.>"[..], &b"workers"[..]), // a wildcard subject is legal on the sub side
+            (&b"metric.cpu"[..], &b""[..]),     // empty group selects the default group
+        ] {
+            let mut buf = Vec::new();
+            encode_sub_subject(&SubSubjectBody { subject, group }, &mut buf).unwrap();
+            let decoded = decode_sub_subject(&buf).unwrap();
+            assert_eq!(decoded.subject, subject);
+            assert_eq!(decoded.group, group);
+        }
+    }
+
+    #[test]
+    fn subject_bodies_fail_closed_on_malformed_input() {
+        // Empty body -> Truncated; unknown version -> BadHandshakeVersion; over-cap subject -> BadLength.
+        assert_eq!(decode_bind_subject(&[]), Err(BodyError::Truncated));
+        assert_eq!(decode_pub_subject(&[]), Err(BodyError::Truncated));
+        assert_eq!(decode_sub_subject(&[]), Err(BodyError::Truncated));
+        assert_eq!(
+            decode_pub_subject(&[STREAM_WIRE_BODY_VERSION + 1, 0, 0]),
+            Err(BodyError::BadHandshakeVersion {
+                version: STREAM_WIRE_BODY_VERSION + 1
+            })
+        );
+        // An over-cap subject length inside the block -> BadLength, never an over-read.
+        let mut huge = vec![STREAM_WIRE_BODY_VERSION];
+        let claimed = u16::try_from(MAX_STREAM_ID_LEN + 1).unwrap();
+        huge.extend_from_slice(&u16::try_from(2usize).unwrap().to_le_bytes());
+        huge.extend_from_slice(&claimed.to_le_bytes());
+        assert_eq!(decode_pub_subject(&huge), Err(BodyError::BadLength));
     }
 }

--- a/crates/ironbus-server/src/codes.rs
+++ b/crates/ironbus-server/src/codes.rs
@@ -117,6 +117,22 @@ impl ErrorCode {
     /// [`EngineError::UnknownStream`].
     pub const ERR_UNKNOWN_STREAM: ErrorCode = ErrorCode("ERR_UNKNOWN_STREAM");
 
+    /// A subject or bind pattern was not valid #567 grammar (#585). Maps
+    /// [`EngineError::InvalidSubject`].
+    pub const ERR_INVALID_SUBJECT: ErrorCode = ErrorCode("ERR_INVALID_SUBJECT");
+
+    /// A `BindSubject` was refused because the resulting binding set would exceed the routing trie's
+    /// fork bound (#585/#568). Maps [`EngineError::BindRejected`].
+    pub const ERR_BIND_REJECTED: ErrorCode = ErrorCode("ERR_BIND_REJECTED");
+
+    /// A subject-addressed publish resolved to NO bound stream — the fail-closed reject, NOT a silent
+    /// drop (#585). Maps [`EngineError::NoStreamForSubject`].
+    pub const ERR_NO_STREAM_FOR_SUBJECT: ErrorCode = ErrorCode("ERR_NO_STREAM_FOR_SUBJECT");
+
+    /// A subject-addressed publish resolved to two-or-more bound streams under the single-home default
+    /// (#585). Maps [`EngineError::AmbiguousSubject`].
+    pub const ERR_AMBIGUOUS_SUBJECT: ErrorCode = ErrorCode("ERR_AMBIGUOUS_SUBJECT");
+
     /// A produce presented a STALE producer epoch (a zombie session reusing an old `producer_id`,
     /// #33): the broker rejects it (`AppendOutcome::Fenced`, the wire `fenced: stale producer
     /// epoch`). Not an `EngineError`: it is an `AppendOutcome`. The contract's `ERR_PRODUCER_FENCED`.
@@ -157,6 +173,10 @@ impl ErrorCode {
             EngineError::InvalidGroupName => Self::ERR_INVALID_GROUP_NAME,
             EngineError::InvalidStreamName { .. } => Self::ERR_INVALID_STREAM_NAME,
             EngineError::UnknownStream { .. } => Self::ERR_UNKNOWN_STREAM,
+            EngineError::InvalidSubject(_) => Self::ERR_INVALID_SUBJECT,
+            EngineError::BindRejected(_) => Self::ERR_BIND_REJECTED,
+            EngineError::NoStreamForSubject { .. } => Self::ERR_NO_STREAM_FOR_SUBJECT,
+            EngineError::AmbiguousSubject { .. } => Self::ERR_AMBIGUOUS_SUBJECT,
             EngineError::GenerationExhausted => Self::ERR_GENERATION_EXHAUSTED,
             EngineError::MissingRecord { .. } => Self::ERR_MISSING_RECORD,
             EngineError::ZeroMaxInFlight => Self::ERR_ZERO_MAX_IN_FLIGHT,
@@ -253,6 +273,30 @@ mod tests {
                     name: "ghost".to_string(),
                 },
                 ErrorCode::ERR_UNKNOWN_STREAM,
+            ),
+            (
+                EngineError::InvalidSubject(ironbus_core::subject::SubjectError::Empty),
+                ErrorCode::ERR_INVALID_SUBJECT,
+            ),
+            (
+                EngineError::BindRejected(ironbus_core::sublist::SublistError::ForkLimitExceeded {
+                    worst_case: 2048,
+                    limit: 1024,
+                }),
+                ErrorCode::ERR_BIND_REJECTED,
+            ),
+            (
+                EngineError::NoStreamForSubject {
+                    subject: "telemetry.cpu".to_string(),
+                },
+                ErrorCode::ERR_NO_STREAM_FOR_SUBJECT,
+            ),
+            (
+                EngineError::AmbiguousSubject {
+                    subject: "order.us.created".to_string(),
+                    matched: 2,
+                },
+                ErrorCode::ERR_AMBIGUOUS_SUBJECT,
             ),
             (
                 EngineError::GenerationExhausted,

--- a/crates/ironbus-server/src/engine.rs
+++ b/crates/ironbus-server/src/engine.rs
@@ -22,6 +22,7 @@ use ironbus_core::attempt::{
     decode_attempt_snapshot, encode_attempt_snapshot, ATTEMPT_SNAPSHOT_MIN_LEN,
 };
 use ironbus_core::backpressure::{AimdLimiter, Codel, FsyncHeadroom, RetryBudget, TokenBucket};
+use ironbus_core::binding::{single_home, Resolution};
 use ironbus_core::clock::Clock;
 use ironbus_core::compress::{
     compress_payload, Codec, CompressConfig, DEFAULT_MAX_DECOMPRESSED_BYTES,
@@ -33,6 +34,8 @@ use ironbus_core::keyshared::{KeyOrdering, KeyRouter, MemberId, RouteDecision};
 use ironbus_core::lease::{
     AckOutcome, Claim, ExtendOutcome, LeaseConfig, LeaseTable, LeaseToken, NackOutcome,
 };
+use ironbus_core::subject::{Subject, SubjectError, SubjectPattern};
+use ironbus_core::sublist::{Sublist, SublistBuilder, SublistError, SublistSnapshot};
 use ironbus_core::types::{Offset, RecordFlags};
 use ironbus_storage::checkpoint::{
     AttemptsCheckpoint, Checkpoint, CountersCheckpoint, ATTEMPTS_PAYLOAD, MAX_PAYLOAD,
@@ -588,6 +591,36 @@ pub enum EngineError {
         /// The name of the unknown (never-declared) named stream.
         name: String,
     },
+    /// A subject or subject pattern handed to the binding / subject-addressed path (#585, M2-I9) was
+    /// not valid #567 grammar (empty, an empty token, an illegal/control rune, a misplaced wildcard, or
+    /// over the depth cap). A bind validates a PATTERN (wildcards allowed); a subject-addressed publish
+    /// validates a LITERAL subject (wildcards rejected). Fail-closed at the boundary, never a panic.
+    /// Carries the typed [`SubjectError`] reason.
+    InvalidSubject(SubjectError),
+    /// A `BindSubject` would make the binding set's worst-case wildcard fork frontier exceed the trie's
+    /// fail-closed cap (#568): the WHOLE binding set is refused rather than admitted and silently
+    /// truncated at match time (so routing can never drop a match). Carries the trie's typed
+    /// [`SublistError`] reason. (An individually-valid pattern can still trip this as a property of the
+    /// accepted SET; the bind is rejected and the previous binding table is left installed unchanged.)
+    BindRejected(SublistError),
+    /// A subject-addressed publish resolved to ZERO bound streams (#585, the single-home FAIL-CLOSED
+    /// reject): the publish is REFUSED, NOT silently dropped — the explicit beat over NATS, which would
+    /// discard a publish to a subject with no matching interest while still acking success. The producer
+    /// must bind the subject to a stream first. Carries the offending subject.
+    NoStreamForSubject {
+        /// The literal subject that matched no binding.
+        subject: String,
+    },
+    /// A subject-addressed publish resolved to TWO OR MORE bound streams (#585, the single-home
+    /// FAIL-CLOSED reject): one record needs one unambiguous destination log, so an ambiguous subject is
+    /// refused rather than guessed or fanned out. The opt-in `overlap_ok` fan-out is a separate, later
+    /// feature. Carries the offending subject and how many streams matched.
+    AmbiguousSubject {
+        /// The literal subject that matched more than one binding.
+        subject: String,
+        /// How many bound streams matched (always `>= 2`).
+        matched: usize,
+    },
 }
 
 impl core::fmt::Display for EngineError {
@@ -641,6 +674,17 @@ impl core::fmt::Display for EngineError {
                 f,
                 "stream {name:?} is not open (produce to it first to declare it)"
             ),
+            EngineError::InvalidSubject(e) => write!(f, "invalid subject: {e}"),
+            EngineError::BindRejected(e) => write!(f, "bind rejected: {e}"),
+            EngineError::NoStreamForSubject { subject } => write!(
+                f,
+                "no stream is bound for subject {subject:?} (bind a subject pattern to a stream first)"
+            ),
+            EngineError::AmbiguousSubject { subject, matched } => write!(
+                f,
+                "subject {subject:?} resolves to {matched} bound streams (single-home: a subject must \
+                 resolve to exactly one stream; overlap fan-out is opt-in)"
+            ),
         }
     }
 }
@@ -674,6 +718,23 @@ impl From<StreamError> for EngineError {
             // validation rejection from an IO fault.
             StreamError::InvalidName { name } => EngineError::InvalidStreamName { name },
             StreamError::Storage(s) => EngineError::Storage(s),
+        }
+    }
+}
+
+impl From<SubjectError> for EngineError {
+    fn from(e: SubjectError) -> Self {
+        EngineError::InvalidSubject(e)
+    }
+}
+
+impl From<SublistError> for EngineError {
+    fn from(e: SublistError) -> Self {
+        match e {
+            // A pattern that fails to re-parse is a subject-grammar rejection (surface its typed
+            // reason); a fork-bound rejection is the binding-SET rejection.
+            SublistError::InvalidPattern(p) => EngineError::InvalidSubject(p),
+            other => EngineError::BindRejected(other),
         }
     }
 }
@@ -1829,6 +1890,99 @@ impl WorkGroup {
 /// default stream. A named stream's groups are in-memory only for now (its consumer position does
 /// not survive a restart — only its LOG recovers, via the `StreamSet`), the explicit trade this
 /// reviewable slice makes.
+/// The subject->stream BINDING table (#585, V2-M2-I9): the authoritative registry of
+/// `(SubjectPattern -> StreamId)` bindings PLUS the wait-free routing trie ([`SublistSnapshot`]) it
+/// compiles to. The registry (`entries`) is the source of truth a rebuild reads; the `snapshot` is the
+/// immutable, generation-stamped trie a publish resolves against wait-free.
+///
+/// # Bind = rebuild + swap (invalidates every connection's resolve cache)
+///
+/// A [`BindingTable::bind`] appends a `pattern -> stream` entry, rebuilds a fresh immutable trie from
+/// the whole registry, and [`SublistSnapshot::store`]s it — which bumps the snapshot's monotonic
+/// generation. Each connection's [`ResolveCache`](ironbus_core::resolve_cache::ResolveCache) compares
+/// that generation on its next resolve and drops its stale cached answer (one O(1) compare, no global
+/// flush — the beat over NATS's per-change global Sublist-cache flush). The rebuild is the rare,
+/// amortized cost a bind pays; every resolve against the installed trie is wait-free.
+///
+/// # Fail-closed at ingest
+///
+/// `bind` validates the pattern through the #567 grammar BEFORE registering it, and the trie rebuild is
+/// itself fail-closed on the fork bound (#568): a binding SET whose worst-case wildcard fork frontier
+/// would exceed the cap is REFUSED and the PREVIOUS table is left installed unchanged, so a bad bind
+/// never corrupts routing and never silently truncates a match.
+struct BindingTable {
+    /// The authoritative `(pattern, stream)` registry, the source of truth a rebuild reads. An owned
+    /// pattern string + its target stream; the same pattern may appear for two DISTINCT streams (which
+    /// makes any subject they both cover ambiguous under single-home). In-memory only this phase.
+    entries: Vec<(String, StreamId)>,
+    /// The compiled, wait-free routing trie: a publish resolves a literal subject against this
+    /// snapshot (directly or through a per-connection resolve cache) with no lock and no walk on a
+    /// cache hit. Rebuilt and swapped on every successful `bind`, advancing its generation.
+    snapshot: SublistSnapshot<StreamId>,
+}
+
+impl BindingTable {
+    /// An empty binding table: no subject is bound, so every resolve is a fail-closed `NoStream` until a
+    /// `bind` registers a pattern. The trie starts at generation 0.
+    fn new() -> BindingTable {
+        BindingTable {
+            entries: Vec::new(),
+            snapshot: SublistSnapshot::empty(),
+        }
+    }
+
+    /// Builds an immutable routing trie from the current registry (generation `0`; the snapshot restamps
+    /// it monotonically on `store`). Fail-closed on the #568 fork bound.
+    fn build(&self) -> Result<Sublist<StreamId>, SublistError> {
+        let mut b = SublistBuilder::new();
+        for (pattern, stream) in &self.entries {
+            // Re-validate + register each stored pattern. `bind` only ever stores patterns that parsed,
+            // so an insert error here is an internal-invariant surface, never reached via the public API.
+            b.insert(pattern, stream.clone())
+                .map_err(SublistError::InvalidPattern)?;
+        }
+        b.build(0)
+    }
+
+    /// Registers `pattern -> stream` and atomically swaps in the rebuilt trie, returning the new
+    /// generation. Validates the pattern through the #567 grammar first (fail-closed). If the rebuilt
+    /// SET would exceed the #568 fork bound, the registry is rolled back and the PREVIOUS trie stays
+    /// installed (a bad bind never corrupts routing). Idempotent: re-binding the SAME `(pattern, stream)`
+    /// pair is a no-op success (it does not duplicate the entry), so a client may re-declare its bindings
+    /// safely.
+    ///
+    /// # Errors
+    /// [`SublistError::InvalidPattern`] for a malformed pattern, or [`SublistError::ForkLimitExceeded`]
+    /// if the resulting binding set would exceed the fork bound.
+    fn bind(&mut self, pattern: &str, stream: StreamId) -> Result<u64, SublistError> {
+        // Validate the pattern at the boundary (fail-closed) before it can enter the registry.
+        SubjectPattern::parse(pattern).map_err(SublistError::InvalidPattern)?;
+        // Idempotent: an identical (pattern, stream) pair is already bound -> no rebuild, no duplicate.
+        if self
+            .entries
+            .iter()
+            .any(|(p, s)| p == pattern && *s == stream)
+        {
+            return Ok(self.snapshot.generation());
+        }
+        // Tentatively register, then rebuild. On a fork-bound rejection, ROLL BACK the registry so the
+        // installed trie and the registry stay consistent (the previous table remains the truth).
+        self.entries.push((pattern.to_owned(), stream));
+        match self.build() {
+            Ok(trie) => Ok(self.snapshot.store(trie)),
+            Err(e) => {
+                self.entries.pop();
+                Err(e)
+            }
+        }
+    }
+
+    /// The number of registered bindings (for tests/metrics).
+    fn len(&self) -> usize {
+        self.entries.len()
+    }
+}
+
 struct NamedStream {
     /// This stream's competing work-groups, keyed by group name, byte-for-byte the SAME machinery
     /// as the default stream's [`Engine::groups`] — independent per stream so the same group NAME
@@ -1873,6 +2027,14 @@ pub struct Engine<F: Filesystem, C: Clock> {
     /// `declare`); the default stream `""` is NEVER a key here (it uses [`Engine::groups`]). Empty
     /// for a deployment that never names a stream, so the default path costs nothing.
     named_streams: BTreeMap<StreamId, NamedStream>,
+    /// The subject->stream BINDING table (#585, V2-M2-I9): the registry of `(SubjectPattern -> StreamId)`
+    /// bindings plus the wait-free routing trie ([`SublistSnapshot`]) it builds. A `BindSubject` adds a
+    /// `pattern -> stream` entry and rebuilds the immutable trie, swapping a fresh generation in — which
+    /// is exactly the signal each connection's resolve cache watches to drop a stale routing answer
+    /// (#569). A subject-addressed publish resolves through this table to ONE bound stream (single-home,
+    /// fail-closed). Empty until the first bind, so a deployment that never binds a subject costs nothing
+    /// here and the explicit-stream-id (#588) + default-stream paths are entirely unaffected.
+    bindings: BindingTable,
     /// Per-work-group consumer state, keyed by group name. The default group (`""`) is the
     /// durable one (checkpointed to `cursor.ckpt`); named groups are independent
     /// broadcast/competing cursors, in-memory for now (durable per-group state is #60).
@@ -2239,6 +2401,12 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
             // consumer cursors across a restart is the flagged #60-style follow-up; today only the
             // named stream's LOG recovers, via the StreamSet.)
             named_streams: BTreeMap::new(),
+            // The subject->stream binding table (#585): EMPTY at open (no subject is bound until a
+            // client `BindSubject`s one). Bindings are in-memory only this phase — a stream's subject
+            // bindings do NOT survive a restart (only its LOG recovers, via the StreamSet); durable
+            // binding persistence is a flagged follow-up. A deployment that never binds keeps this empty,
+            // so the default + explicit-stream-id paths are byte-for-byte unaffected.
+            bindings: BindingTable::new(),
             groups,
             group_last_checkpointed,
             lease_config: config.lease,
@@ -3263,6 +3431,135 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
     pub fn named_stream_count(&self) -> usize {
         // The StreamSet's `len()` includes its inert default `""` slot; the named count is the rest.
         self.streams.len().saturating_sub(1)
+    }
+
+    // ===================================================================================
+    // SUBJECT->STREAM BINDING + FAIL-CLOSED SINGLE-HOME RESOLUTION (#585, V2-M2-I9).
+    //
+    // A stream BINDS a set of subject PATTERNS (e.g. "orders" binds "order.>", "payment.*.done"); a
+    // publish to a literal SUBJECT resolves — via the wait-free trie + a per-connection resolve cache —
+    // to the bound stream(s): EXACTLY ONE routes there, ZERO is a fail-closed NoStreamForSubject reject
+    // (the beat over NATS's silent drop), >= 2 is an AmbiguousSubject reject (single-home default; the
+    // overlap_ok fan-out is the SEPARATE later issue, FLAGGED). The binding lives in the trie with
+    // target = StreamId; a bind rebuilds it and advances the generation, invalidating every connection's
+    // resolve cache. The explicit-stream-id (#588) and default-stream paths are untouched.
+    // ===================================================================================
+
+    /// BINDS the subject `pattern` to the stream named `stream` (#585): registers `pattern -> stream` in
+    /// the routing trie and atomically swaps the rebuilt, generation-advanced trie in (invalidating every
+    /// connection's resolve cache). The named stream is `declare`d on bind (materializing its independent
+    /// log + recovery) so a subsequent subject-addressed publish has a destination log; the DEFAULT
+    /// stream (the EMPTY name) is always present and is `declare`-free. The `pattern` is a #567 PATTERN
+    /// (wildcards `*`/`>` allowed). Idempotent: re-binding the same `(pattern, stream)` pair is a no-op
+    /// success. Returns the new routing generation.
+    ///
+    /// # Errors
+    /// [`EngineError::InvalidSubject`] for a malformed pattern, [`EngineError::InvalidStreamName`] for a
+    /// malformed named stream, [`EngineError::BindRejected`] if the resulting binding SET would exceed
+    /// the trie's #568 fork bound (the previous table stays installed), or [`EngineError::Storage`] from
+    /// declaring the stream's log.
+    pub fn bind_subject(&mut self, stream: &str, pattern: &str) -> Result<u64, EngineError>
+    where
+        F: Clone,
+    {
+        // Validate the pattern up front (fail-closed) so a malformed pattern never declares a stream.
+        SubjectPattern::parse(pattern)?;
+        let id = if stream.is_empty() {
+            // The default stream is always open (it is the root log), so binding a subject TO the default
+            // stream is legitimate and declare-free: a subject-addressed publish then lands in "".
+            StreamId::default_stream()
+        } else {
+            let id = StreamId::named(stream)?;
+            // Declare-on-bind: the stream must have a log to receive a subject-addressed publish later,
+            // exactly as declare-on-first-produce gives the id-routed path one (idempotent).
+            self.streams.declare(&id).map_err(EngineError::Storage)?;
+            self.named_streams
+                .entry(id.clone())
+                .or_insert_with(NamedStream::new);
+            id
+        };
+        // Register + rebuild + swap (advances the generation; rolls back on a fork-bound rejection).
+        Ok(self.bindings.bind(pattern, id)?)
+    }
+
+    /// Resolves the literal `subject` to a single bound stream under the FAIL-CLOSED single-home default
+    /// (#585), WITHOUT the per-connection resolve cache (a one-shot / server-internal resolve; the hot
+    /// publish path uses the session's cache). The subject is validated as a #567 LITERAL (no wildcards);
+    /// then the trie match is reduced single-home: exactly one bound stream -> that [`StreamId`], zero ->
+    /// `NoStreamForSubject`, two-or-more -> `AmbiguousSubject`.
+    ///
+    /// # Errors
+    /// [`EngineError::InvalidSubject`] for a malformed/wildcard subject, [`EngineError::NoStreamForSubject`]
+    /// when no binding matches (fail-closed, never a silent drop), or [`EngineError::AmbiguousSubject`]
+    /// when more than one bound stream matches (single-home).
+    pub fn resolve_subject(&self, subject: &str) -> Result<StreamId, EngineError> {
+        let subj = Subject::parse_literal(subject)?;
+        let mut matched = Vec::new();
+        self.bindings.snapshot.match_into(&subj, &mut matched);
+        match single_home(&matched) {
+            Resolution::Routed(id) => Ok(id),
+            Resolution::NoStream => Err(EngineError::NoStreamForSubject {
+                subject: subject.to_string(),
+            }),
+            Resolution::Ambiguous { matched } => Err(EngineError::AmbiguousSubject {
+                subject: subject.to_string(),
+                matched,
+            }),
+        }
+    }
+
+    /// Produces `message` BY SUBJECT (#585): resolves the literal `subject` to its single bound stream
+    /// (single-home, fail-closed) and routes the append there via the id-routed
+    /// [`Engine::produce_in_stream`] (which is byte-for-byte the default path when the bound stream is
+    /// the default `""`). A subject bound to no stream is a `NoStreamForSubject` reject (the publish is
+    /// REFUSED, not silently dropped — the beat over NATS); a subject bound to two-or-more is an
+    /// `AmbiguousSubject` reject. Returns the assigned [`Offset`] in the resolved stream.
+    ///
+    /// This resolves WITHOUT the per-connection cache (the engine has no per-connection identity); the
+    /// session resolves through its cache and then calls [`Engine::produce_in_stream`] with the resolved
+    /// stream name, so the hot path stays O(1). This entry point exists for callers that want the engine
+    /// to do both steps in one actor job (and for the end-to-end tests).
+    ///
+    /// # Errors
+    /// The [`Engine::resolve_subject`] rejects (invalid/unbound/ambiguous subject), else the
+    /// [`Engine::produce_in_stream`] error taxonomy for the resolved stream.
+    pub fn produce_by_subject(
+        &mut self,
+        subject: &str,
+        message: &Append<'_>,
+    ) -> Result<Offset, EngineError>
+    where
+        F: Clone,
+    {
+        // Resolve first (fail-closed): a NoStream/Ambiguous subject is refused BEFORE any append, so a
+        // publish to an unbound subject never touches a log (no silent drop, no partial write).
+        let id = self.resolve_subject(subject)?;
+        // Route the append to the resolved stream's log via the id-routed path. The default stream `""`
+        // routes byte-for-byte through `produce`; a named stream appends to its own log + commit tick.
+        self.produce_in_stream(id.name(), message)
+    }
+
+    /// The number of registered subject bindings (#585), `0` for a deployment that never bound a subject.
+    /// For tests/metrics.
+    #[must_use]
+    pub fn binding_count(&self) -> usize {
+        self.bindings.len()
+    }
+
+    /// The current routing-table generation (#585): bumped on every successful [`Engine::bind_subject`].
+    /// A per-connection resolve cache compares it to detect a bind change. For tests.
+    #[must_use]
+    pub fn binding_generation(&self) -> u64 {
+        self.bindings.snapshot.generation()
+    }
+
+    /// Borrows the wait-free routing [`SublistSnapshot`] (#585) so a per-connection resolve cache can
+    /// resolve a subject through it (a wait-free `ArcSwap` load + walk on a miss, an O(1) hash lookup on
+    /// a hit). This is the read seam the session's cached subject-resolve uses; the snapshot is immutable
+    /// and generation-stamped, so the cache's generation-guard detects a bind change with one compare.
+    #[must_use]
+    pub fn binding_snapshot(&self) -> &SublistSnapshot<StreamId> {
+        &self.bindings.snapshot
     }
 
     /// Appends `message` durably-pending (write, NO fsync) and records the produce statistics that
@@ -13363,5 +13660,204 @@ mod tests {
         // A consume on a stream that was never produced-to is UnknownStream, not an empty Idle.
         let unknown = e.poll_in_stream("never-declared", "g", 0);
         assert!(matches!(unknown, Err(EngineError::UnknownStream { .. })));
+    }
+
+    // =================================================================================
+    // #585 (V2-M2-I9): subject->stream binding + fail-closed single-home resolution.
+    // A stream BINDS subject patterns; a publish BY SUBJECT resolves single-home to the bound
+    // stream (exactly-one routes, zero is NoStreamForSubject, >=2 is AmbiguousSubject); a bind
+    // change invalidates the resolve cache. The explicit-stream-id (#676) + default "" paths are
+    // unchanged. The beat over NATS: a publish to an unbound subject is a TYPED reject, never a
+    // silent drop.
+    // =================================================================================
+
+    /// Publishes `payload` BY SUBJECT via the subject-addressed entry point (no per-connection cache;
+    /// the engine method resolves through the trie directly).
+    fn produce_subject(
+        e: &mut Engine<InMemoryFs, ManualClock>,
+        subject: &str,
+        payload: &[u8],
+    ) -> Result<Offset, EngineError> {
+        e.produce_by_subject(
+            subject,
+            &Append {
+                timestamp_ms: 0,
+                flags: RecordFlags::EMPTY,
+                key: b"",
+                headers: b"",
+                payload,
+            },
+        )
+    }
+
+    #[test]
+    fn bind_then_publish_by_subject_lands_in_the_bound_stream_end_to_end() {
+        // THE end-to-end happy path: bind "order.>" to stream "orders"; a publish to a LITERAL subject
+        // "order.us.created" resolves single-home to "orders" and the record lands in THAT stream's log,
+        // readable off "orders" (not the default stream, not any other).
+        let mut e = open(config(10, 5));
+        e.bind_subject("orders", "order.>").unwrap();
+        assert_eq!(e.binding_count(), 1);
+
+        // Publish by subject -> offset 0 in "orders".
+        assert_eq!(
+            produce_subject(&mut e, "order.us.created", b"o0").unwrap(),
+            Offset::new(0)
+        );
+        assert_eq!(
+            produce_subject(&mut e, "order.eu.created", b"o1").unwrap(),
+            Offset::new(1)
+        );
+        // The records landed in "orders" — consume them off that stream.
+        assert_eq!(e.stream_head("orders"), Offset::new(2));
+        let d0 = message(e.poll_in_stream("orders", "g", 0).unwrap());
+        assert_eq!(d0.record.payload.as_ref(), b"o0");
+        let d1 = message(e.poll_in_stream("orders", "g", 0).unwrap());
+        assert_eq!(d1.record.payload.as_ref(), b"o1");
+        // The DEFAULT stream got nothing (the subject did not route there).
+        assert_eq!(e.stream_head(""), Offset::ZERO);
+        // And `resolve_subject` agrees the subject maps to exactly "orders".
+        assert_eq!(
+            e.resolve_subject("order.us.created").unwrap(),
+            StreamId::named("orders").unwrap()
+        );
+    }
+
+    #[test]
+    fn a_publish_to_an_unbound_subject_is_a_typed_no_stream_reject_not_a_silent_drop() {
+        // THE beat over NATS: a publish to a subject with NO matching binding is REFUSED with the typed
+        // NoStreamForSubject (fail-closed), never silently dropped while acking success. Nothing is
+        // written to any log.
+        let mut e = open(config(10, 5));
+        e.bind_subject("orders", "order.>").unwrap();
+        let rejected = produce_subject(&mut e, "telemetry.cpu", b"x");
+        assert!(
+            matches!(rejected, Err(EngineError::NoStreamForSubject { .. })),
+            "an unbound subject is fail-closed, got {rejected:?}"
+        );
+        assert_eq!(
+            rejected.unwrap_err().code(),
+            crate::codes::ErrorCode::ERR_NO_STREAM_FOR_SUBJECT
+        );
+        // No silent drop: neither the bound stream nor the default got the record.
+        assert_eq!(e.stream_head("orders"), Offset::ZERO);
+        assert_eq!(e.stream_head(""), Offset::ZERO);
+    }
+
+    #[test]
+    fn an_ambiguous_subject_bound_to_two_streams_is_a_typed_reject() {
+        // Single-home default: a subject covered by bindings on TWO distinct streams is AmbiguousSubject
+        // (one record needs one unambiguous destination). The overlap_ok fan-out is the flagged later
+        // issue.
+        let mut e = open(config(10, 5));
+        e.bind_subject("orders", "order.>").unwrap();
+        e.bind_subject("audit", "order.us.*").unwrap();
+        let rejected = produce_subject(&mut e, "order.us.created", b"x");
+        match rejected {
+            Err(EngineError::AmbiguousSubject { matched, .. }) => assert_eq!(matched, 2),
+            other => panic!("expected AmbiguousSubject, got {other:?}"),
+        }
+        // A subject only ONE of them covers is unambiguous and routes.
+        assert_eq!(
+            produce_subject(&mut e, "order.eu.created", b"y").unwrap(),
+            Offset::new(0)
+        );
+        assert_eq!(e.stream_head("orders"), Offset::new(1));
+        assert_eq!(e.stream_head("audit"), Offset::ZERO);
+    }
+
+    #[test]
+    fn a_bind_change_is_reflected_by_resolution_no_stale_routing() {
+        // A rebind moves a subject's destination; resolution must reflect the NEW binding immediately
+        // (the engine resolves against the swapped-in trie; a per-connection cache's generation-guard
+        // drops its stale answer — proven in the core resolve_cache + binding tests).
+        let mut e = open(config(10, 5));
+        e.bind_subject("a", "order.>").unwrap();
+        let g0 = e.binding_generation();
+        assert_eq!(
+            e.resolve_subject("order.x").unwrap(),
+            StreamId::named("a").unwrap()
+        );
+        // Rebind the SAME pattern to a different stream "b": the generation advances and resolution moves.
+        let g1 = e.bind_subject("b", "order.>").unwrap();
+        assert!(g1 > g0, "a bind advances the routing generation");
+        // Now "order.x" is bound to BOTH a and b -> ambiguous (single-home). This proves the new binding
+        // took effect (no stale single-route to "a").
+        assert!(matches!(
+            e.resolve_subject("order.x"),
+            Err(EngineError::AmbiguousSubject { matched: 2, .. })
+        ));
+    }
+
+    #[test]
+    fn binding_to_the_default_stream_routes_a_subject_to_the_default_log() {
+        // PRESERVE: a subject may be bound to the DEFAULT stream "" — a publish by that subject then
+        // lands in the default log (byte-for-byte the historical produce). A NO-subject default publish
+        // (`produce`) is unaffected.
+        let mut e = open(config(10, 5));
+        e.bind_subject("", "metric.>").unwrap();
+        assert_eq!(
+            produce_subject(&mut e, "metric.cpu", b"m0").unwrap(),
+            Offset::new(0)
+        );
+        // It landed in the DEFAULT stream's log; no named stream was created.
+        assert_eq!(e.stream_head(""), Offset::new(1));
+        assert_eq!(e.named_stream_count(), 0);
+        let d = message(e.poll_in_stream("", DEFAULT_GROUP, 0).unwrap());
+        assert_eq!(d.record.payload.as_ref(), b"m0");
+    }
+
+    #[test]
+    fn an_invalid_subject_or_pattern_fails_closed_at_the_boundary() {
+        // A malformed bind pattern, and a wildcard/malformed PUBLISH subject, are each a typed
+        // InvalidSubject reject — never a panic, never a silent admit.
+        let mut e = open(config(10, 5));
+        // A bind pattern with a non-final `>` is rejected (the #567 grammar).
+        assert!(matches!(
+            e.bind_subject("orders", "order.>.bad"),
+            Err(EngineError::InvalidSubject(_))
+        ));
+        assert_eq!(e.binding_count(), 0, "a rejected bind registers nothing");
+        // A PUBLISH subject may not carry a wildcard (it must be a literal).
+        e.bind_subject("orders", "order.>").unwrap();
+        assert!(matches!(
+            produce_subject(&mut e, "order.*", b"x"),
+            Err(EngineError::InvalidSubject(_))
+        ));
+    }
+
+    #[test]
+    fn binding_is_idempotent_and_a_named_bind_declares_the_stream() {
+        // Re-binding the same (pattern, stream) pair is a no-op success (no duplicate, no generation
+        // churn), and binding a NAMED stream DECLARES it so a subject-addressed publish has a log.
+        let mut e = open(config(10, 5));
+        let g1 = e.bind_subject("orders", "order.>").unwrap();
+        // Binding declared "orders".
+        assert_eq!(e.named_stream_count(), 1);
+        // Idempotent re-bind: same generation, still one binding.
+        let g2 = e.bind_subject("orders", "order.>").unwrap();
+        assert_eq!(
+            g1, g2,
+            "an idempotent re-bind does not advance the generation"
+        );
+        assert_eq!(e.binding_count(), 1);
+    }
+
+    #[test]
+    fn the_explicit_stream_id_and_default_paths_are_unchanged_by_binding() {
+        // PRESERVE: with bindings present, the explicit-stream-id (#676) and default "" produce/consume
+        // paths behave EXACTLY as before — binding adds a parallel route, it never re-routes them.
+        let mut e = open(config(10, 5));
+        e.bind_subject("orders", "order.>").unwrap();
+        // Explicit-stream-id produce to a DIFFERENT named stream still works and is isolated.
+        assert_eq!(produce_to(&mut e, "shipments", b"s0"), Offset::new(0));
+        assert_eq!(e.stream_head("shipments"), Offset::new(1));
+        // A default no-subject produce still targets the default log.
+        let mut e2 = open(config(10, 5));
+        e2.bind_subject("orders", "order.>").unwrap();
+        assert_eq!(produce_to(&mut e2, "", b"d0"), Offset::new(0));
+        assert_eq!(e2.stream_head(""), Offset::new(1));
+        let d = message(e2.poll_in_stream("", DEFAULT_GROUP, 0).unwrap());
+        assert_eq!(d.record.payload.as_ref(), b"d0");
     }
 }

--- a/crates/ironbus-server/src/session.rs
+++ b/crates/ironbus-server/src/session.rs
@@ -20,29 +20,34 @@ use crate::actor::{
     ActorGone, EngineAccess, OwnedAppend, OwnedDedup, ProduceOutcome, ProduceSubmission,
 };
 use crate::engine::{
-    AckResult, EngineError, NackResult, Poll, ProgressResult, StreamBatch, StreamRawBatch,
+    AckResult, Engine, EngineError, NackResult, Poll, ProgressResult, StreamBatch, StreamRawBatch,
 };
 use bytes::Bytes;
+use ironbus_core::binding::{single_home, Resolution};
 use ironbus_core::clock::Clock;
 use ironbus_core::compress::{validate_descriptor_shape, DEFAULT_MAX_DECOMPRESSED_BYTES};
 use ironbus_core::confirm::{ConfirmStatus, ReadyConfirm};
 use ironbus_core::dedup::{MAX_MSG_ID_LEN, MAX_PRODUCER_ID_LEN};
 use ironbus_core::keyshared::{KeyOrdering, MemberId};
 use ironbus_core::lease::LeaseToken;
+use ironbus_core::resolve_cache::ResolveCache;
+use ironbus_core::subject::Subject;
 use ironbus_core::types::{Offset, RecordFlags};
 use ironbus_proto::frame::{decode_frame, encode_frame, FrameDecode, FrameError, FrameType};
 use ironbus_proto::message::{
-    decode_ack, decode_connect, decode_cumulative_ack, decode_fetch, decode_pub, decode_pub_to,
-    decode_stream_commit, decode_stream_declare, decode_stream_fetch, decode_stream_info,
-    decode_sub, decode_sub_to, encode_dead_letter, encode_deliver, encode_deliver_batch,
-    encode_gap_marker, encode_info, encode_produce_confirm, encode_pub_ack,
-    encode_stream_info_response, encode_truncated, gap_reason, produce_confirm_status,
-    pub_ack_level, AckLevel, AckOp, ConsumeTier, CreditAdvert, DeadLetterBody, DeliverBatchHeader,
-    DeliverBody, GapMarkerBody, InfoBody, ProduceConfirmBody, PubAckBody, StreamInfoResponseBody,
-    TruncatedBody, DEAD_LETTER_MAX_DELIVER, PUB_WIRE_ONLY_FLAGS,
+    decode_ack, decode_bind_subject, decode_connect, decode_cumulative_ack, decode_fetch,
+    decode_pub, decode_pub_subject, decode_pub_to, decode_stream_commit, decode_stream_declare,
+    decode_stream_fetch, decode_stream_info, decode_sub, decode_sub_subject, decode_sub_to,
+    encode_dead_letter, encode_deliver, encode_deliver_batch, encode_gap_marker, encode_info,
+    encode_produce_confirm, encode_pub_ack, encode_stream_info_response, encode_truncated,
+    gap_reason, produce_confirm_status, pub_ack_level, AckLevel, AckOp, ConsumeTier, CreditAdvert,
+    DeadLetterBody, DeliverBatchHeader, DeliverBody, GapMarkerBody, InfoBody, ProduceConfirmBody,
+    PubAckBody, StreamInfoResponseBody, TruncatedBody, DEAD_LETTER_MAX_DELIVER,
+    PUB_WIRE_ONLY_FLAGS,
 };
 use ironbus_storage::fs::Filesystem;
 use ironbus_storage::log::Append;
+use ironbus_storage::streamset::StreamId;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -345,6 +350,17 @@ pub struct Session {
     /// connection that did not. `false` by default, so an L0/L1-only connection is byte-for-byte
     /// unchanged.
     produced_l2: bool,
+    /// The per-connection, generation-guarded subject-resolve cache (#585, M2-I9): caches a literal
+    /// subject's single-home resolution (the bound [`StreamId`]) so a hot publisher to the same subject
+    /// routes in O(1) — a hash lookup, no trie walk — after the first publish. It is consulted INSIDE
+    /// the actor job (where the engine's wait-free routing snapshot lives) and moved back out, so the
+    /// cache state stays per-connection while the resolve runs against the shared, lock-free trie. A
+    /// bind change advances the snapshot generation; this cache's generation-guard drops its stale
+    /// answer on the next resolve (one O(1) compare — no global flush, the beat over NATS's per-change
+    /// Sublist-cache flush). EMPTY until this connection publishes/subscribes BY SUBJECT, so a
+    /// connection that never uses subject addressing costs nothing here. Bounded (LRU), so a firehose of
+    /// distinct subjects can never grow it without bound.
+    subject_cache: ResolveCache<StreamId>,
 }
 
 impl Session {
@@ -600,6 +616,20 @@ impl Session {
             }
             Some(FrameType::PubTo) => self.handle_pub_to(engine, body, out).map(|()| false),
             Some(FrameType::SubTo) => self.handle_sub_to(engine, body, out).map(|()| false),
+            // The subject-addressed verbs (#585, M2-I9): also GATED on the negotiated `streams_enabled`
+            // capability (subject routing is the subjects half of the same streams story). A BindSubject
+            // registers a binding (changes no committed cursor, `false`); a SubSubject only binds the
+            // subscription (`false`, like Sub/SubTo); a PubSubject never advances a COMMITTED cursor
+            // (`false`, like Pub/PubTo).
+            Some(FrameType::BindSubject) => {
+                self.handle_bind_subject(engine, body, out).map(|()| false)
+            }
+            Some(FrameType::PubSubject) => {
+                self.handle_pub_subject(engine, body, out).map(|()| false)
+            }
+            Some(FrameType::SubSubject) => {
+                self.handle_sub_subject(engine, body, out).map(|()| false)
+            }
             Some(FrameType::Unsub) => self.handle_unsub(engine, out).map(|()| true),
             // The standalone Nack frame type (a client sends a nack as an Ack frame with the
             // Nack op, handled above), or a response-only verb (Info/Pong/Ok/Err/Deliver) a
@@ -2575,6 +2605,265 @@ impl Session {
         Ok(())
     }
 
+    /// Handles a `BindSubject` (#585, M2-I9): BIND a subject PATTERN to a stream. Routes to the engine's
+    /// [`Engine::bind_subject`] (which validates the pattern, declares the stream, registers the binding,
+    /// and swaps the rebuilt trie in — invalidating every connection's resolve cache via the advanced
+    /// generation). GATED on the negotiated streams capability and fail-closed: a malformed pattern /
+    /// stream name or a fork-bound rejection is a typed `Err`. Idempotent. Never panics.
+    fn handle_bind_subject<
+        F: Filesystem + Clone + 'static,
+        C: Clock + Clone + 'static,
+        E: EngineAccess<F, C>,
+    >(
+        &mut self,
+        engine: &E,
+        body: &[u8],
+        out: &mut Vec<u8>,
+    ) -> Result<(), SessionError> {
+        if !self.connected {
+            reply_err(out, "not connected");
+            return Ok(());
+        }
+        if !self.streams_enabled {
+            reply_err(
+                out,
+                "stream addressing not negotiated (set understands_streams)",
+            );
+            return Ok(());
+        }
+        let Ok(decoded) = decode_bind_subject(body) else {
+            reply_err(out, "malformed bind-subject body");
+            return Ok(());
+        };
+        let Ok(stream) = core::str::from_utf8(decoded.stream_id) else {
+            reply_err(out, "stream id must be valid UTF-8");
+            return Ok(());
+        };
+        let Ok(pattern) = core::str::from_utf8(decoded.pattern) else {
+            reply_err(out, "subject pattern must be valid UTF-8");
+            return Ok(());
+        };
+        let stream = stream.to_string();
+        let pattern = pattern.to_string();
+        match engine.with(move |e| e.bind_subject(&stream, &pattern))? {
+            Ok(_generation) => reply(out, FrameType::Ok, &[]),
+            // A malformed pattern/name or a fork-bound rejection fails closed with the engine's typed
+            // reason (and stable code); the previous binding table stays installed on a rejection.
+            Err(e) => reply_err(out, &e.to_string()),
+        }
+        Ok(())
+    }
+
+    /// Handles a `PubSubject` (#585, M2-I9): publish BY SUBJECT. Resolves the literal subject through
+    /// THIS connection's generation-guarded resolve cache (an O(1) hash lookup on a hot subject, a single
+    /// wait-free trie walk on a miss) under the FAIL-CLOSED single-home default — exactly ONE bound
+    /// stream routes the append there (via [`Engine::produce_in_stream`]), ZERO is a
+    /// `NoStreamForSubject` reject (the explicit beat over NATS's silent drop), two-or-more is an
+    /// `AmbiguousSubject` reject. The verbatim `PubBody` tail is decoded with the UNCHANGED
+    /// [`decode_pub`] codec, so the publish body is shared byte-for-byte with `Pub`/`PubTo`. GATED on the
+    /// negotiated streams capability; fail-closed on a malformed prefix or pub body. Never panics.
+    ///
+    /// The resolve runs INSIDE the actor job (where the engine's wait-free routing snapshot lives): the
+    /// per-connection cache is moved into the job and back out, so the cache stays connection-local while
+    /// the resolve reads the shared, lock-free trie. The append then routes through the SAME id-routed
+    /// produce path a `PubTo` uses, so a subject-addressed publish is at-least-once Level-1-equivalent
+    /// (a `PubAck` after the resolved stream's covering fsync), exactly like `PubTo`.
+    fn handle_pub_subject<
+        F: Filesystem + Clone + 'static,
+        C: Clock + Clone + 'static,
+        E: EngineAccess<F, C>,
+    >(
+        &mut self,
+        engine: &E,
+        body: &[u8],
+        out: &mut Vec<u8>,
+    ) -> Result<(), SessionError> {
+        if !self.connected {
+            reply_err(out, "not connected");
+            return Ok(());
+        }
+        if !self.streams_enabled {
+            reply_err(
+                out,
+                "stream addressing not negotiated (set understands_streams)",
+            );
+            return Ok(());
+        }
+        let Ok(decoded) = decode_pub_subject(body) else {
+            reply_err(out, "malformed pub-subject body");
+            return Ok(());
+        };
+        let Ok(subject) = core::str::from_utf8(decoded.subject) else {
+            reply_err(out, "subject must be valid UTF-8");
+            return Ok(());
+        };
+        let Ok(msg) = decode_pub(decoded.pub_body) else {
+            reply_err(out, "malformed pub body");
+            return Ok(());
+        };
+        // A subject-addressed publish is at-least-once Level-1-equivalent this phase (same scope as
+        // `PubTo`): a non-Level-1 ack level is refused rather than silently downgraded.
+        if !matches!(pub_ack_level(msg.flags), AckLevel::ServerAck) {
+            reply_err(
+                out,
+                "subject-addressed publish supports only server-ack (level 1) this phase",
+            );
+            return Ok(());
+        }
+        // The dedup-id wire caps (#33), enforced at the boundary exactly as the default `handle_pub` and
+        // `handle_pub_to` do, BEFORE the bytes cross into owned storage.
+        if let Some(d) = msg.dedup.as_ref() {
+            if d.producer_id.len() > MAX_PRODUCER_ID_LEN {
+                reply_err(out, "producer_id too long");
+                return Ok(());
+            }
+            if d.msg_id.len() > MAX_MSG_ID_LEN {
+                reply_err(out, "msg_id too long");
+                return Ok(());
+            }
+        }
+        // Compressed-descriptor SHAPE validation at the wire boundary (#438), same gate as the other
+        // publish paths: a stored compressed object must be decodable by every reader.
+        if RecordFlags::from_bits(msg.flags).contains(RecordFlags::COMPRESSED) {
+            if let Err(e) = validate_descriptor_shape(msg.payload, DEFAULT_MAX_DECOMPRESSED_BYTES) {
+                reply_err(out, &format!("malformed compressed descriptor: {e}"));
+                return Ok(());
+            }
+        }
+        // Build the OWNED append (the wire body borrows the connection buffer, which the closure cannot
+        // hold), then RESOLVE + PRODUCE in ONE actor job: the resolve reads the engine's wait-free
+        // routing snapshot through this connection's cache (moved in and back out), and on a single-home
+        // hit the resolved stream's id-routed produce runs in the same job. A NoStream/Ambiguous
+        // resolution is returned as a typed reject WITHOUT touching a log (no silent drop, no partial
+        // write — the fail-closed beat over NATS).
+        let dedup = msg.dedup.map(|d| OwnedDedup {
+            producer_id: Bytes::copy_from_slice(d.producer_id),
+            epoch: d.epoch,
+            msg_id: Bytes::copy_from_slice(d.msg_id),
+        });
+        let append = OwnedAppend {
+            timestamp_ms: msg.timestamp_ms,
+            flags: msg.flags & !PUB_WIRE_ONLY_FLAGS,
+            key: Bytes::copy_from_slice(msg.key),
+            headers: Bytes::copy_from_slice(msg.headers),
+            payload: Bytes::copy_from_slice(msg.payload),
+            dedup,
+            enqueue_monotonic_nanos: engine.now_monotonic_nanos(),
+            fire_and_forget: false,
+        };
+        let subject = subject.to_string();
+        // Move the per-connection resolve cache into the job; the job returns it (and the produce
+        // outcome) so the cache's freshly-cached entry + adopted generation persist across publishes.
+        let cache = std::mem::take(&mut self.subject_cache);
+        let (cache, outcome) = engine.with(move |e| {
+            let mut cache = cache;
+            let outcome = resolve_then_produce(e, &mut cache, &subject, &append);
+            (cache, outcome)
+        })?;
+        self.subject_cache = cache;
+        match outcome {
+            Ok(offset) => {
+                let ack = PubAckBody {
+                    offset: offset.get(),
+                };
+                let mut ack_body = Vec::new();
+                encode_pub_ack(&ack, &mut ack_body);
+                reply(out, FrameType::PubAck, &ack_body);
+                Ok(())
+            }
+            // A fatal storage error on the resolved stream ends the session, exactly like the other
+            // produce paths (a frozen writer / broken invariant is unrecoverable).
+            Err(e) if e.is_fatal() => {
+                reply_err(out, "fatal storage error");
+                Err(SessionError::EngineFatal(e))
+            }
+            // An unbound (NoStreamForSubject) or ambiguous (AmbiguousSubject) subject, a malformed
+            // subject, or a non-fatal storage shed is a typed, connection-preserving reject — never a
+            // panic and (critically) NEVER a silent drop.
+            Err(e) => {
+                reply_err(out, &e.to_string());
+                Ok(())
+            }
+        }
+    }
+
+    /// Handles a `SubSubject` (#585, M2-I9): subscribe BY SUBJECT. Resolves the subject through this
+    /// connection's generation-guarded resolve cache under the single-home default; a LITERAL subject
+    /// resolves to ONE bound stream and this connection's subsequent `Flow`/`Ack` bind to that stream's
+    /// own competing work-group (via the id-routed `poll_in_stream`/`ack_in_stream`). An unbound subject
+    /// is a `NoStreamForSubject` reject and an ambiguous one an `AmbiguousSubject` reject (single-home;
+    /// fanning a wildcard sub over multiple covered streams is the FLAGGED follow-up). GATED on the
+    /// negotiated streams capability; fail-closed on a malformed body. Never panics.
+    ///
+    /// NOTE the scope: a `SubSubject` resolves the subject to ONE stream and binds THAT stream's
+    /// work-group (single-home). A wildcard subject that single-home-resolves (covers exactly one bound
+    /// stream) is accepted; a wildcard covering MANY bound streams is `AmbiguousSubject` here (the
+    /// multi-stream wildcard fan-out subscribe is the flagged later issue, not this PR).
+    fn handle_sub_subject<
+        F: Filesystem + Clone + 'static,
+        C: Clock + Clone + 'static,
+        E: EngineAccess<F, C>,
+    >(
+        &mut self,
+        engine: &E,
+        body: &[u8],
+        out: &mut Vec<u8>,
+    ) -> Result<(), SessionError> {
+        if !self.connected {
+            reply_err(out, "not connected");
+            return Ok(());
+        }
+        if !self.streams_enabled {
+            reply_err(
+                out,
+                "stream addressing not negotiated (set understands_streams)",
+            );
+            return Ok(());
+        }
+        let Ok(decoded) = decode_sub_subject(body) else {
+            reply_err(out, "malformed sub-subject body");
+            return Ok(());
+        };
+        let Ok(subject) = core::str::from_utf8(decoded.subject) else {
+            reply_err(out, "subject must be valid UTF-8");
+            return Ok(());
+        };
+        let Ok(group) = core::str::from_utf8(decoded.group) else {
+            reply_err(out, "group name must be valid UTF-8");
+            return Ok(());
+        };
+        // Resolve the subject to its single bound stream INSIDE the actor (through this connection's
+        // cache, moved in and back out). A wildcard subject is parsed as a literal here only for the
+        // single-home walk — `Subject::parse_literal` rejects a wildcard, so a wildcard subject that the
+        // client sends is resolved through the engine's pattern-aware path below instead. To keep the
+        // bind simple and single-home, resolve via `resolve_subject` (literal) and fall back to a typed
+        // reject for a non-literal/unbound/ambiguous subject.
+        let subject_owned = subject.to_string();
+        let cache = std::mem::take(&mut self.subject_cache);
+        let (cache, resolved) = engine.with(move |e| {
+            let mut cache = cache;
+            let resolved = resolve_subject_cached(e, &mut cache, &subject_owned);
+            (cache, resolved)
+        })?;
+        self.subject_cache = cache;
+        let stream = match resolved {
+            Ok(id) => id,
+            Err(e) => {
+                reply_err(out, &e.to_string());
+                return Ok(());
+            }
+        };
+        // Bind this connection's consume path to the resolved stream + the requested work-group, exactly
+        // as a `SubTo` binds an explicit stream id (the resolved stream is already declared by its bind).
+        self.stream = GroupName::from(stream.name());
+        self.subscription = GroupName::from(group);
+        self.registered_subscription = false;
+        self.joined_key_shared = false;
+        self.leased.clear();
+        reply(out, FrameType::Ok, &[]);
+        Ok(())
+    }
+
     fn handle_unsub<F: Filesystem + 'static, C: Clock + Clone + 'static, E: EngineAccess<F, C>>(
         &mut self,
         engine: &E,
@@ -2722,6 +3011,65 @@ fn negotiate_credit_bytes(requested: Option<u64>, cap: u64) -> u64 {
         // Both finite: tighten to the smaller.
         Some(want) => want.min(cap),
     }
+}
+
+/// Resolves the literal `subject` to its single bound stream (#585) THROUGH the per-connection
+/// `cache`, against the engine's wait-free routing snapshot — INSIDE an actor job (where `&mut Engine`
+/// is borrowable). A cache HIT is an O(1) hash lookup (no trie walk); a MISS walks the trie once and
+/// caches the result; a bind change (a newer snapshot generation) drops the stale cache on the next
+/// resolve. Returns the resolved [`StreamId`] or the typed fail-closed reject — a malformed/wildcard
+/// subject ([`EngineError::InvalidSubject`]), an unbound subject ([`EngineError::NoStreamForSubject`],
+/// NOT a silent drop), or an ambiguous subject ([`EngineError::AmbiguousSubject`]).
+///
+/// This is the cached twin of [`Engine::resolve_subject`]: the engine method walks the trie directly;
+/// this resolves through the connection's cache so a hot subject is O(1). The single-home reduction is
+/// the shared [`single_home`] policy, so the two agree.
+fn resolve_subject_cached<F: Filesystem, C: Clock + Clone>(
+    engine: &Engine<F, C>,
+    cache: &mut ResolveCache<StreamId>,
+    subject: &str,
+) -> Result<StreamId, EngineError> {
+    // Validate as a #567 LITERAL (no wildcards on the publish/subscribe-by-literal side); a wildcard or
+    // malformed subject is a typed reject before any routing.
+    let subj = Subject::parse_literal(subject).map_err(EngineError::InvalidSubject)?;
+    // Resolve through the cache against the engine's wait-free snapshot, then reduce single-home over the
+    // cached target slice WITHOUT cloning the whole Vec (only the one routed id is cloned on the happy
+    // path).
+    match cache.resolve_with(engine.binding_snapshot(), &subj, single_home) {
+        Resolution::Routed(id) => Ok(id),
+        Resolution::NoStream => Err(EngineError::NoStreamForSubject {
+            subject: subject.to_string(),
+        }),
+        Resolution::Ambiguous { matched } => Err(EngineError::AmbiguousSubject {
+            subject: subject.to_string(),
+            matched,
+        }),
+    }
+}
+
+/// Resolves `subject` single-home through `cache` (fail-closed) and, on a single-home hit, routes the
+/// owned `append` to the resolved stream via the id-routed [`Engine::produce_in_stream`] — the publish
+/// half of a `PubSubject` (#585), run in ONE actor job. An unbound/ambiguous/malformed subject is
+/// returned as a typed reject WITHOUT any append (no silent drop, no partial write — the fail-closed
+/// beat over NATS). Returns the assigned [`Offset`] in the resolved stream on success.
+fn resolve_then_produce<F: Filesystem + Clone, C: Clock + Clone>(
+    engine: &mut Engine<F, C>,
+    cache: &mut ResolveCache<StreamId>,
+    subject: &str,
+    append: &OwnedAppend,
+) -> Result<Offset, EngineError> {
+    // Resolve first (fail-closed): a NoStream/Ambiguous/Invalid subject is refused BEFORE any append.
+    let stream = resolve_subject_cached(engine, cache, subject)?;
+    // Route the append to the resolved stream's log via the id-routed produce (the default stream `""`
+    // routes byte-for-byte through `produce`; a named stream appends to its own log + commit tick).
+    let view = Append {
+        timestamp_ms: append.timestamp_ms,
+        flags: RecordFlags::from_bits(append.flags),
+        key: &append.key,
+        headers: &append.headers,
+        payload: &append.payload,
+    };
+    engine.produce_in_stream(stream.name(), &view)
 }
 
 /// Encodes a response frame. Bodies here are tiny (<= 8 bytes, or a short literal), well
@@ -8648,5 +8996,370 @@ mod tests {
                 .is_empty(),
             "a disconnected producer's confirms are dropped, never delivered"
         );
+    }
+
+    // =================================================================================
+    // #585 (V2-M2-I9): subject->stream binding + subject-addressed pub/sub OVER THE WIRE.
+    // A streams-capable client BindSubjects a pattern, then publishes/subscribes BY SUBJECT
+    // and the broker resolves single-home (fail-closed) through the connection's resolve cache.
+    // The explicit-stream-id (#588) and default verbs are unchanged.
+    // =================================================================================
+
+    /// A Connect body that advertises the streams capability (#588/#585): required to use the
+    /// subject-addressed verbs (they are gated on the negotiated `understands_streams`).
+    fn streams_connect_body() -> Vec<u8> {
+        let mut body = Vec::new();
+        ironbus_proto::message::encode_connect(
+            &ironbus_proto::message::ConnectBody {
+                requested_credit: None,
+                requested_credit_bytes: None,
+                wants_gap_marker: false,
+                default_ack_level: None,
+                understands_streaming: false,
+                default_tier: None,
+                understands_deliver_batch: false,
+                understands_streams: true,
+            },
+            &mut body,
+        );
+        body
+    }
+
+    /// A level-1 (server-ack) `PubBody` carrying `payload`, the body shared by Pub/PubTo/PubSubject.
+    fn pub_body(payload: &[u8]) -> Vec<u8> {
+        let mut b = Vec::new();
+        encode_pub(
+            &PubBody {
+                flags: 0,
+                timestamp_ms: 0,
+                key: b"",
+                headers: b"",
+                payload,
+                dedup: None,
+                fire_and_forget: false,
+            },
+            &mut b,
+        )
+        .unwrap();
+        b
+    }
+
+    /// Connects a streams-capable session against a fresh direct engine.
+    fn connect_streams() -> (DirectEngine<InMemoryFs, ManualClock>, Session, Vec<u8>) {
+        let e = DirectEngine::new(engine());
+        let mut s = Session::new();
+        let mut out = Vec::new();
+        s.process(
+            &e,
+            &frame(FrameType::Connect, &streams_connect_body()),
+            &mut out,
+        )
+        .unwrap();
+        assert_eq!(one_response(&out).0, FrameType::Info);
+        out.clear();
+        (e, s, out)
+    }
+
+    #[test]
+    fn bind_publish_and_subscribe_by_subject_end_to_end_over_the_wire() {
+        // THE wire end-to-end: BindSubject "order.>" -> "orders"; PubSubject "order.us.created"
+        // resolves single-home and lands in "orders" (a PubAck comes back); then a SubSubject on a
+        // literal subject covered by the binding resolves to "orders" and a Flow delivers the record.
+        let (e, mut s, mut out) = connect_streams();
+
+        // BIND "order.>" to "orders".
+        let mut bind = Vec::new();
+        ironbus_proto::message::encode_bind_subject(
+            &ironbus_proto::message::BindSubjectBody {
+                stream_id: b"orders",
+                pattern: b"order.>",
+            },
+            &mut bind,
+        )
+        .unwrap();
+        s.process(&e, &frame(FrameType::BindSubject, &bind), &mut out)
+            .unwrap();
+        assert_eq!(one_response(&out).0, FrameType::Ok, "bind acknowledged");
+        out.clear();
+
+        // PUBLISH BY SUBJECT -> PubAck at offset 0 in "orders".
+        let mut pubsub = Vec::new();
+        ironbus_proto::message::encode_pub_subject(
+            &ironbus_proto::message::PubSubjectBody {
+                subject: b"order.us.created",
+                pub_body: &pub_body(b"hello"),
+            },
+            &mut pubsub,
+        )
+        .unwrap();
+        s.process(&e, &frame(FrameType::PubSubject, &pubsub), &mut out)
+            .unwrap();
+        let (ty, body) = one_response(&out);
+        assert_eq!(ty, FrameType::PubAck, "publish-by-subject is acked");
+        assert_eq!(decode_pub_ack(&body).unwrap().offset, 0);
+        out.clear();
+        // The record landed in "orders" (the bound stream), NOT the default stream.
+        assert_eq!(e.engine_mut().stream_head("orders").get(), 1);
+        assert_eq!(e.engine_mut().stream_head("").get(), 0);
+
+        // SUBSCRIBE BY SUBJECT (a literal the binding covers) -> Ok, then a Flow delivers the record.
+        let mut subsub = Vec::new();
+        ironbus_proto::message::encode_sub_subject(
+            &ironbus_proto::message::SubSubjectBody {
+                subject: b"order.us.created",
+                group: b"workers",
+            },
+            &mut subsub,
+        )
+        .unwrap();
+        s.process(&e, &frame(FrameType::SubSubject, &subsub), &mut out)
+            .unwrap();
+        assert_eq!(
+            one_response(&out).0,
+            FrameType::Ok,
+            "subscribe-by-subject resolved"
+        );
+        out.clear();
+        // A Flow on the subject-bound subscription delivers the record off "orders".
+        s.process(&e, &frame(FrameType::Flow, &1u32.to_le_bytes()), &mut out)
+            .unwrap();
+        let frames = decode_all(&out);
+        let delivers: Vec<_> = frames
+            .iter()
+            .filter(|(t, _)| *t == FrameType::Deliver)
+            .collect();
+        assert_eq!(
+            delivers.len(),
+            1,
+            "the subject-resolved consumer got the record: {frames:?}"
+        );
+        assert_eq!(decode_deliver(&delivers[0].1).unwrap().payload, b"hello");
+    }
+
+    #[test]
+    fn publish_to_an_unbound_subject_is_a_typed_err_over_the_wire_not_a_silent_drop() {
+        // THE beat over NATS, on the wire: a PubSubject to a subject with NO binding gets a typed Err
+        // (fail-closed), NOT a PubAck-and-silent-discard. Nothing is written.
+        let (e, mut s, mut out) = connect_streams();
+        let mut pubsub = Vec::new();
+        ironbus_proto::message::encode_pub_subject(
+            &ironbus_proto::message::PubSubjectBody {
+                subject: b"telemetry.cpu",
+                pub_body: &pub_body(b"x"),
+            },
+            &mut pubsub,
+        )
+        .unwrap();
+        s.process(&e, &frame(FrameType::PubSubject, &pubsub), &mut out)
+            .unwrap();
+        let (ty, body) = one_response(&out);
+        assert_eq!(
+            ty,
+            FrameType::Err,
+            "an unbound subject is a typed Err, never a silent drop"
+        );
+        assert!(
+            String::from_utf8_lossy(&body).contains("no stream is bound"),
+            "the reject names the cause: {}",
+            String::from_utf8_lossy(&body)
+        );
+        // No silent drop: the default stream got nothing.
+        assert_eq!(e.engine_mut().stream_head("").get(), 0);
+    }
+
+    #[test]
+    fn publish_to_an_ambiguous_subject_is_a_typed_err_over_the_wire() {
+        // A subject bound to TWO streams is AmbiguousSubject (single-home) on the wire.
+        let (e, mut s, mut out) = connect_streams();
+        for (stream, pattern) in [
+            (&b"orders"[..], &b"order.>"[..]),
+            (&b"audit"[..], &b"order.us.*"[..]),
+        ] {
+            let mut bind = Vec::new();
+            ironbus_proto::message::encode_bind_subject(
+                &ironbus_proto::message::BindSubjectBody {
+                    stream_id: stream,
+                    pattern,
+                },
+                &mut bind,
+            )
+            .unwrap();
+            s.process(&e, &frame(FrameType::BindSubject, &bind), &mut out)
+                .unwrap();
+            assert_eq!(one_response(&out).0, FrameType::Ok);
+            out.clear();
+        }
+        let mut pubsub = Vec::new();
+        ironbus_proto::message::encode_pub_subject(
+            &ironbus_proto::message::PubSubjectBody {
+                subject: b"order.us.created",
+                pub_body: &pub_body(b"x"),
+            },
+            &mut pubsub,
+        )
+        .unwrap();
+        s.process(&e, &frame(FrameType::PubSubject, &pubsub), &mut out)
+            .unwrap();
+        let (ty, body) = one_response(&out);
+        assert_eq!(ty, FrameType::Err);
+        assert!(
+            String::from_utf8_lossy(&body).contains("resolves to 2 bound streams"),
+            "the ambiguous reject names the count: {}",
+            String::from_utf8_lossy(&body)
+        );
+    }
+
+    #[test]
+    fn a_bind_change_invalidates_the_connection_resolve_cache_no_stale_routing() {
+        // A connection publishes by subject (caching the route), then a SECOND bind makes the subject
+        // ambiguous. The connection's NEXT publish must see the change (a typed AmbiguousSubject Err),
+        // proving the per-connection resolve cache was invalidated by the bind's generation bump — no
+        // stale single-route. (This is the wire-level proof of the cache-invalidation property.)
+        let (e, mut s, mut out) = connect_streams();
+        let bind = |stream: &[u8], pattern: &[u8]| {
+            let mut b = Vec::new();
+            ironbus_proto::message::encode_bind_subject(
+                &ironbus_proto::message::BindSubjectBody {
+                    stream_id: stream,
+                    pattern,
+                },
+                &mut b,
+            )
+            .unwrap();
+            b
+        };
+        let pub_subject = || {
+            let mut p = Vec::new();
+            ironbus_proto::message::encode_pub_subject(
+                &ironbus_proto::message::PubSubjectBody {
+                    subject: b"order.us.created",
+                    pub_body: &pub_body(b"x"),
+                },
+                &mut p,
+            )
+            .unwrap();
+            p
+        };
+
+        // Bind "order.>" -> "orders", publish (caches the single-home route to "orders").
+        s.process(
+            &e,
+            &frame(FrameType::BindSubject, &bind(b"orders", b"order.>")),
+            &mut out,
+        )
+        .unwrap();
+        out.clear();
+        s.process(&e, &frame(FrameType::PubSubject, &pub_subject()), &mut out)
+            .unwrap();
+        assert_eq!(
+            one_response(&out).0,
+            FrameType::PubAck,
+            "first publish routed"
+        );
+        out.clear();
+
+        // SECOND bind: "audit" also binds a pattern covering the subject -> now ambiguous.
+        s.process(
+            &e,
+            &frame(FrameType::BindSubject, &bind(b"audit", b"order.us.*")),
+            &mut out,
+        )
+        .unwrap();
+        assert_eq!(one_response(&out).0, FrameType::Ok);
+        out.clear();
+
+        // The SAME connection's next publish of the SAME subject now sees the AMBIGUITY (cache dropped
+        // its stale single-route via the generation guard) — a typed Err, not a stale PubAck.
+        s.process(&e, &frame(FrameType::PubSubject, &pub_subject()), &mut out)
+            .unwrap();
+        let (ty, body) = one_response(&out);
+        assert_eq!(
+            ty,
+            FrameType::Err,
+            "the bind change invalidated the cached route"
+        );
+        assert!(String::from_utf8_lossy(&body).contains("resolves to 2 bound streams"));
+    }
+
+    #[test]
+    fn the_subject_verbs_are_refused_without_the_streams_capability() {
+        // An old client (no understands_streams) is REFUSED the subject verbs with a typed Err, never
+        // the new behavior — so it can only use the default-stream verbs, byte-for-byte unchanged.
+        let e = DirectEngine::new(engine());
+        let mut s = Session::new();
+        let mut out = Vec::new();
+        // Connect WITHOUT the streams capability.
+        s.process(
+            &e,
+            &frame(FrameType::Connect, &gap_marker_connect_body()),
+            &mut out,
+        )
+        .unwrap();
+        out.clear();
+        let mut bind = Vec::new();
+        ironbus_proto::message::encode_bind_subject(
+            &ironbus_proto::message::BindSubjectBody {
+                stream_id: b"orders",
+                pattern: b"order.>",
+            },
+            &mut bind,
+        )
+        .unwrap();
+        s.process(&e, &frame(FrameType::BindSubject, &bind), &mut out)
+            .unwrap();
+        let (ty, body) = one_response(&out);
+        assert_eq!(ty, FrameType::Err);
+        assert!(String::from_utf8_lossy(&body).contains("not negotiated"));
+    }
+
+    #[test]
+    fn the_explicit_stream_id_and_default_publish_paths_are_unchanged_with_subject_routing_present()
+    {
+        // PRESERVE: a plain default-stream Pub and an explicit-id PubTo still work exactly as before even
+        // with subject bindings present — subject routing is an additive parallel path, never a re-route.
+        let (e, mut s, mut out) = connect_streams();
+        // A binding exists, but it must not affect the default/explicit paths.
+        let mut bind = Vec::new();
+        ironbus_proto::message::encode_bind_subject(
+            &ironbus_proto::message::BindSubjectBody {
+                stream_id: b"orders",
+                pattern: b"order.>",
+            },
+            &mut bind,
+        )
+        .unwrap();
+        s.process(&e, &frame(FrameType::BindSubject, &bind), &mut out)
+            .unwrap();
+        out.clear();
+
+        // A plain default-stream Pub still lands in the default stream and is acked.
+        s.process(&e, &frame(FrameType::Pub, &pub_body(b"d0")), &mut out)
+            .unwrap();
+        let dframes = decode_all(&out);
+        assert!(
+            dframes.iter().any(|(t, _)| *t == FrameType::PubAck),
+            "a plain Pub is still acked: {dframes:?}"
+        );
+        assert_eq!(
+            e.engine_mut().stream_head("").get(),
+            1,
+            "the default Pub landed in the default stream"
+        );
+        out.clear();
+
+        // An explicit-id PubTo to "shipments" still routes there (NOT via any subject binding).
+        let mut pubto = Vec::new();
+        ironbus_proto::message::encode_pub_to(
+            &ironbus_proto::message::PubToBody {
+                stream_id: b"shipments",
+                pub_body: &pub_body(b"s0"),
+            },
+            &mut pubto,
+        )
+        .unwrap();
+        s.process(&e, &frame(FrameType::PubTo, &pubto), &mut out)
+            .unwrap();
+        assert_eq!(one_response(&out).0, FrameType::PubAck);
+        assert_eq!(e.engine_mut().stream_head("shipments").get(), 1);
     }
 }


### PR DESCRIPTION
Closes #585 (V2-M2-I9, the subjects story). A client publishes/subscribes by **subject** (not just an explicit stream id), routed to a stream via a **binding** — the NATS-subjects-equivalent feature, but **fail-closed**. Builds on the merged #649 (subject parser), #651 (wait-free trie), #669 (resolve cache), #675/#679 (StreamSet + engine id-routing), #685 (stream wire frames).

## The binding (subject pattern -> StreamId)
A stream **binds** a set of subject patterns (e.g. stream `orders` binds `order.>`, `payment.*.done`). The bindings live in the #651 `Sublist` trie with `target = StreamId`. A `BindSubject` adds a `pattern -> stream` entry, **rebuilds** the immutable trie, and **swaps** a fresh generation in — which is exactly the signal each connection's #669 resolve cache watches to drop a stale routing answer. Fail-closed at ingest: a malformed pattern is rejected via the #649 grammar, and the rebuild is fail-closed on the #651 fork bound (a bad bind leaves the previous table installed).

## Single-home resolution (the default, fail-closed)
A publish to a **literal** subject resolves (via the trie + the per-connection resolve cache) to the bound stream(s):
- **exactly one** bound stream -> route there;
- **zero** -> typed `NoStreamForSubject` reject (**fail-closed, NOT a silent drop**);
- **>= 2** -> typed `AmbiguousSubject` reject (single-home default).

New `ironbus-core` primitive `binding.rs` (IO-free): `Resolution<T>` + the `single_home` reducer + cached/uncached resolve helpers over the existing `Sublist` + `ResolveCache`. The server wires `StreamId` as the target.

## Wire (additive, old clients unchanged)
New **additive** frame tags, all gated on the negotiated `understands_streams` capability:
- `BindSubject` (32): bind a subject pattern to a stream.
- `PubSubject` (33): publish by subject (verbatim `PubBody` tail shared with `Pub`/`PubTo`); resolves through the connection's resolve cache.
- `SubSubject` (34): subscribe by subject (literal -> single-home bind to the resolved stream's work-group).

Explicit-stream-id (`StreamDeclare`/`StreamInfo`/`PubTo`/`SubTo`, tags 28-31) + default-stream (`Pub`/`Sub`/`Flow`) verbs are byte-for-byte unchanged; tags 1-31 untouched.

## Beat-NATS angle
- **NATS silently drops** a publish to a subject with no bound interest while still returning a successful `PubAck` — the producer believes the message landed when it vanished. **IronBus is fail-closed**: a typed `NoStreamForSubject` reject.
- NATS resolves **every** publish through the global `Sublist` (under a lock) per message, and flushes a global results cache on every subscription change. IronBus uses the **per-connection generation-guarded resolve cache** (#669): steady-state resolution is O(1), and a bind change costs a single generation-compare on the next publish (the stale answer is dropped lazily) — **no global cache flush**.

## Tests
- bind `order.>` -> `orders`: a publish to `order.us.created` resolves + **lands in `orders`** (end-to-end over a real server, wire + engine);
- a publish to an **unbound** subject -> typed `NoStreamForSubject` reject (fail-closed, **no silent drop** — asserted nothing was written);
- an **ambiguous** subject (bound to 2 streams) -> typed `AmbiguousSubject` reject;
- a `SubSubject` by subject resolves + a `Flow` delivers from the resolved stream;
- a **bind change invalidates the per-connection resolve cache** (no stale routing — proven at both core and wire level);
- **explicit-stream-id (#685) still works unchanged**; the **default `""`** still works; binding the default stream routes a subject to the default log.

## Preserved
Back-compat (old clients + explicit-stream-id publish/subscribe unchanged); the default stream `""` (a no-subject publish still targets `""`); fail-closed (no silent drops, no panic on a malformed/unbound subject); the wait-free trie read property; `ironbus-core` IO-free (the binding/resolution primitive is in core; the wire + engine wiring is in server); I1-I4 per stream.

## Deferred (flagged)
- The **overlap_ok subject FAN-OUT** (a publish to K bound streams) is a later **opt-in** issue — single-home refuses an ambiguous subject rather than fanning out.
- **Per-subject FILTERED consume** within a stream is **M2-I12 (#594)**.
- **Partitions** are M2-I11.
- The **stored per-record subject field** (a record carrying its subject so a filtered consumer can later filter): #685/#588 did **not** add a subject field to records, so a subject-published record does **not** yet carry its subject. The binding routes to the right stream; the per-record subject is the M2-I12 (#594) follow-up.

## Gates (all pass)
- `cargo fmt --all --check` — clean.
- **FRESH** (from `cargo clean`) `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` (RUSTFLAGS `-D warnings`, MSRV 1.78) — clean.
- `cargo test --workspace --all-features --locked` — **1924 passed / 0 failed**.
- io-free-check core — `binding.rs` is structurally IO-free (23 source files clean).

## What to scrutinize
- The `PubSubject`/`SubSubject` handlers move the per-connection `ResolveCache<StreamId>` **into** the actor `with` job (where the wait-free routing snapshot lives) and **back out**, so the cache stays connection-local while the resolve reads the shared lock-free trie — confirm that ownership round-trip is what you'd want vs. resolving uncached.
- `SubSubject` resolves the subject as a **literal** single-home (a wildcard subject that covers exactly one bound stream is accepted; one covering many is `AmbiguousSubject`) — the multi-stream wildcard fan-out subscribe is deliberately the flagged follow-up.
- Bindings are **in-memory only** this phase (a stream's bindings do not survive a restart; only its log recovers via the StreamSet) — durable binding persistence is a flagged follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVWp2H2txnKGru4q2twxM3