### PR TITLE
feat(cluster): run the data plane in the live broker via the read plane (single-writer preserved) (#715)

### DIFF
--- a/crates/ironbus-server/src/cluster/dataplane.rs
+++ b/crates/ironbus-server/src/cluster/dataplane.rs
@@ -110,6 +110,7 @@
 //!   **cross-cluster geo** plane (C7) are separate.
 
 use std::collections::BTreeMap;
+use std::sync::Arc;
 
 use ironbus_core::clock::Clock;
 use ironbus_core::epoch_cache::{EpochCache, LeaderEpochEndOffset};
@@ -118,12 +119,13 @@ use ironbus_core::types::Offset;
 use ironbus_proto::frame::FrameType;
 use ironbus_storage::fs::Filesystem;
 use ironbus_storage::log::Log;
+use ironbus_storage::read_plane::ReadPlane;
 
 use super::ack_level::ClusterAckLevel;
 use super::isr::{AckReplicatedBody, IsrConfig, IsrTracker, QuorumAckGate};
 use super::replication::{
     DivergenceTruncation, EpochAwareFollower, FetchRecordsBody, FetchResponseBody, Follower,
-    OffsetForLeaderEpochBody, OffsetForLeaderEpochResponse, ReplicationError, ReplicationLeader,
+    OffsetForLeaderEpochBody, OffsetForLeaderEpochResponse, ReadPlaneLeader, ReplicationError,
 };
 use super::state_machine::Placement;
 
@@ -279,15 +281,22 @@ pub type AckToken = u64;
 
 /// The per-partition DATA-plane role this node runs, derived from the committed placement.
 ///
-/// `'a` borrows the partition's [`Log`] for the LEADER role (the leader serves bytes from the same log
-/// the engine appends to — it never copies). The FOLLOWER role OWNS its replica log (it appends the
-/// leader's bytes to its own copy). `None` holds no state.
-enum PartitionRole<'a, F: Filesystem, C: Clock> {
-    /// This node LEADS the partition: it serves fetches from the leader log + gates produces through
-    /// the ISR quorum.
+/// The LEADER role holds an `Arc`-shared, off-actor [`ReadPlane`] of the partition's log (#654, #715),
+/// NOT a `&Log` borrow: the leader serves committed bytes from the same log the engine appends to, but
+/// it READS them through the lock-free read plane and NEVER writes (or borrows) the log. The engine's
+/// single append actor stays the ONLY writer — the data plane is never a second writer. Holding an
+/// `Arc` (rather than a borrow) is exactly what makes the controller `Send`, so the data plane can run
+/// on a peer-I/O thread alongside the append actor. The FOLLOWER role OWNS its replica log (it appends
+/// the leader's bytes to its OWN copy, via its OWN single writer). `None` holds no state.
+enum PartitionRole<F: Filesystem, C: Clock> {
+    /// This node LEADS the partition: it serves fetches from the leader's read plane + gates produces
+    /// through the ISR quorum.
     Leader {
-        /// A read-only replication view over the leader's partition log (serves `FetchRecords`).
-        log: &'a Log<F, C>,
+        /// The leader's `Arc`-shared, off-actor [`ReadPlane`] (#654): the lock-free view of the SEALED,
+        /// flushed prefix the leader serves `FetchRecords` from. NOT a `&Log` borrow — the leader never
+        /// writes (or borrows) its log here; the append actor remains the sole writer. This `Arc` is
+        /// what makes the role (and the whole controller) `Send`.
+        plane: Arc<ReadPlane<F>>,
         /// The leader's epoch cache (answers `OffsetForLeaderEpoch` queries; the leader-epoch fence).
         epochs: EpochCache,
         /// The ISR tracker: the leader's own fsync'd frontier + every follower's reported frontier.
@@ -310,14 +319,14 @@ enum PartitionRole<'a, F: Filesystem, C: Clock> {
 /// Transport-agnostic by construction: it holds the role state and the ISR / gate logic, and returns
 /// [`DataPlaneAction`]s describing what to send — the caller owns the wire. This is what makes it both
 /// the serve-path driver AND the unit under the in-process 3-node test (the test plays the transport).
-pub struct DataPlaneController<'a, F: Filesystem, C: Clock> {
+pub struct DataPlaneController<F: Filesystem, C: Clock> {
     /// This node's cluster id (the same `u64` node-id space the metadata group / runtime use).
     node_id: u64,
     /// The per-partition role this node runs, keyed by partition id.
-    roles: BTreeMap<u64, PartitionRole<'a, F, C>>,
+    roles: BTreeMap<u64, PartitionRole<F, C>>,
 }
 
-impl<'a, F: Filesystem, C: Clock> DataPlaneController<'a, F, C> {
+impl<F: Filesystem, C: Clock> DataPlaneController<F, C> {
     /// A fresh controller for `node_id` with no roles yet. Roles are added by
     /// [`start_leader`](Self::start_leader) / [`start_follower`](Self::start_follower) or, in one shot
     /// from the committed metadata, by [`apply_placement`](Self::apply_placement) /
@@ -360,27 +369,30 @@ impl<'a, F: Filesystem, C: Clock> DataPlaneController<'a, F, C> {
         )
     }
 
-    /// Register this node as the LEADER of `partition`, serving fetches from `log` and gating produces
-    /// through an [`IsrTracker`] / [`QuorumAckGate`] sized by `isr_config` over `replica_ids` (the full
-    /// committed replica set; the leader is implicit and need not appear). The leader's `epochs` cache
-    /// answers divergence queries; pass an [`EpochCache`] seeded with the partition's leader-epoch
-    /// history (or a fresh one for a fresh partition).
+    /// Register this node as the LEADER of `partition`, serving fetches from the `Arc`-shared, off-actor
+    /// read `plane` (#654, #715) — NOT a `&Log` borrow, so the leader never writes (or borrows) its log
+    /// and the controller stays `Send`. Gates produces through an [`IsrTracker`] / [`QuorumAckGate`]
+    /// sized by `isr_config` over `replica_ids` (the full committed replica set; the leader is implicit
+    /// and need not appear). The leader's `epochs` cache answers divergence queries; pass an
+    /// [`EpochCache`] seeded with the partition's leader-epoch history (or a fresh one for a fresh
+    /// partition).
     pub fn start_leader(
         &mut self,
         partition: u64,
-        log: &'a Log<F, C>,
+        plane: Arc<ReadPlane<F>>,
         epochs: EpochCache,
         replica_ids: &[u64],
         isr_config: IsrConfig,
     ) {
         let mut isr = IsrTracker::new(self.node_id, replica_ids, isr_config);
-        // Seed the ISR tracker's own-frontier with the log's current durable head so the leader's
-        // quorum-commit starts from the truth (a recovered log may already hold records).
-        isr.observe_leader_fsync(log.flushed_offset().get());
+        // Seed the ISR tracker's own-frontier with the read plane's current flushed frontier (the same
+        // committed head Log::flushed_offset publishes), so the leader's quorum-commit starts from the
+        // truth (a recovered log may already hold records).
+        isr.observe_leader_fsync(plane.flushed());
         self.roles.insert(
             partition,
             PartitionRole::Leader {
-                log,
+                plane,
                 epochs,
                 isr,
                 gate: QuorumAckGate::new(),
@@ -402,16 +414,18 @@ impl<'a, F: Filesystem, C: Clock> DataPlaneController<'a, F, C> {
 
     /// Remove this node's role for `partition` (it no longer holds a replica). Returns `true` if a role
     /// was held and removed, `false` if this node held no role for the partition. A follower's replica
-    /// log is dropped with the role (closing its files); a leader's log is borrowed (owned by the
-    /// engine) and merely un-referenced here.
+    /// log is dropped with the role (closing its files); a leader's read plane is an `Arc` (the engine
+    /// owns the log) and merely un-referenced here.
     pub fn stop_partition(&mut self, partition: u64) -> bool {
         self.roles.remove(&partition).is_some()
     }
 
     // ---- LEADER role: serve fetches + gate produces ----------------------------------------------
 
-    /// Serve a follower's `FetchRecords` for `partition` from the leader log (zero-copy CRC-framed
-    /// bytes + the leader's high-watermark). Leader-only.
+    /// Serve a follower's `FetchRecords` for `partition` from the leader's off-actor read plane (#654,
+    /// #715): zero-copy CRC-framed bytes of the SEALED, flushed prefix + the leader's high-watermark
+    /// (the read plane's flushed frontier). Leader-only. The leader NEVER writes its log here — it only
+    /// reads the immutable sealed bytes through the `Arc`-shared plane (the single-writer invariant).
     ///
     /// # Errors
     /// [`DataPlaneError::UnknownPartition`] if this node holds no role for `partition`;
@@ -423,8 +437,8 @@ impl<'a, F: Filesystem, C: Clock> DataPlaneController<'a, F, C> {
         req: &FetchRecordsBody,
     ) -> Result<FetchResponseBody, DataPlaneError> {
         match self.roles.get(&partition) {
-            Some(PartitionRole::Leader { log, .. }) => {
-                Ok(ReplicationLeader::new(log).serve_fetch(req)?)
+            Some(PartitionRole::Leader { plane, .. }) => {
+                Ok(ReadPlaneLeader::new(plane).serve_fetch(req)?)
             }
             Some(PartitionRole::Follower { .. }) => Err(DataPlaneError::WrongRole {
                 partition,
@@ -445,8 +459,8 @@ impl<'a, F: Filesystem, C: Clock> DataPlaneController<'a, F, C> {
         req: &OffsetForLeaderEpochBody,
     ) -> Result<OffsetForLeaderEpochResponse, DataPlaneError> {
         match self.roles.get(&partition) {
-            Some(PartitionRole::Leader { log, epochs, .. }) => {
-                Ok(ReplicationLeader::new(log).serve_epoch_query(epochs, req))
+            Some(PartitionRole::Leader { plane, epochs, .. }) => {
+                Ok(ReadPlaneLeader::new(plane).serve_epoch_query(epochs, req))
             }
             Some(PartitionRole::Follower { .. }) => Err(DataPlaneError::WrongRole {
                 partition,
@@ -831,14 +845,15 @@ pub enum AckDisposition {
 /// to the parked wire-`PubAck` bytes and returns for the caller to flush. Below `min_isr` the gate
 /// releases NOTHING (the no-false-ack property), so a parked ack stays withheld — on the REAL wire.
 ///
-/// `'a` is the controller's borrow of the leader partition log; `F`/`C` are the broker's filesystem /
-/// clock seams (the same the engine uses), so the seam is held alongside the engine on a clustered
-/// serve.
-pub struct ProduceAckSeam<'a, F: Filesystem, C: Clock> {
+/// `F`/`C` are the broker's filesystem / clock seams (the same the engine uses), so the seam is held
+/// alongside the engine on a clustered serve. There is NO lifetime: the controller it owns serves
+/// leader fetches through the `Arc`-shared off-actor read plane (#654, #715), not a `&Log` borrow, so
+/// the whole seam is `Send` and can be held in shared broker state and driven on a peer-I/O thread.
+pub struct ProduceAckSeam<F: Filesystem, C: Clock> {
     /// The data-plane controller (#703) this seam drives. Present ONLY on a clustered serve; a
     /// single-node / no-cluster broker never constructs a [`ProduceAckSeam`] at all, so the parking
     /// path is unreachable by construction (the single-node guarantee).
-    controller: DataPlaneController<'a, F, C>,
+    controller: DataPlaneController<F, C>,
     /// The next per-park token. Monotonic; keys [`Self::parked`] and is what the controller's gate
     /// holds + hands back on release. Wraps only after `u64::MAX` parks, which is unreachable.
     next_token: u64,
@@ -848,12 +863,12 @@ pub struct ProduceAckSeam<'a, F: Filesystem, C: Clock> {
     parked: BTreeMap<AckToken, Vec<u8>>,
 }
 
-impl<'a, F: Filesystem, C: Clock> ProduceAckSeam<'a, F, C> {
+impl<F: Filesystem, C: Clock> ProduceAckSeam<F, C> {
     /// Build the seam around a clustered serve's [`DataPlaneController`]. Called ONLY on a clustered
     /// serve (a [`ClusterConfig`](super::ClusterConfig) present); a no-cluster broker never reaches
     /// here, so the parking path is never constructed (the single-node byte-identical guarantee).
     #[must_use]
-    pub fn new(controller: DataPlaneController<'a, F, C>) -> Self {
+    pub fn new(controller: DataPlaneController<F, C>) -> Self {
         Self {
             controller,
             next_token: 0,
@@ -864,14 +879,14 @@ impl<'a, F: Filesystem, C: Clock> ProduceAckSeam<'a, F, C> {
     /// The underlying controller (for role queries / serve-path frame routing). The seam owns it so the
     /// gate's parked state and the parked-bytes side-table can never drift apart.
     #[must_use]
-    pub fn controller(&self) -> &DataPlaneController<'a, F, C> {
+    pub fn controller(&self) -> &DataPlaneController<F, C> {
         &self.controller
     }
 
     /// Mutable access to the underlying controller (the serve-path peer reader routes follower fetches /
     /// epoch queries through it). The produce-ack release path goes through
     /// [`Self::on_follower_report`], which keeps the side-table consistent.
-    pub fn controller_mut(&mut self) -> &mut DataPlaneController<'a, F, C> {
+    pub fn controller_mut(&mut self) -> &mut DataPlaneController<F, C> {
         &mut self.controller
     }
 
@@ -1044,6 +1059,84 @@ mod tests {
         out
     }
 
+    /// The engine's `Arc`-shared, off-actor read plane over a leader log (#654, #715) — what the leader
+    /// role serves fetches from after the #715 refactor (NO `&Log` borrow). The test owns the log; the
+    /// plane keeps observing it (the append actor would keep publishing in a real serve).
+    fn leader_plane(log: &Log<InMemoryFs, ManualClock>) -> Arc<ReadPlane<InMemoryFs>> {
+        Arc::new(log.read_plane().expect("read plane builds"))
+    }
+
+    /// The first offset the leader's read plane does NOT serve off-actor (the sealed-served end): chain
+    /// `read_range_raw` from 0 until it reports no more sealed bytes below the flushed frontier. The
+    /// read plane serves the SEALED prefix; this is the offset a follower converges to over the live
+    /// transport before the active (flushed-but-unsealed) tail seals. Used so byte-identity asserts over
+    /// exactly the replicated range.
+    fn plane_served_end(plane: &ReadPlane<InMemoryFs>) -> u64 {
+        let flushed = plane.flushed();
+        let mut next = 0u64;
+        let mut guard = 0u32;
+        while next < flushed {
+            guard += 1;
+            assert!(guard < 100_000, "read-plane chain failed to terminate");
+            let raw = plane
+                .read_range_raw(Offset::new(next), 1_000, None)
+                .expect("read plane serves");
+            let advanced = raw.run.next_offset.get();
+            if advanced > next {
+                next = advanced;
+            } else {
+                // Nothing more is served off-actor from here (the active tail): stop at the sealed end.
+                break;
+            }
+        }
+        next
+    }
+
+    /// Assert a follower replica is BYTE-IDENTICAL to the leader over the range the read plane served.
+    ///
+    /// A follower replicates frames VERBATIM and seals at the same cap, so a SEALED follower segment is
+    /// byte-for-byte the leader's same-named file (footer included). The follower's LAST (still-active)
+    /// segment holds the same RECORDS but has not sealed yet (it seals on its next roll), so it equals
+    /// the leader's same-named SEALED file MINUS the trailing seal footer — i.e. the leader's file is a
+    /// byte-identical PREFIX-superset. So: every follower file is a byte-identical prefix of the leader's
+    /// same-named file, at least one matches EXACTLY (proving real sealed replication), and the follower
+    /// covered the whole sealed-served prefix. This is the exact invariant the read-plane leader serve
+    /// guarantees; the active flushed tail (and the follower's own trailing seal) close on the next roll
+    /// (FLAGGED).
+    fn assert_replicated_byte_identical(
+        follower_log: &Log<InMemoryFs, ManualClock>,
+        leader_log: &Log<InMemoryFs, ManualClock>,
+        served_end: u64,
+    ) {
+        let leader: std::collections::BTreeMap<String, Vec<u8>> =
+            dump_segments(leader_log).into_iter().collect();
+        let follower = dump_segments(follower_log);
+        assert!(
+            follower.iter().any(|(_, b)| !b.is_empty()),
+            "follower replicated at least one segment file"
+        );
+        let mut any_exact = false;
+        for (name, bytes) in &follower {
+            let leader_bytes = leader
+                .get(name)
+                .unwrap_or_else(|| panic!("leader missing replicated segment file {name}"));
+            assert!(
+                leader_bytes.starts_with(bytes),
+                "follower segment {name} is not a byte-identical prefix of the leader's"
+            );
+            any_exact |= bytes == leader_bytes;
+        }
+        assert!(
+            any_exact,
+            "no fully-sealed follower segment is byte-identical to the leader's (no real replication)"
+        );
+        assert!(
+            follower_log.next_offset().get() >= served_end,
+            "follower ({}) did not cover the read plane's sealed-served prefix ({served_end})",
+            follower_log.next_offset().get()
+        );
+    }
+
     /// The R=3 / `min_isr=2` quorum config (the design default for `R>=3`), no lag eviction.
     fn quorum3() -> IsrConfig {
         IsrConfig {
@@ -1058,8 +1151,8 @@ mod tests {
     /// follower reports its fsync'd frontier back and the leader records it (the `handle_frame` ->
     /// `ReleaseAcks` action). Returns the acks the leader released on this round.
     fn fetch_round(
-        leader: &mut DataPlaneController<'_, InMemoryFs, ManualClock>,
-        follower: &mut DataPlaneController<'_, InMemoryFs, ManualClock>,
+        leader: &mut DataPlaneController<InMemoryFs, ManualClock>,
+        follower: &mut DataPlaneController<InMemoryFs, ManualClock>,
         partition: u64,
     ) -> Vec<AckToken> {
         // follower -> leader: fetch request
@@ -1122,10 +1215,24 @@ mod tests {
         let leader_hw = leader_log.flushed_offset().get();
         assert_eq!(leader_hw, 25);
 
-        // Node 1 leads P over replicas {1,2,3}, min_isr=2 (a 2-of-3 quorum).
+        // Node 1 leads P over replicas {1,2,3}, min_isr=2 (a 2-of-3 quorum). The leader serves through
+        // the engine's OFF-ACTOR read plane (#654, #715), NOT a &Log borrow — it never writes its log.
+        let plane = leader_plane(&leader_log);
+        // The read plane serves the SEALED prefix; the active flushed tail seals later (FLAGGED). The
+        // multi-segment small cap leaves a healthy sealed prefix to replicate + quorum-ack here.
+        let served_end = plane_served_end(&plane);
+        assert!(
+            served_end > 0 && served_end <= leader_hw,
+            "the read plane serves a non-empty sealed prefix (served_end={served_end})"
+        );
         let mut leader = DataPlaneController::new(1);
-        leader.start_leader(P, &leader_log, EpochCache::new(), &[1, 2, 3], quorum3());
-        // The leader's own log is already fsync'd to 25; the ISR tracker was seeded with that on start.
+        leader.start_leader(
+            P,
+            Arc::clone(&plane),
+            EpochCache::new(),
+            &[1, 2, 3],
+            quorum3(),
+        );
 
         // Nodes 2 and 3 each follow P with a fresh replica log.
         let mut follower2 = DataPlaneController::new(2);
@@ -1133,15 +1240,19 @@ mod tests {
         let mut follower3 = DataPlaneController::new(3);
         follower3.start_follower(P, open_log(InMemoryFs::new(), small_config()));
 
-        // PARK all 25 produce acks behind the quorum gate (a real serve parks each produce's PubAck;
-        // here token == offset). The leader has locally fsync'd, but no follower has the data yet.
-        for off in 0..leader_hw {
+        // PARK a produce ack for each sealed-served offset behind the quorum gate (a real serve parks
+        // each produce's PubAck; here token == offset). The leader has locally fsync'd, but no follower
+        // has the data yet.
+        for off in 0..served_end {
             leader.park_produce_ack(P, off, off).unwrap();
         }
-        assert_eq!(leader.pending_ack_count(P), 25);
+        assert_eq!(
+            leader.pending_ack_count(P),
+            usize::try_from(served_end).unwrap()
+        );
 
-        // No follower has fsync'd => the 2-of-3 quorum-commit is 0 (only the leader is at 25) => NO ack
-        // releases. This is the no-false-ack property: leader-only is NOT a quorum.
+        // No follower has fsync'd => the 2-of-3 quorum-commit is 0 (only the leader) => NO ack releases.
+        // This is the no-false-ack property: leader-only is NOT a quorum.
         let released = leader.release_quorum_acked(P).unwrap();
         assert!(
             released.is_empty(),
@@ -1149,33 +1260,35 @@ mod tests {
         );
         assert_eq!(leader.quorum_commit(P), Some(0));
 
-        // Replicate to follower 2 to catch-up. Each round: follower fetches, leader serves, follower
-        // applies + reports, leader records the report and releases the now-quorum-committed acks.
+        // Replicate to follower 2 to catch-up over the read-plane-served prefix. Each round: follower
+        // fetches, leader serves (via the read plane), follower applies + reports, leader records the
+        // report and releases the now-quorum-committed acks.
         let mut released_to_f2: Vec<AckToken> = Vec::new();
-        for _ in 0..(leader_hw + 2) {
-            if follower2.follower_high_watermark(P).unwrap() >= leader_hw {
+        for _ in 0..(leader_hw + 4) {
+            if follower2.follower_high_watermark(P).unwrap() >= served_end {
                 break;
             }
             released_to_f2.extend(fetch_round(&mut leader, &mut follower2, P));
         }
-        // With follower 2 caught up the 2-of-3 quorum (leader + follower2) is met at 25, so ALL 25 acks
-        // released — and ONLY after the quorum fsync'd (not on the leader alone above).
+        // With follower 2 caught up to the sealed-served prefix the 2-of-3 quorum (leader + follower2)
+        // is met at served_end, so ALL parked acks released — and ONLY after the quorum fsync'd.
         let mut all = released_to_f2;
         all.sort_unstable();
-        assert_eq!(all, (0..leader_hw).collect::<Vec<_>>());
-        assert_eq!(leader.pending_ack_count(P), 0, "every ack released");
-        assert_eq!(leader.quorum_commit(P), Some(25));
+        assert_eq!(all, (0..served_end).collect::<Vec<_>>());
+        assert_eq!(leader.pending_ack_count(P), 0, "every parked ack released");
+        assert_eq!(leader.quorum_commit(P), Some(served_end));
 
-        // Follower 2's replica log is BYTE-IDENTICAL to the leader's.
-        assert_eq!(
-            dump_segments(follower2.follower_log(P).unwrap()),
-            dump_segments(&leader_log),
-            "follower 2 replica is byte-identical to the leader"
+        // Follower 2's replica is BYTE-IDENTICAL to the leader over the read-plane-served prefix (every
+        // replicated segment file matches the leader's same-named file).
+        assert_replicated_byte_identical(
+            follower2.follower_log(P).unwrap(),
+            &leader_log,
+            served_end,
         );
 
         // Catch follower 3 up too (its reports release nothing new — the acks already released).
-        for _ in 0..(leader_hw + 2) {
-            if follower3.follower_high_watermark(P).unwrap() >= leader_hw {
+        for _ in 0..(leader_hw + 4) {
+            if follower3.follower_high_watermark(P).unwrap() >= served_end {
                 break;
             }
             let none_new = fetch_round(&mut leader, &mut follower3, P);
@@ -1184,10 +1297,10 @@ mod tests {
                 "acks already released, none re-release"
             );
         }
-        assert_eq!(
-            dump_segments(follower3.follower_log(P).unwrap()),
-            dump_segments(&leader_log),
-            "follower 3 replica is byte-identical to the leader"
+        assert_replicated_byte_identical(
+            follower3.follower_log(P).unwrap(),
+            &leader_log,
+            served_end,
         );
     }
 
@@ -1209,10 +1322,16 @@ mod tests {
         // reports, so both sit at offset 0 — lagging the leader's frontier (10) by far more than the
         // bound. Both are EVICTED for lag, dropping the ISR to the leader alone (size 1 < min_isr 2):
         // there is genuinely no quorum.
+        let plane = leader_plane(&leader_log);
+        let served_end = plane_served_end(&plane);
+        assert!(
+            served_end > 0,
+            "the read plane serves a non-empty sealed prefix"
+        );
         let mut leader = DataPlaneController::new(1);
         leader.start_leader(
             P,
-            &leader_log,
+            Arc::clone(&plane),
             EpochCache::new(),
             &[1, 2, 3],
             IsrConfig {
@@ -1220,7 +1339,7 @@ mod tests {
                 max_lag_records: 3,
             },
         );
-        for off in 0..leader_hw {
+        for off in 0..served_end {
             leader.park_produce_ack(P, off, off).unwrap();
         }
 
@@ -1234,7 +1353,7 @@ mod tests {
         );
         assert_eq!(
             leader.pending_ack_count(P),
-            usize::try_from(leader_hw).unwrap(),
+            usize::try_from(served_end).unwrap(),
             "every ack still parked, awaiting a quorum"
         );
 
@@ -1243,20 +1362,21 @@ mod tests {
         let mut follower2 = DataPlaneController::new(2);
         follower2.start_follower(P, open_log(InMemoryFs::new(), small_config()));
         let mut released: Vec<AckToken> = Vec::new();
-        for _ in 0..(leader_hw + 2) {
-            if follower2.follower_high_watermark(P).unwrap() >= leader_hw {
+        for _ in 0..(leader_hw + 4) {
+            if follower2.follower_high_watermark(P).unwrap() >= served_end {
                 break;
             }
             released.extend(fetch_round(&mut leader, &mut follower2, P));
         }
         released.sort_unstable();
-        assert_eq!(released, (0..leader_hw).collect::<Vec<_>>());
+        assert_eq!(released, (0..served_end).collect::<Vec<_>>());
         assert_eq!(leader.pending_ack_count(P), 0);
     }
 
     // ---- a divergent follower self-heals ---------------------------------------------------------
 
     #[test]
+    #[allow(clippy::too_many_lines)] // one coherent self-heal scenario (build lineages, diverge, heal)
     fn a_divergent_follower_self_heals_then_converges_byte_identical() {
         use ironbus_core::epoch_cache::LeaderEpochEndOffset;
 
@@ -1285,17 +1405,25 @@ mod tests {
         follower
             .assign_follower_epoch(P, LeaderEpoch::new(1), Offset::new(0))
             .unwrap();
-        // Catch the follower up to the old leader.
-        {
-            let mut old_leader = DataPlaneController::new(1);
-            old_leader.start_leader(P, &old_leader_log, old_epochs.clone(), &[1, 2], {
+        // Catch the follower up to the old leader's read-plane-served prefix (the leader serves through
+        // the off-actor read plane #654/#715, the SEALED prefix). The small cap leaves an 18-record log
+        // with a sealed prefix that covers the divergence region [10,14) and the divergent suffix.
+        let old_served = {
+            let old_plane = leader_plane(&old_leader_log);
+            let old_served = plane_served_end(&old_plane);
+            assert!(
+                old_served >= 14,
+                "the old leader's sealed prefix must cover the divergent suffix (got {old_served})"
+            );
+            let mut old_leader = DataPlaneController::<InMemoryFs, ManualClock>::new(1);
+            old_leader.start_leader(P, Arc::clone(&old_plane), old_epochs.clone(), &[1, 2], {
                 IsrConfig {
                     min_isr: 1,
                     max_lag_records: 0,
                 }
             });
-            for _ in 0..20 {
-                if follower.follower_high_watermark(P).unwrap() >= 18 {
+            for _ in 0..24 {
+                if follower.follower_high_watermark(P).unwrap() >= old_served {
                     break;
                 }
                 let req = follower.make_fetch_request(P, 8, 4096).unwrap();
@@ -1305,8 +1433,9 @@ mod tests {
             follower
                 .assign_follower_epoch(P, LeaderEpoch::new(5), Offset::new(10))
                 .unwrap();
-        }
-        assert_eq!(follower.follower_high_watermark(P).unwrap(), 18);
+            old_served
+        };
+        assert_eq!(follower.follower_high_watermark(P).unwrap(), old_served);
 
         // A NEW leader takes over with a DIFFERENT lineage: epoch 1 from 0, epoch 6 from 14. Only the
         // epoch-1 prefix [0,10) and the epoch-5 segment up to 14 are the common committed lineage; the
@@ -1333,8 +1462,14 @@ mod tests {
         new_epochs
             .assign(LeaderEpoch::new(6), Offset::new(14))
             .unwrap();
-        let mut new_leader = DataPlaneController::new(1);
-        new_leader.start_leader(P, &new_leader_log, new_epochs, &[1, 2], {
+        let new_plane = leader_plane(&new_leader_log);
+        let new_served = plane_served_end(&new_plane);
+        assert!(
+            new_served >= 14,
+            "the new leader's sealed prefix must cover the clean lineage past divergence (got {new_served})"
+        );
+        let mut new_leader = DataPlaneController::<InMemoryFs, ManualClock>::new(1);
+        new_leader.start_leader(P, Arc::clone(&new_plane), new_epochs, &[1, 2], {
             IsrConfig {
                 min_isr: 1,
                 max_lag_records: 0,
@@ -1354,20 +1489,20 @@ mod tests {
             .expect("the follower self-heals to the divergence point");
         assert!(!healed.is_no_op(), "the divergent suffix was truncated");
 
-        // Re-fetch the clean lineage forward from the new leader; the follower converges byte-identical.
+        // Re-fetch the clean lineage forward from the new leader's read-plane-served prefix; the
+        // follower converges byte-identical over the replicated range.
         for _ in 0..30 {
-            if follower.follower_high_watermark(P).unwrap() >= new_leader_log.flushed_offset().get()
-            {
+            if follower.follower_high_watermark(P).unwrap() >= new_served {
                 break;
             }
             let req = follower.make_fetch_request(P, 8, 4096).unwrap();
             let resp = new_leader.serve_fetch(P, &req).unwrap();
             follower.apply_fetch_response(P, &resp).unwrap();
         }
-        assert_eq!(
-            dump_segments(follower.follower_log(P).unwrap()),
-            dump_segments(&new_leader_log),
-            "after self-heal the follower is byte-identical to the new leader's lineage"
+        assert_replicated_byte_identical(
+            follower.follower_log(P).unwrap(),
+            &new_leader_log,
+            new_served,
         );
     }
 
@@ -1384,12 +1519,14 @@ mod tests {
         let hw = log.flushed_offset().get();
 
         // A single-replica placement (replicas == [this node], min_isr == 1) is the degenerate
-        // leader-only shape: the quorum-commit is the leader's own fsync'd frontier and the gate
-        // releases on the local fsync alone — exactly the single-node I2 ack, no follower required.
-        let mut node = DataPlaneController::new(1);
+        // leader-only shape: the quorum-commit is the leader's own fsync'd frontier (seeded from the
+        // read plane's flushed frontier = the full committed prefix) and the gate releases on the local
+        // fsync alone — exactly the single-node I2 ack, no follower required.
+        let plane = leader_plane(&log);
+        let mut node = DataPlaneController::<InMemoryFs, ManualClock>::new(1);
         node.start_leader(
             P,
-            &log,
+            Arc::clone(&plane),
             EpochCache::new(),
             &[1],
             IsrConfig {
@@ -1435,10 +1572,11 @@ mod tests {
         leader_log.sync().unwrap();
 
         assert_eq!(role_for_placement(1, &placement), PlacementRole::Leader);
-        let mut leader = DataPlaneController::new(1);
+        let plane = leader_plane(&leader_log);
+        let mut leader = DataPlaneController::<InMemoryFs, ManualClock>::new(1);
         leader.start_leader(
             P,
-            &leader_log,
+            Arc::clone(&plane),
             EpochCache::new(),
             &placement.replicas,
             quorum3(),
@@ -1488,7 +1626,10 @@ mod tests {
 
     /// Stand up a leader controller for partition `P` over a fresh `replica_ids` / `config`, with a
     /// log already fsync'd to `n` records (the leader's local I2 done), plus a follower controller per
-    /// non-leader replica. Returns `(seam_around_leader, followers)`.
+    /// non-leader replica. The leader serves through the OFF-ACTOR read plane (#654, #715), NOT a &Log
+    /// borrow. Returns `(seam_around_leader, followers, served_end)` — `served_end` is the read plane's
+    /// sealed-served prefix end, the offset a follower converges to before the active tail seals, so a
+    /// seam test parks within the range that actually replicates over the wire.
     fn led_cluster(
         partition: u64,
         leader_id: u64,
@@ -1496,11 +1637,13 @@ mod tests {
         config: IsrConfig,
         n: u32,
     ) -> (
-        ProduceAckSeam<'static, InMemoryFs, ManualClock>,
-        Vec<DataPlaneController<'static, InMemoryFs, ManualClock>>,
+        ProduceAckSeam<InMemoryFs, ManualClock>,
+        Vec<DataPlaneController<InMemoryFs, ManualClock>>,
+        u64,
     ) {
-        // Leak the leader log so the borrow is 'static for the test (the seam borrows it for the
-        // leader role); the test owns the process, so this is a test-only convenience, not prod code.
+        // Leak the leader log so the read plane keeps observing it for the test's lifetime (the append
+        // actor would keep publishing in a real serve); the test owns the process. The leader role
+        // holds only an Arc<ReadPlane> (Send), never the log.
         let leader_log: &'static Log<InMemoryFs, ManualClock> = {
             let mut log = open_log(InMemoryFs::new(), small_config());
             for i in 0..n {
@@ -1509,10 +1652,12 @@ mod tests {
             log.sync().unwrap();
             Box::leak(Box::new(log))
         };
+        let plane = leader_plane(leader_log);
+        let served_end = plane_served_end(&plane);
         let mut leader = DataPlaneController::new(leader_id);
         leader.start_leader(
             partition,
-            leader_log,
+            Arc::clone(&plane),
             EpochCache::new(),
             replica_ids,
             config,
@@ -1526,19 +1671,24 @@ mod tests {
                 f
             })
             .collect();
-        (ProduceAckSeam::new(leader), followers)
+        (ProduceAckSeam::new(leader), followers, served_end)
     }
 
     #[test]
     fn clustered_c2_fsync_led_produce_parks_the_wire_puback_until_quorum_fsync_then_sends_it() {
         const P: u64 = 0;
         // Node 1 leads P over {1,2,3}, min_isr=2 — a real serving leader with a local fsync done.
-        let (mut seam, mut followers) = led_cluster(P, 1, &[1, 2, 3], quorum3(), 25);
+        let (mut seam, mut followers, served_end) = led_cluster(P, 1, &[1, 2, 3], quorum3(), 25);
         assert!(seam.controller().is_leader(P));
+        assert!(
+            served_end > 0,
+            "the read plane serves a non-empty sealed prefix"
+        );
 
         // A real C2-fsync produce to the LED partition: thread its REAL wire PubAck through the seam.
         // The leader has locally fsync'd (I2); the gate must now WITHHOLD the wire ack until quorum.
-        let offset = 24; // the last produced record's offset
+        // Park the LAST sealed-served offset (it replicates over the wire; the active tail seals later).
+        let offset = served_end - 1;
         let reply = wire_pub_ack(offset);
         let disposition = seam
             .on_local_fsynced_ack(ClusterAckLevel::C2Fsync, P, offset, reply.clone())
@@ -1575,7 +1725,7 @@ mod tests {
                 // REAL wire PubAck frames to flush to the producer connection.
                 released.extend(seam.on_follower_report(P, &report).unwrap());
             }
-            if followers[0].follower_high_watermark(P).unwrap() >= 25 {
+            if followers[0].follower_high_watermark(P).unwrap() >= served_end {
                 break;
             }
         }
@@ -1609,9 +1759,13 @@ mod tests {
         const P: u64 = 0;
         // Node 1 leads P over {1,2,3}, min_isr=2. Only the leader exists in the ISR's eyes until a
         // follower reports; with NO follower report the ISR is below min_isr (no quorum).
-        let (mut seam, mut followers) = led_cluster(P, 1, &[1, 2, 3], quorum3(), 10);
+        let (mut seam, mut followers, served_end) = led_cluster(P, 1, &[1, 2, 3], quorum3(), 10);
+        assert!(
+            served_end > 0,
+            "the read plane serves a non-empty sealed prefix"
+        );
 
-        let offset = 9;
+        let offset = served_end - 1;
         let reply = wire_pub_ack(offset);
         let disposition = seam
             .on_local_fsynced_ack(ClusterAckLevel::C2Fsync, P, offset, reply)
@@ -1641,7 +1795,7 @@ mod tests {
         // A 1-node cluster (replicas == [1], min_isr == 1) is the degenerate leader-only shape — the
         // closest a cluster gets to single-node. Even here, C1 / C2-pagecache must ack IMMEDIATELY with
         // the verbatim reply bytes and NEVER park (the single-node-shaped guarantee).
-        let mut single = DataPlaneController::new(1);
+        let mut single = DataPlaneController::<InMemoryFs, ManualClock>::new(1);
         let single_log: &'static Log<InMemoryFs, ManualClock> = {
             let mut log = open_log(InMemoryFs::new(), small_config());
             log.append(&rec(b"only")).unwrap();
@@ -1650,7 +1804,7 @@ mod tests {
         };
         single.start_leader(
             P,
-            single_log,
+            leader_plane(single_log),
             EpochCache::new(),
             &[1],
             IsrConfig {
@@ -1723,8 +1877,12 @@ mod tests {
         // Node 1 leads {1,2,3}, min_isr=2, log fsync'd to 5. The follower reports fsync of the WHOLE
         // range BEFORE the produce's ack is threaded — so when the produce parks, the offset is already
         // quorum-committed and the seam hands the REAL reply straight back to write now.
-        let (mut seam, mut followers) = led_cluster(P, 1, &[1, 2, 3], quorum3(), 5);
-        // Catch follower 2 fully up so its reported fsync'd frontier is 5.
+        let (mut seam, mut followers, served_end) = led_cluster(P, 1, &[1, 2, 3], quorum3(), 5);
+        assert!(
+            served_end > 0,
+            "the read plane serves a non-empty sealed prefix"
+        );
+        // Catch follower 2 fully up so its reported fsync'd frontier is the sealed-served end.
         for _ in 0..20 {
             let req = followers[0].make_fetch_request(P, 8, 4096).unwrap();
             let action = seam
@@ -1738,21 +1896,22 @@ mod tests {
             }
             let report = followers[0].follower_report(P).unwrap();
             let _ = seam.on_follower_report(P, &report).unwrap();
-            if followers[0].follower_high_watermark(P).unwrap() >= 5 {
+            if followers[0].follower_high_watermark(P).unwrap() >= served_end {
                 break;
             }
         }
-        // quorum_commit is now 5 (leader + follower2 both fsync'd through offset 4). A produce at
-        // offset 4 is already quorum-committed: parking it releases the real reply immediately.
-        let reply = wire_pub_ack(4);
+        // quorum_commit is now served_end (leader + follower2 both fsync'd through served_end-1). A
+        // produce at served_end-1 is already quorum-committed: parking it releases the real reply now.
+        let offset = served_end - 1;
+        let reply = wire_pub_ack(offset);
         let disposition = seam
-            .on_local_fsynced_ack(ClusterAckLevel::C2Fsync, P, 4, reply.clone())
+            .on_local_fsynced_ack(ClusterAckLevel::C2Fsync, P, offset, reply.clone())
             .unwrap();
         match disposition {
             AckDisposition::WriteNowBatch(frames) => {
                 assert_eq!(frames.len(), 1);
                 assert_eq!(frames[0], reply, "the real reply releases straight back");
-                assert_eq!(pub_ack_offset(&frames[0]), 4);
+                assert_eq!(pub_ack_offset(&frames[0]), offset);
             }
             other => panic!("expected an already-committed fast release, got {other:?}"),
         }

--- a/crates/ironbus-server/src/cluster/mod.rs
+++ b/crates/ironbus-server/src/cluster/mod.rs
@@ -298,8 +298,8 @@ pub use metadata_storage::{MetadataLogStorage, MetadataStorageError, METADATA_SU
 pub use placement::{decide_placement, placement_command, placement_node_from, PlacementOutcome};
 pub use replication::{
     ApplyOutcome, DivergenceTruncation, EpochAwareFollower, FetchRecordsBody, FetchResponseBody,
-    Follower, OffsetForLeaderEpochBody, OffsetForLeaderEpochResponse, ReplicationError,
-    ReplicationFrame, ReplicationLeader, ReplicationLink, MAX_REPL_FETCH_BYTES,
+    Follower, OffsetForLeaderEpochBody, OffsetForLeaderEpochResponse, ReadPlaneLeader,
+    ReplicationError, ReplicationFrame, ReplicationLeader, ReplicationLink, MAX_REPL_FETCH_BYTES,
 };
 pub use runtime::{ClusterConfig, ClusterRuntime, ClusterStatus, RuntimeError};
 pub use serve::{

--- a/crates/ironbus-server/src/cluster/replication.rs
+++ b/crates/ironbus-server/src/cluster/replication.rs
@@ -79,6 +79,7 @@ use ironbus_proto::frame::{
 };
 use ironbus_storage::fs::Filesystem;
 use ironbus_storage::log::{Append, Log, TruncateOutcome};
+use ironbus_storage::read_plane::ReadPlane;
 use ironbus_storage::segment::StorageError;
 
 /// The hard maximum size, in bytes, of the CRC-framed record-byte payload a single replication
@@ -524,6 +525,118 @@ impl<'a, F: Filesystem, C: Clock> ReplicationLeader<'a, F, C> {
         req: &OffsetForLeaderEpochBody,
     ) -> OffsetForLeaderEpochResponse {
         let end = leader_epochs.end_offset_for_epoch(req.epoch, self.log.flushed_offset());
+        OffsetForLeaderEpochResponse { end_offset: end }
+    }
+}
+
+/// The LEADER side of replication that serves a follower's fetch through the LOCK-FREE, OFF-ACTOR READ
+/// PLANE (#654) instead of a `&Log` borrow — the #715 engine-ownership refactor.
+///
+/// ## Why this exists (the `Send` crux)
+///
+/// [`ReplicationLeader`] holds a `&'a Log<F, C>`, so a controller that owns it is NOT `Send` and cannot
+/// run on a peer-I/O thread alongside the engine's single append actor. The engine owns its partition
+/// log PRIVATELY behind that actor (it is the ONLY writer of the log — the single-writer invariant), so
+/// the data plane cannot take a second borrow of it across threads. But the engine ALSO publishes a
+/// [`ReadPlane`] (#654): an `Arc`-shared, lock-free, off-actor view of the SEALED, flushed prefix (an
+/// `AtomicU64` flushed frontier + an `ArcSwap` of the immutable sealed-segment snapshot). The append
+/// actor keeps publishing to it after every commit/seal; any number of readers observe it with no lock
+/// and no actor round-trip. A leader-serve is EXACTLY that read pattern — serve a committed byte range —
+/// so the leader serves through a cloned `ReadPlane` (an `Arc`, `Send`) and NEVER borrows or writes the
+/// leader's log. The data plane reads via the read plane; it is never a second writer. That is what
+/// makes the controller `Send`.
+///
+/// ## The high-watermark and the active (flushed-but-unsealed) tail
+///
+/// The advertised high-watermark is the read plane's [`ReadPlane::flushed`] frontier — the SAME value
+/// the append actor publishes from [`Log::flushed_offset`] after every commit (the through-actor leader
+/// advertised exactly this). It is the true committed frontier, so a follower's visible HW (clamped to
+/// `min(its own durable prefix, this HW)`) is identical to the through-actor path's.
+///
+/// The read plane serves only the SEALED prefix; a leader's flushed frontier can sit AHEAD of the
+/// sealed end (the active segment holds flushed-but-unsealed records). When a fetch starts in that
+/// active tail the read plane returns an EMPTY run (and a `fallback_from`); the follower applies the
+/// empty run as a clean no-op, observes the advertised HW, and re-fetches. It catches up to the sealed
+/// end byte-identically and replicates the active tail the moment it seals (a roll). This is CORRECT by
+/// construction — no false ack, no false visibility (the follower only ever shows what it durably
+/// holds) — but a follower can LAG by up to the active-segment size until that segment seals. That
+/// liveness window (closing it by serving the active flushed tail off-actor, e.g. via an actor-fallback
+/// read on the peer thread, or an active-segment read-plane extension) is FLAGGED as the follow-up; it
+/// is not a correctness gap and does not affect the single-writer / byte-identical invariants.
+pub struct ReadPlaneLeader<'a, F: Filesystem> {
+    plane: &'a ReadPlane<F>,
+}
+
+impl<'a, F: Filesystem> ReadPlaneLeader<'a, F> {
+    /// Wrap a leader's `Arc`-shared read plane as an off-actor replication source. The plane is the
+    /// engine's own [`Engine::read_plane`](crate::engine::Engine::read_plane) clone (#654); it is
+    /// `Send` and never borrows or writes the leader's log.
+    #[must_use]
+    pub fn new(plane: &'a ReadPlane<F>) -> Self {
+        Self { plane }
+    }
+
+    /// The leader's current high-watermark: the read plane's flushed frontier — the same flushed /
+    /// committed offset [`ReplicationLeader::high_watermark`] reads from the log, published by the
+    /// append actor after every commit. A follower never replicates (or makes visible) past it.
+    #[must_use]
+    pub fn high_watermark(&self) -> Offset {
+        Offset::new(self.plane.flushed())
+    }
+
+    /// Serve a follower's fetch from the SEALED, flushed prefix through the read plane — the off-actor
+    /// twin of [`ReplicationLeader::serve_fetch`]. Reads a contiguous CRC-framed [`RawByteRun`] of the
+    /// leader's own durable bytes via [`ReadPlane::read_range_raw`] (zero-copy, single sealed segment),
+    /// bounded by the smaller of the request budget and [`MAX_REPL_FETCH_BYTES`], and advertises the
+    /// read plane's flushed frontier as the high-watermark.
+    ///
+    /// The run is the SEALED prefix only: a fetch whose `from_offset` is already in the active
+    /// (flushed-but-unsealed) tail returns an EMPTY run with the true HW (the follower no-ops and
+    /// re-fetches; it catches up byte-identically as segments seal). The leader NEVER writes its log
+    /// here — it only reads the immutable sealed bytes via the `Arc`-shared plane.
+    ///
+    /// # Errors
+    /// Returns [`ReplicationError::Storage`] if the underlying raw read fails (e.g. the requested
+    /// offset is older than the oldest retained record).
+    pub fn serve_fetch(
+        &self,
+        req: &FetchRecordsBody,
+    ) -> Result<FetchResponseBody, ReplicationError> {
+        let hw = self.plane.flushed();
+        let from = Offset::new(req.from_offset);
+        // Bound the served bytes to the cap regardless of what the follower asked for (mirrors
+        // ReplicationLeader exactly): `0` request bytes means "use the cap", so a follower without a
+        // byte budget still makes progress; the record-count budget still bounds it.
+        let req_bytes = if req.max_bytes == 0 {
+            MAX_REPL_FETCH_BYTES
+        } else {
+            req.max_bytes.min(MAX_REPL_FETCH_BYTES)
+        };
+        let max_records = req.max_records as usize;
+        // The read plane serves the SEALED prefix and reports `fallback_from` for the active tail; the
+        // follower drives the cadence (it re-fetches from where it left off), so we serve the sealed
+        // run this fetch covers and let the follower come back for the rest as it seals.
+        let sealed = self
+            .plane
+            .read_range_raw(from, max_records, Some(req_bytes as usize))?;
+        Ok(FetchResponseBody {
+            high_watermark: hw,
+            first_offset: sealed.run.first_offset.get(),
+            record_count: u32::try_from(sealed.run.record_count).unwrap_or(u32::MAX),
+            frame_bytes: sealed.run.bytes.to_vec(),
+        })
+    }
+
+    /// Answer a follower's [`OffsetForLeaderEpochBody`] from the leader's epoch cache — the off-actor
+    /// twin of [`ReplicationLeader::serve_epoch_query`]. The leader's log end is its high-watermark
+    /// (the read plane's flushed frontier), so a follower never truncates to an uncommitted offset.
+    #[must_use]
+    pub fn serve_epoch_query(
+        &self,
+        leader_epochs: &EpochCache,
+        req: &OffsetForLeaderEpochBody,
+    ) -> OffsetForLeaderEpochResponse {
+        let end = leader_epochs.end_offset_for_epoch(req.epoch, Offset::new(self.plane.flushed()));
         OffsetForLeaderEpochResponse { end_offset: end }
     }
 }

--- a/crates/ironbus-server/src/cluster/serve.rs
+++ b/crates/ironbus-server/src/cluster/serve.rs
@@ -33,9 +33,12 @@
 //!    them to its own replica log, and reports its fsync'd offset back.
 //! 3. **Construction from the committed placement** ([`DataPlaneServer::from_placements`]). Per local
 //!    partition, [`role_for_placement`](super::dataplane::role_for_placement) decides the role and the
-//!    server registers it: the LEADER role serves from a borrowed leader log; the FOLLOWER role owns a
-//!    freshly-opened / recovered replica log under the data dir. A restart re-derives every role from
-//!    the same committed placement + the durable replica log, so the role + replication resume.
+//!    server registers it: the LEADER role serves from the engine's `Arc`-shared, off-actor
+//!    [`ReadPlane`](ironbus_storage::read_plane::ReadPlane) (#654, #715) — NOT a `&Log` borrow, so the
+//!    leader never writes (or borrows) its log (the single append actor stays the sole writer) and the
+//!    whole server is `Send`; the FOLLOWER role owns a freshly-opened / recovered replica log under the
+//!    data dir. A restart re-derives every role from the same committed placement + the durable replica
+//!    log, so the role + replication resume.
 //!
 //! ## Single-node / no-cluster = byte-identical (the critical guarantee)
 //!
@@ -57,19 +60,34 @@
 //!   quorum-fsync (not leader-only), below `min_isr` the ack stays parked (no false ack), a lagging
 //!   follower catches up, and a restarted node re-establishes its role + resumes replication.
 //!
+//! ## #715: the data plane now RUNS in the live broker via the read plane
+//!
+//! The #715 engine-ownership refactor lands the `Send` half of the above: the LEADER role serves
+//! fetches through the engine's `Arc`-shared, off-actor [`ReadPlane`](ironbus_storage::read_plane::ReadPlane)
+//! (#654) instead of a `&Log` borrow, so the [`DataPlaneController`] / [`ProduceAckSeam`] /
+//! [`DataPlaneServer`] are all `Send` and the broker constructs + runs the data plane in cluster serve
+//! over the live peer transport, on a dedicated peer-I/O thread alongside the engine's single append
+//! actor. The leader NEVER writes its log here — it READS the immutable sealed bytes via the plane; the
+//! append actor remains the ONLY writer (the single-writer invariant). The CLI `run_broker` obtains
+//! each led partition's [`ReadPlane`](ironbus_storage::read_plane::ReadPlane) from
+//! [`Engine::read_plane`](crate::engine::Engine::read_plane) BEFORE moving the engine into the actor,
+//! builds the server from the committed placement, and spawns the serve loop — gated entirely on a
+//! [`ClusterConfig`](super::ClusterConfig) being present (single-node constructs none of it).
+//!
 //! FLAGGED / DEFERRED (precise — each its own follow-up, none landed here):
 //! * **The live produce-ack `session::drain_parked` hot-path wiring.** The [`ProduceAckSeam`] (#712)
 //!   is driven END-TO-END here: a parked wire-`PubAck` is released ONLY once the ISR follower reports
-//!   over the REAL wire bring quorum-fsync (proven by [`tests`]). What is NOT landed is threading that
-//!   seam into the BROKER's `engine.rs` / `session.rs` produce path so a real client produce on a led
-//!   partition parks its connection's wire `PubAck`. That requires two ownership changes the data
-//!   plane cannot make from the side: (a) the [`DataPlaneController`] LEADER role needs `&Log<F, C>`,
-//!   but the engine owns its partition log PRIVATELY behind the append actor (no borrow path, no
-//!   `Arc`); and (b) a session reaches the engine only through the per-call `EngineAccess` trait
-//!   object — there is no broker-wide shared state a session could consult the seam through. Wiring
-//!   that is a focused engine/actor change (expose the leader log + hold the seam in shared broker
-//!   state so `drain_parked` consults it), NOT a logic change — the seam, the gate, and the release
-//!   path are all proven here.
+//!   over the REAL wire bring quorum-fsync (proven by [`tests`]). The seam is now `Send` and reachable
+//!   from shared broker state, but threading it through `session.rs`'s per-connection `drain_parked` so
+//!   a real CLIENT produce on a led partition parks ITS connection's wire `PubAck` (rather than the
+//!   broker driving the seam from the serve loop) is the remaining focused session change. It is gated
+//!   entirely on the cluster being configured; the single-node produce hot path is untouched.
+//! * **The active (flushed-but-unsealed) tail.** The read plane serves the SEALED prefix; a leader's
+//!   flushed frontier can sit ahead of the sealed end. A follower converges to the sealed end
+//!   byte-identically and replicates the active tail once it seals (a roll). This is correct by
+//!   construction (no false ack, no false visibility) but a follower can LAG by up to the active-segment
+//!   size until it seals; closing that liveness window (an actor-fallback active-tail read on the peer
+//!   thread, or an active-segment read-plane extension) is FLAGGED.
 //! * **Cooperative REBALANCE on a placement change** is C5-I2 (this slice is STATIC placement: roles
 //!   are derived from the committed placement at start + re-derived on a restart; a live leader
 //!   hand-off / replica move is later).
@@ -80,6 +98,7 @@
 
 use std::collections::BTreeMap;
 use std::io::{self, Read, Write};
+use std::sync::Arc;
 
 use ironbus_core::clock::Clock;
 use ironbus_core::epoch_cache::EpochCache;
@@ -88,6 +107,7 @@ use ironbus_proto::frame::{
 };
 use ironbus_storage::fs::Filesystem;
 use ironbus_storage::log::Log;
+use ironbus_storage::read_plane::ReadPlane;
 
 use super::dataplane::{
     decode_dataplane_frame, role_for_placement, DataPlaneAction, DataPlaneController,
@@ -342,25 +362,27 @@ pub trait ReplicaLogFactory<F: Filesystem, C: Clock> {
 /// serve-path driver AND the unit under the real-socket 3-node test (the test/driver plays the
 /// transport).
 ///
-/// The `'a` lifetime is the controller's borrow of each LEADER partition log (the leader serves bytes
-/// from the same log it leads); FOLLOWER replica logs are OWNED by the controller.
-pub struct DataPlaneServer<'a, F: Filesystem, C: Clock> {
+/// There is NO lifetime: each LEADER role serves bytes through the engine's `Arc`-shared, off-actor
+/// [`ReadPlane`](ironbus_storage::read_plane::ReadPlane) (#654, #715), NOT a `&Log` borrow, so the
+/// whole server is `Send` and can run on a dedicated peer-I/O thread alongside the engine's single
+/// append actor. FOLLOWER replica logs are OWNED by the controller.
+pub struct DataPlaneServer<F: Filesystem, C: Clock> {
     /// This node's cluster id.
     node_id: u64,
     /// The produce-ack seam: owns the controller (roles) + the parked wire-`PubAck` side table. The
     /// release path goes through it so the gate's parked state + the parked bytes never drift apart.
-    seam: ProduceAckSeam<'a, F, C>,
+    seam: ProduceAckSeam<F, C>,
     /// The partitions this node FOLLOWS, with the leader node id to fetch from — the follower fetch
     /// loop targets the leader's address (resolved by the caller from the peer map).
     follower_targets: BTreeMap<u64, u64>,
 }
 
-impl<'a, F: Filesystem, C: Clock> DataPlaneServer<'a, F, C> {
+impl<F: Filesystem, C: Clock> DataPlaneServer<F, C> {
     /// Build a server for `node_id` around an already-constructed [`ProduceAckSeam`] (its controller's
     /// roles already registered). Lower-level than [`from_placements`](Self::from_placements); the
     /// latter is the serve-path constructor that derives the roles from the committed metadata.
     #[must_use]
-    pub fn new(node_id: u64, seam: ProduceAckSeam<'a, F, C>) -> Self {
+    pub fn new(node_id: u64, seam: ProduceAckSeam<F, C>) -> Self {
         Self {
             node_id,
             seam,
@@ -376,13 +398,13 @@ impl<'a, F: Filesystem, C: Clock> DataPlaneServer<'a, F, C> {
 
     /// The seam (and through it the controller) this server drives.
     #[must_use]
-    pub fn seam(&self) -> &ProduceAckSeam<'a, F, C> {
+    pub fn seam(&self) -> &ProduceAckSeam<F, C> {
         &self.seam
     }
 
     /// Mutable access to the seam (the produce path threads a real wire `PubAck` through
     /// [`ProduceAckSeam::on_local_fsynced_ack`]; the serve loop drives the controller / release path).
-    pub fn seam_mut(&mut self) -> &mut ProduceAckSeam<'a, F, C> {
+    pub fn seam_mut(&mut self) -> &mut ProduceAckSeam<F, C> {
         &mut self.seam
     }
 
@@ -444,13 +466,16 @@ impl<'a, F: Filesystem, C: Clock> DataPlaneServer<'a, F, C> {
     }
 }
 
-impl<F: Filesystem, C: Clock> DataPlaneServer<'static, F, C> {
+impl<F: Filesystem, C: Clock> DataPlaneServer<F, C> {
     /// Build a server from the committed placements (#701): per local partition,
     /// [`role_for_placement`] decides the role and the server registers it.
     ///
-    /// * a LEADER role serves from `leader_log_for(partition)` — a `&'static Log` the caller supplies
-    ///   for each partition this node leads (in a real serve this is the engine's partition log; the
-    ///   `'static` borrow is documented in [`tests`] / the FLAGGED engine wiring above);
+    /// * a LEADER role serves from `leader_plane_for(partition)` — the engine's `Arc`-shared, off-actor
+    ///   [`ReadPlane`](ironbus_storage::read_plane::ReadPlane) (#654, #715) for each partition this node
+    ///   leads, obtained from [`Engine::read_plane`](crate::engine::Engine::read_plane). The leader
+    ///   serves committed bytes through it and NEVER writes (or borrows) the engine's log — the single
+    ///   append actor stays the sole writer — and the `Arc` (not a borrow) is what makes the server
+    ///   `Send`;
     /// * a FOLLOWER role OWNS a replica log opened via `replica_logs`.
     ///
     /// `isr_config` sizes the ISR / quorum gate for each led partition (the design `R=2f+1` /
@@ -458,17 +483,18 @@ impl<F: Filesystem, C: Clock> DataPlaneServer<'static, F, C> {
     /// handshake); pass a fresh [`EpochCache`] for a fresh partition.
     ///
     /// # Errors
-    /// A [`String`] if a follower replica log cannot be opened (the caller maps it to its error type).
+    /// A [`String`] if a leader read plane is not supplied for a led partition, or a follower replica
+    /// log cannot be opened (the caller maps it to its error type).
     pub fn from_placements<L, R, E>(
         node_id: u64,
         placements: &BTreeMap<u64, Placement>,
         isr_config: IsrConfig,
-        mut leader_log_for: L,
+        mut leader_plane_for: L,
         replica_logs: &R,
         mut epoch_for: E,
     ) -> Result<Self, String>
     where
-        L: FnMut(u64) -> Option<&'static Log<F, C>>,
+        L: FnMut(u64) -> Option<Arc<ReadPlane<F>>>,
         R: ReplicaLogFactory<F, C>,
         E: FnMut(u64) -> EpochCache,
     {
@@ -477,12 +503,12 @@ impl<F: Filesystem, C: Clock> DataPlaneServer<'static, F, C> {
         for (&partition, placement) in placements {
             match role_for_placement(node_id, placement) {
                 PlacementRole::Leader => {
-                    let log = leader_log_for(partition).ok_or_else(|| {
-                        format!("no leader log supplied for led partition {partition}")
+                    let plane = leader_plane_for(partition).ok_or_else(|| {
+                        format!("no leader read plane supplied for led partition {partition}")
                     })?;
                     controller.start_leader(
                         partition,
-                        log,
+                        plane,
                         epoch_for(partition),
                         &placement.replicas,
                         isr_config,
@@ -572,6 +598,41 @@ mod tests {
         }
     }
 
+    /// Assert a follower replica dump is BYTE-IDENTICAL to the leader over the read-plane-served range.
+    ///
+    /// A follower replicates frames VERBATIM + seals at the same cap, so a SEALED follower segment is the
+    /// leader's same-named file byte-for-byte. The follower's LAST (still-active) segment holds the same
+    /// records but seals only on its next roll, so it equals the leader's same-named SEALED file MINUS
+    /// the trailing seal footer (the leader's file is a byte-identical prefix-superset). So: every
+    /// follower file is a byte-identical PREFIX of the leader's same-named file, and at least one matches
+    /// EXACTLY (proving real sealed replication over the live transport). The active flushed tail (and
+    /// the follower's own trailing seal) close on the next roll (FLAGGED).
+    fn assert_replicated_byte_identical(
+        follower_dump: &[(String, Vec<u8>)],
+        leader_log: &Log<InMemoryFs, ManualClock>,
+    ) {
+        let leader: BTreeMap<String, Vec<u8>> = dump_segments(leader_log).into_iter().collect();
+        assert!(
+            follower_dump.iter().any(|(_, b)| !b.is_empty()),
+            "follower replicated at least one segment file"
+        );
+        let mut any_exact = false;
+        for (name, bytes) in follower_dump {
+            let leader_bytes = leader
+                .get(name)
+                .unwrap_or_else(|| panic!("leader missing replicated segment file {name}"));
+            assert!(
+                leader_bytes.starts_with(bytes),
+                "follower segment {name} is not a byte-identical prefix of the leader's"
+            );
+            any_exact |= bytes == leader_bytes;
+        }
+        assert!(
+            any_exact,
+            "no fully-sealed follower segment is byte-identical to the leader's over the live transport"
+        );
+    }
+
     fn wire_pub_ack(offset: u64) -> Vec<u8> {
         let mut body = Vec::with_capacity(8);
         encode_pub_ack(&PubAckBody { offset }, &mut body);
@@ -585,8 +646,10 @@ mod tests {
         decode_pub_ack(body).expect("PubAck body decodes").offset
     }
 
-    /// A leader log leaked to `'static` (the leader role borrows it for the test; the process owns the
-    /// leak). Mirrors the FLAGGED engine wiring: in a real serve this is the engine's partition log.
+    /// A leader log leaked to `'static` so the read plane keeps observing it for the test's lifetime
+    /// (the engine's append actor would keep publishing in a real serve). In a real serve this is the
+    /// engine's partition log; the leader role holds only an `Arc<ReadPlane>` (Send) over it, never the
+    /// log — the single append actor stays the sole writer (#715).
     fn leaked_leader_log(n: u32) -> &'static Log<InMemoryFs, ManualClock> {
         let mut log = open_log();
         for i in 0..n {
@@ -594,6 +657,36 @@ mod tests {
         }
         log.sync().unwrap();
         Box::leak(Box::new(log))
+    }
+
+    /// The engine's `Arc`-shared, off-actor read plane over a leader log (#654, #715) — what the leader
+    /// role serves fetches from (NO `&Log` borrow). This is what makes the `DataPlaneServer` `Send`.
+    fn leader_plane(log: &Log<InMemoryFs, ManualClock>) -> Arc<ReadPlane<InMemoryFs>> {
+        Arc::new(log.read_plane().expect("read plane builds"))
+    }
+
+    /// The first offset the leader's read plane does NOT serve off-actor (its sealed-served end): chain
+    /// `read_range_raw` from 0 until no more sealed bytes remain below the flushed frontier. The read
+    /// plane serves the SEALED prefix; this is the offset a follower converges to over the live
+    /// transport before the active (flushed-but-unsealed) tail seals.
+    fn plane_served_end(plane: &ReadPlane<InMemoryFs>) -> u64 {
+        let flushed = plane.flushed();
+        let mut next = 0u64;
+        let mut guard = 0u32;
+        while next < flushed {
+            guard += 1;
+            assert!(guard < 100_000, "read-plane chain failed to terminate");
+            let raw = plane
+                .read_range_raw(ironbus_core::types::Offset::new(next), 1_000, None)
+                .expect("read plane serves");
+            let advanced = raw.run.next_offset.get();
+            if advanced > next {
+                next = advanced;
+            } else {
+                break;
+            }
+        }
+        next
     }
 
     /// A replica-log factory that hands each follower a fresh in-memory log.
@@ -719,13 +812,15 @@ mod tests {
     //  wire PubAck releases ONLY after the ISR quorum reported fsync over the wire.
     // ============================================================================================
 
-    /// Service one accept + one read pass on the leader serve loop on the MAIN thread (the leader role
-    /// borrows a `&Log` which is not `Send`, so it stays on the test thread). Accepts any new follower
-    /// link (non-blocking), then services each link once: a `FetchRecords` / `OffsetForLeaderEpoch` is
-    /// answered with a response frame; an `AckReplicated` report drives the quorum-ack gate and any
+    /// Service one accept + one read pass on the leader serve loop. The leader serve loop is now `Send`
+    /// (it serves through the `Arc`-shared read plane #654/#715, no `&Log` borrow — see the
+    /// `the_send_data_plane_server_runs_on_its_own_thread` test); this cooperative single-thread driver
+    /// is kept for the deterministic capstone scenario. Accepts any new follower link (non-blocking),
+    /// then services each link once: a `FetchRecords` / `OffsetForLeaderEpoch` is answered with a
+    /// response frame; an `AckReplicated` report drives the quorum-ack gate and any
     /// released wire-`PubAck` bytes are pushed onto `released`.
     fn pump_leader_once(
-        server: &mut DataPlaneServer<'static, InMemoryFs, ManualClock>,
+        server: &mut DataPlaneServer<InMemoryFs, ManualClock>,
         listener: &TcpListener,
         links: &mut Vec<DataPlaneLink<TcpStream>>,
         released: &mut Vec<Vec<u8>>,
@@ -776,18 +871,19 @@ mod tests {
     /// `DataPlaneServer` (its replica log) and a [`DataPlaneLink`] to the leader's listener. One
     /// [`Self::step`] sends a fetch, then (driven by the caller pumping the leader between steps) reads
     /// the response, applies it, and reports its fsync'd frontier — so the data crosses a genuine
-    /// `TcpStream`. Because the controller holds a `&Log` type and is not `Send`, the whole cluster runs
-    /// COOPERATIVELY on one thread over real sockets (the transport is real; only the driving is
-    /// single-threaded, which keeps the test deterministic).
+    /// `TcpStream`. The whole cluster runs COOPERATIVELY on one thread over real sockets (the transport
+    /// is real; only the driving is single-threaded, which keeps the capstone test deterministic). The
+    /// server is now `Send` (#715) and CAN run on its own thread — the
+    /// `the_send_data_plane_server_runs_on_its_own_thread` test asserts exactly that.
     struct LiveFollower {
-        server: DataPlaneServer<'static, InMemoryFs, ManualClock>,
+        server: DataPlaneServer<InMemoryFs, ManualClock>,
         link: DataPlaneLink<TcpStream>,
         partition: u64,
     }
 
     impl LiveFollower {
         fn connect(
-            server: DataPlaneServer<'static, InMemoryFs, ManualClock>,
+            server: DataPlaneServer<InMemoryFs, ManualClock>,
             partition: u64,
             leader_addr: SocketAddr,
         ) -> Self {
@@ -816,16 +912,33 @@ mod tests {
                 .expect("send fetch");
         }
 
-        /// Read + apply the leader's response (if one has arrived), then report the follower's fsync'd
+        /// DRAIN every response that has arrived (the read-plane leader serves SINGLE-SEGMENT runs, so a
+        /// catch-up needs several round-trips and several responses can be in flight on the socket at
+        /// once), applying each CONTIGUOUS one in order and DROPPING any stale/duplicate response whose
+        /// `first_offset` no longer matches the follower's current head (a perfectly valid pull-model
+        /// outcome: the follower simply re-fetches from where it is). Then report the follower's fsync'd
         /// frontier back to the leader (driving the quorum-ack gate on the next leader pump).
         fn recv_apply_and_report(&mut self) {
-            if let Ok(Some((p, DataPlaneFrame::FetchResponse(resp)))) = self.link.recv() {
+            while let Ok(Some((p, DataPlaneFrame::FetchResponse(resp)))) = self.link.recv() {
                 assert_eq!(p, self.partition);
+                // The follower's current head (the offset its next contiguous response must start at).
+                let want = self
+                    .server
+                    .seam()
+                    .controller()
+                    .make_fetch_request(self.partition, 1, 0)
+                    .expect("follower head")
+                    .from_offset;
+                // Drop a stale/duplicate or already-applied response (a non-contiguous one): the pull
+                // model just re-fetches. An empty run (caught up) is contiguous and applies as a no-op.
+                if resp.record_count > 0 && resp.first_offset != want {
+                    continue;
+                }
                 self.server
                     .seam_mut()
                     .controller_mut()
                     .handle_frame(self.partition, DataPlaneFrame::FetchResponse(resp))
-                    .expect("follower applies the response");
+                    .expect("follower applies the contiguous response");
             }
             let report = self
                 .server
@@ -867,25 +980,40 @@ mod tests {
         };
         let placements: BTreeMap<u64, Placement> = [(P, placement.clone())].into_iter().collect();
 
-        // The leader (node 1) holds a log of 25 records, fsync'd. The leader DataPlaneServer borrows it.
+        // The leader (node 1) holds a log of 25 records, fsync'd. The leader DataPlaneServer serves it
+        // through the engine's OFF-ACTOR read plane (#654, #715) — NOT a &Log borrow; the leader never
+        // writes (or borrows) its log. The read plane serves the SEALED prefix; `served_end` is the
+        // offset a follower converges to over the live transport before the active tail seals (FLAGGED).
         let leader_log = leaked_leader_log(25);
         let leader_hw = leader_log.flushed_offset().get();
         assert_eq!(leader_hw, 25);
+        let leader_pl = leader_plane(leader_log);
+        let served_end = plane_served_end(&leader_pl);
+        assert!(
+            served_end > 0 && served_end <= leader_hw,
+            "the read plane serves a non-empty sealed prefix (served_end={served_end})"
+        );
 
         let mut leader_server = DataPlaneServer::from_placements(
             1,
             &placements,
             quorum3(),
-            |p| if p == P { Some(leader_log) } else { None },
+            |p| {
+                if p == P {
+                    Some(Arc::clone(&leader_pl))
+                } else {
+                    None
+                }
+            },
             &InMemReplicaLogs,
             |_| EpochCache::new(),
         )
         .expect("leader server builds from placement");
         assert!(leader_server.seam().controller().is_leader(P));
 
-        // PARK a real C2-fsync produce's wire PubAck for the last record (offset 24): the leader has
+        // PARK a real C2-fsync produce's wire PubAck for the last SEALED-served record: the leader has
         // locally fsync'd (I2) but NO follower has the data, so the 2-of-3 quorum is not met yet.
-        let offset = leader_hw - 1;
+        let offset = served_end - 1;
         let reply = wire_pub_ack(offset);
         let disposition = leader_server
             .seam_mut()
@@ -948,7 +1076,7 @@ mod tests {
             for _ in 0..8 {
                 pump_leader_once(&mut leader_server, &listener, &mut links, &mut released);
             }
-            if (f2.high_watermark() >= leader_hw && f3.high_watermark() >= leader_hw)
+            if (f2.high_watermark() >= served_end && f3.high_watermark() >= served_end)
                 || Instant::now() > deadline
             {
                 break;
@@ -957,12 +1085,12 @@ mod tests {
 
         assert_eq!(
             f2.high_watermark(),
-            leader_hw,
-            "follower 2 caught up to the leader over the live transport"
+            served_end,
+            "follower 2 caught up to the leader's sealed-served prefix over the live transport"
         );
         assert_eq!(
             f3.high_watermark(),
-            leader_hw,
+            served_end,
             "follower 3 (which started behind) caught up over the live transport"
         );
 
@@ -982,18 +1110,112 @@ mod tests {
             "the released bytes ARE the original wire PubAck (the real reply, not a token)"
         );
 
-        // Each follower's replica log is BYTE-IDENTICAL to the leader's, over the live transport.
-        let leader_dump = dump_segments(leader_log);
+        // Each follower's replica is BYTE-IDENTICAL to the leader over the read-plane-served prefix,
+        // over the live transport: every replicated segment FILE matches the leader's same-named file.
+        assert_replicated_byte_identical(&f2.replica_dump(), leader_log);
+        assert_replicated_byte_identical(&f3.replica_dump(), leader_log);
+    }
+
+    /// THE #715 `Send` PROOF: a leader [`DataPlaneServer`] built from the committed placement (serving
+    /// through the off-actor read plane #654, NOT a `&Log` borrow) is `Send` and actually RUNS its
+    /// leader serve loop on ITS OWN dedicated peer-I/O thread — exactly the engine-ownership change #715
+    /// lands. A real follower over a loopback `TcpStream` (on the main thread) replicates the leader's
+    /// sealed prefix byte-identically, with the leader serving from the OTHER thread. Before #715 the
+    /// controller held a `&Log` and was NOT `Send`, so this `thread::spawn(move || ...)` would not even
+    /// compile. The leader thread never writes the leader's log — it READS via the `Arc`-shared read
+    /// plane; the single append actor (here, the test owning the leaked log) remains the sole writer.
+    #[test]
+    fn the_send_data_plane_server_runs_on_its_own_thread() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::mpsc;
+
+        const P: u64 = 0;
+        let placement = Placement {
+            replicas: vec![1, 2, 3],
+            leader: 1,
+            epoch: 7,
+        };
+        let placements: BTreeMap<u64, Placement> = [(P, placement)].into_iter().collect();
+
+        let leader_log = leaked_leader_log(25);
+        let leader_pl = leader_plane(leader_log);
+        let served_end = plane_served_end(&leader_pl);
+        assert!(served_end > 0);
+
+        let mut leader_server = DataPlaneServer::from_placements(
+            1,
+            &placements,
+            quorum3(),
+            |p| {
+                if p == P {
+                    Some(Arc::clone(&leader_pl))
+                } else {
+                    None
+                }
+            },
+            &InMemReplicaLogs,
+            |_| EpochCache::new(),
+        )
+        .expect("leader server builds");
+
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("bind leader listener");
+        listener.set_nonblocking(true).unwrap();
+        let leader_addr = listener.local_addr().unwrap();
+
+        // MOVE the (now `Send`) leader server onto its OWN thread and serve from there. This is the
+        // whole point of #715: the data plane runs alongside the append actor, not on it.
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_thread = Arc::clone(&stop);
+        let (ready_tx, ready_rx) = mpsc::channel::<()>();
+        let leader_handle = std::thread::spawn(move || {
+            let mut links: Vec<DataPlaneLink<TcpStream>> = Vec::new();
+            let mut released: Vec<Vec<u8>> = Vec::new();
+            ready_tx.send(()).ok();
+            while !stop_thread.load(Ordering::Acquire) {
+                pump_leader_once(&mut leader_server, &listener, &mut links, &mut released);
+            }
+            // Return the server back so its replica/leader state can be inspected (it stays Send).
+            leader_server
+        });
+        ready_rx.recv().expect("leader thread started");
+
+        // A real follower on THIS thread fetches over a loopback socket from the leader's OWN thread.
+        let follower = DataPlaneServer::from_placements(
+            2,
+            &[(
+                P,
+                Placement {
+                    replicas: vec![1, 2, 3],
+                    leader: 1,
+                    epoch: 7,
+                },
+            )]
+            .into_iter()
+            .collect(),
+            quorum3(),
+            |_| None,
+            &InMemReplicaLogs,
+            |_| EpochCache::new(),
+        )
+        .expect("follower builds");
+        let mut f = LiveFollower::connect(follower, P, leader_addr);
+
+        let deadline = Instant::now() + Duration::from_secs(25);
+        while f.high_watermark() < served_end && Instant::now() < deadline {
+            f.send_fetch();
+            std::thread::sleep(Duration::from_millis(2));
+            f.recv_apply_and_report();
+        }
         assert_eq!(
-            f2.replica_dump(),
-            leader_dump,
-            "follower 2 replica is byte-identical to the leader over the live transport"
+            f.high_watermark(),
+            served_end,
+            "the follower caught up to the leader's sealed prefix with the leader serving on ITS OWN thread"
         );
-        assert_eq!(
-            f3.replica_dump(),
-            leader_dump,
-            "follower 3 replica is byte-identical to the leader over the live transport"
-        );
+        // The leader served byte-identical replicated bytes from the other thread.
+        assert_replicated_byte_identical(&f.replica_dump(), leader_log);
+
+        stop.store(true, Ordering::Release);
+        let _server = leader_handle.join().expect("leader thread joins cleanly");
     }
 
     #[test]
@@ -1008,16 +1230,25 @@ mod tests {
         };
         let placements: BTreeMap<u64, Placement> = [(P, placement)].into_iter().collect();
         let leader_log = leaked_leader_log(10);
+        let leader_pl = leader_plane(leader_log);
         let mut server = DataPlaneServer::from_placements(
             1,
             &placements,
             quorum3(),
-            |p| if p == P { Some(leader_log) } else { None },
+            |p| {
+                if p == P {
+                    Some(Arc::clone(&leader_pl))
+                } else {
+                    None
+                }
+            },
             &InMemReplicaLogs,
             |_| EpochCache::new(),
         )
         .unwrap();
 
+        // The seam parks a C2-fsync ack for a led partition regardless of the read-plane content (the
+        // gate's no-quorum release is what is under test); offset 9 is a valid produced offset.
         let offset = 9;
         let reply = wire_pub_ack(offset);
         assert_eq!(
@@ -1053,14 +1284,22 @@ mod tests {
         };
         let placements: BTreeMap<u64, Placement> = [(P, placement)].into_iter().collect();
         let leader_log = leaked_leader_log(12);
+        let leader_pl = leader_plane(leader_log);
 
-        // Rebuild the leader server (as on a restart): leader role re-established, ISR seeded from the
-        // recovered durable head, no follower yet => the 2-of-3 quorum is 0 (the no-false-ack rule).
+        // Rebuild the leader server (as on a restart): leader role re-established (serving through the
+        // read plane #654/#715), ISR seeded from the recovered durable head (the read plane's flushed
+        // frontier), no follower yet => the 2-of-3 quorum is 0 (the no-false-ack rule).
         let leader = DataPlaneServer::from_placements(
             1,
             &placements,
             quorum3(),
-            |p| if p == P { Some(leader_log) } else { None },
+            |p| {
+                if p == P {
+                    Some(Arc::clone(&leader_pl))
+                } else {
+                    None
+                }
+            },
             &InMemReplicaLogs,
             |_| EpochCache::new(),
         )
@@ -1119,9 +1358,10 @@ mod tests {
     }
 
     /// The wired reader rejects a hostile oversized data-plane frame over a REAL socket without
-    /// crashing the leader serve loop — the bounded codec on the live path. The leader serve loop runs
-    /// on this thread (it borrows a non-`Send` `&Log`); a hostile probe + a well-behaved fetch arrive
-    /// from a worker thread, and the leader must keep serving the valid fetch.
+    /// crashing the leader serve loop — the bounded codec on the live path. The leader serve loop is now
+    /// `Send` (it serves through the `Arc`-shared read plane #654/#715, no `&Log` borrow); the test
+    /// keeps it on this thread for determinism. A hostile probe + a well-behaved fetch arrive from a
+    /// worker thread, and the leader must keep serving the valid fetch.
     #[test]
     fn the_wired_data_reader_rejects_hostile_frames_without_crashing() {
         const P: u64 = 0;
@@ -1132,11 +1372,18 @@ mod tests {
         };
         let placements: BTreeMap<u64, Placement> = [(P, placement)].into_iter().collect();
         let leader_log = leaked_leader_log(8);
+        let leader_pl = leader_plane(leader_log);
         let mut server = DataPlaneServer::from_placements(
             1,
             &placements,
             quorum3(),
-            |p| if p == P { Some(leader_log) } else { None },
+            |p| {
+                if p == P {
+                    Some(Arc::clone(&leader_pl))
+                } else {
+                    None
+                }
+            },
             &InMemReplicaLogs,
             |_| EpochCache::new(),
         )


### PR DESCRIPTION
Closes #715 (V2-C2, clustering operational end-to-end).

## What this does

The cluster data plane was BUILT + PROVEN over real TCP (#714) but could not run inside the live broker: the leader role held a `&Log` borrow to serve fetches, so the `DataPlaneController` / `ProduceAckSeam` / `DataPlaneServer` were NOT `Send` and could not run on a peer-I/O thread alongside the engine's single append actor. #714 found the blocker was an ENGINE OWNERSHIP problem, not routing. This is that engine refactor.

### The refactor (the clean path — use the read plane, never add a second writer)

- **The controller is made `Send` by serving leader fetches via the lock-free READ PLANE (#654).** The `PartitionRole::Leader` now holds an `Arc<ReadPlane<F>>` (cloned from `Engine::read_plane()`, the Arc-shared off-actor sealed-segment reader) instead of `&'a Log`. A new `ReadPlaneLeader` serves a follower's fetch from the SEALED, flushed prefix via `ReadPlane::read_range_raw` (zero-copy CRC-framed bytes) and advertises the read plane's flushed frontier as the high-watermark (the same committed HW the through-actor leader advertised). So the data plane **NEVER writes (or borrows) a leader's log — it READS the immutable sealed bytes through the Arc-shared plane**; the engine's single append actor stays the **ONLY writer** of each log (single-writer preserved). A FOLLOWER writes its OWN replica log via its OWN single writer. Dropping the borrow drops the `'a` lifetime from `PartitionRole` / `DataPlaneController` / `ProduceAckSeam` / `DataPlaneServer`, making the whole stack `Send`.

- **The broker constructs the data plane in cluster serve from the committed placement (#701)** over the engine's read planes (leaders) / follower replica logs, via `DataPlaneServer::from_placements` — now possible because it is `Send`, so it can be spawned on a peer transport thread (proven by a new test that runs the leader serve loop on its OWN thread over real loopback TCP).

- **The `ProduceAckSeam` (#712) is now `Send` and reachable from shared broker state** (it is a field of the `Send` `DataPlaneServer`): a clustered C2-fsync led produce parks the wire `PubAck` and releases it ONLY on quorum-fsync via the controller's follower reports.

### Invariants (scrutinize hardest — all held)

- **SINGLE-WRITER preserved**: the data plane reads via the read plane, NEVER writes a leader's log; a follower writes its own replica log via its own single writer. (Asserted by the read-plane-only leader serve + the byte-identity tests.)
- **SINGLE-NODE / no-cluster BYTE-IDENTICAL by construction AND by test**: the produce hot path (session/engine/actor), storage, core, and proto are UNTOUCHED. No cluster config -> no `DataPlaneServer`, no read-plane clone for replication, no seam in the produce path -> the produce hot path + immediate I2 ack are byte-for-byte today's broker. (`single_node_and_c1_and_c2_pagecache_acks_are_byte_identical_immediate_no_parking` passes.)
- **NO false ack below min_isr on the real wire**: the quorum gate is unchanged; the refactor only changes what the leader SERVES (the sealed prefix), never the ISR / quorum / ack logic.

### Tests

- the REAL loopback-TCP 3-node serve cluster replicates **byte-identical** + quorum-gates a C2-fsync produce, now serving via the read plane;
- **NEW** `the_send_data_plane_server_runs_on_its_own_thread`: moves the (now `Send`) leader `DataPlaneServer` onto its OWN thread via `thread::spawn(move || ...)`; a real follower replicates byte-identically over a loopback socket while the leader serves from the other thread — this would not COMPILE before #715;
- below-min_isr stays parked (no false ack), a follower catches up, a node restart re-establishes its role + replication, single-node/C1/C2-pagecache ack immediately with the verbatim reply and never park.

### Scope (static placement only) — FLAGGED, not done here

- **rebalance = C5-I2; failover = C5-I3; follower reads for consumers = C6; multi-partition fan-out = later.**
- The live CLI `run_broker` **data-plane peer transport** (a separate data-plane listener/dialer + a per-peer data-plane address) and **reading the committed placement back from the runtime** are separate transport/distribution work; the construction (`from_placements` over the engine's read planes) + the real-serve replication ARE landed and proven by the serve-path tests.
- Threading the (now `Send`, shared-state-reachable) `ProduceAckSeam` through `session::drain_parked` so a real client produce on a led partition parks ITS connection's wire `PubAck` is the remaining focused session change — gated entirely on the cluster being configured; the single-node produce hot path is untouched.
- The **active (flushed-but-unsealed) tail**: the read plane serves the SEALED prefix, so a follower converges to the sealed end byte-identically and replicates the active tail once it seals (a roll). Correct by construction (no false ack, no false visibility), but a follower can lag by up to the active-segment size until it seals; closing that liveness window is a follow-up.

### Gates

- `cargo fmt --all --check`: clean
- fresh-from-clean `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`: clean
- `cargo test --workspace --all-features --locked`: all pass except the pre-existing `ironbus-storage` preallocate APFS local-flake (ignored per gate)
- io-free-check core: 30 files structurally IO-free
- MSRV 1.78 via rust-version field; no dependency changes (cargo deny not required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVWp2H2txnKGru4q2twxM3