### PR TITLE
feat(cluster): replica placement policy (spread + balanced leaders + eligibility) (#616)

### DIFF
--- a/crates/ironbus-core/src/lib.rs
+++ b/crates/ironbus-core/src/lib.rs
@@ -32,6 +32,7 @@ pub mod keyshared;
 pub mod leader_lease;
 pub mod lease;
 pub mod partition;
+pub mod placement;
 pub mod resolve_cache;
 pub mod segment;
 pub mod subject;

--- a/crates/ironbus-core/src/placement.rs
+++ b/crates/ironbus-core/src/placement.rs
@@ -1,0 +1,700 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! The replica-placement POLICY (V2-C5-I1, #616): the deterministic, IO-free function that decides
+//! WHICH nodes hold a partition's `R` replicas and WHICH eligible replica leads it.
+//!
+//! This is the prerequisite for data-plane serve-wiring: before a partition can be replicated, the
+//! cluster must AGREE on the ordered set of `R` nodes that hold it and the one node that leads it.
+//! The metadata plane commits that decision as ONE metadata-log entry (a [`crate::placement`]-shaped
+//! `Placement`, assigned by a `MetadataCommand` in `ironbus-server`) — NOT a new Raft group per
+//! partition, the group-explosion / per-asset-meta-SPOF the design indicts NATS for (`#4502`).
+//!
+//! The POLICY itself lives HERE, IO-free in `ironbus-core`, for the same reason the leader-eligibility
+//! predicate ([`crate::cluster_invariants::LeaderEligibility`]) does: it is a pure function over small
+//! value-types, so the identical decision runs in a unit test, a property sweep, AND the running
+//! metadata state machine. The `ironbus-server` plane projects its rich cluster state (the live
+//! membership table + the ISR tracker + the divergence report) onto these inputs and commits the
+//! result; this module never touches the disk, the wire, or the clock.
+//!
+//! ## The policy in one paragraph (deterministic; same inputs -> same placement)
+//!
+//! Given the candidate nodes (each with an optional failure-domain label), a replication factor `R`,
+//! the cluster-known committed high-watermark, and a running tally of how many partitions each node
+//! already LEADS, the policy:
+//!
+//! 1. **Spreads the `R` replicas across DISTINCT nodes** — a partition is never placed twice on one
+//!    node (a node holding two copies tolerates zero of its own failures). Where failure-domain labels
+//!    exist, it prefers spreading across DISTINCT domains first (so an entire rack/host/AZ failure
+//!    takes at most one replica), filling within a domain only once every domain holds one. If fewer
+//!    than `R` distinct nodes (or domains) exist, it places as many as it can and FLAGS the shortfall
+//!    in the returned [`Placement::under_replicated`] reason — it never invents a node or doubles up.
+//! 2. **Picks a BALANCED, ELIGIBLE leader** — the leader is chosen from the placed replicas that are
+//!    ELIGIBLE ([`crate::cluster_invariants::LeaderEligibility`]: in-ISR, complete to the committed HW,
+//!    non-divergent), preferring the eligible replica that currently LEADS the FEWEST partitions
+//!    (least-loaded leader balancing, ties broken by ascending node id for determinism). A
+//!    stale/corrupt/out-of-ISR replica is NEVER chosen leader — the Jepsen-failure prevention,
+//!    composed straight into placement.
+//!
+//! Determinism (I6): the decision reads NO wall clock and NO RNG. Ties are always broken by ascending
+//! node id, so the same membership + the same leader tally + the same eligibility inputs yield a
+//! byte-identical placement on every voter — which is exactly what a replicated state machine needs.
+//!
+//! ## Failure domains: modeled, but optional (FLAGGED)
+//!
+//! A node MAY carry a [`PlacementNode::failure_domain`] label (a small integer the operator assigns —
+//! a rack / host / AZ id). When present, the spread prefers distinct domains. When ABSENT (every node
+//! `failure_domain == None`), the policy degrades cleanly to plain distinct-NODE spread — which is the
+//! current reality, since the metadata membership table does not yet carry domain labels. Wiring a
+//! real domain label INTO the membership table (so the metadata plane can supply it) is a follow-up;
+//! this module already accepts and honors the label so that wiring is purely additive.
+//!
+//! ## Scope boundary (FLAGGED)
+//!
+//! This is the placement POLICY + the placement VALUE only. It DECIDES a placement; it does not ACT on
+//! one. The cooperative REBALANCE on node join/leave (minimal-reshuffle learner back-fill) is C5-I2
+//! (#617); leaderless-node FAILOVER is C5-I3 (#618); the DATA-plane serve-wiring that actually
+//! replicates to the placed replicas is a follow-up. None of those are done here.
+//!
+//! ## Single node is degenerate (the Edge-First non-negotiable)
+//!
+//! With `n = 1` the lone node is the only candidate: it trivially HOLDS the single replica and (being
+//! its own ISR, complete to its own HW, unable to diverge from itself) is trivially ELIGIBLE, so it
+//! LEADS. The placement is `{ replicas: [the node], leader: the node }` with no shortfall — exactly
+//! the degenerate "the lone node holds + leads everything" the single-node broker already implies. A
+//! standalone broker never constructs a placement at all; this is the n=1 cluster case.
+
+use crate::cluster_invariants::{LeaderCandidate, LeaderEligibility};
+use std::collections::{BTreeMap, BTreeSet};
+
+/// One candidate node the placement policy may place a replica on: its cluster node id, an optional
+/// failure-domain label, and the leader-completeness inputs the eligibility predicate needs.
+///
+/// The `ironbus-server` plane builds this from its membership table (the id + domain) and the live ISR
+/// tracker + divergence report (the eligibility fields), exactly as
+/// [`crate::cluster_invariants::LeaderCandidate`] is built for the eligibility predicate today.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PlacementNode {
+    /// The candidate node's cluster id.
+    pub node: u64,
+    /// The node's failure-domain label (a rack / host / AZ id the operator assigns), if known. `None`
+    /// means the cluster does not (yet) model this node's domain, and the policy spreads by node only.
+    pub failure_domain: Option<u64>,
+    /// Whether this node is currently in the in-sync replica set (the #691 ISR). A node that is not
+    /// in-sync may still HOLD a replica (it back-fills), but it is NOT eligible to LEAD.
+    pub in_isr: bool,
+    /// The node's durable (fsync'd) prefix frontier: the first offset it has NOT durably appended. A
+    /// node behind the committed HW is missing committed records and is not eligible to lead.
+    pub durable_prefix: u64,
+    /// Whether a divergence has been detected for this node's log against the committed lineage (#697).
+    /// A divergent node holds corrupt data and is never eligible to lead.
+    pub divergent: bool,
+}
+
+impl PlacementNode {
+    /// A convenience constructor for a node with NO failure-domain label and the leader-completeness
+    /// inputs of a healthy, in-sync, complete, non-divergent replica (the common test / n=1 case).
+    #[must_use]
+    pub fn healthy(node: u64, durable_prefix: u64) -> Self {
+        PlacementNode {
+            node,
+            failure_domain: None,
+            in_isr: true,
+            durable_prefix,
+            divergent: false,
+        }
+    }
+
+    /// Set this node's failure-domain label (builder-style), returning the updated node.
+    #[must_use]
+    pub fn with_failure_domain(mut self, domain: u64) -> Self {
+        self.failure_domain = Some(domain);
+        self
+    }
+
+    /// Project this node onto the IO-free [`LeaderCandidate`] the eligibility predicate consumes — the
+    /// SAME projection [`crate::cluster_invariants::LeaderEligibility`] uses, so a node is eligible to
+    /// LEAD a partition iff it would be eligible to win that partition's election.
+    #[must_use]
+    fn as_candidate(&self) -> LeaderCandidate {
+        LeaderCandidate {
+            replica: self.node,
+            in_isr: self.in_isr,
+            durable_prefix: self.durable_prefix,
+            divergent: self.divergent,
+        }
+    }
+}
+
+/// Why a partition could not be placed at the full replication factor `R`. A placement that achieves
+/// `R` distinct replicas with an eligible leader carries `None`; a degraded placement explains itself
+/// (never a silent shortfall), so the metadata plane can surface it and a later rebalance (C5-I2) can
+/// repair it once more capacity exists.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PlacementShortfall {
+    /// Fewer than `R` distinct candidate NODES exist, so the partition is under-replicated. The
+    /// placement holds as many distinct nodes as the cluster offers.
+    TooFewNodes {
+        /// The replication factor that was requested.
+        requested: usize,
+        /// The number of distinct replicas actually placed.
+        placed: usize,
+    },
+    /// `R` replicas were placed, but NONE of them is eligible to lead (every placed replica is
+    /// out-of-ISR, behind the committed HW, or divergent). The placement holds the replicas but has NO
+    /// leader — the partition is unavailable for writes until an eligible replica appears (which a
+    /// re-sync / rebalance will produce). This is fail-closed: a stale/corrupt replica is NEVER named
+    /// leader just to fill the slot.
+    NoEligibleLeader {
+        /// The number of replicas placed (all ineligible to lead).
+        placed: usize,
+    },
+}
+
+/// A computed replica placement for one partition: the ordered set of `R` (or as many as possible)
+/// distinct replica nodes plus the designated leader among them. This is the value the metadata plane
+/// commits as ONE metadata-log entry; reads serve the committed value.
+///
+/// `replicas` is in placement order (the order the spread chose, leader-first when a leader was
+/// designated); `leader` is `Some(node)` iff an ELIGIBLE replica was found, else `None` with a
+/// [`PlacementShortfall::NoEligibleLeader`] reason. `under_replicated` is `Some(reason)` iff the
+/// placement is degraded (fewer than `R` replicas, or no eligible leader).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Placement {
+    /// The ordered set of distinct replica nodes (leader first when a leader was designated).
+    pub replicas: Vec<u64>,
+    /// The designated leader (an ELIGIBLE replica), or `None` if no placed replica is eligible to lead.
+    pub leader: Option<u64>,
+    /// `Some(reason)` iff the placement is degraded (under-replicated or leaderless); `None` if it
+    /// achieved `R` distinct replicas with an eligible leader.
+    pub under_replicated: Option<PlacementShortfall>,
+}
+
+impl Placement {
+    /// The number of distinct replicas this placement holds.
+    #[must_use]
+    pub fn replication_factor(&self) -> usize {
+        self.replicas.len()
+    }
+
+    /// Whether the placement is fully healthy: `R` distinct replicas AND an eligible leader.
+    #[must_use]
+    pub fn is_complete(&self) -> bool {
+        self.under_replicated.is_none()
+    }
+}
+
+/// The leader-balance tally the policy reads (and the caller maintains across a batch of placements):
+/// how many partitions each node currently LEADS. Passing the running tally in — rather than computing
+/// it from nothing — is what lets a sweep of placements spread leadership evenly across nodes (each
+/// placement picks the least-loaded eligible node, then the caller bumps that node's count).
+///
+/// It is a plain `BTreeMap` (deterministic iteration order) so the balance decision is reproducible.
+pub type LeaderLoad = BTreeMap<u64, usize>;
+
+/// Compute the placement for ONE partition deterministically.
+///
+/// * `candidates` — the nodes the partition MAY be placed on (the cluster membership, projected). The
+///   order is irrelevant to the result: the policy sorts internally so the placement is a pure function
+///   of the SET of candidates, not their argument order.
+/// * `replication_factor` — the desired `R` (clamped to `>= 1`; `0` is treated as `1`).
+/// * `committed_hw` — the cluster-known committed high-watermark the leader must be complete to.
+/// * `leader_load` — how many partitions each node currently leads (for least-loaded leader balancing).
+///   READ-ONLY here; the caller bumps the chosen leader's count (see [`place_partitions`]).
+///
+/// The result spreads the `R` replicas across distinct nodes (distinct failure domains first, when
+/// labeled) and designates the least-loaded ELIGIBLE replica as leader. It reads no wall clock and no
+/// RNG; ties break by ascending node id, so it is fully deterministic (I6).
+#[must_use]
+pub fn place_partition(
+    candidates: &[PlacementNode],
+    replication_factor: usize,
+    committed_hw: u64,
+    leader_load: &LeaderLoad,
+) -> Placement {
+    let r = replication_factor.max(1);
+
+    // Spread the R replicas across distinct nodes, preferring distinct failure domains. The candidate
+    // set is reduced to one entry per node id (a duplicate id is ignored, never doubled up) and sorted
+    // by (failure_domain, node) so the spread is deterministic regardless of input order.
+    let replicas = spread_replicas(candidates, r);
+
+    // Pick the least-loaded ELIGIBLE leader from the placed replicas. Eligibility composes the SAME
+    // predicate as a partition election, so a stale/corrupt/out-of-ISR replica is never named leader.
+    let by_id: BTreeMap<u64, &PlacementNode> = candidates.iter().map(|c| (c.node, c)).collect();
+    let leader = choose_leader(&replicas, &by_id, committed_hw, leader_load);
+
+    // Order the replica list leader-first (a stable, deterministic presentation) when a leader exists.
+    let ordered = order_leader_first(replicas, leader);
+
+    let under_replicated = if ordered.len() < r {
+        Some(PlacementShortfall::TooFewNodes {
+            requested: r,
+            placed: ordered.len(),
+        })
+    } else if leader.is_none() {
+        Some(PlacementShortfall::NoEligibleLeader {
+            placed: ordered.len(),
+        })
+    } else {
+        None
+    };
+
+    Placement {
+        replicas: ordered,
+        leader,
+        under_replicated,
+    }
+}
+
+/// Compute placements for a BATCH of partitions, balancing leadership ACROSS the batch.
+///
+/// This is the function that delivers "leaders balanced across nodes": it threads a running
+/// [`LeaderLoad`] tally through the partitions in ascending id order, so each partition's leader is the
+/// least-loaded eligible node AT THAT POINT, and the next partition sees the updated tally. Over many
+/// partitions on a healthy cluster this round-robins leadership evenly (no node piles up
+/// disproportionately many leaders).
+///
+/// `partitions` is the list of partition ids to place; the same `candidates` / `replication_factor` /
+/// `committed_hw` apply to all of them (the common case — a per-partition override is a future
+/// refinement). Returns a deterministic map of partition id -> its [`Placement`]. Reads no wall clock.
+#[must_use]
+pub fn place_partitions(
+    partitions: &[u64],
+    candidates: &[PlacementNode],
+    replication_factor: usize,
+    committed_hw: u64,
+) -> BTreeMap<u64, Placement> {
+    let mut load: LeaderLoad = LeaderLoad::new();
+    let mut out: BTreeMap<u64, Placement> = BTreeMap::new();
+    // Place in ascending partition id so the balance is reproducible regardless of input order.
+    let mut ids: Vec<u64> = partitions.to_vec();
+    ids.sort_unstable();
+    ids.dedup();
+    for partition in ids {
+        let placement = place_partition(candidates, replication_factor, committed_hw, &load);
+        if let Some(leader) = placement.leader {
+            *load.entry(leader).or_insert(0) += 1;
+        }
+        out.insert(partition, placement);
+    }
+    out
+}
+
+/// Spread up to `r` replicas across distinct nodes, preferring distinct failure domains.
+///
+/// Dedup by node id, then sort by `(failure_domain, node_id)` (an unlabeled node sorts as if its domain
+/// were the maximum, so labeled domains are filled first). Walk the sorted candidates in ROUNDS: each
+/// round takes one node from each not-yet-used domain (and one per unlabeled node), so the first `r`
+/// chosen land in as many distinct domains as exist before any domain gets a second replica.
+fn spread_replicas(candidates: &[PlacementNode], r: usize) -> Vec<u64> {
+    // One entry per node id (lowest occurrence wins is irrelevant — same id, same node), sorted for
+    // determinism by (domain-present-first, domain, node).
+    let mut nodes: Vec<&PlacementNode> = {
+        let mut seen: BTreeSet<u64> = BTreeSet::new();
+        let mut v: Vec<&PlacementNode> = Vec::new();
+        for c in candidates {
+            if seen.insert(c.node) {
+                v.push(c);
+            }
+        }
+        v
+    };
+    // Sort key: labeled domains first (ascending), then unlabeled; ties by node id. `None` domains sort
+    // after every labeled one but among themselves keep ascending node order.
+    nodes.sort_by(|a, b| {
+        let ka = a.failure_domain;
+        let kb = b.failure_domain;
+        match (ka, kb) {
+            (Some(x), Some(y)) => x.cmp(&y).then(a.node.cmp(&b.node)),
+            (Some(_), None) => std::cmp::Ordering::Less,
+            (None, Some(_)) => std::cmp::Ordering::Greater,
+            (None, None) => a.node.cmp(&b.node),
+        }
+    });
+
+    // Round-robin across distinct domains: a node with no domain label is its own singleton "domain"
+    // keyed by a unique sentinel so two unlabeled nodes are never treated as the same domain.
+    let mut chosen: Vec<u64> = Vec::with_capacity(r.min(nodes.len()));
+    let mut used_in_domain: BTreeMap<DomainKey, usize> = BTreeMap::new();
+    let mut round = 0usize;
+    while chosen.len() < r && chosen.len() < nodes.len() {
+        let mut progressed = false;
+        for n in &nodes {
+            if chosen.len() >= r {
+                break;
+            }
+            if chosen.contains(&n.node) {
+                continue;
+            }
+            let key = domain_key(n);
+            let count = used_in_domain.get(&key).copied().unwrap_or(0);
+            // In round `k` (0-based) take a node from a domain only if it already holds exactly `k`
+            // replicas — i.e. every domain gets its first replica before any gets its second.
+            if count == round {
+                chosen.push(n.node);
+                *used_in_domain.entry(key).or_insert(0) += 1;
+                progressed = true;
+            }
+        }
+        if !progressed {
+            // No domain could take another replica at this round level: every remaining slot would
+            // double a domain, so advance the round (allow a second replica per domain) — but only if
+            // there are still unplaced nodes, which the outer `while` guards.
+            round += 1;
+        }
+        // Safety: `round` can never exceed the node count (each round places at least one node when
+        // any node is unplaced), so the loop terminates.
+        if round > nodes.len() {
+            break;
+        }
+    }
+    chosen
+}
+
+/// A domain identity for the round-robin spread: a labeled node groups by its domain; an unlabeled node
+/// is its own singleton (keyed by node id) so two unlabeled nodes never collapse into one "domain".
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+enum DomainKey {
+    Labeled(u64),
+    Unlabeled(u64),
+}
+
+fn domain_key(n: &PlacementNode) -> DomainKey {
+    match n.failure_domain {
+        Some(d) => DomainKey::Labeled(d),
+        None => DomainKey::Unlabeled(n.node),
+    }
+}
+
+/// Choose the least-loaded ELIGIBLE leader from the placed replicas, or `None` if none is eligible.
+///
+/// Eligibility composes [`LeaderEligibility::is_eligible`] (in-ISR AND complete to `committed_hw` AND
+/// non-divergent) — the SAME predicate a partition election uses — so a stale/corrupt/out-of-ISR
+/// replica is never returned. Among the eligible replicas, the one currently leading the FEWEST
+/// partitions wins (least-loaded balancing); ties break by ascending node id (determinism).
+fn choose_leader(
+    replicas: &[u64],
+    by_id: &BTreeMap<u64, &PlacementNode>,
+    committed_hw: u64,
+    leader_load: &LeaderLoad,
+) -> Option<u64> {
+    replicas
+        .iter()
+        .filter_map(|&node| by_id.get(&node).copied().map(|n| (node, n)))
+        .filter(|(_, n)| LeaderEligibility::is_eligible(&n.as_candidate(), committed_hw))
+        .min_by(|(a_node, _), (b_node, _)| {
+            let la = leader_load.get(a_node).copied().unwrap_or(0);
+            let lb = leader_load.get(b_node).copied().unwrap_or(0);
+            la.cmp(&lb).then(a_node.cmp(b_node))
+        })
+        .map(|(node, _)| node)
+}
+
+/// Present the replica list leader-first when a leader exists (a stable, deterministic ordering the
+/// metadata plane stores), keeping the remaining replicas in ascending node-id order.
+fn order_leader_first(replicas: Vec<u64>, leader: Option<u64>) -> Vec<u64> {
+    match leader {
+        Some(l) if replicas.contains(&l) => {
+            let mut rest: Vec<u64> = replicas.into_iter().filter(|&n| n != l).collect();
+            rest.sort_unstable();
+            let mut out = Vec::with_capacity(rest.len() + 1);
+            out.push(l);
+            out.extend(rest);
+            out
+        }
+        _ => {
+            let mut out = replicas;
+            out.sort_unstable();
+            out
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn healthy(node: u64) -> PlacementNode {
+        PlacementNode::healthy(node, 100)
+    }
+
+    // ----- spread: R replicas land on R DISTINCT nodes -----
+
+    #[test]
+    fn r_replicas_land_on_r_distinct_nodes() {
+        let nodes: Vec<PlacementNode> = (1..=5).map(healthy).collect();
+        let p = place_partition(&nodes, 3, 100, &LeaderLoad::new());
+        assert_eq!(p.replication_factor(), 3);
+        let distinct: BTreeSet<u64> = p.replicas.iter().copied().collect();
+        assert_eq!(distinct.len(), 3, "all placed replicas are distinct nodes");
+        assert!(p.is_complete());
+        assert!(p.under_replicated.is_none());
+    }
+
+    #[test]
+    fn a_node_is_never_placed_twice_even_with_duplicate_candidates() {
+        // The same node id appears twice in the candidate list; it must still be placed at most once.
+        let nodes = vec![healthy(1), healthy(1), healthy(2)];
+        let p = place_partition(&nodes, 3, 100, &LeaderLoad::new());
+        let distinct: BTreeSet<u64> = p.replicas.iter().copied().collect();
+        assert_eq!(distinct.len(), p.replicas.len(), "no node placed twice");
+        assert_eq!(p.replicas.len(), 2, "only two distinct nodes exist");
+        assert_eq!(
+            p.under_replicated,
+            Some(PlacementShortfall::TooFewNodes {
+                requested: 3,
+                placed: 2
+            }),
+            "fewer than R distinct nodes is a flagged shortfall, not a doubled-up node"
+        );
+    }
+
+    #[test]
+    fn fewer_than_r_nodes_is_flagged_under_replicated() {
+        let nodes = vec![healthy(1), healthy(2)];
+        let p = place_partition(&nodes, 3, 100, &LeaderLoad::new());
+        assert_eq!(p.replicas.len(), 2);
+        assert_eq!(
+            p.under_replicated,
+            Some(PlacementShortfall::TooFewNodes {
+                requested: 3,
+                placed: 2
+            })
+        );
+        assert!(!p.is_complete());
+        // Even degraded, a leader is still chosen from the placed (eligible) replicas.
+        assert!(p.leader.is_some());
+    }
+
+    // ----- failure domains: spread across DISTINCT domains first -----
+
+    #[test]
+    fn replicas_spread_across_distinct_failure_domains_first() {
+        // Two domains, two nodes each. R=2 must take one from EACH domain (not two from one), so a
+        // whole-domain failure loses at most one replica.
+        let nodes = vec![
+            healthy(1).with_failure_domain(10),
+            healthy(2).with_failure_domain(10),
+            healthy(3).with_failure_domain(20),
+            healthy(4).with_failure_domain(20),
+        ];
+        let p = place_partition(&nodes, 2, 100, &LeaderLoad::new());
+        assert_eq!(p.replicas.len(), 2);
+        let domains: BTreeSet<u64> = p
+            .replicas
+            .iter()
+            .map(|n| {
+                nodes
+                    .iter()
+                    .find(|c| c.node == *n)
+                    .unwrap()
+                    .failure_domain
+                    .unwrap()
+            })
+            .collect();
+        assert_eq!(
+            domains.len(),
+            2,
+            "the two replicas land in two distinct domains"
+        );
+    }
+
+    #[test]
+    fn more_replicas_than_domains_doubles_up_only_after_each_domain_has_one() {
+        // Two domains, R=3: each domain gets one, then one domain gets a second — never a domain with
+        // three while the other has zero.
+        let nodes = vec![
+            healthy(1).with_failure_domain(10),
+            healthy(2).with_failure_domain(10),
+            healthy(3).with_failure_domain(20),
+        ];
+        let p = place_partition(&nodes, 3, 100, &LeaderLoad::new());
+        assert_eq!(p.replicas.len(), 3);
+        let mut per_domain: BTreeMap<u64, usize> = BTreeMap::new();
+        for n in &p.replicas {
+            let d = nodes
+                .iter()
+                .find(|c| c.node == *n)
+                .unwrap()
+                .failure_domain
+                .unwrap();
+            *per_domain.entry(d).or_insert(0) += 1;
+        }
+        assert_eq!(per_domain.get(&10), Some(&2));
+        assert_eq!(per_domain.get(&20), Some(&1));
+    }
+
+    #[test]
+    fn unlabeled_nodes_spread_across_distinct_nodes() {
+        // With no domain labels the policy degrades to distinct-NODE spread (the current reality).
+        let nodes: Vec<PlacementNode> = (1..=4).map(healthy).collect();
+        let p = place_partition(&nodes, 3, 100, &LeaderLoad::new());
+        let distinct: BTreeSet<u64> = p.replicas.iter().copied().collect();
+        assert_eq!(distinct.len(), 3);
+    }
+
+    // ----- leader balance: leadership is balanced across nodes over many partitions -----
+
+    #[test]
+    fn leadership_is_balanced_across_nodes_over_many_partitions() {
+        let nodes: Vec<PlacementNode> = (1..=3).map(healthy).collect();
+        let partitions: Vec<u64> = (0..30).collect();
+        let placements = place_partitions(&partitions, &nodes, 3, 100);
+
+        let mut leader_count: BTreeMap<u64, usize> = BTreeMap::new();
+        for p in placements.values() {
+            *leader_count
+                .entry(p.leader.expect("eligible leader"))
+                .or_insert(0) += 1;
+        }
+        // 30 partitions over 3 nodes: a perfectly balanced round-robin gives each node 10. Assert no
+        // node holds disproportionately many leaders (within 1 of the even share).
+        for node in 1..=3u64 {
+            let c = leader_count.get(&node).copied().unwrap_or(0);
+            assert!(
+                (9..=11).contains(&c),
+                "node {node} leads {c} partitions; expected ~10 (balanced)"
+            );
+        }
+        let max = leader_count.values().max().copied().unwrap_or(0);
+        let min = leader_count.values().min().copied().unwrap_or(0);
+        assert!(
+            max - min <= 1,
+            "leadership spread is within 1 (max {max}, min {min})"
+        );
+    }
+
+    // ----- eligibility composed into placement: a stale/corrupt node is NEVER placed as leader -----
+
+    #[test]
+    fn a_stale_replica_is_never_placed_as_leader() {
+        // Node 1 is behind the committed HW (stale); nodes 2 and 3 are complete. The leader must be an
+        // eligible replica — never the stale node — even if node 1 leads the fewest partitions.
+        let nodes = vec![
+            PlacementNode::healthy(1, 60), // durable prefix 60 < HW 100 => INELIGIBLE
+            PlacementNode::healthy(2, 100),
+            PlacementNode::healthy(3, 100),
+        ];
+        let p = place_partition(&nodes, 3, 100, &LeaderLoad::new());
+        assert!(
+            p.replicas.contains(&1),
+            "the stale node still HOLDS a replica"
+        );
+        let leader = p.leader.expect("an eligible leader exists");
+        assert_ne!(leader, 1, "the stale node is NEVER the leader");
+        assert!([2, 3].contains(&leader));
+    }
+
+    #[test]
+    fn a_corrupt_replica_is_never_placed_as_leader() {
+        let mut corrupt = PlacementNode::healthy(1, 100);
+        corrupt.divergent = true; // detected divergence => INELIGIBLE
+        let nodes = vec![
+            corrupt,
+            PlacementNode::healthy(2, 100),
+            PlacementNode::healthy(3, 100),
+        ];
+        let p = place_partition(&nodes, 3, 100, &LeaderLoad::new());
+        let leader = p.leader.expect("an eligible leader exists");
+        assert_ne!(leader, 1, "the corrupt node is NEVER the leader");
+    }
+
+    #[test]
+    fn an_out_of_isr_replica_is_never_placed_as_leader() {
+        let mut evicted = PlacementNode::healthy(1, 100);
+        evicted.in_isr = false; // evicted for lag => INELIGIBLE
+        let nodes = vec![
+            evicted,
+            PlacementNode::healthy(2, 100),
+            PlacementNode::healthy(3, 100),
+        ];
+        let p = place_partition(&nodes, 3, 100, &LeaderLoad::new());
+        let leader = p.leader.expect("an eligible leader exists");
+        assert_ne!(leader, 1, "the out-of-ISR node is NEVER the leader");
+    }
+
+    #[test]
+    fn no_eligible_replica_yields_a_leaderless_flagged_placement() {
+        // Every candidate is ineligible (all behind the committed HW). The replicas are still placed
+        // (they back-fill), but NO leader is named — fail-closed, never a stale leader to fill the slot.
+        let nodes = vec![
+            PlacementNode::healthy(1, 50),
+            PlacementNode::healthy(2, 50),
+            PlacementNode::healthy(3, 50),
+        ];
+        let p = place_partition(&nodes, 3, 100, &LeaderLoad::new());
+        assert_eq!(
+            p.replicas.len(),
+            3,
+            "replicas are still placed (they back-fill)"
+        );
+        assert_eq!(p.leader, None, "no eligible replica => no leader");
+        assert_eq!(
+            p.under_replicated,
+            Some(PlacementShortfall::NoEligibleLeader { placed: 3 })
+        );
+    }
+
+    // ----- determinism (I6): same inputs -> identical placement -----
+
+    #[test]
+    fn placement_is_deterministic_regardless_of_input_order() {
+        let a = vec![healthy(3), healthy(1), healthy(5), healthy(2), healthy(4)];
+        let b = vec![healthy(5), healthy(4), healthy(3), healthy(2), healthy(1)];
+        let pa = place_partition(&a, 3, 100, &LeaderLoad::new());
+        let pb = place_partition(&b, 3, 100, &LeaderLoad::new());
+        assert_eq!(
+            pa, pb,
+            "the placement is a pure function of the candidate SET, not its order"
+        );
+    }
+
+    #[test]
+    fn batch_placement_is_deterministic() {
+        let nodes: Vec<PlacementNode> = (1..=4).map(healthy).collect();
+        let partitions: Vec<u64> = (0..20).collect();
+        let first = place_partitions(&partitions, &nodes, 3, 100);
+        let second = place_partitions(&partitions, &nodes, 3, 100);
+        assert_eq!(
+            first, second,
+            "the same membership + partitions yield an identical batch placement"
+        );
+    }
+
+    // ----- single node degenerate: n=1 holds + leads everything -----
+
+    #[test]
+    fn single_node_holds_and_leads_everything() {
+        let lone = vec![PlacementNode::healthy(1, 42)];
+        let p = place_partition(&lone, 3, 42, &LeaderLoad::new());
+        assert_eq!(p.replicas, vec![1], "the lone node holds the only replica");
+        assert_eq!(p.leader, Some(1), "the lone node leads");
+        // R=3 requested but only one node exists: a flagged (honest) shortfall, not a silent one.
+        assert_eq!(
+            p.under_replicated,
+            Some(PlacementShortfall::TooFewNodes {
+                requested: 3,
+                placed: 1
+            })
+        );
+    }
+
+    #[test]
+    fn single_node_rf_one_is_a_complete_placement() {
+        // The true single-node case (R=1): the lone node holds + leads, with no shortfall at all.
+        let lone = vec![PlacementNode::healthy(1, 42)];
+        let p = place_partition(&lone, 1, 42, &LeaderLoad::new());
+        assert_eq!(p.replicas, vec![1]);
+        assert_eq!(p.leader, Some(1));
+        assert!(
+            p.is_complete(),
+            "n=1, R=1 is a complete, degenerate placement"
+        );
+    }
+
+    #[test]
+    fn zero_replication_factor_is_clamped_to_one() {
+        let nodes: Vec<PlacementNode> = (1..=3).map(healthy).collect();
+        let p = place_partition(&nodes, 0, 100, &LeaderLoad::new());
+        assert_eq!(p.replicas.len(), 1, "R=0 is clamped to R=1");
+    }
+}

--- a/crates/ironbus-server/src/cluster/metadata_group.rs
+++ b/crates/ironbus-server/src/cluster/metadata_group.rs
@@ -685,10 +685,7 @@ mod tests {
         settle(&mut group);
         assert_eq!(
             group.state().placement(7),
-            Some(Placement {
-                leader: 1,
-                epoch: group.term()
-            })
+            Some(Placement::leader_only(1, group.term()))
         );
         assert!(group.state().applied_index() > prev_index);
     }
@@ -732,10 +729,7 @@ mod tests {
             settle(&mut group);
             assert_eq!(
                 group.state().placement(3),
-                Some(Placement {
-                    leader: 1,
-                    epoch: 1
-                })
+                Some(Placement::leader_only(1, 1))
             );
             (
                 group.term(),
@@ -774,11 +768,54 @@ mod tests {
         settle(&mut reopened);
         assert_eq!(
             reopened.state().placement(3),
-            Some(Placement {
-                leader: 1,
-                epoch: 1
-            }),
+            Some(Placement::leader_only(1, 1)),
             "the committed placement must survive a reopen of the durable group"
+        );
+    }
+
+    /// The C5-I1 (#616) durability acceptance test: a full REPLICA-SET placement (a
+    /// `PlacePartition` command — `R` replicas + a designated leader) commits through the metadata
+    /// log and SURVIVES a reopen, exactly like the leader-only placement above. This proves the
+    /// placement is durable-through-the-metadata-log (one entry, reusing the #659 round-trip), not
+    /// a transient in-memory decision.
+    #[test]
+    fn committed_replica_set_placement_survives_a_group_reopen() {
+        let fs = InMemoryFs::new();
+        let expected = Placement {
+            replicas: vec![1, 2, 3],
+            leader: 1,
+            epoch: 4,
+        };
+        {
+            let mut group = open_on(&fs, 1, &[1]);
+            group.campaign().expect("campaign");
+            settle(&mut group);
+            assert!(group.is_leader());
+
+            group
+                .propose(&MetadataCommand::PlacePartition {
+                    partition: 8,
+                    replicas: vec![1, 2, 3],
+                    leader: 1,
+                    epoch: 4,
+                })
+                .expect("propose placement");
+            settle(&mut group);
+            assert_eq!(
+                group.state().placement(8),
+                Some(expected.clone()),
+                "the replica-set placement applied on the live group"
+            );
+        }
+
+        // Reopen over the SAME durable image (a process restart): re-applying the durable entries
+        // must reconstruct the identical replica-set placement.
+        let mut reopened = open_on(&fs, 1, &[1]);
+        settle(&mut reopened);
+        assert_eq!(
+            reopened.state().placement(8),
+            Some(expected),
+            "the committed replica-set placement must survive a reopen of the durable group"
         );
     }
 

--- a/crates/ironbus-server/src/cluster/mod.rs
+++ b/crates/ironbus-server/src/cluster/mod.rs
@@ -205,6 +205,7 @@ pub mod isr;
 pub mod membership;
 pub mod metadata_group;
 pub mod metadata_storage;
+pub mod placement;
 pub mod replication;
 pub mod runtime;
 pub mod state_machine;
@@ -224,6 +225,7 @@ pub use isr::{AckReplicatedBody, IsrConfig, IsrMembership, IsrTracker, PendingAc
 pub use membership::{MemberOp, MembershipChange, PeerIdError};
 pub use metadata_group::{GroupError, MetadataRaftGroup};
 pub use metadata_storage::{MetadataLogStorage, MetadataStorageError, METADATA_SUBDIR};
+pub use placement::{decide_placement, placement_command, placement_node_from, PlacementOutcome};
 pub use replication::{
     ApplyOutcome, DivergenceTruncation, EpochAwareFollower, FetchRecordsBody, FetchResponseBody,
     Follower, OffsetForLeaderEpochBody, OffsetForLeaderEpochResponse, ReplicationError,

--- a/crates/ironbus-server/src/cluster/placement.rs
+++ b/crates/ironbus-server/src/cluster/placement.rs
@@ -1,0 +1,331 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! Replica placement: the server-side bridge from the IO-free placement POLICY to a metadata-log
+//! COMMAND (V2-C5-I1, #616).
+//!
+//! The placement POLICY itself — spread `R` replicas across distinct nodes / failure domains and pick
+//! a balanced, ELIGIBLE leader — lives IO-free in [`ironbus_core::placement`] (a pure function over
+//! small value-types, the same shape as the [`super::eligibility`] predicate). THIS module is the thin
+//! `ironbus-server` adapter that:
+//!
+//! * builds the policy's [`PlacementNode`] inputs from the live cluster state — the membership table
+//!   (node ids + optional failure-domain labels) plus, for each candidate, the leader-completeness
+//!   inputs the [`super::isr::IsrTracker`] and the C4 divergence report already expose (so a replica's
+//!   eligibility to LEAD a placement is the SAME predicate as its eligibility to WIN that partition's
+//!   election — #700, composed straight into placement); and
+//! * turns the policy's decision into a [`MetadataCommand::PlacePartition`] — the command the metadata
+//!   plane commits through the metadata raft log as ONE entry (durable, replicated; NOT a per-partition
+//!   Raft group), after which a read serves the committed placement.
+//!
+//! ## Eligibility is composed into the placement, never bypassed (the part to scrutinize most)
+//!
+//! [`placement_command`] returns a command ONLY when the policy found an ELIGIBLE leader. A policy
+//! result with no eligible leader (every placed replica stale / corrupt / out-of-ISR) yields
+//! [`PlacementOutcome::Leaderless`] — NOT a command — so a stale/corrupt replica can never be COMMITTED
+//! as a leader. This is the construction that carries the Jepsen-failure prevention (#700) all the way
+//! to the committed metadata: the only leaders that ever reach the log are eligible ones.
+//!
+//! ## Single node is degenerate (the Edge-First non-negotiable)
+//!
+//! With one node the policy places `[the node]` and (the node being its own ISR, complete to its own
+//! HW, unable to diverge) names it leader; this module emits the corresponding `PlacePartition` whose
+//! replica set is exactly `[the node]` — identical in effect to the C1 leader-only `AssignPartition`.
+//! A standalone broker never constructs a placement at all; merely linking this changes nothing.
+//!
+//! ## Scope boundary (FLAGGED)
+//!
+//! This DECIDES + emits a placement command; it does not ACT on the placement (the data-plane wiring
+//! that actually replicates to the placed replicas is a follow-up), does not REBALANCE on join/leave
+//! (C5-I2, #617), and does not do leaderless-node FAILOVER (C5-I3, #618).
+
+use ironbus_core::placement::{place_partition, LeaderLoad, PlacementNode, PlacementShortfall};
+
+use super::divergence::DivergenceReport;
+use super::isr::{IsrMembership, IsrTracker};
+use super::state_machine::MetadataCommand;
+
+/// The result of deciding a placement for one partition: either a committable command, or a flagged
+/// "no eligible leader" outcome (which is NEVER committed — a stale/corrupt replica is never made a
+/// committed leader).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PlacementOutcome {
+    /// The placement found an eligible leader; this is the [`MetadataCommand::PlacePartition`] to
+    /// commit through the metadata log. `under_replicated` carries the (honest) shortfall reason iff
+    /// fewer than `R` distinct nodes were available, so the caller can surface a degraded-but-led
+    /// placement.
+    Placed {
+        /// The command to commit through the metadata raft log.
+        command: MetadataCommand,
+        /// `Some(reason)` iff the placement holds fewer than `R` replicas (under-replicated but led).
+        under_replicated: Option<PlacementShortfall>,
+    },
+    /// No placed replica is eligible to lead (every candidate is stale / corrupt / out-of-ISR). NO
+    /// command is produced — the partition is left leaderless (unavailable for writes) until an
+    /// eligible replica appears, rather than committing a stale/corrupt leader. Fail-closed.
+    Leaderless {
+        /// The replica nodes that WERE placed (they back-fill toward eligibility), for observability.
+        replicas: Vec<u64>,
+    },
+}
+
+/// Decide the placement for `partition` over `candidates` at replication factor `r`, balancing the
+/// leader against `leader_load` (how many partitions each node already leads), and committed to
+/// `committed_hw`.
+///
+/// Returns a [`PlacementOutcome::Placed`] carrying a [`MetadataCommand::PlacePartition`] when an
+/// eligible leader is found, or [`PlacementOutcome::Leaderless`] when none is — so a stale/corrupt
+/// replica is never committed as leader. The decision is the IO-free [`place_partition`] policy, so it
+/// reads no wall clock and is deterministic (I6).
+#[must_use]
+pub fn decide_placement(
+    partition: u64,
+    candidates: &[PlacementNode],
+    r: usize,
+    committed_hw: u64,
+    epoch: u64,
+    leader_load: &LeaderLoad,
+) -> PlacementOutcome {
+    let placement = place_partition(candidates, r, committed_hw, leader_load);
+    match placement.leader {
+        Some(leader) => PlacementOutcome::Placed {
+            command: MetadataCommand::PlacePartition {
+                partition,
+                replicas: placement.replicas,
+                leader,
+                epoch,
+            },
+            under_replicated: match placement.under_replicated {
+                // A "no eligible leader" shortfall cannot co-occur with a `Some(leader)`; only the
+                // under-replication reason is meaningful here.
+                Some(PlacementShortfall::TooFewNodes { requested, placed }) => {
+                    Some(PlacementShortfall::TooFewNodes { requested, placed })
+                }
+                _ => None,
+            },
+        },
+        None => PlacementOutcome::Leaderless {
+            replicas: placement.replicas,
+        },
+    }
+}
+
+/// Convenience: decide a placement and return JUST the committable command, or `None` if no eligible
+/// leader exists (the leaderless, fail-closed case). The `under_replicated` reason is dropped; use
+/// [`decide_placement`] when the caller needs it.
+#[must_use]
+pub fn placement_command(
+    partition: u64,
+    candidates: &[PlacementNode],
+    r: usize,
+    committed_hw: u64,
+    epoch: u64,
+    leader_load: &LeaderLoad,
+) -> Option<MetadataCommand> {
+    match decide_placement(partition, candidates, r, committed_hw, epoch, leader_load) {
+        PlacementOutcome::Placed { command, .. } => Some(command),
+        PlacementOutcome::Leaderless { .. } => None,
+    }
+}
+
+/// Build a [`PlacementNode`] for `node` from the leader's [`IsrTracker`], the node's reported durable
+/// (fsync'd) frontier, and the (optional) C4 [`DivergenceReport`] for it — the SAME projection
+/// [`super::eligibility::replica_state_from`] uses, so a node placed here is eligible to LEAD iff it is
+/// eligible to WIN the partition's election (#700). `failure_domain` is the operator-assigned domain
+/// label (a rack / host / AZ id) when the membership models it, else `None`.
+///
+/// Returns `None` if `node` is neither the leader nor a tracked follower (an unknown node is never a
+/// placement candidate).
+#[must_use]
+pub fn placement_node_from(
+    tracker: &IsrTracker,
+    node: u64,
+    durable_prefix: u64,
+    failure_domain: Option<u64>,
+    divergence: Option<&DivergenceReport>,
+) -> Option<PlacementNode> {
+    let in_isr = if node == tracker.leader_id() {
+        true
+    } else {
+        match tracker.membership(node)? {
+            IsrMembership::InSync => true,
+            IsrMembership::EvictedForLag => false,
+        }
+    };
+    let divergent = divergence.is_some_and(|d| !d.is_clean());
+    Some(PlacementNode {
+        node,
+        failure_domain,
+        in_isr,
+        durable_prefix,
+        divergent,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cluster::isr::{AckReplicatedBody, IsrConfig};
+    use crate::cluster::state_machine::{MetadataStateMachine, Placement};
+
+    fn nodes(ids: &[u64]) -> Vec<PlacementNode> {
+        ids.iter()
+            .map(|&n| PlacementNode::healthy(n, 100))
+            .collect()
+    }
+
+    #[test]
+    fn decide_placement_emits_a_place_partition_command() {
+        let outcome = decide_placement(5, &nodes(&[1, 2, 3]), 3, 100, 7, &LeaderLoad::new());
+        match outcome {
+            PlacementOutcome::Placed {
+                command,
+                under_replicated,
+            } => {
+                assert_eq!(under_replicated, None, "3 nodes, R=3 is fully replicated");
+                match command {
+                    MetadataCommand::PlacePartition {
+                        partition,
+                        replicas,
+                        leader,
+                        epoch,
+                    } => {
+                        assert_eq!(partition, 5);
+                        assert_eq!(epoch, 7);
+                        assert_eq!(replicas.len(), 3, "R distinct replicas");
+                        assert!(
+                            replicas.contains(&leader),
+                            "the leader is one of the replicas"
+                        );
+                    }
+                    other => panic!("expected PlacePartition, got {other:?}"),
+                }
+            }
+            PlacementOutcome::Leaderless { .. } => panic!("expected Placed, got Leaderless"),
+        }
+    }
+
+    #[test]
+    fn the_committed_placement_holds_the_replica_set_and_an_eligible_leader() {
+        // The end-to-end shape: decide -> command -> apply into the state machine -> read it back.
+        let outcome = decide_placement(9, &nodes(&[1, 2, 3]), 3, 100, 4, &LeaderLoad::new());
+        let command = match outcome {
+            PlacementOutcome::Placed { command, .. } => command,
+            PlacementOutcome::Leaderless { .. } => panic!("expected Placed, got Leaderless"),
+        };
+        let mut sm = MetadataStateMachine::new();
+        sm.apply(1, &command);
+        let placement: Placement = sm.placement(9).expect("placement committed");
+        assert_eq!(placement.replication_factor(), 3);
+        assert!(
+            placement.replicas.contains(&placement.leader),
+            "the committed leader is one of the committed replicas"
+        );
+    }
+
+    #[test]
+    fn a_stale_replica_is_never_committed_as_leader() {
+        // Node 1 is behind the committed HW (stale). The emitted command's leader must be eligible —
+        // never node 1 — so the stale node can never be COMMITTED as leader.
+        let candidates = vec![
+            PlacementNode::healthy(1, 60), // stale: durable 60 < HW 100
+            PlacementNode::healthy(2, 100),
+            PlacementNode::healthy(3, 100),
+        ];
+        let outcome = decide_placement(1, &candidates, 3, 100, 1, &LeaderLoad::new());
+        if let PlacementOutcome::Placed { command, .. } = outcome {
+            if let MetadataCommand::PlacePartition {
+                leader, replicas, ..
+            } = command
+            {
+                assert!(
+                    replicas.contains(&1),
+                    "the stale node still HOLDS a replica"
+                );
+                assert_ne!(
+                    leader, 1,
+                    "but the stale node is NEVER the committed leader"
+                );
+            } else {
+                panic!("expected PlacePartition");
+            }
+        } else {
+            panic!("expected Placed (an eligible leader exists among 2/3)");
+        }
+    }
+
+    #[test]
+    fn no_eligible_leader_yields_leaderless_and_no_command() {
+        // Every candidate is behind the committed HW: no command is produced (fail-closed), so a
+        // stale/corrupt replica is never committed as leader.
+        let candidates = vec![
+            PlacementNode::healthy(1, 50),
+            PlacementNode::healthy(2, 50),
+            PlacementNode::healthy(3, 50),
+        ];
+        let outcome = decide_placement(1, &candidates, 3, 100, 1, &LeaderLoad::new());
+        assert!(
+            matches!(outcome, PlacementOutcome::Leaderless { .. }),
+            "no eligible replica => leaderless, never a stale committed leader"
+        );
+        assert_eq!(
+            placement_command(1, &candidates, 3, 100, 1, &LeaderLoad::new()),
+            None
+        );
+    }
+
+    #[test]
+    fn placement_node_from_projects_an_evicted_follower_as_out_of_isr() {
+        // A 3-node tracker; follower 3 lags out of the ISR. The projected placement node is not-in-ISR,
+        // so it is never chosen leader by the policy.
+        let config = IsrConfig {
+            min_isr: 2,
+            max_lag_records: 10,
+        };
+        let mut tracker = IsrTracker::new(1, &[2, 3], config);
+        tracker.observe_leader_fsync(100);
+        tracker.observe_follower_report(&AckReplicatedBody {
+            follower_id: 2,
+            fsynced_offset: 95,
+        });
+        tracker.observe_follower_report(&AckReplicatedBody {
+            follower_id: 3,
+            fsynced_offset: 50, // lag 50 > 10 => evicted
+        });
+
+        let leader = placement_node_from(&tracker, 1, 100, None, None).unwrap();
+        assert!(leader.in_isr);
+        let f2 = placement_node_from(&tracker, 2, 95, None, None).unwrap();
+        assert!(f2.in_isr);
+        let f3 = placement_node_from(&tracker, 3, 50, None, None).unwrap();
+        assert!(!f3.in_isr, "the evicted follower projects as out-of-ISR");
+
+        // Placing over these projected nodes never makes the evicted follower leader.
+        let candidates = vec![leader, f2, f3];
+        let cmd = placement_command(7, &candidates, 3, 95, 1, &LeaderLoad::new()).unwrap();
+        if let MetadataCommand::PlacePartition { leader, .. } = cmd {
+            assert_ne!(
+                leader, 3,
+                "the out-of-ISR follower is never the placed leader"
+            );
+        } else {
+            panic!("expected PlacePartition");
+        }
+
+        // An unknown node is not a placement candidate.
+        assert!(placement_node_from(&tracker, 99, 0, None, None).is_none());
+    }
+
+    #[test]
+    fn single_node_emits_a_lone_replica_placement() {
+        let candidates = vec![PlacementNode::healthy(1, 42)];
+        let cmd = placement_command(0, &candidates, 1, 42, 1, &LeaderLoad::new()).unwrap();
+        match cmd {
+            MetadataCommand::PlacePartition {
+                replicas, leader, ..
+            } => {
+                assert_eq!(replicas, vec![1], "the lone node holds the only replica");
+                assert_eq!(leader, 1, "and leads it");
+            }
+            other => panic!("expected PlacePartition, got {other:?}"),
+        }
+    }
+}

--- a/crates/ironbus-server/src/cluster/state_machine.rs
+++ b/crates/ironbus-server/src/cluster/state_machine.rs
@@ -51,15 +51,49 @@ impl NodeRole {
     }
 }
 
-/// The current placement of a single partition: which node leads it and under which
-/// monotonic leader epoch. The epoch is the fencing token (a stale leader's writes are
-/// rejected once a higher epoch exists); exposing it to the broker is C1-I3.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// The current placement of a single partition: the ordered set of `R` replica nodes that hold
+/// it, which one of them leads it, and under which monotonic leader epoch. The epoch is the
+/// fencing token (a stale leader's writes are rejected once a higher epoch exists); exposing it
+/// to the broker is C1-I3.
+///
+/// `replicas` is the ordered replica set the C5-I1 placement policy
+/// ([`ironbus_core::placement`]) decided — `R` distinct nodes spread across failure domains, the
+/// leader first. The `leader` is always one of `replicas` and is always an ELIGIBLE replica
+/// (#700: in-ISR, complete, non-divergent), because the policy only ever designates an eligible
+/// replica leader.
+///
+/// For BACKWARD compatibility, a [`MetadataCommand::AssignPartition`] (the C1 leader-only command,
+/// which carries no replica set) yields a placement whose `replicas` is just `[leader]` — the
+/// single-node degenerate shape, unchanged on the wire.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Placement {
-    /// The node id currently designated leader for the partition.
+    /// The ordered set of replica node ids that hold this partition (leader first). For an
+    /// `AssignPartition` (leader-only) command this is `[leader]`.
+    pub replicas: Vec<u64>,
+    /// The node id currently designated leader for the partition (always one of `replicas`, always
+    /// an eligible replica).
     pub leader: u64,
     /// The monotonic leadership epoch assigned at this placement.
     pub epoch: u64,
+}
+
+impl Placement {
+    /// A leader-only placement: the single-node / `AssignPartition` degenerate shape, whose replica
+    /// set is exactly `[leader]`.
+    #[must_use]
+    pub fn leader_only(leader: u64, epoch: u64) -> Self {
+        Placement {
+            replicas: vec![leader],
+            leader,
+            epoch,
+        }
+    }
+
+    /// The replication factor (number of replica nodes holding this partition).
+    #[must_use]
+    pub fn replication_factor(&self) -> usize {
+        self.replicas.len()
+    }
 }
 
 /// One deterministic mutation of the metadata state machine. A committed Raft log entry's
@@ -72,9 +106,25 @@ pub enum MetadataCommand {
     AddNode { node: u64, role: NodeRole },
     /// Remove a node from the membership table.
     RemoveNode { node: u64 },
-    /// Assign `partition` to `leader` at `epoch` (placement + leader-epoch in one step).
+    /// Assign `partition` to `leader` at `epoch` (placement + leader-epoch in one step). The
+    /// leader-only C1 command: it carries no replica set, so it yields a placement whose replicas
+    /// are exactly `[leader]`. Retained for backward compatibility and the n=1 degenerate case.
     AssignPartition {
         partition: u64,
+        leader: u64,
+        epoch: u64,
+    },
+    /// Place `partition`'s full replica set (the C5-I1 command): the ordered `replicas` the
+    /// placement policy decided, the `leader` among them (always an eligible replica), and the
+    /// monotonic `epoch`. This commits a whole placement — `R` replicas + a balanced eligible
+    /// leader — through the metadata log as ONE entry (not a per-partition Raft group).
+    ///
+    /// The leader MUST be one of `replicas` (the placement policy guarantees this); a command whose
+    /// leader is absent from its replica set is rejected at decode time
+    /// ([`DecodeError::LeaderNotAReplica`]) so a malformed placement can never enter the state.
+    PlacePartition {
+        partition: u64,
+        replicas: Vec<u64>,
         leader: u64,
         epoch: u64,
     },
@@ -97,6 +147,12 @@ pub enum DecodeError {
     BadUtf8,
     /// Bytes remained after a single command was decoded.
     TrailingBytes,
+    /// A `PlacePartition` command named a leader that is not in its own replica set — a malformed
+    /// placement (the leader must always be one of the replicas), rejected fail-closed.
+    LeaderNotAReplica,
+    /// A `PlacePartition` command had an empty replica set (a placement must hold at least one
+    /// replica).
+    EmptyReplicaSet,
 }
 
 impl core::fmt::Display for DecodeError {
@@ -110,6 +166,10 @@ impl core::fmt::Display for DecodeError {
             }
             DecodeError::BadUtf8 => write!(f, "metadata command string field is not valid UTF-8"),
             DecodeError::TrailingBytes => write!(f, "trailing bytes after a metadata command"),
+            DecodeError::LeaderNotAReplica => {
+                write!(f, "placement leader is not in its own replica set")
+            }
+            DecodeError::EmptyReplicaSet => write!(f, "placement has an empty replica set"),
         }
     }
 }
@@ -121,6 +181,7 @@ const TAG_ADD_NODE: u8 = 1;
 const TAG_REMOVE_NODE: u8 = 2;
 const TAG_ASSIGN_PARTITION: u8 = 3;
 const TAG_SET_CONFIG: u8 = 4;
+const TAG_PLACE_PARTITION: u8 = 5;
 
 impl MetadataCommand {
     /// Encode the command to its canonical little-endian wire bytes.
@@ -147,6 +208,22 @@ impl MetadataCommand {
             } => {
                 out.push(TAG_ASSIGN_PARTITION);
                 out.extend_from_slice(&partition.to_le_bytes());
+                out.extend_from_slice(&leader.to_le_bytes());
+                out.extend_from_slice(&epoch.to_le_bytes());
+            }
+            MetadataCommand::PlacePartition {
+                partition,
+                replicas,
+                leader,
+                epoch,
+            } => {
+                out.push(TAG_PLACE_PARTITION);
+                out.extend_from_slice(&partition.to_le_bytes());
+                let count = u32::try_from(replicas.len()).unwrap_or(u32::MAX);
+                out.extend_from_slice(&count.to_le_bytes());
+                for r in replicas {
+                    out.extend_from_slice(&r.to_le_bytes());
+                }
                 out.extend_from_slice(&leader.to_le_bytes());
                 out.extend_from_slice(&epoch.to_le_bytes());
             }
@@ -185,6 +262,33 @@ impl MetadataCommand {
                 let epoch = cur.u64()?;
                 MetadataCommand::AssignPartition {
                     partition,
+                    leader,
+                    epoch,
+                }
+            }
+            TAG_PLACE_PARTITION => {
+                let partition = cur.u64()?;
+                let count = cur.u32()? as usize;
+                // Each replica is a u64 (8 bytes): reject a count whose bytes cannot all be present
+                // BEFORE allocating, so a hostile/truncated length can never over-allocate.
+                if cur.remaining() < count.saturating_mul(8) {
+                    return Err(DecodeError::BadLength);
+                }
+                let mut replicas = Vec::with_capacity(count);
+                for _ in 0..count {
+                    replicas.push(cur.u64()?);
+                }
+                let leader = cur.u64()?;
+                let epoch = cur.u64()?;
+                if replicas.is_empty() {
+                    return Err(DecodeError::EmptyReplicaSet);
+                }
+                if !replicas.contains(&leader) {
+                    return Err(DecodeError::LeaderNotAReplica);
+                }
+                MetadataCommand::PlacePartition {
+                    partition,
+                    replicas,
                     leader,
                     epoch,
                 }
@@ -303,9 +407,19 @@ impl MetadataStateMachine {
                 leader,
                 epoch,
             } => {
+                self.placements
+                    .insert(*partition, Placement::leader_only(*leader, *epoch));
+            }
+            MetadataCommand::PlacePartition {
+                partition,
+                replicas,
+                leader,
+                epoch,
+            } => {
                 self.placements.insert(
                     *partition,
                     Placement {
+                        replicas: replicas.clone(),
                         leader: *leader,
                         epoch: *epoch,
                     },
@@ -376,7 +490,7 @@ impl MetadataStateMachine {
     /// The current placement for `partition`, if assigned.
     #[must_use]
     pub fn placement(&self, partition: u64) -> Option<Placement> {
-        self.placements.get(&partition).copied()
+        self.placements.get(&partition).cloned()
     }
 
     /// A config value by key.
@@ -441,15 +555,97 @@ mod tests {
                 value: "3".to_owned(),
             },
         );
-        assert_eq!(
-            sm.placement(4),
-            Some(Placement {
-                leader: 2,
-                epoch: 9
-            })
-        );
+        assert_eq!(sm.placement(4), Some(Placement::leader_only(2, 9)));
         assert_eq!(sm.config("replication"), Some("3"));
         assert_eq!(sm.config("missing"), None);
+    }
+
+    #[test]
+    fn place_partition_applies_the_full_replica_set_and_leader() {
+        let mut sm = MetadataStateMachine::new();
+        sm.apply(
+            1,
+            &MetadataCommand::PlacePartition {
+                partition: 4,
+                replicas: vec![2, 1, 3],
+                leader: 2,
+                epoch: 9,
+            },
+        );
+        let placement = sm.placement(4).expect("placement applied");
+        assert_eq!(
+            placement.replicas,
+            vec![2, 1, 3],
+            "the ordered replica set is stored"
+        );
+        assert_eq!(placement.leader, 2, "the designated leader is stored");
+        assert_eq!(placement.epoch, 9);
+        assert_eq!(placement.replication_factor(), 3);
+        assert!(
+            placement.replicas.contains(&placement.leader),
+            "the leader is always one of the replicas"
+        );
+    }
+
+    #[test]
+    fn assign_partition_yields_a_leader_only_replica_set() {
+        // The backward-compatible C1 command: a leader-only placement has replicas == [leader].
+        let mut sm = MetadataStateMachine::new();
+        sm.apply(
+            1,
+            &MetadataCommand::AssignPartition {
+                partition: 7,
+                leader: 5,
+                epoch: 3,
+            },
+        );
+        let placement = sm.placement(7).expect("placement applied");
+        assert_eq!(placement.replicas, vec![5]);
+        assert_eq!(placement.leader, 5);
+        assert_eq!(placement.replication_factor(), 1);
+    }
+
+    #[test]
+    fn decode_rejects_a_placement_whose_leader_is_not_a_replica() {
+        // A hand-built PlacePartition whose leader (99) is absent from its replica set must be
+        // rejected fail-closed at decode time — a malformed placement can never enter the state.
+        let cmd = MetadataCommand::PlacePartition {
+            partition: 1,
+            replicas: vec![1, 2, 3],
+            leader: 99,
+            epoch: 1,
+        };
+        let bytes = cmd.encode();
+        assert_eq!(
+            MetadataCommand::decode(&bytes),
+            Err(DecodeError::LeaderNotAReplica)
+        );
+    }
+
+    #[test]
+    fn decode_rejects_a_placement_with_an_empty_replica_set() {
+        let cmd = MetadataCommand::PlacePartition {
+            partition: 1,
+            replicas: vec![],
+            leader: 0,
+            epoch: 1,
+        };
+        let bytes = cmd.encode();
+        assert_eq!(
+            MetadataCommand::decode(&bytes),
+            Err(DecodeError::EmptyReplicaSet)
+        );
+    }
+
+    #[test]
+    fn decode_rejects_a_placement_with_an_overrunning_replica_count() {
+        // A length prefix claiming more replicas than the buffer holds must be rejected BEFORE any
+        // large allocation (the hostile-length guard).
+        let mut buf = vec![TAG_PLACE_PARTITION];
+        buf.extend_from_slice(&1u64.to_le_bytes()); // partition
+        buf.extend_from_slice(&1000u32.to_le_bytes()); // claims 1000 replicas
+        buf.extend_from_slice(&1u64.to_le_bytes()); // but only one u64 follows
+        assert_eq!(MetadataCommand::decode(&buf), Err(DecodeError::BadLength));
     }
 
     #[test]
@@ -468,6 +664,18 @@ mod tests {
                 partition: 1,
                 leader: 5,
                 epoch: 12,
+            },
+            MetadataCommand::PlacePartition {
+                partition: 8,
+                replicas: vec![3, 1, 2],
+                leader: 3,
+                epoch: 7,
+            },
+            MetadataCommand::PlacePartition {
+                partition: 9,
+                replicas: vec![42],
+                leader: 42,
+                epoch: 1,
             },
             MetadataCommand::SetConfig {
                 key: "k".to_owned(),


### PR DESCRIPTION
Closes #616 (V2-C5-I1).

## What

The metadata plane now **decides WHICH node holds + leads WHICH partition** — the step that lets the cluster place each partition's `R` replicas + a designated leader. This is the prerequisite for data-plane serve-wiring (acting on the placement to replicate is the follow-up). Builds on the merged metadata runtime (#683), membership (#677), leader-completeness eligibility (#700), and ISR (#691).

## The placement

- **A deterministic, IO-free placement POLICY** (`ironbus-core::placement`, a pure function over value-types — the same shape as the `#700` eligibility predicate, so the identical decision runs in a unit test and the running state machine):
  - **Spread**: a partition's `R` replicas land on `R` **distinct nodes**, and (when failure-domain labels exist) across **distinct domains first** so a whole-rack/host/AZ failure loses at most one replica. Domains are modeled but **optional** — with no labels it degrades cleanly to distinct-node spread (the current reality; wiring real domain labels into the membership table is purely additive). **FLAGGED.**
  - **Balanced leader**: the leader is the **least-loaded eligible** replica across nodes (ties by node id), so leaders don't pile onto one node.
  - **Eligibility composed in**: the leader is chosen only from `LeaderEligibility` (#700: in-ISR + complete-to-HW + non-divergent), so a **stale / corrupt / out-of-ISR replica is NEVER placed as leader** — the Jepsen-failure prevention carried all the way into the committed metadata.
- **Deterministic (I6)**: no wall-clock, no RNG; ties always break by node id, so the same membership + inputs yield a **byte-identical** placement on every voter (what a replicated state machine needs).
- **Committed through the metadata log**: a new `MetadataCommand::PlacePartition` variant commits a whole placement (R replicas + leader + epoch) as **ONE metadata-log entry** — durable, replicated, **NOT a per-partition Raft group** (the beat over NATS's per-asset meta SPOF [#4502](https://github.com/nats-io/nats-server/issues/4502)). Reads serve the committed placement; it **survives a reopen** (reuses the #659 durable round-trip). Decode is fail-closed (a leader absent from its replica set, an empty set, or an overrunning length prefix is a typed error).

## Preserved

- **Single-node degenerate**: with `n=1` the lone node holds + leads everything (`replicas: [node]`), **byte-identical** to today's broker; a standalone binary never constructs a placement at all.
- The **metadata log/group is unchanged** — placement is a state-machine field + a command reusing the committed log.
- A **placed leader is always eligible** (#700); `ironbus-core` stays **IO-free** (the policy is a pure fn in core; the state-machine integration is in server); **MSRV 1.78**.

## Scope boundary (deferred, FLAGGED)

- Cooperative **rebalance** on node join/leave (learner back-fill, minimal reshuffle) = **C5-I2 (#617)**
- Leaderless-node **failover** = **C5-I3 (#618)**
- The **data-plane serve-wiring** that ACTS on the placement to replicate = **follow-up**

Here we *decide + commit + serve* the placement; *acting on it* is next.

## Tests

- a partition's `R` replicas land on `R` **distinct** nodes (+ duplicate-candidate never doubles up; under-replication is flagged, not silently dropped)
- replicas **spread across distinct failure domains** first; double up only after every domain has one
- **leadership balanced** across nodes over many partitions (30 partitions / 3 nodes → ~10 each, spread ≤ 1)
- a **placed leader is always eligible** — stale / corrupt / out-of-ISR is never placed; no-eligible-leader → leaderless + **no command** (fail-closed)
- **deterministic** regardless of candidate input order; batch placement reproducible
- the placement command **commits through the metadata log + survives a reopen**
- **single-node degenerate** (n=1 holds + leads; R=1 is a complete placement)

## Gates (all green)

- `cargo fmt --all --check` ✅
- **fresh** `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` (from `cargo clean`, `RUSTFLAGS=-D warnings`) ✅
- `cargo test --workspace --all-features --locked` — **2096 passed, 0 failed** ✅
- **io-free-check** on `ironbus-core/src` (AST walk: 27 files structurally IO-free) + dependency-tree runtime-free ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVWp2H2txnKGru4q2twxM3