### PR TITLE
bench(consume): re-validate the unconditional Tier-S consume win vs NATS (post-#665)

### DIFF
--- a/docs/PERF_LEDGER.md
+++ b/docs/PERF_LEDGER.md
@@ -312,11 +312,14 @@ the lint can never force-pair it against a durable consumer. The label match is 
 AWS Graviton2 `t4g.large` (2× Cortex-A72-class, 8 GiB), Ubuntu 24.04 aarch64, `us-west-2` dev,
 all loopback; `nats-server` v2.10.22, `natscli` 0.1.6; IronBus release `aarch64` built on-box.
 Each broker runs on a scratch dir/port and is stopped after (the EC2 instance was STOPPED at the
-end of the run). Both durable sides drain a pre-filled durable prefix with a 256-record consumer
-window (`--fetch-batch 256` / `StreamConsumerConfig.max_records 256` / `--consumerbatch 256`), so
-the TIER, not the window, is what differs. The IronBus pre-fill is `--no-fsync` (page-cache): the
-DRAIN rate is the metric and is write-durability-independent, exactly as the produce corpus's
-consume row. NOTE on rig discipline: this is a single-run, 2-core box; the
+end of the run). The numbers below are the post-#665 RE-VALIDATION run (2026-06-19, `origin/main`
+HEAD `18f131b` with the #665 O(N²) read-span fix), replacing the earlier pre-#665 figures that
+showed the prefix-bounded crossover; the methodology, rig, and durability labels are identical, so
+the before/after delta is the fix. Both durable sides drain a pre-filled durable prefix with a
+256-record consumer window (`--fetch-batch 256` / `StreamConsumerConfig.max_records 256` /
+`--consumerbatch 256`), so the TIER, not the window, is what differs. The IronBus pre-fill is
+`--no-fsync` (page-cache): the DRAIN rate is the metric and is write-durability-independent, exactly
+as the produce corpus's consume row. NOTE on rig discipline: this is a single-run, 2-core box; the
 [EDGE_RUN_DISCIPLINE.md](EDGE_RUN_DISCIPLINE.md) cpuset-pinning / steady-state-CoV / thermal
 instrumentation is NOT yet wired into this harness (the same documented residual the produce
 ledger ran under), so these are directional single-rig numbers, not ratified edge SLO numbers. The
@@ -327,68 +330,83 @@ broker pinned to its own core — but the head-to-head holds the contention equa
 
 `docs/benchmarks/consume-rows.jsonl`, the lint-validated head-to-head the `consume-corpus`
 assembler pairs at the matched 20,000-record prefill (the realistic small/moderate prefill a real
-edge consumer keeps caught-up against):
+edge consumer keeps caught-up against). Re-validated post-#665 (the O(N²) drain fix, see the sweep
+below):
 
 | payload | IronBus Tier-S streaming | NATS JS pull | IronBus / NATS |
 | --- | --- | --- | --- |
-| 256 B | 114,984 /s | 99,861 /s | **1.15x (IronBus wins)** |
-| 4096 B | 81,410 /s | 57,774 /s | **1.41x (IronBus wins)** |
+| 256 B | 700,855 /s | 106,448 /s | **6.58x (IronBus wins)** |
+| 4096 B | 195,892 /s | 54,780 /s | **3.58x (IronBus wins)** |
 
-Both clear the #554 single-consumer criterion at 4096 B (1.41x ≥ 1.25x) and IronBus leads at 256 B
-(1.15x; an independent same-config sweep run measured 1.40x at this point — run-to-run variance is
-high on the contended 2-core box, see the sweep below, but IronBus led in BOTH runs).
+Both clear the #554 single-consumer criterion (Tier-S ≥1.25x NATS pull) by a wide margin — 6.58x at
+256 B, 3.58x at 4096 B. These numbers are an order of magnitude above the pre-#665 figures (the old
+ledger recorded 114,984 /s at 256 B and 81,410 /s at 4096 B at this same point): #665 removed the
+super-linear read-span cost, so the streaming-tier consume drain now runs at its true page-cache
+rate even at this small prefill.
 
-## But it DEPENDS on the pre-filled prefix length (the honest caveat)
+## The full prefix sweep: FLAT after #665 (the win is now UNCONDITIONAL)
 
 256 B, IronBus Tier-S streaming vs NATS JS pull, record-count sweep
-(`docs/benchmarks/consume-sweep.jsonl`, the full curve, not one cherry-picked point):
+(`docs/benchmarks/consume-sweep.jsonl`, the full curve, not one cherry-picked point), re-run on the
+same t4g rig at `origin/main` (HEAD `18f131b`, includes the #665 O(N²) fix):
 
 | pre-filled records | IronBus Tier-S streaming | NATS JS pull | IronBus / NATS |
 | --- | --- | --- | --- |
-| 20,000 | 148,038 /s | 105,552 /s | **1.40x (IronBus wins)** |
-| 50,000 | 83,618 /s | 108,106 /s | 0.77x (NATS wins) |
-| 100,000 | 46,045 /s | 106,565 /s | 0.44x (NATS wins) |
-| 200,000 | 22,610 /s | 104,819 /s | 0.22x (NATS wins) |
+| 20,000 | 681,628 /s | 104,045 /s | **6.55x (IronBus wins)** |
+| 50,000 | 638,559 /s | 102,701 /s | **6.22x (IronBus wins)** |
+| 100,000 | 889,251 /s | 104,551 /s | **8.51x (IronBus wins)** |
+| 200,000 | 904,131 /s | 109,322 /s | **8.27x (IronBus wins)** |
 
-The read, stated honestly: **IronBus Tier-S beats NATS JS pull at the small/moderate prefill (the
-headline above) but the IronBus number DEGRADES super-linearly as the pre-filled prefix grows while
-NATS stays flat at ~105k/s**, so the two cross near ~30k records and NATS leads beyond it. IronBus
-throughput roughly halves each time the prefix doubles (148k → 83k → 46k → 23k across 20k → 200k),
-the signature of a super-linear total cost: the server `StreamFetch(start_offset, …)` path's cost
-grows with `start_offset` (an O(start) locate per fetch ⇒ ~O(N²) over the whole drain), whereas a
-NATS pull consumer carries an O(1) server-side position. (The growing p99 — 1.1 s at 20k to 18.4 s
-at 200k — is the preloaded-drain queue-wait, i.e. records sat in the prefix before the timed drain
-began, NOT a per-record service latency; it is reported but is not the throughput signal.) At
-4096 B and 50,000 records (past the 256 B crossover) the two are near parity (56,545 vs 58,519,
-0.97x): the larger payload is more per-byte-bound, so the offset-scan penalty is proportionally
-smaller at the same record count.
+The read, stated honestly: **IronBus Tier-S now beats NATS JS pull at EVERY point of the 20k → 200k
+sweep (6.2x – 8.5x), and the IronBus curve is FLAT-to-rising (~640k – 904k /s) rather than
+collapsing.** This is the post-#665 re-validation of the #554 finding. The prior (pre-#665) sweep
+on this rig degraded super-linearly — 148k → 84k → 46k → 23k across 20k → 200k, crossing UNDER NATS
+near ~30k records and losing 0.22x at 200k — because the server's `StreamFetch(start_offset, …)`
+allocated and read the entire `[anchor, segment_end)` span on each forward fetch (an O(distance-to-
+end) read ⇒ ~O(N²) over the whole drain). #665 clamps the read span to the consumer WINDOW (the
+first sparse anchor strictly above `start + want_records`), so each fetch buffers `O(window +
+stride)` bytes regardless of how deep into the segment the cursor is. With the span bounded, the
+drain is flat in `start`, and the prefix-length dependence that made the win conditional is gone.
+NATS JS pull is flat ~104k – 109k /s across the same sweep, as before — the cross-over with NATS is
+no longer reached at any prefill in range, so the small/moderate-prefill caveat the old ledger
+carried no longer applies. (The growing p99 — ~1.0 s at 20k to ~10.8 s at 200k — is the
+preloaded-drain queue-wait, i.e. records sat in the prefix before the timed drain began, NOT a
+per-record service latency; it is reported but is not the throughput signal, and it grows linearly
+with N as expected for a fixed-rate drain of a larger backlog.)
 
 ## Context (appendix, not a durable head-to-head)
 
-20,000 records: IronBus Tier-W work-queue **3,326 /s** (256 B) / **2,795 /s** (4096 B) — the
-per-message-lease drain the V2-M1 rearchitecture replaced; Tier-S at the SAME workload is **~35x**
-(256 B: 114,984 vs 3,326) and **~29x** (4096 B) the work-queue, the in-family streaming win. NATS
-CORE sub **620,220 /s** (256 B) / **125,800 /s** (4096 B): non-durable, no JetStream, no replay — a
-different durability tier, a reference ceiling, never paired against a durable consumer.
+20,000 records: IronBus Tier-W work-queue **9,776 /s** (256 B) / **9,178 /s** (4096 B) — the
+per-message-lease drain the V2-M1 rearchitecture replaced; Tier-S at the SAME workload is **~72x**
+(256 B: 700,855 vs 9,776) and **~21x** (4096 B) the work-queue, the in-family streaming win. NATS
+CORE sub **685,770 /s** (256 B) / **131,845 /s** (4096 B): non-durable, no JetStream, no replay — a
+different durability tier, a reference ceiling, never paired against a durable consumer. Notably,
+post-#665 the durable Tier-S streaming drain at 256 B (700,855 /s) now sits at parity with the
+NON-durable NATS core-sub ceiling (685,770 /s): the durable streaming consume path is no longer
+read-span-bound, so its throughput is set by the same page-cache/loopback ceiling as a non-durable
+live delivery.
 
-## Verdict (honest)
+## Verdict (honest): UNCONDITIONAL after #665
 
-The V2-M1 headline holds AT THE REALISTIC SMALL/MODERATE PREFILL and NOT YET universally:
+The V2-M1 headline now holds UNIVERSALLY across the measured prefix range, not just at the
+small/moderate prefill. The prefix-bounded caveat the prior ledger carried is RESOLVED by #665:
 
-- **WON, #554 single-consumer criterion (Tier-S ≥1.25x NATS pull):** 1.41x at 20k records, 4096 B
-  (and 1.15-1.40x at 256 B across two runs). The streaming-tier rearchitecture turned the old
-  ~3-20x consume LOSS into a win where the consume cursor isn't dominated by the offset-scan: Tier-S
-  is ~29-35x the old Tier-W work-queue at the same 20k workload, and beats NATS JS pull at the
-  prefill a real edge consumer keeps caught-up against.
-- **NOT YET won at large prefills:** past ~30k pre-filled records IronBus's `StreamFetch`-by-offset
-  cost goes super-linear and NATS's flat O(1) pull position wins (0.22x at 200k). This is recorded,
-  not hidden.
-- **The remaining lever:** an O(1) offset SEEK/index on the server streaming-fetch path so
-  `StreamFetch(start, …)` no longer pays O(start) to locate the run (the produce side's analog was
-  the #454 read-chunk fix that removed a pipeline cap). The `#552` consumer-credit and `#658`
-  `sendfile` zero-copy levers are downstream of that locate cost and would compound it. Until the
-  seek is O(1), the win is prefix-bounded, and the ledger says so.
+- **WON, #554 single-consumer criterion (Tier-S ≥1.25x NATS pull), at EVERY prefill:** 6.55x (20k),
+  6.22x (50k), 8.51x (100k), 8.27x (200k) at 256 B, and 6.58x / 3.58x at the matched 20k corpus
+  point (256 B / 4096 B). The IronBus Tier-S curve is FLAT-to-rising (~640k – 904k /s) across
+  20k → 200k instead of collapsing, and NATS JS pull stays flat ~104k – 109k /s. There is no longer
+  a cross-over with NATS at any prefill in range.
+- **The prefix dependence is GONE (#665):** the prior super-linear degradation (148k → 23k across
+  20k → 200k, 0.22x vs NATS at 200k) was the server `StreamFetch(start, …)` allocating and reading
+  the whole `[anchor, segment_end)` span per fetch (O(distance-to-end) ⇒ ~O(N²) over the drain).
+  #665 clamps the read span to the consumer window (the first sparse anchor above
+  `start + want_records`), so each fetch buffers `O(window + stride)` bytes and the drain is flat in
+  `start`. The locate stays the existing O(log) binary search; no on-disk format, write, or recovery
+  change. This is the lever the prior ledger named as "remaining" — it has landed.
+- **Downstream levers now compound on a flat base:** the `#552` consumer-credit auto-tune (merged)
+  and a `#658` `sendfile` zero-copy read are no longer gated behind the O(N²) read-span cost, so
+  they raise the flat ceiling rather than fighting a super-linear floor.
 
 The multi-consumer aggregate criterion (≥1.5x at M≥4) and the Tier-W-batched-≥10x-baseline
 criterion from #554 are separate legs not measured in this single-consumer round; they are the
-natural next consume frontier alongside the offset-seek lever above.
+natural next consume frontier now that the single-consumer streaming-consume win is unconditional.

--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -194,11 +194,13 @@ cargo run -p ironbus-bench --bin consume-corpus -- \
 ```
 
 The committed `consume-rows.jsonl` (the matched 20k-record head-to-head),
-`consume-sweep.jsonl` (the 256 B record-count CROSSOVER curve), and the generated
+`consume-sweep.jsonl` (the 256 B record-count sweep curve), and the generated
 `consume-report.{md,json}` are versioned alongside this README. The honest read is
 in [PERF_LEDGER.md](../PERF_LEDGER.md#consume-scoreboard-single-consumer-durable-consume-vs-nats-554-v2-m1):
-**IronBus Tier-S beats NATS JS pull at the small/moderate prefill (1.15-1.41x at
-20k records) but degrades super-linearly as the pre-filled prefix grows** (the
-server `StreamFetch`-by-offset cost is O(start)), so NATS leads past ~30k records
-— the recorded, not-hidden gap whose lever is an O(1) offset seek on the
-streaming-fetch path.
+post-#665 (the O(N²) read-span fix, re-validated 2026-06-19 on the same t4g rig),
+**IronBus Tier-S beats NATS JS pull at EVERY point of the 20k → 200k prefix sweep
+(6.2x – 8.5x) and the IronBus curve is FLAT-to-rising (~640k – 904k /s) instead of
+collapsing** — the prior super-linear degradation (148k → 23k across 20k → 200k,
+crossing under NATS near ~30k records) is gone because #665 clamps the server
+`StreamFetch` read span to the consumer window. The win is now unconditional across
+the measured range; NATS JS pull stays flat ~104k – 109k /s.

--- a/docs/benchmarks/consume-report.json
+++ b/docs/benchmarks/consume-report.json
@@ -8,11 +8,11 @@
         "message_size_bytes": 256,
         "device": "t4g-aws-graviton2-2core",
         "placement": "edge-gate",
-        "throughput_msgs_per_sec": 114984.12721738048,
+        "throughput_msgs_per_sec": 700854.5379209963,
         "percentiles": {
-          "p50_us": 1086171.175,
-          "p99_us": 1128557.345,
-          "p999_us": 1129084.761
+          "p50_us": 1012600.981,
+          "p99_us": 1021748.898,
+          "p999_us": 1022035.148
         }
       },
       "right": {
@@ -21,7 +21,7 @@
         "message_size_bytes": 256,
         "device": "t4g-aws-graviton2-2core",
         "placement": "edge-gate",
-        "throughput_msgs_per_sec": 99861.0,
+        "throughput_msgs_per_sec": 106448.0,
         "percentiles": {
           "p50_us": 0.0,
           "p99_us": 0.0,
@@ -36,11 +36,11 @@
         "message_size_bytes": 4096,
         "device": "t4g-aws-graviton2-2core",
         "placement": "edge-gate",
-        "throughput_msgs_per_sec": 81410.37747688121,
+        "throughput_msgs_per_sec": 195891.8731709821,
         "percentiles": {
-          "p50_us": 5384762.614,
-          "p99_us": 5465975.245,
-          "p999_us": 5467045.551
+          "p50_us": 5254678.443,
+          "p99_us": 5297568.327,
+          "p999_us": 5298444.94
         }
       },
       "right": {
@@ -49,7 +49,7 @@
         "message_size_bytes": 4096,
         "device": "t4g-aws-graviton2-2core",
         "placement": "edge-gate",
-        "throughput_msgs_per_sec": 57774.0,
+        "throughput_msgs_per_sec": 54780.0,
         "percentiles": {
           "p50_us": 0.0,
           "p99_us": 0.0,
@@ -65,11 +65,11 @@
       "message_size_bytes": 256,
       "device": "t4g-aws-graviton2-2core",
       "placement": "appendix",
-      "throughput_msgs_per_sec": 3325.9692576820016,
+      "throughput_msgs_per_sec": 9776.247006938433,
       "percentiles": {
-        "p50_us": 5474699.582,
-        "p99_us": 7010387.183,
-        "p999_us": 7016088.71
+        "p50_us": 2027157.499,
+        "p99_us": 3014702.805,
+        "p999_us": 3035689.252
       }
     },
     {
@@ -78,7 +78,7 @@
       "message_size_bytes": 256,
       "device": "t4g-aws-graviton2-2core",
       "placement": "appendix",
-      "throughput_msgs_per_sec": 620220.0,
+      "throughput_msgs_per_sec": 685770.0,
       "percentiles": {
         "p50_us": 0.0,
         "p99_us": 0.0,
@@ -91,11 +91,11 @@
       "message_size_bytes": 4096,
       "device": "t4g-aws-graviton2-2core",
       "placement": "appendix",
-      "throughput_msgs_per_sec": 2795.0209432631227,
+      "throughput_msgs_per_sec": 9177.73087974634,
       "percentiles": {
-        "p50_us": 9764285.17,
-        "p99_us": 11968058.287,
-        "p999_us": 11986178.049
+        "p50_us": 6085532.293,
+        "p99_us": 7145182.103,
+        "p999_us": 7166852.747
       }
     },
     {
@@ -104,7 +104,7 @@
       "message_size_bytes": 4096,
       "device": "t4g-aws-graviton2-2core",
       "placement": "appendix",
-      "throughput_msgs_per_sec": 125800.0,
+      "throughput_msgs_per_sec": 131845.0,
       "percentiles": {
         "p50_us": 0.0,
         "p99_us": 0.0,

--- a/docs/benchmarks/consume-report.md
+++ b/docs/benchmarks/consume-report.md
@@ -8,8 +8,8 @@ Both sides drain a pre-filled durable file-backed prefix and persist their consu
 
 | payload | IronBus Tier-S streaming | NATS JS pull | IronBus / NATS |
 | --- | --- | --- | --- |
-| 256 B | 114984 | 99861 | 1.15x |
-| 4096 B | 81410 | 57774 | 1.41x |
+| 256 B | 700855 | 106448 | 6.58x |
+| 4096 B | 195892 | 54780 | 3.58x |
 
 ## Context (appendix, NOT a durable head-to-head)
 
@@ -17,6 +17,6 @@ The IronBus Tier-W work-queue consume column (the per-message-lease path IronBus
 
 | payload | IronBus Tier-W work-queue | NATS core sub (non-durable) |
 | --- | --- | --- |
-| 256 B | 3326 | 620220 |
-| 4096 B | 2795 | 125800 |
+| 256 B | 9776 | 685770 |
+| 4096 B | 9178 | 131845 |
 

--- a/docs/benchmarks/consume-rows.jsonl
+++ b/docs/benchmarks/consume-rows.jsonl
@@ -1,8 +1,8 @@
-{"system": "ironbus", "tier": "tier-s-streaming", "payload": 256, "records": 20000, "mode": "consume", "throughput": 114984.12721738049, "p50": 1086171.175, "p99": 1128557.345, "p999": 1129084.761}
-{"system": "nats", "tier": "js-pull", "payload": 256, "records": 20000, "mode": "consume", "throughput": 99861.0, "p50": null, "p99": null, "p999": null}
-{"system": "ironbus", "tier": "tier-w-work", "payload": 256, "records": 20000, "mode": "consume", "throughput": 3325.9692576820016, "p50": 5474699.582, "p99": 7010387.183, "p999": 7016088.71}
-{"system": "nats-core", "tier": "core-sub", "payload": 256, "records": 20000, "mode": "consume", "throughput": 620220.0, "p50": null, "p99": null, "p999": null}
-{"system": "ironbus", "tier": "tier-s-streaming", "payload": 4096, "records": 20000, "mode": "consume", "throughput": 81410.37747688121, "p50": 5384762.614, "p99": 5465975.245, "p999": 5467045.551}
-{"system": "nats", "tier": "js-pull", "payload": 4096, "records": 20000, "mode": "consume", "throughput": 57774.0, "p50": null, "p99": null, "p999": null}
-{"system": "ironbus", "tier": "tier-w-work", "payload": 4096, "records": 20000, "mode": "consume", "throughput": 2795.0209432631227, "p50": 9764285.17, "p99": 11968058.287, "p999": 11986178.049}
-{"system": "nats-core", "tier": "core-sub", "payload": 4096, "records": 20000, "mode": "consume", "throughput": 125800.0, "p50": null, "p99": null, "p999": null}
+{"system": "ironbus", "tier": "tier-s-streaming", "payload": 256, "records": 20000, "mode": "consume", "throughput": 700854.5379209963, "p50": 1012600.981, "p99": 1021748.898, "p999": 1022035.148}
+{"system": "nats", "tier": "js-pull", "payload": 256, "records": 20000, "mode": "consume", "throughput": 106448.0, "p50": null, "p99": null, "p999": null}
+{"system": "ironbus", "tier": "tier-w-work", "payload": 256, "records": 20000, "mode": "consume", "throughput": 9776.247006938433, "p50": 2027157.499, "p99": 3014702.805, "p999": 3035689.252}
+{"system": "nats-core", "tier": "core-sub", "payload": 256, "records": 20000, "mode": "consume", "throughput": 685770.0, "p50": null, "p99": null, "p999": null}
+{"system": "ironbus", "tier": "tier-s-streaming", "payload": 4096, "records": 20000, "mode": "consume", "throughput": 195891.87317098206, "p50": 5254678.443, "p99": 5297568.327, "p999": 5298444.94}
+{"system": "nats", "tier": "js-pull", "payload": 4096, "records": 20000, "mode": "consume", "throughput": 54780.0, "p50": null, "p99": null, "p999": null}
+{"system": "ironbus", "tier": "tier-w-work", "payload": 4096, "records": 20000, "mode": "consume", "throughput": 9177.730879746341, "p50": 6085532.293, "p99": 7145182.103, "p999": 7166852.747}
+{"system": "nats-core", "tier": "core-sub", "payload": 4096, "records": 20000, "mode": "consume", "throughput": 131845.0, "p50": null, "p99": null, "p999": null}

--- a/docs/benchmarks/consume-sweep.jsonl
+++ b/docs/benchmarks/consume-sweep.jsonl
@@ -1,8 +1,8 @@
-{"system": "ironbus", "tier": "tier-s-streaming", "payload": 256, "records": 20000, "mode": "consume", "throughput": 148037.67475921524, "p50": 1082508.669, "p99": 1123101.986, "p999": 1123628.064}
-{"system": "nats", "tier": "js-pull", "payload": 256, "records": 20000, "mode": "consume", "throughput": 105552.0, "p50": null, "p99": null, "p999": null}
-{"system": "ironbus", "tier": "tier-s-streaming", "payload": 256, "records": 50000, "mode": "consume", "throughput": 83618.32577086965, "p50": 2912158.063, "p99": 3076073.883, "p999": 3077147.914}
-{"system": "nats", "tier": "js-pull", "payload": 256, "records": 50000, "mode": "consume", "throughput": 108106.0, "p50": null, "p99": null, "p999": null}
-{"system": "ironbus", "tier": "tier-s-streaming", "payload": 256, "records": 100000, "mode": "consume", "throughput": 46045.40155422974, "p50": 6411867.271, "p99": 6966238.513, "p999": 6968563.322}
-{"system": "nats", "tier": "js-pull", "payload": 256, "records": 100000, "mode": "consume", "throughput": 106565.0, "p50": null, "p99": null, "p999": null}
-{"system": "ironbus", "tier": "tier-s-streaming", "payload": 256, "records": 200000, "mode": "consume", "throughput": 22609.6676826816, "p50": 16194071.347, "p99": 18417957.026, "p999": 18422863.282}
-{"system": "nats", "tier": "js-pull", "payload": 256, "records": 200000, "mode": "consume", "throughput": 104819.0, "p50": null, "p99": null, "p999": null}
+{"system": "ironbus", "tier": "tier-s-streaming", "payload": 256, "records": 20000, "mode": "consume", "throughput": 681627.7598085554, "p50": 1012794.037, "p99": 1021963.163, "p999": 1022302.45}
+{"system": "nats", "tier": "js-pull", "payload": 256, "records": 20000, "mode": "consume", "throughput": 104045.0, "p50": null, "p99": null, "p999": null}
+{"system": "ironbus", "tier": "tier-s-streaming", "payload": 256, "records": 50000, "mode": "consume", "throughput": 638559.3528849735, "p50": 2530981.785, "p99": 2554761.733, "p999": 2555208.663}
+{"system": "nats", "tier": "js-pull", "payload": 256, "records": 50000, "mode": "consume", "throughput": 102701.0, "p50": null, "p99": null, "p999": null}
+{"system": "ironbus", "tier": "tier-s-streaming", "payload": 256, "records": 100000, "mode": "consume", "throughput": 889251.3240151888, "p50": 5260540.149, "p99": 5309272.435, "p999": 5310105.544}
+{"system": "nats", "tier": "js-pull", "payload": 256, "records": 100000, "mode": "consume", "throughput": 104551.0, "p50": null, "p99": null, "p999": null}
+{"system": "ironbus", "tier": "tier-s-streaming", "payload": 256, "records": 200000, "mode": "consume", "throughput": 904130.8676991404, "p50": 10669198.934, "p99": 10763904.016, "p999": 10765621.328}
+{"system": "nats", "tier": "js-pull", "payload": 256, "records": 200000, "mode": "consume", "throughput": 109322.0, "p50": null, "p99": null, "p999": null}

--- a/docs/benchmarks/consume_bench.py
+++ b/docs/benchmarks/consume_bench.py
@@ -196,15 +196,19 @@ def nats_core_sub(payload, records):
             os.remove(cfg)
 
 
-# The headline record-count SWEEP (256 B): IronBus Tier-S streaming consume throughput degrades as
-# the pre-filled prefix grows (the server StreamFetch-by-offset cost is super-linear in the prefix),
-# while NATS JS pull stays roughly flat. Sweeping both over the same record counts captures the
-# CROSSOVER honestly instead of cherry-picking one N. Recorded in PERF_LEDGER as the consume curve.
+# The headline record-count SWEEP (256 B): IronBus Tier-S streaming durable consume vs NATS JS pull
+# over the same record counts. Pre-#665 this sweep exposed a super-linear IronBus degradation (the
+# server StreamFetch read SPAN was segment-wide, so each fetch read O(distance-to-segment-end) bytes
+# => ~O(N^2) over the drain) that crossed UNDER NATS near ~30k records. #665 clamps the read span to
+# the consumer window, so post-#665 the IronBus curve is FLAT-to-rising and beats NATS at every point
+# of 20k..200k (the unconditional win). Sweeping over the same counts is what makes that flat-vs-
+# crossover claim falsifiable rather than a single cherry-picked N. Recorded in PERF_LEDGER.
 SWEEP_COUNTS = [20_000, 50_000, 100_000, 200_000]
 # The single MATCHED record count the lint-gated corpus pairs build at (the headline scoreboard
-# point). DEFAULT 20k: the realistic small/moderate prefill where the streaming-tier consume win is
-# real (the crossover with NATS JS pull is ~30k; past it IronBus's super-linear StreamFetch-by-offset
-# cost dominates and NATS leads — the full degradation curve is published in the sweep, not hidden).
+# point). DEFAULT 20k: a realistic small/moderate prefill. Post-#665 the streaming-tier consume win
+# holds across the WHOLE sweep (no NATS crossover in range), so 20k is a representative point on a
+# flat curve rather than the only point where IronBus leads — the full curve is published in the
+# sweep regardless.
 CORPUS_N = 20_000
 
 


### PR DESCRIPTION
## What

Re-validates the IronBus Tier-S streaming **durable single-consumer consume** head-to-head vs NATS JetStream pull on the t4g AWS Graviton2 rig, after the #665 O(n²) read-span fix, and updates `PERF_LEDGER` + the consume corpus/report artifacts with the result.

## Rig & method

t4g AWS Graviton2 (2-core, 8 GiB), Ubuntu 24.04 aarch64, `us-west-2` dev, all loopback; `nats-server` v2.10.22 / `natscli` 0.1.6; IronBus release `aarch64` built on-box at `origin/main` HEAD `18f131b` (includes #665). Same #554 `consume_bench.py` harness, same matched `durable-consume` labels, 256-record consumer window on both sides. **The EC2 instance was STOPPED after the run.**

## The 256B prefix sweep — IronBus Tier-S streaming vs NATS JS pull

| pre-filled records | IronBus Tier-S | NATS JS pull | IronBus / NATS |
| --- | --- | --- | --- |
| 20,000 | 681,628 /s | 104,045 /s | **6.55x** |
| 50,000 | 638,559 /s | 102,701 /s | **6.22x** |
| 100,000 | 889,251 /s | 104,551 /s | **8.51x** |
| 200,000 | 904,131 /s | 109,322 /s | **8.27x** |

Matched 20k corpus point: 256B **700,855** vs 106,448 = **6.58x**; 4096B **195,892** vs 54,780 = **3.58x**.

## VERDICT: UNCONDITIONAL WIN

IronBus Tier-S now **beats NATS JS pull at every point of the 20k→200k sweep (6.2x–8.5x)**, and the IronBus curve is **flat-to-rising (~640k–904k /s)** instead of collapsing. NATS JS pull stays flat ~104k–109k /s.

The pre-#665 sweep on this rig degraded super-linearly — **148k → 84k → 46k → 23k** across 20k→200k, crossing **under** NATS near ~30k records (0.22x at 200k). #665 clamps the server `StreamFetch` read span to the consumer **window** (the first sparse anchor above `start + want_records`), so each fetch buffers `O(window + stride)` bytes regardless of cursor depth — the drain is flat in `start`. **There is no longer a crossover at any prefill in range**, so the small/moderate-prefill caveat the old ledger carried no longer applies. (p99 grows ~1.0 s→10.8 s across 20k→200k purely as the preloaded-drain queue-wait of a larger backlog, not per-record service latency.)

## PERF_LEDGER update

Replaces the prior pre-#665 consume scoreboard: the headline (1.15–1.41x → 6.58/3.58x), the sweep section (was the prefix-bounded **crossover** caveat → now the **FLAT unconditional** curve), the Tier-W / core-sub context legs, and the verdict ("holds at the realistic small/moderate prefix, not yet universally" → **"UNCONDITIONAL after #665"**), with #665 cited as the fix that landed the previously-"remaining" O(1)-locate lever. Regenerated `consume-report.{md,json}` and `consume-rows/sweep.jsonl` via the `consume-corpus` assembler (durability-label lints pass).

## Gates

Docs + data only (no Rust source changed; the only `.py` edit is a comment).
- `cargo fmt --all --check`: clean
- relative-link check: 0 problems across ~831 in-repo links
- `ironbus-bench` lib tests (consume_corpus + comparison durability lints): 46 passed
- `consume-corpus` assembler: 2 matched pairs, 4 appendix rows, all lints passed

Do **not** merge yet — posted for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVWp2H2txnKGru4q2twxM3