### PR TITLE
feat(cluster): gate the client produce-ack on quorum-fsync (thread the ProduceAckSeam into the produce path) (#719)

### DIFF
--- a/crates/ironbus-cli/src/main.rs
+++ b/crates/ironbus-cli/src/main.rs
@@ -92,8 +92,8 @@ use ironbus_server::clock::SystemClock;
 use ironbus_server::cluster::ClusterConfig;
 #[cfg(unix)]
 use ironbus_server::cluster::{
-    dataplane_addr, ClusterRuntime, DataPlaneRuntime, DataPlaneServer, IsrConfig, MetadataCommand,
-    MetadataProposer, Placement, ReplicaLogFactory, RuntimeError,
+    dataplane_addr, ClusterAckLevel, ClusterRuntime, DataPlaneRuntime, DataPlaneServer, IsrConfig,
+    MetadataCommand, MetadataProposer, Placement, ReplicaLogFactory, RuntimeError,
 };
 use std::io::{self, Read, Write};
 use std::path::Path;
@@ -4390,6 +4390,10 @@ fn cmd_serve(
                 Some(runtime) => Some(spawn_dataplane_serve(&engine, runtime, data_dir, config)?),
                 None => None,
             };
+            // The shared client produce-ack slot (#719) the bootstrap fills, cloned out BEFORE the
+            // handle moves into `run_broker`, so `run_broker` can install it on the engine handle. `None`
+            // when no data plane runs (the single-node disk serve).
+            let client_ack_slot = dataplane.as_ref().map(|dp| dp.client_ack_slot.clone());
             run_broker(
                 engine,
                 addr,
@@ -4400,6 +4404,7 @@ fn cmd_serve(
                 config_warnings,
                 cluster_runtime,
                 dataplane,
+                client_ack_slot,
                 auth,
                 reload,
                 out,
@@ -4431,6 +4436,7 @@ fn cmd_serve(
                 health_addr,
                 health_bind,
                 config_warnings,
+                None,
                 None,
                 None,
                 auth,
@@ -4534,10 +4540,22 @@ impl ReplicaLogFactory<StdFs, SystemClock> for DiskReplicaLogs {
 /// placement, builds the [`DataPlaneServer`], and starts its [`DataPlaneRuntime`]) plus the shutdown
 /// flag the broker's serve teardown flips to stop it deterministically. Held by `run_broker` ONLY on a
 /// clustered serve; a single-node serve never constructs one, so its presence is the cluster opt-in.
+/// The shared, set-once slot the data-plane bootstrap fills with the clustered
+/// [`ClientAckGate`](ironbus_server::cluster::ClientAckGate) (#719), and which every per-connection
+/// [`EngineHandle`](ironbus_server::actor::EngineHandle) clone reads to gate its produce-acks on
+/// quorum-fsync. Created at serve start (empty) and shared into BOTH `run_broker` (which installs it on
+/// the engine handle before any connection clones it) and the bootstrap thread (which fills it once the
+/// placement commits).
+#[cfg(unix)]
+type ClientAckSlot = ironbus_server::actor::ClientAckSlot<StdFs, SystemClock>;
+
 #[cfg(unix)]
 struct DataPlaneServeHandle {
     shutdown: std::sync::Arc<std::sync::atomic::AtomicBool>,
     bootstrap: Option<std::thread::JoinHandle<()>>,
+    /// The shared client produce-ack slot (#719), handed to `run_broker` to install on the engine
+    /// handle so every connection's produce-ack path reaches the gate the bootstrap fills.
+    client_ack_slot: ClientAckSlot,
 }
 
 #[cfg(unix)]
@@ -4624,6 +4642,19 @@ fn spawn_dataplane_serve(
         max_lag_records: 0,
     };
 
+    // The serve-wide CONFIGURED cluster ack level (#696/#719): resolved from the replication factor —
+    // a 3+-replica cluster defaults to `C2-fsync` (quorum-fsync-gated produce-acks), a 1-replica
+    // "cluster" to `C1`. A per-publish wire override is later. This is the level the client produce-ack
+    // gate holds a led produce to.
+    let configured_level = ClusterAckLevel::default_for_replication_factor(replicas.len());
+
+    // The shared, set-once client produce-ack slot (#719): created EMPTY here, shared into both the
+    // bootstrap (which fills it once the placement commits + the data-plane server is built) and
+    // `run_broker` (which installs it on the engine handle before any connection clones it). Until it is
+    // filled, the produce-ack path acks immediately exactly as the non-cluster path.
+    let client_ack_slot: ClientAckSlot = std::sync::Arc::new(std::sync::OnceLock::new());
+    let client_ack_slot_t = std::sync::Arc::clone(&client_ack_slot);
+
     let shutdown = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
     let shutdown_t = std::sync::Arc::clone(&shutdown);
 
@@ -4634,12 +4665,14 @@ fn spawn_dataplane_serve(
                 node_id,
                 &replicas,
                 isr_config,
+                configured_level,
                 read_plane,
                 &peers,
                 &status,
                 &proposer,
                 &data_dir,
                 log_config,
+                &client_ack_slot_t,
                 &shutdown_t,
             );
         })
@@ -4648,6 +4681,7 @@ fn spawn_dataplane_serve(
     Ok(DataPlaneServeHandle {
         shutdown,
         bootstrap: Some(bootstrap),
+        client_ack_slot,
     })
 }
 
@@ -4666,12 +4700,14 @@ fn run_dataplane_bootstrap(
     node_id: u64,
     replicas: &[u64],
     isr_config: IsrConfig,
+    configured_level: ClusterAckLevel,
     read_plane: std::sync::Arc<ironbus_storage::read_plane::ReadPlane<StdFs>>,
     peers: &std::collections::BTreeMap<u64, std::net::SocketAddr>,
     status: &std::sync::Arc<std::sync::Mutex<ironbus_server::cluster::ClusterStatus>>,
     proposer: &MetadataProposer,
     data_dir: &Path,
     log_config: LogConfig,
+    client_ack_slot: &ClientAckSlot,
     shutdown: &std::sync::atomic::AtomicBool,
 ) {
     use std::sync::atomic::Ordering;
@@ -4758,16 +4794,32 @@ fn run_dataplane_bootstrap(
         .map(|(&id, &addr)| (id, dataplane_addr(addr)))
         .collect();
 
-    let mut dp_runtime = match DataPlaneRuntime::start(server, self_data_addr, &peer_data_addrs) {
+    // Start the runtime WITH the client produce-ack gate (#719): it builds the shared
+    // `ClientAckGate` (at the configured cluster ack level) around the runtime's own server Arc, and
+    // routes each quorum-fsync'd release into its owner connection's outbox. PUBLISH the built gate into
+    // the shared slot so every per-connection produce path (which captured the slot at serve start)
+    // reaches it: from now on a clustered `C2-fsync` led produce's wire `PubAck` is withheld until
+    // quorum-fsync. Before this fill, the produce path acked immediately (the brief bootstrap window).
+    let mut dp_runtime = match DataPlaneRuntime::start_with_client_gate(
+        server,
+        self_data_addr,
+        &peer_data_addrs,
+        configured_level,
+    ) {
         Ok(r) => r,
         Err(e) => {
             eprintln!("ironbus: data plane: cannot bind the data-plane peer listener; data plane not started: {e}");
             return;
         }
     };
+    if let Some(gate) = dp_runtime.client_gate() {
+        // Set-once: this is the only filler of the slot, on this one bootstrap thread.
+        let _ = client_ack_slot.set(std::sync::Arc::clone(gate));
+    }
 
     eprintln!(
-        "ironbus: data plane started on node {node_id} for partition {DEFAULT_PARTITION}: replicating + quorum-gating produces over the cluster"
+        "ironbus: data plane started on node {node_id} for partition {DEFAULT_PARTITION} at cluster ack level {}: replicating + quorum-gating produces over the cluster",
+        configured_level.as_str()
     );
 
     // Hold the runtime until the broker shuts down, then stop it (joins every data-plane peer thread).
@@ -4819,6 +4871,7 @@ fn run_broker<F: Filesystem + Clone + 'static>(
     config_warnings: &[String],
     cluster_runtime: Option<ClusterRuntime>,
     dataplane: Option<DataPlaneServeHandle>,
+    client_ack_slot: Option<ironbus_server::actor::ClientAckSlot<F, SystemClock>>,
     auth: Option<std::sync::Arc<ironbus_server::auth::AuthConfig>>,
     reload: ReloadSource<'_>,
     out: &mut impl Write,
@@ -4829,6 +4882,15 @@ fn run_broker<F: Filesystem + Clone + 'static>(
     // the graceful-shutdown cursor flush (#195) completes before the process exits 0.
     let (shared, actor) =
         spawn_actor_with_gather(engine, DEFAULT_CHANNEL_BOUND, config.commit_gather_us);
+    // Install the SHARED client produce-ack slot (#719) onto the base handle BEFORE any per-connection
+    // clone, so every connection's produce-ack path reaches the gate the data-plane bootstrap fills.
+    // `None` on a single-node / no-cluster / memory serve: the handle carries no slot and the produce
+    // path is byte-for-byte today's (the single-node guarantee). The base handle is rebound so the
+    // installed slot rides into every `serve_with_auth` clone.
+    let shared = match client_ack_slot {
+        Some(slot) => shared.with_client_ack_slot(slot),
+        None => shared,
+    };
     let listener = TcpListener::bind(addr)
         .map_err(|e| CliError::Internal(format!("cannot bind {addr}: {e}")))?;
     let local = listener

--- a/crates/ironbus-client/src/lib.rs
+++ b/crates/ironbus-client/src/lib.rs
@@ -5782,4 +5782,283 @@ mod tests {
         shutdown.store(true, Ordering::Release);
         handle.join().unwrap();
     }
+
+    // ---------------------------------------------------------------------------------------------
+    // #719 (V2-C2): a REAL client connection over a clustered C2-fsync broker observes QUORUM-FSYNC
+    // ack timing — its wire PubAck arrives ONLY after the data plane's follower report brings
+    // quorum-fsync, NOT on leader-only-fsync.
+    // ---------------------------------------------------------------------------------------------
+
+    /// The default partition the single-stream broker maps to (the client produce-ack gate routes every
+    /// produce here; multi-partition is #693).
+    #[cfg(unix)]
+    const C2_PARTITION: u64 = 0;
+
+    /// Start an in-process broker whose produce-ack path is gated by a CLUSTERED C2-fsync
+    /// `ClientAckGate` (#719): this node LEADS partition 0 of `{1,2,3}` with `min_isr = 2`. Returns the
+    /// broker address, its shutdown flag + serve-thread handle, and the SHARED gate so the test can
+    /// DRIVE a follower's quorum-fsync report (standing in for the data-plane runtime's follower thread).
+    /// A real `serve` loop accepts the real client connection; only the produce-ack gating + the
+    /// follower-report driver are simulated in-process.
+    #[cfg(unix)]
+    #[allow(clippy::type_complexity)]
+    fn start_clustered_c2_server() -> (
+        std::net::SocketAddr,
+        Arc<AtomicBool>,
+        std::thread::JoinHandle<()>,
+        Arc<ironbus_server::cluster::ClientAckGate<InMemoryFs, SystemClock>>,
+    ) {
+        use ironbus_server::actor::EngineHandle;
+        use ironbus_server::cluster::{
+            ClientAckGate, ClusterAckLevel, DataPlaneController, DataPlaneServer, IsrConfig,
+            ProduceAckSeam,
+        };
+        use ironbus_storage::log::Log;
+        use std::sync::{Mutex, OnceLock};
+
+        let engine = Engine::open(
+            InMemoryFs::new(),
+            SystemClock::new(),
+            EngineConfig {
+                log: LogConfig::default(),
+                lease: LeaseConfig::default(),
+                delivery: DeliveryConfig::new(5, false, vec![]).unwrap(),
+                max_in_flight: 16,
+                consumer_credit: 64,
+                consumer_credit_bytes: 0,
+                checkpoint_interval: 1024,
+                max_retained_bytes: 0,
+                max_age_ms: 0,
+                max_messages: 0,
+                max_groups: DEFAULT_MAX_GROUPS,
+                group_idle_evict_ms: DEFAULT_GROUP_IDLE_EVICT_MS,
+                ram_ceiling_bytes: 0,
+                disk_full_policy: DiskFullPolicy::DropNew,
+                dedup: ironbus_core::dedup::DedupConfig::default(),
+                durability_level: ironbus_server::engine::DurabilityLevel::Sync,
+                flush_interval_ms: 0,
+                flush_max_bytes: 0,
+                codel_target_ms: 0,
+                codel_interval_ms: 0,
+                retry_budget_ratio_per_million: 0,
+                retry_budget_window_ms: 0,
+                fire_and_forget_msg_rate: 0,
+                fire_and_forget_byte_rate: 0,
+                fire_and_forget_refill_ms: 0,
+                egress_limit: 0,
+                wal_fsync_headroom_bytes: 0,
+                compression: ironbus_core::compress::Codec::None,
+                default_message_ttl_ms: 0,
+                dead_letter_exchange: None,
+                dead_letter_expired: false,
+            },
+        )
+        .unwrap();
+
+        // Build a data-plane server that LEADS partition 0 of {1,2,3} with min_isr=2. A leaked, empty
+        // leader log gives the read plane a `'static` lifetime; the gate's quorum decision (not the read
+        // plane content) is what the test exercises, and the leader-fsync frontier is advanced by the
+        // produce path itself (#719) as records append.
+        let leader_log: &'static Log<InMemoryFs, SystemClock> = Box::leak(Box::new(
+            Log::open(InMemoryFs::new(), SystemClock::new(), LogConfig::default()).unwrap(),
+        ));
+        let plane = Arc::new(leader_log.read_plane().unwrap());
+        let mut controller = DataPlaneController::new(1);
+        controller.start_leader(
+            C2_PARTITION,
+            plane,
+            ironbus_core::epoch_cache::EpochCache::new(),
+            &[1, 2, 3],
+            IsrConfig {
+                min_isr: 2,
+                max_lag_records: 0,
+            },
+        );
+        let server = Arc::new(Mutex::new(DataPlaneServer::new(
+            1,
+            ProduceAckSeam::new(controller),
+        )));
+        let gate = Arc::new(ClientAckGate::new(server, ClusterAckLevel::C2Fsync));
+
+        // Install the gate on the engine handle via the shared set-once slot (exactly the serve path:
+        // the slot is filled, then the handle is installed before any per-connection clone).
+        let slot: ironbus_server::actor::ClientAckSlot<InMemoryFs, SystemClock> =
+            Arc::new(OnceLock::new());
+        slot.set(Arc::clone(&gate)).ok();
+        let (handle_engine, _actor): (EngineHandle<InMemoryFs, SystemClock>, _) =
+            spawn_actor(engine, DEFAULT_CHANNEL_BOUND);
+        let handle_engine = handle_engine.with_client_ack_slot(slot);
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let serve_handle = std::thread::spawn({
+            let shutdown = Arc::clone(&shutdown);
+            move || {
+                let clock = SystemClock::new();
+                let beacon =
+                    ironbus_server::liveness::LivenessBeacon::new(clock.now_monotonic_nanos());
+                serve(&listener, &handle_engine, &shutdown, 16, &clock, &beacon).unwrap();
+            }
+        });
+        (addr, shutdown, serve_handle, gate)
+    }
+
+    /// A raw wire connection that keeps a PERSISTENT read buffer across reads, so a single TCP read that
+    /// returns several frames (e.g. a released `PubAck` flushed alongside the Pong on one pass) never
+    /// drops the trailing frames.
+    #[cfg(unix)]
+    struct RawConn {
+        stream: std::net::TcpStream,
+        buf: Vec<u8>,
+    }
+
+    #[cfg(unix)]
+    impl RawConn {
+        /// Pull the next whole frame, decoding from the persistent buffer first and reading more bytes
+        /// only when no whole frame is buffered. `None` on a clean close or a read timeout with no whole
+        /// frame.
+        fn next_frame(&mut self) -> Option<(FrameType, Vec<u8>)> {
+            let mut chunk = [0u8; 4096];
+            loop {
+                match decode_frame(&self.buf) {
+                    Ok(FrameDecode::Frame {
+                        type_tag,
+                        body,
+                        consumed,
+                    }) => {
+                        let f = (FrameType::from_u8(type_tag).unwrap(), body.to_vec());
+                        self.buf.drain(..consumed);
+                        return Some(f);
+                    }
+                    _ => match self.stream.read(&mut chunk) {
+                        // A clean close (0) or a read timeout (Err) with no whole frame: stop.
+                        Ok(0) | Err(_) => return None,
+                        Ok(n) => self.buf.extend_from_slice(&chunk[..n]),
+                    },
+                }
+            }
+        }
+
+        fn write_frame(&mut self, ty: FrameType, body: &[u8]) {
+            self.stream.write_all(&frame(ty, body)).unwrap();
+        }
+
+        /// Send a `Ping` and collect every frame the broker flushes this round, up to (and including) the
+        /// `Pong` boundary. A withheld-then-released `PubAck` is flushed alongside (or before) the Pong on
+        /// the pass the Ping drives, exactly as the L2 `ProduceConfirm` drain works.
+        fn ping_round(&mut self) -> Vec<(FrameType, Vec<u8>)> {
+            self.write_frame(FrameType::Ping, &[]);
+            let mut frames = Vec::new();
+            while let Some((ty, body)) = self.next_frame() {
+                let is_pong = ty == FrameType::Pong;
+                frames.push((ty, body));
+                if is_pong {
+                    break;
+                }
+            }
+            frames
+        }
+    }
+
+    /// Do the Connect handshake by hand on a raw stream against the real serve: send a default
+    /// `Connect`, read the `Info` reply. Returns the connected [`RawConn`] (persistent buffer).
+    #[cfg(unix)]
+    fn raw_connect(addr: std::net::SocketAddr) -> RawConn {
+        use ironbus_proto::message::{encode_connect, ConnectBody};
+        let stream = std::net::TcpStream::connect(addr).unwrap();
+        stream
+            .set_read_timeout(Some(Duration::from_millis(500)))
+            .unwrap();
+        let mut conn = RawConn {
+            stream,
+            buf: Vec::new(),
+        };
+        let mut body = Vec::new();
+        encode_connect(&ConnectBody::default(), &mut body);
+        conn.write_frame(FrameType::Connect, &body);
+        let (ty, _b) = conn.next_frame().expect("Info handshake reply");
+        assert_eq!(ty, FrameType::Info, "the broker replies Info to a Connect");
+        conn
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_real_client_c2_fsync_produce_acks_only_after_quorum_fsync_not_leader_only() {
+        use ironbus_proto::message::{encode_pub, PubBody as ProtoPubBody};
+        let (addr, shutdown, serve_handle, gate) = start_clustered_c2_server();
+
+        // A REAL client connection over loopback.
+        let mut conn = raw_connect(addr);
+
+        // Send a normal (Level-1) PUB. On this clustered C2-fsync serve the produce is durable on the
+        // leader (its local fsync, I2) but its wire PubAck is WITHHELD by the gate until the ISR quorum
+        // fsyncs the offset — the leader-only-fsync ack is NOT sent.
+        let mut pub_body = Vec::new();
+        encode_pub(
+            &ProtoPubBody {
+                flags: 0,
+                timestamp_ms: 0,
+                key: b"",
+                headers: b"",
+                dedup: None,
+                fire_and_forget: false,
+                payload: b"quorum-gated",
+            },
+            &mut pub_body,
+        )
+        .unwrap();
+        conn.write_frame(FrameType::Pub, &pub_body);
+
+        // BEFORE quorum: drive a few broker passes (Pings). The PubAck must NOT appear — the leader has
+        // locally fsync'd (durable) but no follower has reported, so the 2-of-3 quorum is not met. This
+        // is the property under test: NO leader-only-fsync ack on the real client wire.
+        for _ in 0..3 {
+            let frames = conn.ping_round();
+            assert!(
+                frames.iter().all(|(ty, _)| *ty != FrameType::PubAck),
+                "the C2-fsync produce's wire PubAck is WITHHELD before quorum-fsync (got {frames:?})"
+            );
+        }
+
+        // The data plane (here, the test driving the SHARED gate exactly as the runtime's follower
+        // thread does) receives a follower's report bringing the 2-of-3 quorum: follower 2 has fsync'd
+        // offset 0 (frontier 1), and the leader already fsync'd it (the produce path advanced the leader
+        // frontier), so the quorum-commit now covers offset 0 and the parked ack RELEASES into this
+        // connection's outbox.
+        let released = gate.on_follower_report(
+            C2_PARTITION,
+            &ironbus_server::cluster::AckReplicatedBody {
+                follower_id: 2,
+                fsynced_offset: 1,
+            },
+        );
+        assert_eq!(
+            released, 1,
+            "the follower report brought quorum and released the parked ack"
+        );
+
+        // AFTER quorum: the next broker pass (Ping) flushes the released PubAck onto the wire. The CLIENT
+        // now observes its quorum-durable ack — only after quorum-fsync, never on leader-only-fsync.
+        let mut got_ack = None;
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        while got_ack.is_none() && std::time::Instant::now() < deadline {
+            for (ty, body) in conn.ping_round() {
+                if ty == FrameType::PubAck {
+                    got_ack = Some(body);
+                    break;
+                }
+            }
+        }
+        let ack_body = got_ack.expect("the wire PubAck arrives after the quorum-fsync report");
+        let ack = ironbus_proto::message::decode_pub_ack(&ack_body).unwrap();
+        assert_eq!(
+            ack.offset, 0,
+            "the released PubAck is the REAL reply for the produced offset (the durable offset 0)"
+        );
+
+        drop(conn);
+        shutdown.store(true, Ordering::Release);
+        serve_handle.join().unwrap();
+    }
 }

--- a/crates/ironbus-server/src/actor.rs
+++ b/crates/ironbus-server/src/actor.rs
@@ -39,7 +39,11 @@ use ironbus_core::types::Offset;
 use ironbus_storage::fs::Filesystem;
 use ironbus_storage::log::Append;
 use std::sync::mpsc::{sync_channel, Receiver, SyncSender};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
+
+use crate::cluster::client_ack::ClientAckGate;
+use crate::cluster::dataplane::AckDisposition;
+use ironbus_core::keyshared::MemberId;
 
 /// The default bound on the actor command channel: the most produce/engine commands that may be
 /// in flight before a sender blocks (backpressure). Sized for the edge box's bounded connection
@@ -373,7 +377,21 @@ pub struct EngineHandle<F: Filesystem, C: Clock> {
     /// only; the actor's own byte-cap check stays authoritative (I2 / ordering), and the gate is
     /// engineered to NEVER false-reject (see [`crate::produce_gate`]).
     cap_gate: Arc<ProduceCapGate>,
+    /// The CLUSTER produce-ack gate slot (#719, V2-C2): `None` on a SINGLE-NODE / no-cluster broker
+    /// (the slot is never even created, so the produce-ack hot path never consults it and is
+    /// byte-for-byte today's — the single-node guarantee, owned by this `Option`). On a clustered serve
+    /// it is `Some(Arc<OnceLock<..>>)`: a shared, set-once slot created at serve start and POPULATED by
+    /// the data-plane bootstrap thread once the committed placement builds the
+    /// [`ClientAckGate`](crate::cluster::client_ack::ClientAckGate). The `Arc` is SHARED on clone (like
+    /// `cap_gate`): every connection reads the one slot the bootstrap fills. Until it is filled (the
+    /// brief bootstrap window) the produce path acks immediately exactly as the non-cluster path does.
+    client_ack: Option<ClientAckSlot<F, C>>,
 }
+
+/// The shared, set-once slot holding the clustered [`ClientAckGate`] (#719). Created empty at serve
+/// start and filled by the data-plane bootstrap once the placement commits, so every per-connection
+/// [`EngineHandle`] clone (which captured the slot at serve start) reaches the SAME gate.
+pub type ClientAckSlot<F, C> = Arc<OnceLock<Arc<ClientAckGate<F, C>>>>;
 
 // Derived `Clone` would demand `F: Clone`; the handle clones the `SyncSender` and the clock (`C` is
 // already `Clock + Clone` everywhere a handle is built), so spell it out for any `F`.
@@ -390,11 +408,45 @@ impl<F: Filesystem, C: Clock + Clone> Clone for EngineHandle<F, C> {
             // The SAME shared gate (#476): every connection reads the one byte-cap snapshot the actor
             // publishes, so the `Arc` is shared on clone (NOT freshened like `reply_pool`).
             cap_gate: Arc::clone(&self.cap_gate),
+            // The SAME shared cluster produce-ack slot (#719): every connection reads the one slot the
+            // data-plane bootstrap fills, so the `Arc<OnceLock>` is shared on clone. `None` off-cluster.
+            client_ack: self.client_ack.clone(),
         }
     }
 }
 
 impl<F: Filesystem + 'static, C: Clock + 'static> EngineHandle<F, C> {
+    /// Install the SHARED cluster produce-ack slot (#719) on this base handle, returning the handle.
+    /// Called ONCE on a clustered serve, RIGHT AFTER [`spawn_actor_with_gather`] and BEFORE any
+    /// per-connection clone, so every connection's handle captures the same slot. The slot is filled
+    /// later by the data-plane bootstrap once the placement commits. A single-node / no-cluster serve
+    /// never calls this, so its handles carry `None` and the produce-ack path stays byte-for-byte
+    /// today's (the single-node guarantee).
+    #[must_use]
+    pub fn with_client_ack_slot(mut self, slot: ClientAckSlot<F, C>) -> Self {
+        self.client_ack = Some(slot);
+        self
+    }
+
+    /// The shared cluster produce-ack gate (#719), once the data-plane bootstrap has filled the slot;
+    /// `None` on a single-node / no-cluster serve (no slot) or during the brief bootstrap window before
+    /// the placement commits (the slot exists but is empty). The produce path consults it ONLY when it
+    /// is `Some` — the single-node path never reaches here.
+    #[must_use]
+    fn client_ack_gate(&self) -> Option<&Arc<ClientAckGate<F, C>>> {
+        self.client_ack.as_ref().and_then(|slot| slot.get())
+    }
+
+    /// Drop any released-but-undrained cluster produce-acks for a DISCONNECTED producer connection
+    /// (#719), so the gate's outbox does not leak. An inherent forwarder (the connection-cleanup path in
+    /// `server.rs` holds a concrete [`EngineHandle`], not an `EngineAccess` bound). A no-op on a
+    /// single-node / no-cluster broker (no gate), so the disconnect path is byte-for-byte unchanged.
+    pub fn drop_client_acks(&self, member: MemberId) {
+        if let Some(gate) = self.client_ack_gate() {
+            gate.drop_connection(member);
+        }
+    }
+
     /// The static per-consumer credit caps (#292): `(consumer_credit, consumer_credit_bytes)`,
     /// snapshotted from the engine config at `spawn_actor`. Read by the `Connect` handshake to
     /// negotiate the per-consumer credit WITHOUT a round-trip through the actor (so a stalled produce
@@ -637,6 +689,57 @@ pub trait EngineAccess<F: Filesystem, C: Clock> {
     /// off the actor's hot path and a stalled produce cannot head-of-line-block a handshake (#177).
     /// `.0` is the message-count cap (floored to >= 1); `.1` of `0` is unlimited.
     fn consumer_credit_caps(&self) -> (u32, u64);
+
+    /// Whether this engine carries a CLUSTER produce-ack gate (#719): `false` on a SINGLE-NODE /
+    /// no-cluster broker (the DEFAULT), so the produce-ack hot path can skip building the gate's bytes
+    /// and write the immediate ack directly — the zero-cost byte-identical fast path. A cheap LOCAL read
+    /// (no actor round-trip, no lock). [`EngineHandle`] overrides it to report whether its cluster slot
+    /// is filled.
+    fn has_client_ack_gate(&self) -> bool {
+        false
+    }
+
+    /// The CLUSTER produce-ack decision (#719) for one durable produce on connection `member`: called
+    /// AFTER the local group-commit fsync returned `Appended(offset)`, with the `offset`, and the EXACT
+    /// wire-`PubAck` frame bytes the session would otherwise write now.
+    ///
+    /// Returns `None` on a SINGLE-NODE / no-cluster broker (the DEFAULT impl): there is no gate, so the
+    /// session writes the immediate ack-after-local-fsync reply exactly as today — byte-for-byte, with
+    /// ZERO added work (no lock, no allocation). [`EngineHandle`] overrides it to consult the shared
+    /// [`ClientAckGate`](crate::cluster::client_ack::ClientAckGate) ONLY when the cluster slot is filled
+    /// (a clustered serve past bootstrap); even then it returns `None` unless the gate is present, so the
+    /// non-cluster and pre-bootstrap paths stay the immediate ack. A `Some(AckDisposition)` tells the
+    /// session whether to WRITE the reply now or WITHHOLD it (the gate parked it; the data plane releases
+    /// it on quorum-fsync, drained later via [`EngineAccess::drain_client_acks`]).
+    ///
+    /// The DEFAULT-partition scoping (#693 is multi-partition routing) is the gate's concern; the session
+    /// passes the default partition. `reply_bytes` is returned verbatim inside `WriteNow` so the caller
+    /// can move them back out without a clone on the common immediate-ack path.
+    fn client_ack_disposition(
+        &self,
+        _member: MemberId,
+        _offset: u64,
+        _reply_bytes: Vec<u8>,
+    ) -> Option<AckDisposition> {
+        None
+    }
+
+    /// Drain (and remove) every cluster produce-ack the data plane RELEASED for connection `member`
+    /// since its last pass (#719), in release/offset order, for the session to flush on its OWN pass —
+    /// the cross-thread hand-off (the data plane releases on a peer-I/O thread; only the owning
+    /// connection's thread may write its socket), exactly like the #497 `ProduceConfirm` drain. The
+    /// DEFAULT impl returns empty (single-node / no-cluster: nothing is ever parked, so nothing
+    /// releases) WITHOUT any work. [`EngineHandle`] overrides it to drain the gate's outbox when the
+    /// cluster slot is filled.
+    fn drain_client_acks(&self, _member: MemberId) -> Vec<Vec<u8>> {
+        Vec::new()
+    }
+
+    /// Drop any released-but-undrained cluster produce-acks for a producer connection that DISCONNECTED
+    /// (#719), so the gate's outbox does not leak. The DEFAULT impl is a no-op (no gate). [`EngineHandle`]
+    /// overrides it to clear the gate's outbox entry when the cluster slot is filled. Called from the
+    /// connection-cleanup path, like #497's `drop_l2_confirms`.
+    fn drop_client_acks(&self, _member: MemberId) {}
 }
 
 impl<F: Filesystem + 'static, C: Clock + Clone + 'static> EngineAccess<F, C>
@@ -674,6 +777,43 @@ impl<F: Filesystem + 'static, C: Clock + Clone + 'static> EngineAccess<F, C>
     fn consumer_credit_caps(&self) -> (u32, u64) {
         // A LOCAL read of the snapshotted caps, no actor round-trip (the #177 head-of-line guard).
         EngineHandle::consumer_credit_caps(self)
+    }
+
+    fn has_client_ack_gate(&self) -> bool {
+        // A cheap local read: the slot exists AND is filled (a clustered serve past bootstrap).
+        self.client_ack_gate().is_some()
+    }
+
+    fn client_ack_disposition(
+        &self,
+        member: MemberId,
+        offset: u64,
+        reply_bytes: Vec<u8>,
+    ) -> Option<AckDisposition> {
+        // SINGLE-NODE / no-cluster / pre-bootstrap: `client_ack_gate` is `None`, so this returns `None`
+        // with ZERO work (no lock, no alloc) and the session writes the immediate ack exactly as today.
+        // Only a clustered serve past bootstrap reaches the gate, which itself NO-OPs (writes now) for
+        // every non-C2-fsync configured level or non-led partition.
+        let gate = self.client_ack_gate()?;
+        Some(gate.on_local_fsynced_ack(
+            member,
+            crate::cluster::client_ack::DEFAULT_PARTITION,
+            offset,
+            reply_bytes,
+        ))
+    }
+
+    fn drain_client_acks(&self, member: MemberId) -> Vec<Vec<u8>> {
+        // No gate (single-node / pre-bootstrap): nothing was ever parked, so nothing releases — empty,
+        // no work. With a gate, drain this connection's released wire PubAcks (the common case is empty).
+        match self.client_ack_gate() {
+            Some(gate) => gate.drain_released(member),
+            None => Vec::new(),
+        }
+    }
+
+    fn drop_client_acks(&self, member: MemberId) {
+        EngineHandle::drop_client_acks(self, member);
     }
 }
 
@@ -947,6 +1087,11 @@ where
             reply_pool: Arc::new(Mutex::new(Vec::new())),
             // The shared fast-reject gate (#476); every connection `clone` shares this same `Arc`.
             cap_gate,
+            // No cluster produce-ack slot by default (#719): the single-node / no-cluster broker never
+            // creates one. A clustered serve installs the shared slot via
+            // [`EngineHandle::with_client_ack_slot`] right after this returns, BEFORE any connection's
+            // handle is cloned, so every connection sees it.
+            client_ack: None,
         },
         join,
     )

--- a/crates/ironbus-server/src/cluster/client_ack.rs
+++ b/crates/ironbus-server/src/cluster/client_ack.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
 //! The CLIENT produce-ack gate (#719, V2-C2): the one shared handle that makes the (`Send`)
 //! [`ProduceAckSeam`](super::dataplane::ProduceAckSeam) reachable from a real producer connection's
 //! per-connection produce-ack path, so a clustered `C2-fsync` produce to a LED partition gets its wire

--- a/crates/ironbus-server/src/cluster/client_ack.rs
+++ b/crates/ironbus-server/src/cluster/client_ack.rs
@@ -1,0 +1,443 @@
+//! The CLIENT produce-ack gate (#719, V2-C2): the one shared handle that makes the (`Send`)
+//! [`ProduceAckSeam`](super::dataplane::ProduceAckSeam) reachable from a real producer connection's
+//! per-connection produce-ack path, so a clustered `C2-fsync` produce to a LED partition gets its wire
+//! `PubAck` only AFTER quorum-fsync — not the immediate local-fsync ack.
+//!
+//! # The problem it closes
+//!
+//! After #718 the data plane RUNS: the [`DataPlaneRuntime`](super::serve::DataPlaneRuntime) replicates
+//! over real TCP and DRIVES the seam's park/release end-to-end from the live follower reports — but a
+//! real EXTERNAL CLIENT's wire `PubAck` was still sent on the immediate local-fsync ack, because the
+//! seam lives inside the runtime's peer-I/O thread and the per-connection produce path (`session.rs`)
+//! could not reach it: sessions touch the engine only via the per-call
+//! [`EngineAccess`](crate::actor::EngineAccess) trait, with no shared mutable seam state, and a
+//! released ack arrives on the RUNTIME's thread while only the owning connection's OWN thread may write
+//! its socket.
+//!
+//! # The shape (mirrors the #497 Level-2 confirm registry)
+//!
+//! [`ClientAckGate`] is an `Arc`-shared, `Send + Sync` bundle of:
+//! * the SAME [`Arc<Mutex<DataPlaneServer>>`](super::serve::DataPlaneServer) the
+//!   [`DataPlaneRuntime`](super::serve::DataPlaneRuntime) drives (ONE seam — one source of truth for the
+//!   parked state); and
+//! * a per-producer-connection OUTBOX of RELEASED-but-not-yet-flushed wire `PubAck` bytes, keyed by the
+//!   producer's [`MemberId`](ironbus_core::keyshared::MemberId).
+//!
+//! The produce path, on `Appended(offset)` for a clustered `C2-fsync` led produce, calls
+//! [`ClientAckGate::on_local_fsynced_ack`] tagging the park with the connection's member id; if the
+//! ack is PARKED it withholds the wire `PubAck`. The runtime's follower-report path calls
+//! [`ClientAckGate::on_follower_report`], which drives the gate and DEPOSITS each released reply into
+//! its owner's outbox. The owning connection then DRAINS its outbox on its OWN next pass
+//! ([`ClientAckGate::drain_released`]) — exactly the cross-thread hand-off the #497 `ProduceConfirm`
+//! registry uses (a terminal produced on another thread, drained on the producer's own pass).
+//!
+//! # Single-node byte-identical (BY CONSTRUCTION)
+//!
+//! A non-clustered broker NEVER constructs a [`ClientAckGate`] (it is created only on the clustered
+//! disk serve path), so the produce-ack hot path never consults it: the
+//! [`EngineAccess`](crate::actor::EngineAccess) handle carries `None`, the produce path's
+//! cluster-gated branch is skipped, and the immediate ack-after-local-fsync path is byte-for-byte
+//! today's, with ZERO added work, latency, or allocation. The gate is a no-op without a cluster.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use ironbus_core::clock::Clock;
+use ironbus_core::keyshared::MemberId;
+use ironbus_storage::fs::Filesystem;
+
+use super::ack_level::ClusterAckLevel;
+use super::dataplane::AckDisposition;
+use super::isr::AckReplicatedBody;
+use super::serve::DataPlaneServer;
+
+/// The fixed partition the broker's DEFAULT-stream log maps to in a clustered serve (#717/#719).
+/// Today's broker is single-stream; the data plane replicates that one log as partition `0` and the
+/// client produce-ack gate routes every produce to it. Multi-partition routing (a produce to the right
+/// partition leader's seam) is the #693 multi-partition engine — FLAGGED, out of scope here.
+pub const DEFAULT_PARTITION: u64 = 0;
+
+/// The shared client produce-ack gate (#719): the seam (via the shared
+/// [`DataPlaneServer`](super::serve::DataPlaneServer)) plus the per-connection released-ack outbox.
+/// Held in an `Arc` and shared between every producer connection (via the
+/// [`EngineAccess`](crate::actor::EngineAccess) handle) and the
+/// [`DataPlaneRuntime`](super::serve::DataPlaneRuntime). Created ONLY on a clustered serve.
+pub struct ClientAckGate<F: Filesystem, C: Clock> {
+    /// The SAME shared data-plane server the runtime drives — the one [`ProduceAckSeam`] and its parked
+    /// state. Locked briefly per produce-ack decision / per follower report; the lock is NEVER held
+    /// across a socket write.
+    ///
+    /// [`ProduceAckSeam`]: super::dataplane::ProduceAckSeam
+    server: Arc<Mutex<DataPlaneServer<F, C>>>,
+    /// The serve-wide CONFIGURED cluster ack level (#696): the durability contract a produce to a led
+    /// partition is held to. Only [`ClusterAckLevel::C2Fsync`] gates a produce on quorum-fsync; every
+    /// other level acks immediately. Resolved at serve time (today from the replication factor via
+    /// [`ClusterAckLevel::default_for_replication_factor`]); a per-publish wire override is later.
+    configured_level: ClusterAckLevel,
+    /// Per-producer-connection released wire `PubAck` byte-frames, keyed by the producer's member id,
+    /// in release (offset) order. The runtime deposits here on quorum-fsync; the owning connection
+    /// drains here on its own pass. Empty for any connection with nothing released-pending.
+    outbox: Mutex<HashMap<u64, Vec<Vec<u8>>>>,
+}
+
+impl<F: Filesystem, C: Clock> ClientAckGate<F, C> {
+    /// Build the gate around the SAME shared server the runtime drives, held to `configured_level`.
+    /// Called ONLY on a clustered serve.
+    #[must_use]
+    pub fn new(
+        server: Arc<Mutex<DataPlaneServer<F, C>>>,
+        configured_level: ClusterAckLevel,
+    ) -> Self {
+        Self {
+            server,
+            configured_level,
+            outbox: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// The serve-wide configured cluster ack level this gate holds produces to (#696).
+    #[must_use]
+    pub fn configured_level(&self) -> ClusterAckLevel {
+        self.configured_level
+    }
+
+    /// The shared data-plane server, for the runtime to drive (the runtime is built around the SAME
+    /// `Arc<Mutex<DataPlaneServer>>` so the seam's parked state is one source of truth).
+    #[must_use]
+    pub fn server(&self) -> &Arc<Mutex<DataPlaneServer<F, C>>> {
+        &self.server
+    }
+
+    /// The PRODUCE-ACK decision for one produce on connection `member` (#719): called AFTER the local
+    /// group-commit fsync returned `Appended(offset)` (the leader's I2 holds), with the `partition` it
+    /// landed on, the appended `offset`, and the EXACT wire-`PubAck` frame bytes the caller would
+    /// otherwise write now. The produce is held to the gate's serve-wide [`Self::configured_level`].
+    ///
+    /// Returns [`AckDisposition::Parked`] — the caller WITHHOLDS the wire reply, and the runtime
+    /// releases it into this connection's outbox on quorum-fsync — ONLY for a `C2-fsync` configured
+    /// level AND a partition THIS node leads, below or at quorum. In every other case (not `C2-fsync`,
+    /// not the leader) it returns [`AckDisposition::WriteNow`] with the bytes verbatim and the caller
+    /// writes them immediately, byte-for-byte the existing path. A just-parked ack whose quorum was
+    /// ALREADY met (a fast follower reported first) comes back as [`AckDisposition::WriteNowBatch`].
+    ///
+    /// Locks the shared server briefly (never across a socket write).
+    ///
+    /// A poisoned server lock yields [`AckDisposition::WriteNow`] (fail to the immediate ack rather than
+    /// withhold a reply that nothing will ever release).
+    pub fn on_local_fsynced_ack(
+        &self,
+        member: MemberId,
+        partition: u64,
+        offset: u64,
+        reply_bytes: Vec<u8>,
+    ) -> AckDisposition {
+        // FAST NON-CLUSTER-LEVEL GATE: only a C2-fsync configured serve ever locks the server / parks.
+        // Any other configured level (C0/C1/C2-pagecache) is the immediate ack, decided WITHOUT taking
+        // the shared lock — so a clustered serve at C1 pays no per-produce lock either.
+        if !self.configured_level.ack_implies_quorum_fsync() {
+            return AckDisposition::WriteNow(reply_bytes);
+        }
+        let Ok(mut srv) = self.server.lock() else {
+            // A poisoned lock means the runtime is tearing down; fall back to the immediate ack rather
+            // than withhold a reply that nothing will ever release. Correctness-safe: the immediate ack
+            // is the leader's already-durable I2 ack (it never over-claims durability — only the
+            // quorum-wait is dropped on this teardown edge).
+            return AckDisposition::WriteNow(reply_bytes);
+        };
+        // NOT THE LEADER of this partition (the #693 multi-partition routing concern, or a stale role on
+        // a teardown/rebalance edge): ack IMMEDIATELY with the REAL bytes — never quorum-withhold a
+        // produce this node does not lead, and never lose the reply. Checked HERE (before the seam call
+        // that would move `reply_bytes`) so a non-led produce keeps its real wire PubAck. The seam's own
+        // `on_local_fsynced_ack_owned` makes the same non-led decision (`WriteNow(reply_bytes)`); this
+        // mirror just keeps the bytes recoverable in the gate.
+        if !srv.seam().controller().is_leader(partition) {
+            return AckDisposition::WriteNow(reply_bytes);
+        }
+        // ADVANCE the leader's OWN fsync'd frontier in the seam's ISR tracker to past this offset (#719):
+        // the leader has ALREADY locally fsync'd through `offset` (the I2 that just returned `Appended`),
+        // so its frontier is `offset + 1`. The ISR seeds the leader frontier ONCE at start (#718), so
+        // without this the quorum-commit would be capped at the stale start frontier and a real produce
+        // would never release. The leader is one of the `min_isr` quorum members, so its frontier is
+        // load-bearing. Saturating so `u64::MAX` cannot overflow (unreachable in practice).
+        srv.seam_mut()
+            .controller_mut()
+            .observe_leader_fsync(partition, offset.saturating_add(1));
+        // Park (or fast-release) the REAL wire bytes. The leader role is confirmed above, so the seam
+        // never errors here (its only error is a non-led / unknown partition). The fallback is purely
+        // defensive (NO panic on the serve path, #11): on the unreachable error it acks immediately with
+        // the real bytes (cloned cheaply only on this rare clustered C2-fsync path, never on the
+        // single-node hot path), so a produce can never silently lose its reply.
+        let fallback = reply_bytes.clone();
+        match srv.seam_mut().on_local_fsynced_ack_owned(
+            member.get(),
+            self.configured_level,
+            partition,
+            offset,
+            reply_bytes,
+        ) {
+            Ok(disposition) => disposition,
+            Err(_) => AckDisposition::WriteNow(fallback),
+        }
+    }
+
+    /// Feed a follower's [`AckReplicatedBody`] for `partition` into the gate (driven by the runtime's
+    /// follower-report path) and DEPOSIT each released wire `PubAck` into its OWNER connection's outbox,
+    /// in offset order, for that connection to flush on its own pass. Below `min_isr` releases NOTHING
+    /// (the no-false-ack property, on the real client wire). Returns the number of replies released.
+    ///
+    /// Locks the shared server, then the outbox — both briefly, NEVER across a socket write (the
+    /// release just moves bytes into the outbox; the owning connection's thread does the actual write).
+    pub fn on_follower_report(&self, partition: u64, report: &AckReplicatedBody) -> usize {
+        let released = {
+            let Ok(mut srv) = self.server.lock() else {
+                return 0;
+            };
+            match srv.seam_mut().on_follower_report_owned(partition, report) {
+                Ok(r) => r,
+                Err(_) => return 0,
+            }
+        };
+        if released.is_empty() {
+            return 0;
+        }
+        let count = released.len();
+        let mut outbox = self
+            .outbox
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        for (owner, bytes) in released {
+            outbox.entry(owner).or_default().push(bytes);
+        }
+        count
+    }
+
+    /// Drain (and remove) every RELEASED wire `PubAck` for producer connection `member`, in release
+    /// (offset) order, for the connection to flush on its OWN pass. Empty for a connection with nothing
+    /// released-pending (the common case), so a connection that never parked a clustered `C2-fsync`
+    /// produce pays only a brief lock + miss.
+    #[must_use]
+    pub fn drain_released(&self, member: MemberId) -> Vec<Vec<u8>> {
+        let mut outbox = self
+            .outbox
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        outbox.remove(&member.get()).unwrap_or_default()
+    }
+
+    /// Drop any released-but-undrained acks for a producer connection that DISCONNECTED (#719): nobody
+    /// is left to flush them, so the outbox entry is removed rather than leaked. Called from the
+    /// connection-cleanup path, like the #497 `drop_l2_confirms`. (A still-PARKED ack — withheld inside
+    /// the seam, not yet released — is left to the seam's bounded gate; this only clears the outbox.)
+    pub fn drop_connection(&self, member: MemberId) {
+        let mut outbox = self
+            .outbox
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        outbox.remove(&member.get());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cluster::dataplane::{DataPlaneController, ProduceAckSeam};
+    use crate::cluster::isr::IsrConfig;
+    use crate::cluster::state_machine::Placement;
+    use ironbus_core::clock::ManualClock;
+    use ironbus_storage::fs::InMemoryFs;
+    use ironbus_storage::log::{Log, LogConfig};
+
+    const P: u64 = 0;
+
+    /// A leaked leader log so the read plane's `Arc` lifetime is `'static` for the test (the same
+    /// pattern the serve.rs cluster tests use). The gate's seam logic does not read the plane content —
+    /// the gate/quorum decision is what is under test — so an empty leader log suffices.
+    fn leader_plane() -> Arc<ironbus_storage::read_plane::ReadPlane<InMemoryFs>> {
+        let log: &'static Log<InMemoryFs, ManualClock> = Box::leak(Box::new(
+            Log::open(InMemoryFs::new(), ManualClock::new(), LogConfig::default())
+                .expect("open leader log"),
+        ));
+        Arc::new(log.read_plane().expect("read plane"))
+    }
+
+    fn quorum3() -> IsrConfig {
+        IsrConfig {
+            min_isr: 2,
+            max_lag_records: 0,
+        }
+    }
+
+    /// Build a leader [`ClientAckGate`] for node 1 leading `{1,2,3}` with `min_isr = 2`, held to
+    /// `level`. `leader_fsync` seeds the leader's OWN fsync'd frontier (the leader has locally fsync'd
+    /// through it, the I2 ack), so a follower report at or past an offset can bring the 2-of-3 quorum.
+    fn leader_gate_at(
+        level: ClusterAckLevel,
+        leader_fsync: u64,
+    ) -> ClientAckGate<InMemoryFs, ManualClock> {
+        let placement = Placement {
+            replicas: vec![1, 2, 3],
+            leader: 1,
+            epoch: 1,
+        };
+        let mut controller = DataPlaneController::new(1);
+        controller.start_leader(
+            P,
+            leader_plane(),
+            ironbus_core::epoch_cache::EpochCache::new(),
+            &placement.replicas,
+            quorum3(),
+        );
+        // The leader has locally fsync'd through `leader_fsync` (its own I2). The quorum-commit is the
+        // min_isr-th largest fsync'd frontier, so a single in-sync follower past an offset meets the
+        // 2-of-3 quorum for it.
+        controller.observe_leader_fsync(P, leader_fsync);
+        let seam = ProduceAckSeam::new(controller);
+        let server = DataPlaneServer::new(1, seam);
+        ClientAckGate::new(Arc::new(Mutex::new(server)), level)
+    }
+
+    /// A C2-fsync gate (the quorum-gated default for a 3-replica cluster).
+    fn leader_gate(leader_fsync: u64) -> ClientAckGate<InMemoryFs, ManualClock> {
+        leader_gate_at(ClusterAckLevel::C2Fsync, leader_fsync)
+    }
+
+    fn wire_ack(offset: u64) -> Vec<u8> {
+        // A stand-in for the real wire PubAck frame bytes — the gate treats them as opaque; the test
+        // asserts the EXACT bytes round-trip through park -> release -> drain.
+        let mut v = b"PUBACK".to_vec();
+        v.extend_from_slice(&offset.to_le_bytes());
+        v
+    }
+
+    #[test]
+    fn a_c2_fsync_led_produce_is_parked_then_released_to_its_owner_outbox_on_quorum() {
+        // The leader has locally fsync'd record 0 (frontier 1); no follower has it yet, so the 2-of-3
+        // quorum is not met.
+        let gate = leader_gate(1);
+        let member = MemberId::new(42);
+        let offset = 0;
+        let reply = wire_ack(offset);
+
+        // The clustered C2-fsync led produce parks: the wire PubAck is WITHHELD.
+        let disposition = gate.on_local_fsynced_ack(member, P, offset, reply.clone());
+        assert_eq!(disposition, AckDisposition::Parked);
+        // Nothing is in the owner's outbox yet (no quorum).
+        assert!(gate.drain_released(member).is_empty());
+
+        // A single follower at offset 0 brings min_isr=2 (leader + follower 2) for offset 0.
+        let report = AckReplicatedBody {
+            follower_id: 2,
+            fsynced_offset: 1,
+        };
+        let released = gate.on_follower_report(P, &report);
+        assert_eq!(
+            released, 1,
+            "the quorum-fsync released exactly one parked ack"
+        );
+
+        // The owner connection drains the REAL reply bytes (byte-identical to what was parked).
+        let drained = gate.drain_released(member);
+        assert_eq!(
+            drained,
+            vec![reply],
+            "the released bytes ARE the original PubAck"
+        );
+        // A second drain is empty (the outbox entry was removed).
+        assert!(gate.drain_released(member).is_empty());
+    }
+
+    #[test]
+    fn below_min_isr_the_wire_puback_stays_withheld_no_false_ack() {
+        // The leader has fsync'd through offset 5 (frontier 6), but with NO follower in sync the ISR is
+        // the leader alone (size 1 < min_isr 2): no quorum, so a parked ack is NEVER released.
+        let gate = leader_gate(6);
+        let member = MemberId::new(7);
+        let offset = 5;
+        let disposition = gate.on_local_fsynced_ack(member, P, offset, wire_ack(offset));
+        assert_eq!(disposition, AckDisposition::Parked);
+        // A follower at offset 0 does NOT bring quorum at offset 5: nothing released.
+        let report = AckReplicatedBody {
+            follower_id: 2,
+            fsynced_offset: 0,
+        };
+        assert_eq!(gate.on_follower_report(P, &report), 0);
+        assert!(
+            gate.drain_released(member).is_empty(),
+            "below min_isr the client's wire PubAck is NEVER released (no false ack)"
+        );
+    }
+
+    #[test]
+    fn non_c2_fsync_levels_ack_immediately_never_parked() {
+        let member = MemberId::new(1);
+        for level in [
+            ClusterAckLevel::C0,
+            ClusterAckLevel::C1,
+            ClusterAckLevel::C2Pagecache,
+        ] {
+            // A gate CONFIGURED at a non-C2-fsync level acks immediately (never quorum-gated), without
+            // even taking the shared lock.
+            let gate = leader_gate_at(level, 1);
+            let reply = wire_ack(0);
+            let disposition = gate.on_local_fsynced_ack(member, P, 0, reply.clone());
+            assert_eq!(
+                disposition,
+                AckDisposition::WriteNow(reply),
+                "{level:?} acks immediately (never quorum-gated)"
+            );
+            // Nothing was ever parked or released.
+            assert!(gate.drain_released(member).is_empty());
+        }
+    }
+
+    #[test]
+    fn a_produce_to_a_partition_this_node_does_not_lead_acks_immediately() {
+        // Node 1 FOLLOWS partition 0 (leader is node 2). A produce routed here (the #693 multi-partition
+        // routing concern, or a stale role) must ack IMMEDIATELY with the REAL bytes — never quorum-
+        // withhold a produce this node does not lead, and never lose the reply.
+        let placement = Placement {
+            replicas: vec![1, 2, 3],
+            leader: 2,
+            epoch: 1,
+        };
+        let mut controller = DataPlaneController::new(1);
+        let replica_log =
+            Log::open(InMemoryFs::new(), ManualClock::new(), LogConfig::default()).unwrap();
+        controller.start_follower(P, replica_log);
+        let _ = placement; // the role is set directly via start_follower (node 1 is a follower here)
+        let seam = ProduceAckSeam::new(controller);
+        let server = DataPlaneServer::new(1, seam);
+        let gate = ClientAckGate::new(Arc::new(Mutex::new(server)), ClusterAckLevel::C2Fsync);
+
+        let member = MemberId::new(3);
+        let reply = wire_ack(7);
+        assert_eq!(
+            gate.on_local_fsynced_ack(member, P, 7, reply.clone()),
+            AckDisposition::WriteNow(reply),
+            "a non-led produce acks immediately with the REAL reply (no quorum withholding, no loss)"
+        );
+        assert!(gate.drain_released(member).is_empty());
+    }
+
+    #[test]
+    fn a_disconnect_drops_undrained_released_acks() {
+        let gate = leader_gate(1);
+        let member = MemberId::new(99);
+        let reply = wire_ack(0);
+        assert_eq!(
+            gate.on_local_fsynced_ack(member, P, 0, reply),
+            AckDisposition::Parked
+        );
+        let report = AckReplicatedBody {
+            follower_id: 2,
+            fsynced_offset: 1,
+        };
+        assert_eq!(gate.on_follower_report(P, &report), 1);
+        // The released ack is waiting in the outbox; the connection disconnects before draining.
+        gate.drop_connection(member);
+        assert!(
+            gate.drain_released(member).is_empty(),
+            "a disconnect drops the undrained released acks (no outbox leak)"
+        );
+    }
+}

--- a/crates/ironbus-server/src/cluster/dataplane.rs
+++ b/crates/ironbus-server/src/cluster/dataplane.rs
@@ -857,10 +857,14 @@ pub struct ProduceAckSeam<F: Filesystem, C: Clock> {
     /// The next per-park token. Monotonic; keys [`Self::parked`] and is what the controller's gate
     /// holds + hands back on release. Wraps only after `u64::MAX` parks, which is unreachable.
     next_token: u64,
-    /// The parked wire-`PubAck` frame bytes, keyed by the token the controller's gate holds. The REAL
-    /// reply each parked produce will get; removed and returned in offset order on quorum-fsync
-    /// release. Empty whenever nothing is withheld (single-node / no-cluster never inserts).
-    parked: BTreeMap<AckToken, Vec<u8>>,
+    /// The parked wire-`PubAck` frame bytes, keyed by the token the controller's gate holds, each
+    /// tagged with the OPAQUE OWNER id (the producer connection's [`MemberId`](ironbus_core::keyshared::MemberId)
+    /// `u64`) that parked it, so a real serve can route the released reply back to the RIGHT producer
+    /// connection. The REAL reply each parked produce will get; removed and returned in offset order on
+    /// quorum-fsync release. Empty whenever nothing is withheld (single-node / no-cluster never inserts).
+    /// The owner is opaque here (the in-process #703 test and the existing un-owned API tag it `0`; the
+    /// client-ack path #719 tags it with the connection's member id), exactly like [`AckToken`].
+    parked: BTreeMap<AckToken, (u64, Vec<u8>)>,
 }
 
 impl<F: Filesystem, C: Clock> ProduceAckSeam<F, C> {
@@ -919,30 +923,59 @@ impl<F: Filesystem, C: Clock> ProduceAckSeam<F, C> {
         offset: u64,
         reply_bytes: Vec<u8>,
     ) -> Result<AckDisposition, DataPlaneError> {
+        // The un-owned API (the in-process #703 test + the serve-path observability callers) tags the
+        // park with owner `0`; routing the released bytes back to a specific producer connection is the
+        // #719 client-ack path, which calls `on_local_fsynced_ack_owned`. The decision logic is shared.
+        self.on_local_fsynced_ack_owned(0, ack_level, partition, offset, reply_bytes)
+    }
+
+    /// The OWNER-tagged produce-ack decision (#719): identical to [`Self::on_local_fsynced_ack`] but
+    /// records the OPAQUE `owner` id (a producer connection's [`MemberId`](ironbus_core::keyshared::MemberId))
+    /// alongside the parked reply, so the release path ([`Self::on_follower_report_owned`]) can route the
+    /// released wire `PubAck` back to the RIGHT producer connection. The seam never interprets `owner`.
+    ///
+    /// Single-node byte-identical is unchanged: the seam is never CONSTRUCTED off-cluster, and this
+    /// returns [`AckDisposition::WriteNow`] verbatim for every non-`C2-fsync` / non-led case (no park,
+    /// no owner recorded).
+    ///
+    /// # Errors
+    /// [`DataPlaneError`] only if the controller rejects the park (never for a led partition — the
+    /// `Parked` branch is taken only when [`DataPlaneController::is_leader`] is already true).
+    pub fn on_local_fsynced_ack_owned(
+        &mut self,
+        owner: u64,
+        ack_level: ClusterAckLevel,
+        partition: u64,
+        offset: u64,
+        reply_bytes: Vec<u8>,
+    ) -> Result<AckDisposition, DataPlaneError> {
         // The seam engages ONLY for a clustered C2-fsync produce to a LED partition. Anything else is
         // the existing immediate ack: returned verbatim, no parking state constructed.
         if !ack_level.ack_implies_quorum_fsync() || !self.controller.is_leader(partition) {
             return Ok(AckDisposition::WriteNow(reply_bytes));
         }
-        // Park the REAL wire bytes keyed by a fresh token, then thread that token through the
-        // controller's gate at the appended offset. The leader has ALREADY locally fsync'd (the I2
-        // ack-after-its-own-fsync); the gate adds the quorum-fsync condition.
+        // Park the REAL wire bytes keyed by a fresh token (tagged with the owner), then thread that token
+        // through the controller's gate at the appended offset. The leader has ALREADY locally fsync'd
+        // (the I2 ack-after-its-own-fsync); the gate adds the quorum-fsync condition.
         let token = self.next_token;
         self.next_token = self.next_token.wrapping_add(1);
-        self.parked.insert(token, reply_bytes);
+        self.parked.insert(token, (owner, reply_bytes));
         self.controller.park_produce_ack(partition, offset, token)?;
         // Re-check the CURRENT quorum-commit: a follower may already have reported past this offset
         // (its report arrived before this produce's local fsync completed), in which case the ack is
         // immediately quorum-committed and we hand the real bytes straight back to write now. Below
         // min_isr this releases nothing and the ack stays parked (no false ack on the wire).
-        let released = self.take_released(partition)?;
+        let released = self.take_released_owned(partition)?;
         if released.is_empty() {
             Ok(AckDisposition::Parked)
         } else {
             // The quorum had already fsync'd this offset (a follower reported past it before this
             // produce's local fsync completed), so the gate released the real reply (and any
-            // co-released earlier ones, in offset order) straight back to write now.
-            Ok(AckDisposition::WriteNowBatch(released))
+            // co-released earlier ones, in offset order) straight back to write now. The un-owned
+            // disposition drops the owner tags (the caller of the un-owned path holds one connection).
+            Ok(AckDisposition::WriteNowBatch(
+                released.into_iter().map(|(_owner, bytes)| bytes).collect(),
+            ))
         }
     }
 
@@ -959,22 +992,44 @@ impl<F: Filesystem, C: Clock> ProduceAckSeam<F, C> {
         partition: u64,
         report: &AckReplicatedBody,
     ) -> Result<Vec<Vec<u8>>, DataPlaneError> {
+        Ok(self
+            .on_follower_report_owned(partition, report)?
+            .into_iter()
+            .map(|(_owner, bytes)| bytes)
+            .collect())
+    }
+
+    /// The OWNER-tagged release (#719): like [`Self::on_follower_report`] but returns each released wire
+    /// `PubAck` paired with the OPAQUE owner id ([`Self::on_local_fsynced_ack_owned`]'s `owner`) that
+    /// parked it, so a real serve routes each reply back to the RIGHT producer connection. Below
+    /// `min_isr` releases nothing (the no-false-ack property, on the real wire).
+    ///
+    /// # Errors
+    /// [`DataPlaneError`] if the controller rejects the report (an unknown / non-led partition).
+    pub fn on_follower_report_owned(
+        &mut self,
+        partition: u64,
+        report: &AckReplicatedBody,
+    ) -> Result<Vec<(u64, Vec<u8>)>, DataPlaneError> {
         let tokens = self.controller.apply_follower_report(partition, report)?;
-        Ok(self.bytes_for_tokens(&tokens))
+        Ok(self.owned_bytes_for_tokens(&tokens))
     }
 
     /// Re-drive the quorum-ack release for `partition` against the CURRENT ISR state (e.g. after the
     /// leader's own local fsync advanced, or a follower rejoined the ISR) and return any newly-released
-    /// wire `PubAck` byte-frames in offset order. Below `min_isr` releases nothing.
-    fn take_released(&mut self, partition: u64) -> Result<Vec<Vec<u8>>, DataPlaneError> {
+    /// owner-tagged wire `PubAck` byte-frames in offset order. Below `min_isr` releases nothing.
+    fn take_released_owned(
+        &mut self,
+        partition: u64,
+    ) -> Result<Vec<(u64, Vec<u8>)>, DataPlaneError> {
         let tokens = self.controller.release_quorum_acked(partition)?;
-        Ok(self.bytes_for_tokens(&tokens))
+        Ok(self.owned_bytes_for_tokens(&tokens))
     }
 
-    /// Map released gate tokens (in offset order) back to their parked wire-`PubAck` bytes, removing
-    /// them from the side-table. A token with no entry is skipped defensively (it can only happen if a
-    /// token was released twice, which the gate's `released_through` prevents).
-    fn bytes_for_tokens(&mut self, tokens: &[AckToken]) -> Vec<Vec<u8>> {
+    /// Map released gate tokens (in offset order) back to their parked `(owner, wire-PubAck bytes)`,
+    /// removing them from the side-table. A token with no entry is skipped defensively (it can only
+    /// happen if a token was released twice, which the gate's `released_through` prevents).
+    fn owned_bytes_for_tokens(&mut self, tokens: &[AckToken]) -> Vec<(u64, Vec<u8>)> {
         tokens
             .iter()
             .filter_map(|t| self.parked.remove(t))

--- a/crates/ironbus-server/src/cluster/mod.rs
+++ b/crates/ironbus-server/src/cluster/mod.rs
@@ -263,6 +263,7 @@
 //! activates in a multi-node config).
 
 pub mod ack_level;
+pub mod client_ack;
 pub mod dataplane;
 pub mod divergence;
 pub mod eligibility;
@@ -278,6 +279,7 @@ pub mod state_machine;
 pub mod transport;
 
 pub use ack_level::{ClusterAckLevel, ClusterAckLevelMetrics};
+pub use client_ack::ClientAckGate;
 pub use dataplane::{
     decode_dataplane_frame, role_for_placement, AckDisposition, AckToken, DataPlaneAction,
     DataPlaneController, DataPlaneError, DataPlaneFrame, PlacementRole, ProduceAckSeam,

--- a/crates/ironbus-server/src/cluster/serve.rs
+++ b/crates/ironbus-server/src/cluster/serve.rs
@@ -580,12 +580,43 @@ const FETCH_MAX_BYTES: u32 = 1024 * 1024;
 pub struct DataPlaneRuntime<F: Filesystem, C: Clock> {
     /// The shared, `Send` data-plane server every peer thread drives under a short per-frame lock.
     server: Arc<Mutex<DataPlaneServer<F, C>>>,
+    /// The CLIENT produce-ack gate (#719) the leader-side readers release quorum-fsync'd acks through,
+    /// when this runtime was started with one ([`DataPlaneRuntime::start_with_client_gate`]). It wraps
+    /// the SAME `server` Arc, so the one seam is the single source of truth. `None` for a runtime
+    /// started without a client gate (the in-process tests / the observability serve).
+    client_gate: Option<Arc<super::client_ack::ClientAckGate<F, C>>>,
     /// The shutdown flag the runtime OWNS; `stop` sets it and joins every thread.
     shutdown: Arc<AtomicBool>,
     /// The data-plane peer LISTENER thread (leader side: accepts inbound links, spawns readers).
     listener: Option<JoinHandle<()>>,
     /// One FOLLOWER fetch thread per followed partition (dials the leader, fetch + apply + report).
     followers: Vec<JoinHandle<()>>,
+}
+
+/// How a leader-side data-plane reader RELEASES a quorum-fsync'd produce ack from a follower's
+/// [`AckReplicatedBody`](super::isr::AckReplicatedBody) report (#719): either the CLIENT produce-ack
+/// gate (which deposits each released wire `PubAck` into its owner connection's outbox to flush) or, in
+/// the no-client-gate case, the server-only path that drives the gate and drops the bytes (the ISR /
+/// parked state is still advanced — observability / a self-driven test).
+enum AckRelease<F: Filesystem, C: Clock> {
+    /// The clustered client serve (#719): route the report through the shared
+    /// [`ClientAckGate`](super::client_ack::ClientAckGate), depositing each released wire `PubAck` into
+    /// its owner connection's outbox.
+    Gate(Arc<super::client_ack::ClientAckGate<F, C>>),
+    /// No client gate (a runtime started without one): drive the seam directly and drop the released
+    /// bytes (the gate's parked / ISR state is still correctly advanced).
+    ServerOnly,
+}
+
+// Hand-written (a derive would demand `F: Clone` / `C: Clone`): each variant is just an `Arc` clone or
+// a unit, so cloning is cheap and `F`/`C`-free.
+impl<F: Filesystem, C: Clock> Clone for AckRelease<F, C> {
+    fn clone(&self) -> Self {
+        match self {
+            AckRelease::Gate(g) => AckRelease::Gate(Arc::clone(g)),
+            AckRelease::ServerOnly => AckRelease::ServerOnly,
+        }
+    }
 }
 
 impl<F, C> DataPlaneRuntime<F, C>
@@ -614,6 +645,47 @@ where
         self_data_addr: SocketAddr,
         peer_data_addrs: &BTreeMap<u64, SocketAddr>,
     ) -> io::Result<Self> {
+        Self::start_inner(server, self_data_addr, peer_data_addrs, None)
+    }
+
+    /// Like [`Self::start`], but BUILDS a shared CLIENT produce-ack
+    /// [`ClientAckGate`](super::client_ack::ClientAckGate) (#719) at `configured_level` around the SAME
+    /// `Arc<Mutex<DataPlaneServer>>` this runtime drives (so the one seam is the single source of truth),
+    /// and routes the leader-side quorum-ack release THROUGH it: a follower's `AckReplicated` report that
+    /// brings quorum-fsync past a parked offset deposits the released wire `PubAck` into its owner
+    /// connection's outbox, for that connection to flush on its own pass. The built gate is returned by
+    /// [`Self::client_gate`] so the caller can publish it to its per-connection produce paths. Below
+    /// `min_isr` nothing releases (no false ack on the real client wire).
+    ///
+    /// # Errors
+    /// As [`Self::start`].
+    ///
+    /// # Panics
+    /// As [`Self::start`].
+    pub fn start_with_client_gate(
+        server: DataPlaneServer<F, C>,
+        self_data_addr: SocketAddr,
+        peer_data_addrs: &BTreeMap<u64, SocketAddr>,
+        configured_level: super::ack_level::ClusterAckLevel,
+    ) -> io::Result<Self> {
+        Self::start_inner(
+            server,
+            self_data_addr,
+            peer_data_addrs,
+            Some(configured_level),
+        )
+    }
+
+    /// The shared work of [`Self::start`] / [`Self::start_with_client_gate`]: when `client_level` is
+    /// `Some`, a [`ClientAckGate`](super::client_ack::ClientAckGate) is built around the wrapped server
+    /// Arc and the leader-side readers release through it (`AckRelease::Gate`); when `None`, the readers
+    /// drive the seam directly and drop the released bytes (`AckRelease::ServerOnly`).
+    fn start_inner(
+        server: DataPlaneServer<F, C>,
+        self_data_addr: SocketAddr,
+        peer_data_addrs: &BTreeMap<u64, SocketAddr>,
+        client_level: Option<super::ack_level::ClusterAckLevel>,
+    ) -> io::Result<Self> {
         // Bind the data-plane peer listener BEFORE spawning anything, so a bind failure is synchronous
         // (no half-started runtime). Non-blocking so the accept loop polls the shutdown flag.
         let listener = TcpListener::bind(self_data_addr)?;
@@ -622,13 +694,27 @@ where
         let follower_partitions = server.follower_partitions();
         let server = Arc::new(Mutex::new(server));
         let shutdown = Arc::new(AtomicBool::new(false));
+        // Build the client produce-ack gate around the SAME server Arc when a configured level was given
+        // (#719). The gate and every leader-side reader share this one Arc, so the seam's parked state is
+        // one source of truth.
+        let client_gate = client_level.map(|level| {
+            Arc::new(super::client_ack::ClientAckGate::new(
+                Arc::clone(&server),
+                level,
+            ))
+        });
+        let release = match &client_gate {
+            Some(g) => AckRelease::Gate(Arc::clone(g)),
+            None => AckRelease::ServerOnly,
+        };
 
         // The LEADER side: accept inbound peer links and serve fetches / record reports.
         let shutdown_l = Arc::clone(&shutdown);
         let server_l = Arc::clone(&server);
+        let release_l = release.clone();
         let listener_handle = std::thread::Builder::new()
             .name("ib-dataplane-listen".to_string())
-            .spawn(move || run_dataplane_listener(listener, server_l, shutdown_l))
+            .spawn(move || run_dataplane_listener(listener, server_l, release_l, shutdown_l))
             .expect("spawn data-plane listener thread");
 
         // The FOLLOWER side: one fetch loop per followed partition, dialing the leader's data address.
@@ -658,6 +744,7 @@ where
 
         Ok(Self {
             server,
+            client_gate,
             shutdown,
             listener: Some(listener_handle),
             followers,
@@ -669,6 +756,14 @@ where
     #[must_use]
     pub fn server(&self) -> &Arc<Mutex<DataPlaneServer<F, C>>> {
         &self.server
+    }
+
+    /// The CLIENT produce-ack gate (#719) this runtime drives, when it was started with
+    /// [`Self::start_with_client_gate`]; `None` otherwise. The caller publishes it to its per-connection
+    /// produce paths so a clustered `C2-fsync` led produce gets its wire `PubAck` only on quorum-fsync.
+    #[must_use]
+    pub fn client_gate(&self) -> Option<&Arc<super::client_ack::ClientAckGate<F, C>>> {
+        self.client_gate.as_ref()
     }
 
     /// Signal shutdown and join every data-plane thread. Idempotent. Called by the broker's serve teardown
@@ -702,6 +797,7 @@ impl<F: Filesystem, C: Clock> Drop for DataPlaneRuntime<F, C> {
 fn run_dataplane_listener<F, C>(
     listener: TcpListener,
     server: Arc<Mutex<DataPlaneServer<F, C>>>,
+    release: AckRelease<F, C>,
     shutdown: Arc<AtomicBool>,
 ) where
     F: Filesystem + Send + Sync + 'static,
@@ -714,10 +810,13 @@ fn run_dataplane_listener<F, C>(
                 // idle inbound link never wedges a stop.
                 let _ = stream.set_read_timeout(Some(DATAPLANE_POLL));
                 let server = Arc::clone(&server);
+                let release = release.clone();
                 let sd = Arc::clone(&shutdown);
                 let _ = std::thread::Builder::new()
                     .name("ib-dataplane-read".to_string())
-                    .spawn(move || run_dataplane_reader(DataPlaneLink::new(stream), &server, &sd));
+                    .spawn(move || {
+                        run_dataplane_reader(DataPlaneLink::new(stream), &server, &release, &sd);
+                    });
             }
             Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
                 sleep_interruptible(DATAPLANE_POLL, &shutdown);
@@ -730,16 +829,19 @@ fn run_dataplane_listener<F, C>(
 /// A per-connection data-plane reader (the LEADER side of one follower's link): pull bounded,
 /// CRC-revalidated frames off the wire and route each through the shared server, writing any response
 /// back on the SAME link. A `FetchRecords` / `OffsetForLeaderEpoch` is answered with a response frame
-/// served from the off-actor read plane; an `AckReplicated` report drives the quorum-ack gate (the
-/// released wire-`PubAck` bytes are the produce path's to flush — when the seam is threaded — so they
-/// are taken under the lock and dropped here, since this slice does not yet own the parked producer
-/// connections; the gate's parked state is correctly advanced regardless).
+/// served from the off-actor read plane; an `AckReplicated` report drives the quorum-ack gate (#719):
+/// with a [`ClientAckGate`](super::client_ack::ClientAckGate) (`release = Gate`) each released wire
+/// `PubAck` is deposited into its OWNER producer connection's outbox, for that connection to flush on
+/// its own pass; without one (`release = ServerOnly`) the seam is driven and the bytes are dropped (the
+/// ISR / parked state is still advanced). Below `min_isr` nothing releases (no false ack on the real
+/// client wire).
 ///
 /// Every bound in [`DataPlaneLink::recv`] is applied: a hostile / oversized / corrupt frame is a typed
 /// error that drops the link, never a panic or an over-allocation (the fail-closed bounded codec).
 fn run_dataplane_reader<F, C>(
     mut link: DataPlaneLink<TcpStream>,
     server: &Arc<Mutex<DataPlaneServer<F, C>>>,
+    release: &AckRelease<F, C>,
     shutdown: &AtomicBool,
 ) where
     F: Filesystem + Send + Sync + 'static,
@@ -747,6 +849,26 @@ fn run_dataplane_reader<F, C>(
 {
     while !shutdown.load(Ordering::Acquire) {
         match link.recv() {
+            // An `AckReplicated` report drives the quorum-ack gate (#719). Route it through the CLIENT
+            // produce-ack gate when present (it deposits each released wire `PubAck` into its owner
+            // connection's outbox, for that connection to flush on its own pass); without a gate, drive
+            // the seam directly and drop the bytes (the ISR / parked state is still advanced). Handled
+            // OUTSIDE the server lock — the gate takes its own server lock — so no re-entrant lock.
+            Ok(Some((partition, DataPlaneFrame::AckReplicated(report)))) => {
+                match release {
+                    AckRelease::Gate(gate) => {
+                        // Deposits each released reply into its owner connection's outbox; below min_isr
+                        // releases nothing (no false ack on the real client wire).
+                        let _ = gate.on_follower_report(partition, &report);
+                    }
+                    AckRelease::ServerOnly => {
+                        let Ok(mut srv) = server.lock() else {
+                            return; // poisoned: the runtime is tearing down
+                        };
+                        let _ = srv.on_follower_report_bytes(partition, &report);
+                    }
+                }
+            }
             Ok(Some((partition, frame))) => {
                 // Route one frame under a short lock, computing the outbound action, then RELEASE the
                 // lock before writing it to the wire (never hold the server lock across a socket write).
@@ -754,16 +876,7 @@ fn run_dataplane_reader<F, C>(
                     let Ok(mut srv) = server.lock() else {
                         return; // poisoned: the runtime is tearing down
                     };
-                    match frame {
-                        DataPlaneFrame::AckReplicated(report) => {
-                            // Drive the quorum-ack gate. The released wire-`PubAck` bytes belong to the
-                            // produce path (FLAGGED: the per-connection seam thread); advancing the gate
-                            // here keeps the ISR / parked state correct. Drop the bytes for now.
-                            let _ = srv.on_follower_report_bytes(partition, &report);
-                            None
-                        }
-                        other => srv.handle_frame(partition, other).ok(),
-                    }
+                    srv.handle_frame(partition, frame).ok()
                 };
                 match action {
                     Some(DataPlaneAction::SendFetchResponse {

--- a/crates/ironbus-server/src/server.rs
+++ b/crates/ironbus-server/src/server.rs
@@ -209,6 +209,12 @@ where
     if session.produced_l2() {
         let _ = engine.with(move |e| e.drop_l2_confirms(member_id));
     }
+    // Drop any released-but-undrained CLUSTER produce-acks for this connection (#719): a producer that
+    // parked a `C2-fsync` ack, had it quorum-released into its outbox, then disconnected before draining
+    // it leaves nothing to flush, so the gate's outbox entry is cleared rather than leaked. Off-actor (a
+    // gate outbox lock only) and a no-op on a single-node / no-cluster broker (no gate), so the
+    // single-node disconnect path is byte-for-byte unchanged.
+    engine.drop_client_acks(member_id);
     let group = session.subscription().to_string();
     let _ = engine.with(move |e| {
         let _ = e.checkpoint_group(&group);

--- a/crates/ironbus-server/src/session.rs
+++ b/crates/ironbus-server/src/session.rs
@@ -571,6 +571,19 @@ impl Session {
         // the close), but the FIRST error wins: a drain error after a loop error is the same fatal
         // engine event and is subsumed by it.
         let drained = drain_parked(engine, member_id, &mut parked, out);
+        // Drain any CLUSTER produce-acks the data plane RELEASED for this connection onto the wire
+        // (#719): a clustered `C2-fsync` produce's wire `PubAck` was WITHHELD when it parked (in
+        // `drain_parked` above), and the data plane flushes it onto this connection's outbox once the
+        // ISR quorum has fsync'd the offset — on a peer-I/O thread, which may not write this socket. So
+        // the OWNING connection drains and writes them HERE on its own pass (the cross-thread hand-off,
+        // exactly like the L2 confirm drain below). BYTE-IDENTICAL single-node guarantee: the default
+        // `drain_client_acks` (no cluster) returns empty with ZERO work — no lock, no actor round-trip —
+        // so a single-node / no-cluster / pre-bootstrap connection's pass is unchanged. Off the actor
+        // (an outbox lock only), so it never head-of-line-blocks a ping (#177). FIFO/offset order is the
+        // gate's release order, written after this window's own replies and before the L2 confirms.
+        for frame in engine.drain_client_acks(member_id) {
+            out.extend_from_slice(&frame);
+        }
         // Drain any READY Level-2 `ProduceConfirm`s for THIS producer connection onto the wire (#497),
         // so a producer awaiting a confirm receives it on its next pass. A confirm becomes ready when a
         // consumer in the designated group acks the record (or it dead-letters / force-reaps / times
@@ -3438,7 +3451,7 @@ fn drain_parked<F: Filesystem + 'static, C: Clock + Clone + 'static, E: EngineAc
             ProduceOutcome::Appended(offset) if p.wants_confirm => Some(*offset),
             _ => None,
         };
-        write_pub_reply(outcome, p.fire_and_forget, out)?;
+        write_pub_reply_gated(engine, member_id, outcome, p.fire_and_forget, out)?;
         if let Some(offset) = confirm_offset {
             // Register AFTER the `PubAck` was written: the record is durable (the covering fsync ran
             // before the actor reported `Appended`) and its durability ack is already on the wire, so
@@ -3449,6 +3462,72 @@ fn drain_parked<F: Filesystem + 'static, C: Clock + Clone + 'static, E: EngineAc
         }
     }
     Ok(())
+}
+
+/// Like [`write_pub_reply`], but for a FRESH durable `Appended` it routes the wire `PubAck` through the
+/// CLUSTER produce-ack gate (#719) FIRST: on a clustered `C2-fsync` produce to a led partition the gate
+/// PARKS the ack (returns [`AckDisposition::Parked`]) and this WITHHOLDS the frame — the data plane
+/// flushes it onto this connection's outbox once the ISR quorum has fsync'd the offset, and the session
+/// drains it on a later pass ([`EngineAccess::drain_client_acks`]). For every OTHER outcome — and for
+/// `Appended` on a SINGLE-NODE / no-cluster broker (the gate returns `None`), a non-`C2-fsync` level, or
+/// a non-led partition (the gate returns `WriteNow`) — it writes the SAME bytes immediately, BYTE-FOR-
+/// BYTE today's path. A fire-and-forget produce never reaches the gate (its `Appended` is
+/// `FireAndForgetAppended`, a no-frame outcome).
+///
+/// # Single-node byte-identical
+/// On a single-node / no-cluster broker `engine.has_client_ack_gate()` is `false` (a cheap local bool,
+/// zero work), so the `Appended` arm writes the `PubAck` DIRECTLY — same frame, same order, NO temp
+/// allocation, NO lock, byte-for-byte [`write_pub_reply`]. The gate is consulted (and the bytes built
+/// for it) ONLY on a clustered serve past bootstrap.
+fn write_pub_reply_gated<
+    F: Filesystem + 'static,
+    C: Clock + Clone + 'static,
+    E: EngineAccess<F, C>,
+>(
+    engine: &E,
+    member_id: MemberId,
+    outcome: ProduceOutcome,
+    fire_and_forget: bool,
+    out: &mut Vec<u8>,
+) -> Result<(), SessionError> {
+    if let ProduceOutcome::Appended(offset) = outcome {
+        // SINGLE-NODE / no-cluster FAST PATH (zero added cost): with NO cluster gate the produce-ack is
+        // written DIRECTLY into `out`, byte-for-byte today's path — no temp allocation, no lock, no extra
+        // work. `has_client_ack_gate` is a cheap local bool (default `false`), so the non-cluster hot
+        // path never even builds the bytes the gate would need.
+        if !engine.has_client_ack_gate() {
+            reply_pub_ack(out, FrameType::PubAck, offset);
+            return Ok(());
+        }
+        // CLUSTERED path: build the EXACT wire PubAck bytes the immediate-ack path would write, then let
+        // the gate decide whether to write them now or withhold them for quorum-fsync.
+        let mut reply_bytes = Vec::with_capacity(11);
+        reply_pub_ack(&mut reply_bytes, FrameType::PubAck, offset);
+        match engine.client_ack_disposition(member_id, offset.get(), reply_bytes) {
+            // The gate vanished between the bool check and here (a teardown race), or handed the bytes
+            // back (non-C2-fsync level, or a partition this node does not lead): write them now,
+            // byte-identical.
+            None => {
+                reply_pub_ack(out, FrameType::PubAck, offset);
+            }
+            Some(crate::cluster::dataplane::AckDisposition::WriteNow(bytes)) => {
+                out.extend_from_slice(&bytes);
+            }
+            // A just-parked C2-fsync ack whose quorum was ALREADY met (a fast follower reported first):
+            // write the released real replies now, in offset order.
+            Some(crate::cluster::dataplane::AckDisposition::WriteNowBatch(frames)) => {
+                for f in frames {
+                    out.extend_from_slice(&f);
+                }
+            }
+            // Clustered C2-fsync to a led partition, below/at quorum: WITHHOLD the wire PubAck. The data
+            // plane releases it onto this connection's outbox on quorum-fsync; the session drains it on a
+            // later pass. No false ack below min_isr (the gate releases nothing).
+            Some(crate::cluster::dataplane::AckDisposition::Parked) => {}
+        }
+        return Ok(());
+    }
+    write_pub_reply(outcome, fire_and_forget, out)
 }
 
 /// Maps one produce outcome to its wire reply, byte-identical to the pre-pipelining inline match:


### PR DESCRIPTION
Closes #719 (V2-C2, the last clustering produce-durability gap, **default partition / single-log engine**). A real external client's clustered **C2-fsync** produce to a led partition now gets its wire `PubAck` only **after quorum-fsync**, not the immediate local-fsync ack.

## How the (Send) ProduceAckSeam is made reachable from the per-connection produce-ack path

After #718 the data plane RAN the seam end-to-end on its own peer-I/O thread, but a real client's wire `PubAck` was still the immediate local-fsync ack: sessions reach the engine only via the per-call `EngineAccess` trait (no shared mutable seam state), and a released ack arrives on the runtime's thread while only the owning connection's own thread may write its socket.

A new `Send + Sync` **`ClientAckGate`** (`cluster/client_ack.rs`) closes this, mirroring the #497 Level-2 `ProduceConfirm` registry:
- it wraps the **same** `Arc<Mutex<DataPlaneServer>>` the `DataPlaneRuntime` drives (one seam, one source of truth for the parked state) plus a **per-connection outbox** of released-but-not-yet-flushed wire `PubAck` bytes, keyed by the producer's `MemberId`;
- it is shared into every connection via a **set-once slot on `EngineHandle`** (installed before any per-connection clone; filled by the data-plane bootstrap once the placement commits) and into the runtime (whose follower-report path routes each release into the owning connection's outbox);
- the seam (`dataplane.rs`) gained owner-tagged `on_local_fsynced_ack_owned` / `on_follower_report_owned` so a release routes back to the right producer connection (the existing un-owned API is unchanged, owner `0`).

## The produce-ack gating (default partition)

After the local group-commit fsync returns `Appended(offset)`, for a clustered **C2-fsync** produce to a partition this node **leads**, the gate parks the **real** wire `PubAck` and the session **withholds** it (`AckDisposition::Parked`). The `DataPlaneRuntime` releases it into the connection's outbox when follower reports bring **quorum-fsync**, and the owning connection flushes it on its own next pass (the cross-thread hand-off). **Below `min_isr` nothing releases — no false ack on the real client wire.** The leader's own fsync frontier is advanced past the just-appended offset on park (the leader is one of the `min_isr` quorum members). Everything else (no cluster, C0/C1/C2-pagecache, not the leader) acks **immediately** exactly as today.

## SINGLE-NODE byte-identical (scrutinize hardest)

By construction: the gate is **never constructed** off-cluster, `EngineHandle` carries **no slot**, and `has_client_ack_gate()` (a cheap local bool, default `false`) short-circuits the produce-ack path to write the immediate ack **directly** — no lock, no allocation, no extra work, byte-for-byte today's reply. Verified by construction **and** test. The **single-writer** append actor is untouched: the seam only withholds/releases the **reply**, never writes the log.

## Tests

- `cluster::client_ack` unit tests: a C2-fsync led produce parks then releases to its owner outbox on quorum; below `min_isr` it stays withheld (no false ack); non-C2-fsync levels and a non-led partition ack immediately; a disconnect drops the undrained outbox.
- **A REAL client connection over the loopback broker** (`ironbus-client`): a C2-fsync produce's wire `PubAck` is **withheld before quorum** (asserted across several broker passes) and **delivered only after** the follower-report quorum-fsync, carrying the real produced offset — the client observes quorum-durable ack timing, never leader-only-fsync.

## Scope / flagged

- **Multi-partition routing** (a client produce to the right partition leader's seam) needs the multi-partition engine = **#693** — FLAGGED, out of scope. This PR closes the single-stream-cluster produce-durability case (the common case).
- Rebalance / failover / follower-reads = later.
- The leader-fsync observation cadence beyond the per-park advance, and an idle-producer wake (a parked client must drive a pass — a Ping — to flush its released ack, exactly like the #497 confirm drain) are noted as follow-ups.

## Gates

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — clean
- `cargo test --workspace --all-features --locked` — green except the known `ironbus-storage` `preallocate_reserves_real_blocks_on_a_supporting_fs` APFS local flake
- io-free-check (ironbus-core) — pass; MSRV 1.78 preserved
- Windows: all new cluster/serve code is cross-platform (no `std::os::unix`); the new client integration test + helpers are `#[cfg(unix)]`-gated; the cli serve wiring is inside the existing `#[cfg(unix)]` region

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVWp2H2txnKGru4q2twxM3
