### PR TITLE
feat(cluster): automatic leaderless failover — detect a dead leader and auto-promote an ISR successor (#618)

### DIFF
--- a/crates/ironbus-cli/src/main.rs
+++ b/crates/ironbus-cli/src/main.rs
@@ -4698,9 +4698,10 @@ fn spawn_dataplane_serve(
 // a thread entry point: each input is a distinct piece the
 // bootstrap needs for the whole thread lifetime; a bundling
 // struct would only move the noise.
-#[allow(clippy::needless_pass_by_value)] // a thread entry point: it OWNS the read-plane Arc (cloned
-                                         // into the leader role) + the log config for its lifetime;
-                                         // a borrow would fight the 'static spawn bound.
+#[allow(clippy::needless_pass_by_value)]
+// a thread entry point: it OWNS the read-plane Arc (cloned
+// into the leader role) + the log config for its lifetime;
+// a borrow would fight the 'static spawn bound.
 #[allow(clippy::too_many_lines)] // one linear bootstrap sequence (await placement, build the server,
                                  // start the runtime, install the F2 cross-plane inputs, hold until
                                  // shutdown); splitting it would scatter a single startup concern.

--- a/crates/ironbus-cli/src/main.rs
+++ b/crates/ironbus-cli/src/main.rs
@@ -4826,22 +4826,26 @@ fn run_dataplane_bootstrap(
         let _ = client_ack_slot.set(std::sync::Arc::clone(gate));
     }
 
-    // INSTALL the cross-plane F2 auto-failover inputs (#618): now that the data plane is live, the
-    // metadata-Raft leader can auto-promote an ISR successor on a leader crash. The survivor-state
-    // provider surfaces the LIVE ISR: for THIS node it reports its real data-plane frontier (its
-    // follower high-watermark, or the served frontier if it leads), for a remote survivor it reports
-    // a node complete to the committed HW IFF that survivor was a committed replica — sound because the
-    // committed HW is the quorum-fsync'd frontier every ISR member holds by definition.
+    // INSTALL the cross-plane F2 auto-failover inputs (#618 / #618b): now that the data plane is live,
+    // these surface THIS node's real data-plane frontiers to the metadata driver. They serve two roles:
     //
-    // FLAGGED (the honest cross-plane gap): a remote survivor that had LAGGED OUT of the ISR before the
-    // crash is not distinguished here without ISR gossip across the data plane; the conservative default
-    // treats a committed replica as in-ISR. THIS node's own out-of-ISR state IS detected (its real
-    // frontier is read). Full ISR gossip so any node can vet any survivor is the multi-partition / ISR-
-    // gossip follow-on (#693). For the single-partition target the surviving committed replicas that
-    // caught up ARE the ISR, so the default is correct for the shipped scope.
+    //   1. when this node LEADS the partition's data plane + the metadata group, the driver periodically
+    //      CHECKPOINTS `committed_hw` into the metadata Raft (so the committed bar SURVIVES the leader's
+    //      death — the persisted SAFE bar a successor must hold); and
+    //   2. on a leader death, the driver's provably-complete-or-fail-closed rule compares `own_frontier`
+    //      (THIS node's real durable frontier) against that persisted bar to decide whether THIS node may
+    //      safely SELF-promote — it never blind-promotes a remote node whose frontier it cannot see.
+    //
+    // CRITICAL (#618b safety): we report ONLY frontiers this node actually KNOWS — its OWN. We do NOT
+    // claim a remote committed replica is "complete" (the previous optimistic default did, which could
+    // promote a LAGGING survivor and silently lose committed data). A remote node's true frontier is
+    // unknown without cross-data-plane ISR gossip (#693), so `survivors` reports completeness ONLY for
+    // THIS node; the driver consequently self-promotes only this node and otherwise fails closed. The
+    // shipped guarantee: auto-failover never loses committed data; it self-heals whenever the surviving
+    // metadata leader is itself a complete replica, and fails closed (leaderless, recoverable) otherwise.
     {
         // This node's live committed frontier for a partition (its follower HW, or its leader
-        // quorum-commit) — the quorum-fsync'd prefix the ISR holds by definition.
+        // quorum-commit) — the quorum-fsync'd prefix it durably holds.
         let own_frontier_for = {
             let server = std::sync::Arc::clone(dp_runtime.server());
             move |partition: u64| -> u64 {
@@ -4857,35 +4861,44 @@ fn run_dataplane_bootstrap(
                     .unwrap_or(0)
             }
         };
-        let committed_replicas: std::collections::BTreeSet<u64> =
-            replicas.iter().copied().collect();
         let own_frontier_s = own_frontier_for.clone();
+        let own_frontier_s2 = own_frontier_for.clone();
+        // The survivor-state projection reports completeness ONLY for THIS node (its REAL frontier). A
+        // remote node's frontier is UNKNOWN here, so it is reported as out-of-ISR (never a blind-promotion
+        // candidate) — the conservative, committed-safe default. Full ISR gossip that lets any node vet a
+        // remote survivor's completeness is the follow-on (#693).
         let survivors: std::sync::Arc<ironbus_server::cluster::SurvivorStateFn> =
             std::sync::Arc::new(move |partition: u64, survivor_ids: &[u64]| {
                 let own_hw = own_frontier_s(partition);
                 survivor_ids
                     .iter()
-                    .filter_map(|&n| {
+                    .map(|&n| {
                         if n == node_id {
-                            // THIS node: report its REAL durable frontier (out-of-ISR if it lags).
-                            Some(ironbus_core::placement::PlacementNode::healthy(n, own_hw))
-                        } else if committed_replicas.contains(&n) {
-                            // A remote committed replica: report it complete to THIS node's committed HW
-                            // (the quorum-fsync'd prefix the ISR holds). Eligible iff it was a committed
-                            // replica — the conservative single-partition default (FLAGGED above).
-                            Some(ironbus_core::placement::PlacementNode::healthy(n, own_hw))
+                            // THIS node: report its REAL durable frontier (in-ISR + complete iff it holds
+                            // the committed prefix; out-of-ISR if it lags).
+                            ironbus_core::placement::PlacementNode::healthy(n, own_hw)
                         } else {
-                            None // not a committed replica — never a candidate.
+                            // A REMOTE survivor: its true frontier is unknown without ISR gossip. Report
+                            // it OUT-OF-ISR so it is never blind-promoted (committed-safe default, #618b).
+                            let mut node = ironbus_core::placement::PlacementNode::healthy(n, 0);
+                            node.in_isr = false;
+                            node
                         }
                     })
                     .collect()
             });
-        // The committed HW the successor must be complete to: this node's own committed frontier.
+        // The committed HW this node observes (its own committed frontier): what it CHECKPOINTS when it
+        // leads, and the bar a successor must clear.
         let committed_hw: std::sync::Arc<ironbus_server::cluster::CommittedHwFn> =
             std::sync::Arc::new(move |partition: u64| own_frontier_for(partition));
+        // THIS node's own real durable frontier — what the provably-complete rule compares to the
+        // persisted committed-HW checkpoint to decide a safe self-promotion.
+        let own_frontier: std::sync::Arc<ironbus_server::cluster::OwnFrontierFn> =
+            std::sync::Arc::new(move |partition: u64| own_frontier_s2(partition));
         failover_installer.install(ironbus_server::cluster::FailoverInputs {
             survivors,
             committed_hw,
+            own_frontier,
         });
     }
 

--- a/crates/ironbus-cli/src/main.rs
+++ b/crates/ironbus-cli/src/main.rs
@@ -4698,10 +4698,9 @@ fn spawn_dataplane_serve(
 // a thread entry point: each input is a distinct piece the
 // bootstrap needs for the whole thread lifetime; a bundling
 // struct would only move the noise.
-#[allow(clippy::needless_pass_by_value)]
-// a thread entry point: it OWNS the read-plane Arc (cloned
-// into the leader role) + the log config for its lifetime;
-// a borrow would fight the 'static spawn bound.
+#[allow(clippy::needless_pass_by_value)] // a thread entry point: it OWNS the read-plane Arc (cloned
+                                         // into the leader role) + the log config for its lifetime;
+                                         // a borrow would fight the 'static spawn bound.
 #[allow(clippy::too_many_lines)] // one linear bootstrap sequence (await placement, build the server,
                                  // start the runtime, install the F2 cross-plane inputs, hold until
                                  // shutdown); splitting it would scatter a single startup concern.

--- a/crates/ironbus-cli/src/main.rs
+++ b/crates/ironbus-cli/src/main.rs
@@ -4621,6 +4621,10 @@ fn spawn_dataplane_serve(
     let peers = runtime.peers();
     let status = runtime.status_handle();
     let proposer = runtime.metadata_proposer();
+    // The cross-plane F2 auto-failover installer (#618): the bootstrap installs the LIVE ISR
+    // survivor-state + committed-HW providers once the data plane is up, so the metadata-Raft leader can
+    // auto-promote an ISR successor when a leader crashes. Until installed, auto-failover is fail-closed.
+    let failover_installer = runtime.failover_installer();
     let log_config = LogConfig::new(config.max_segment_bytes)
         .map_err(|e| CliError::Internal(format!("replica log config: {e}")))?
         .with_max_total_bytes(config.max_total_bytes);
@@ -4670,6 +4674,7 @@ fn spawn_dataplane_serve(
                 &peers,
                 &status,
                 &proposer,
+                &failover_installer,
                 &data_dir,
                 log_config,
                 &client_ack_slot_t,
@@ -4696,6 +4701,9 @@ fn spawn_dataplane_serve(
 #[allow(clippy::needless_pass_by_value)] // a thread entry point: it OWNS the read-plane Arc (cloned
                                          // into the leader role) + the log config for its lifetime;
                                          // a borrow would fight the 'static spawn bound.
+#[allow(clippy::too_many_lines)] // one linear bootstrap sequence (await placement, build the server,
+                                 // start the runtime, install the F2 cross-plane inputs, hold until
+                                 // shutdown); splitting it would scatter a single startup concern.
 fn run_dataplane_bootstrap(
     node_id: u64,
     replicas: &[u64],
@@ -4705,6 +4713,7 @@ fn run_dataplane_bootstrap(
     peers: &std::collections::BTreeMap<u64, std::net::SocketAddr>,
     status: &std::sync::Arc<std::sync::Mutex<ironbus_server::cluster::ClusterStatus>>,
     proposer: &MetadataProposer,
+    failover_installer: &ironbus_server::cluster::FailoverInstaller,
     data_dir: &Path,
     log_config: LogConfig,
     client_ack_slot: &ClientAckSlot,
@@ -4815,6 +4824,69 @@ fn run_dataplane_bootstrap(
     if let Some(gate) = dp_runtime.client_gate() {
         // Set-once: this is the only filler of the slot, on this one bootstrap thread.
         let _ = client_ack_slot.set(std::sync::Arc::clone(gate));
+    }
+
+    // INSTALL the cross-plane F2 auto-failover inputs (#618): now that the data plane is live, the
+    // metadata-Raft leader can auto-promote an ISR successor on a leader crash. The survivor-state
+    // provider surfaces the LIVE ISR: for THIS node it reports its real data-plane frontier (its
+    // follower high-watermark, or the served frontier if it leads), for a remote survivor it reports
+    // a node complete to the committed HW IFF that survivor was a committed replica — sound because the
+    // committed HW is the quorum-fsync'd frontier every ISR member holds by definition.
+    //
+    // FLAGGED (the honest cross-plane gap): a remote survivor that had LAGGED OUT of the ISR before the
+    // crash is not distinguished here without ISR gossip across the data plane; the conservative default
+    // treats a committed replica as in-ISR. THIS node's own out-of-ISR state IS detected (its real
+    // frontier is read). Full ISR gossip so any node can vet any survivor is the multi-partition / ISR-
+    // gossip follow-on (#693). For the single-partition target the surviving committed replicas that
+    // caught up ARE the ISR, so the default is correct for the shipped scope.
+    {
+        // This node's live committed frontier for a partition (its follower HW, or its leader
+        // quorum-commit) — the quorum-fsync'd prefix the ISR holds by definition.
+        let own_frontier_for = {
+            let server = std::sync::Arc::clone(dp_runtime.server());
+            move |partition: u64| -> u64 {
+                server
+                    .lock()
+                    .ok()
+                    .and_then(|s| {
+                        s.seam()
+                            .controller()
+                            .follower_high_watermark(partition)
+                            .or_else(|| s.seam().controller().quorum_commit(partition))
+                    })
+                    .unwrap_or(0)
+            }
+        };
+        let committed_replicas: std::collections::BTreeSet<u64> =
+            replicas.iter().copied().collect();
+        let own_frontier_s = own_frontier_for.clone();
+        let survivors: std::sync::Arc<ironbus_server::cluster::SurvivorStateFn> =
+            std::sync::Arc::new(move |partition: u64, survivor_ids: &[u64]| {
+                let own_hw = own_frontier_s(partition);
+                survivor_ids
+                    .iter()
+                    .filter_map(|&n| {
+                        if n == node_id {
+                            // THIS node: report its REAL durable frontier (out-of-ISR if it lags).
+                            Some(ironbus_core::placement::PlacementNode::healthy(n, own_hw))
+                        } else if committed_replicas.contains(&n) {
+                            // A remote committed replica: report it complete to THIS node's committed HW
+                            // (the quorum-fsync'd prefix the ISR holds). Eligible iff it was a committed
+                            // replica — the conservative single-partition default (FLAGGED above).
+                            Some(ironbus_core::placement::PlacementNode::healthy(n, own_hw))
+                        } else {
+                            None // not a committed replica — never a candidate.
+                        }
+                    })
+                    .collect()
+            });
+        // The committed HW the successor must be complete to: this node's own committed frontier.
+        let committed_hw: std::sync::Arc<ironbus_server::cluster::CommittedHwFn> =
+            std::sync::Arc::new(move |partition: u64| own_frontier_for(partition));
+        failover_installer.install(ironbus_server::cluster::FailoverInputs {
+            survivors,
+            committed_hw,
+        });
     }
 
     eprintln!(

--- a/crates/ironbus-server/src/cluster/dataplane.rs
+++ b/crates/ironbus-server/src/cluster/dataplane.rs
@@ -152,6 +152,19 @@ pub enum DataPlaneError {
     /// An underlying replication / codec / storage fault (a corrupt fetch response, a malformed
     /// report, a truncation failure). The replication layer's typed error, surfaced verbatim.
     Replication(ReplicationError),
+    /// The apply-time committed-completeness self-verify FAILED (#618b): a failover named THIS node the
+    /// new leader, but its own durable log does NOT cover the committed-HW bar carried with the
+    /// promotion — promoting it would lose committed data. The promotion is ABORTED fail-closed (no false
+    /// leader is created; the partition stays leaderless / recoverable). This is the defense-in-depth net
+    /// that makes committed-data loss impossible even from an optimistic / buggy proposal.
+    FailoverIncomplete {
+        /// The partition whose failover was aborted.
+        partition: u64,
+        /// THIS node's durable frontier (the first offset it has NOT durably appended).
+        durable_frontier: u64,
+        /// The committed-HW bar the successor had to hold (and did not).
+        committed_hw: u64,
+    },
 }
 
 impl core::fmt::Display for DataPlaneError {
@@ -168,6 +181,16 @@ impl core::fmt::Display for DataPlaneError {
                 "partition {partition} operation needs the {needed} role on this node"
             ),
             DataPlaneError::Replication(e) => write!(f, "replication fault: {e}"),
+            DataPlaneError::FailoverIncomplete {
+                partition,
+                durable_frontier,
+                committed_hw,
+            } => write!(
+                f,
+                "partition {partition} failover aborted (fail-closed): this node's durable frontier \
+                 {durable_frontier} is behind the committed-HW bar {committed_hw}; it is missing \
+                 committed data and must not become leader"
+            ),
         }
     }
 }
@@ -807,10 +830,22 @@ impl<F: Filesystem + Clone, C: Clock> DataPlaneController<F, C> {
     /// this via [`reassign_leadership`](super::placement::reassign_leadership)); the epoch-cache `assign`
     /// enforces strict monotonicity and fails closed if it does not.
     ///
+    /// ## Apply-time committed-completeness self-verify (defense in depth, #618b)
+    ///
+    /// `committed_hw_bar` is the SAFE bar carried with the failover (the persisted committed-HW
+    /// checkpoint the metadata plane proved this node holds before proposing the promotion). Even though
+    /// the proposer already gated on it, this method RE-CHECKS it against THIS node's OWN durable log
+    /// before it becomes leader: if its durable frontier does NOT cover the bar it ABORTS the promotion
+    /// (fail-closed — the partition stays leaderless; no false leader is created), so even an
+    /// optimistic / buggy / hand-built proposal can never make a leader that is missing committed data.
+    /// Pass `0` to skip the check (the n=1 / no-bar degenerate, where there is no committed data to lose).
+    ///
     /// # Errors
     /// - [`DataPlaneError::WrongRole`] if this node is already the leader (idempotent re-promotion is a
     ///   no-op caller-side; a double-promote is a logic error surfaced here);
     /// - [`DataPlaneError::UnknownPartition`] if this node holds no role for `partition`;
+    /// - [`DataPlaneError::FailoverIncomplete`] if this node's durable log does not cover
+    ///   `committed_hw_bar` (the apply-time self-verify fails closed — no false leader is created);
     /// - [`DataPlaneError::Replication`] if the read plane cannot be built or the epoch boundary cannot
     ///   be assigned (a backward epoch — fail-closed).
     pub fn promote_follower_to_leader(
@@ -819,6 +854,7 @@ impl<F: Filesystem + Clone, C: Clock> DataPlaneController<F, C> {
         new_epoch: LeaderEpoch,
         replica_ids: &[u64],
         isr_config: IsrConfig,
+        committed_hw_bar: u64,
     ) -> Result<(), DataPlaneError> {
         // Take the role out so we can consume the follower (or restore it on a wrong-role error).
         let role = self
@@ -836,6 +872,24 @@ impl<F: Filesystem + Clone, C: Clock> DataPlaneController<F, C> {
                 });
             }
         };
+        // APPLY-TIME COMMITTED-COMPLETENESS SELF-VERIFY (defense in depth, #618b). Before this node takes
+        // leadership, re-check that its OWN durable log covers the committed-HW bar carried with the
+        // failover. `next_offset()` is its durable frontier (the first offset it has NOT durably
+        // appended); it must be >= the bar (so every offset below the bar is durably held here). If not,
+        // ABORT — restore the follower role and fail closed, so no leader missing committed data is ever
+        // created (the partition stays leaderless / recoverable). This catches an optimistic or buggy
+        // proposal that the proposer-side gate somehow let through.
+        let durable_frontier = follower.follower().log().next_offset().get();
+        if durable_frontier < committed_hw_bar {
+            // Put the follower role back UNCHANGED — we did not consume it; this node keeps following.
+            self.roles
+                .insert(partition, PartitionRole::Follower { follower });
+            return Err(DataPlaneError::FailoverIncomplete {
+                partition,
+                durable_frontier,
+                committed_hw: committed_hw_bar,
+            });
+        }
         // Split the follower into its owned log + its learned epoch history. The log is the committed
         // data this node ALREADY holds — promotion serves it as-is (no fetch, no copy).
         let (follower, mut epochs) = follower.into_parts();
@@ -1732,6 +1786,86 @@ mod tests {
         assert_eq!(
             req.from_offset, 0,
             "the follower resumes from its recovered head"
+        );
+    }
+
+    // ---- #618b apply-time committed-completeness self-verify (defense in depth) -------------------
+
+    #[test]
+    fn promote_aborts_fail_closed_when_the_node_is_behind_the_committed_hw_bar() {
+        // Build a follower caught up to a known durable frontier, then attempt to promote it with a
+        // committed-HW bar ABOVE that frontier (modeling an optimistic/buggy proposal that names an
+        // incomplete node leader). The apply-time self-verify MUST abort fail-closed: it returns
+        // FailoverIncomplete, the node STAYS a follower (no false leader is created), and no committed
+        // data is exposed under a leader missing it.
+        const P: u64 = 0;
+        let mut leader_log = open_log(InMemoryFs::new(), small_config());
+        for i in 0..12u32 {
+            leader_log
+                .append(&rec(format!("rec-{i:02}").as_bytes()))
+                .unwrap();
+        }
+        leader_log.sync().unwrap();
+        let plane = leader_plane(&leader_log);
+        let served_end = plane_served_end(&plane);
+        assert!(
+            served_end > 0,
+            "the leader serves a non-empty sealed prefix"
+        );
+
+        let mut leader = DataPlaneController::<InMemoryFs, ManualClock>::new(1);
+        leader.start_leader(P, Arc::clone(&plane), EpochCache::new(), &[1, 2], quorum3());
+
+        let mut follower = DataPlaneController::new(2);
+        follower.start_follower(P, open_log(InMemoryFs::new(), small_config()));
+        // Catch the follower up to the served prefix.
+        for _ in 0..24 {
+            if follower.follower_high_watermark(P).unwrap() >= served_end {
+                break;
+            }
+            let req = follower.make_fetch_request(P, 8, 4096).unwrap();
+            let resp = leader.serve_fetch(P, &req).unwrap();
+            follower.apply_fetch_response(P, &resp).unwrap();
+        }
+        let durable = follower
+            .follower_log(P)
+            .expect("follower log")
+            .next_offset()
+            .get();
+        assert!(durable > 0, "the follower durably holds some records");
+
+        // A bar ABOVE the follower's durable frontier => the self-verify aborts fail-closed.
+        let bar_above = durable + 1;
+        let err = follower
+            .promote_follower_to_leader(P, LeaderEpoch::new(6), &[2], quorum3(), bar_above)
+            .expect_err("promotion with a bar above the durable frontier must fail closed");
+        match err {
+            DataPlaneError::FailoverIncomplete {
+                partition,
+                durable_frontier,
+                committed_hw,
+            } => {
+                assert_eq!(partition, P);
+                assert_eq!(durable_frontier, durable);
+                assert_eq!(committed_hw, bar_above);
+            }
+            other => panic!("expected FailoverIncomplete, got {other:?}"),
+        }
+        // CRITICAL: the node is STILL a follower (no false leader was created) and is NOT a leader.
+        assert!(
+            follower.is_follower(P),
+            "the aborted promotion left the node a follower (no false leader)"
+        );
+        assert!(!follower.is_leader(P), "the node did not become leader");
+
+        // A bar AT the follower's durable frontier (it really holds the committed prefix) => the
+        // promotion SUCCEEDS — the safe path is not over-zealous.
+        follower
+            .promote_follower_to_leader(P, LeaderEpoch::new(6), &[2], quorum3(), durable)
+            .expect("promotion with a bar the node holds succeeds");
+        assert!(
+            follower.is_leader(P),
+            "a complete node (durable frontier >= bar) is promoted to leader"
         );
     }
 

--- a/crates/ironbus-server/src/cluster/mod.rs
+++ b/crates/ironbus-server/src/cluster/mod.rs
@@ -309,7 +309,7 @@ pub use replication::{
 pub use runtime::{
     dataplane_addr, partitions_led_by, plan_failovers, ClusterConfig, ClusterRuntime,
     ClusterStatus, CommittedHwFn, FailoverInputs, FailoverInstaller, LivenessConfig,
-    MetadataProposer, RuntimeError, SurvivorStateFn, DATAPLANE_PORT_OFFSET,
+    MetadataProposer, OwnFrontierFn, RuntimeError, SurvivorStateFn, DATAPLANE_PORT_OFFSET,
     DEFAULT_LIVENESS_TIMEOUT,
 };
 pub use serve::{

--- a/crates/ironbus-server/src/cluster/mod.rs
+++ b/crates/ironbus-server/src/cluster/mod.rs
@@ -329,12 +329,14 @@ pub use transport::{
 /// clusters). Both modules acquire [`heavy_cluster_test_guard`] for the duration of such a test, so the
 /// clusters form on an un-contended host and the timing waits stay truthful and flake-free. Test-only;
 /// it is NOT a dependency (no `serial_test`) — a plain `static Mutex`.
-#[cfg(test)]
+#[cfg(all(test, unix))]
 pub(crate) static HEAVY_CLUSTER_TEST_SERIAL: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 /// Acquire the shared heavy-cluster-test serial guard, recovering a poisoned lock (only mutual
-/// exclusion is needed, not the protected unit value).
-#[cfg(test)]
+/// exclusion is needed, not the protected unit value). Gated `all(test, unix)` to match its callers —
+/// the heavy multi-node cluster tests are unix-only (the broker/serve path is `cfg(unix)` via StdFs),
+/// so on Windows the guard and its callers vanish together (no `dead_code` under `-D warnings`).
+#[cfg(all(test, unix))]
 pub(crate) fn heavy_cluster_test_guard() -> std::sync::MutexGuard<'static, ()> {
     HEAVY_CLUSTER_TEST_SERIAL
         .lock()

--- a/crates/ironbus-server/src/cluster/mod.rs
+++ b/crates/ironbus-server/src/cluster/mod.rs
@@ -334,7 +334,7 @@ pub(crate) static HEAVY_CLUSTER_TEST_SERIAL: std::sync::Mutex<()> = std::sync::M
 
 /// Acquire the shared heavy-cluster-test serial guard, recovering a poisoned lock (only mutual
 /// exclusion is needed, not the protected unit value). Gated `all(test, unix)` to match its callers —
-/// the heavy multi-node cluster tests are unix-only (the broker/serve path is `cfg(unix)` via StdFs),
+/// the heavy multi-node cluster tests are unix-only (the broker/serve path is `cfg(unix)` via `StdFs`),
 /// so on Windows the guard and its callers vanish together (no `dead_code` under `-D warnings`).
 #[cfg(all(test, unix))]
 pub(crate) fn heavy_cluster_test_guard() -> std::sync::MutexGuard<'static, ()> {

--- a/crates/ironbus-server/src/cluster/mod.rs
+++ b/crates/ironbus-server/src/cluster/mod.rs
@@ -308,7 +308,9 @@ pub use replication::{
 };
 pub use runtime::{
     dataplane_addr, partitions_led_by, plan_failovers, ClusterConfig, ClusterRuntime,
-    ClusterStatus, MetadataProposer, RuntimeError, DATAPLANE_PORT_OFFSET,
+    ClusterStatus, CommittedHwFn, FailoverInputs, FailoverInstaller, LivenessConfig,
+    MetadataProposer, RuntimeError, SurvivorStateFn, DATAPLANE_PORT_OFFSET,
+    DEFAULT_LIVENESS_TIMEOUT,
 };
 pub use serve::{
     decode_dataplane_peer_frame, encode_dataplane_peer_frame, DataPlaneLink, DataPlaneRuntime,
@@ -319,3 +321,22 @@ pub use transport::{
     decode_peer_frame, decode_raft_message, encode_raft_message, PeerLink, PeerRegistry,
     PeerWireError, MAX_RAFT_MSG_BYTES, RAFT_DECODE_RECURSION_LIMIT,
 };
+
+/// A process-wide SERIAL guard shared by the HEAVY multi-node cluster tests across the `runtime` and
+/// `serve` test modules (each spins several raft / data-plane driver threads + listeners; running many
+/// at once on a shared CI runner thrashes the scheduler so a starved driver cannot accumulate its
+/// election ticks even inside the host-scaled bound — the #687 starvation, amplified by N concurrent
+/// clusters). Both modules acquire [`heavy_cluster_test_guard`] for the duration of such a test, so the
+/// clusters form on an un-contended host and the timing waits stay truthful and flake-free. Test-only;
+/// it is NOT a dependency (no `serial_test`) — a plain `static Mutex`.
+#[cfg(test)]
+pub(crate) static HEAVY_CLUSTER_TEST_SERIAL: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Acquire the shared heavy-cluster-test serial guard, recovering a poisoned lock (only mutual
+/// exclusion is needed, not the protected unit value).
+#[cfg(test)]
+pub(crate) fn heavy_cluster_test_guard() -> std::sync::MutexGuard<'static, ()> {
+    HEAVY_CLUSTER_TEST_SERIAL
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}

--- a/crates/ironbus-server/src/cluster/runtime.rs
+++ b/crates/ironbus-server/src/cluster/runtime.rs
@@ -929,10 +929,9 @@ struct DriverFailover<C: Clock + Clone> {
 /// metadata-Raft leader, both go through the metadata Raft log (committed, ordered), and both are
 /// idempotent (a removal of an already-gone node and a promotion of an already-converged placement are
 /// skipped) — so no two nodes can drive a different failover; the Raft log linearizes it.
-#[allow(clippy::too_many_lines)]
-// the driver loop is ONE linear consensus cycle (tick, step+record,
-// drive_ready, registry refresh, F1 detect, F2 auto-fire, publish);
-// splitting it would scatter a single tightly-ordered concern.
+#[allow(clippy::too_many_lines)] // the driver loop is ONE linear consensus cycle (tick, step+record,
+                                 // drive_ready, registry refresh, F1 detect, F2 auto-fire, publish);
+                                 // splitting it would scatter a single tightly-ordered concern.
 #[allow(clippy::needless_pass_by_value)] // a thread entry point: it OWNS the group + the shared
                                          // channels/Arcs + the failover wiring for the thread's whole
                                          // lifetime; a borrow would fight the 'static spawn bound.

--- a/crates/ironbus-server/src/cluster/runtime.rs
+++ b/crates/ironbus-server/src/cluster/runtime.rs
@@ -2500,8 +2500,16 @@ mod tests {
     /// nobody, and promotes nobody — the placement is untouched, the leader unchanged.
     #[test]
     fn a_healthy_cluster_never_auto_fails_over() {
+        // Host-scale the liveness deadline: on a contended CI runner the driver threads heartbeat more
+        // slowly, so the deadline must scale by the SAME factor that slows the heartbeats to preserve the
+        // deadline >> heartbeat ratio — otherwise a healthy-but-starved node would be falsely suspected
+        // during/after bring-up (a CI scheduler artifact, not a product fault). The ratio — and thus the
+        // no-false-failover property under test — is unchanged; only the absolute timing tracks the host.
         let (_serial, mut nodes, ids, _dirs, leader_idx) =
-            bring_up_placed_cluster(LivenessConfig::default());
+            bring_up_placed_cluster(LivenessConfig {
+                timeout: host_scaled(DEFAULT_LIVENESS_TIMEOUT),
+                enabled: true,
+            });
         let leader_id = ids[leader_idx];
         let placement0 = nodes[leader_idx]
             .status()
@@ -2510,10 +2518,11 @@ mod tests {
             .expect("placement")
             .clone();
 
-        // Let the cluster run for a window MANY heartbeat intervals long (the heartbeat is ~300 ms; we
-        // observe for ~3 s). The default deadline (3 s) is 10x the heartbeat, so a healthy heartbeating
-        // peer is NEVER suspected within this window.
-        let observe_until = Instant::now() + Duration::from_secs(3);
+        // Observe for a window many heartbeat intervals long but strictly SHORTER than the (host-scaled)
+        // deadline, so a healthy heartbeating peer is NEVER suspected within it. Both the window and the
+        // deadline host-scale, so the margin holds on a fast host (deadline 3 s ≈ 10x the ~300 ms
+        // heartbeat) and on a slow/contended runner alike.
+        let observe_until = Instant::now() + host_scaled(Duration::from_secs(2));
         while Instant::now() < observe_until {
             for n in &nodes {
                 let s = n.status();

--- a/crates/ironbus-server/src/cluster/runtime.rs
+++ b/crates/ironbus-server/src/cluster/runtime.rs
@@ -52,7 +52,7 @@
 //!   discovery** are out of scope: peers are a static configured set, plaintext TCP, bound by the
 //!   [`transport`] codec's size + recursion limits and the [`PeerRegistry`] peer-id check.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::io;
 use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -62,10 +62,12 @@ use std::thread::JoinHandle;
 use std::time::Duration;
 
 use ironbus_core::clock::Clock;
+use ironbus_core::placement::{LeaderLoad, PlacementNode};
 use ironbus_storage::fs::Filesystem;
 use ironbus_storage::log::LogConfig;
 use raft::eraftpb::Message;
 
+use crate::cluster::membership::MembershipChange;
 use crate::cluster::metadata_group::{GroupError, MetadataRaftGroup};
 use crate::cluster::state_machine::{MetadataCommand, Placement};
 use crate::cluster::transport::{PeerLink, PeerRegistry, PeerWireError};
@@ -91,6 +93,26 @@ const PEER_OUTBOUND_BOUND: usize = 1024;
 /// The reconnect backoff a dialer waits after a failed connect / a dropped link before retrying, so
 /// a down peer is retried at a steady, low rate rather than in a hot reconnect loop.
 const DIALER_RECONNECT_BACKOFF: Duration = Duration::from_millis(500);
+
+/// The DEFAULT peer-liveness death-detection deadline (F1, #618): how long a voter peer may be
+/// SILENT (no metadata-Raft message stepped from it) before the metadata leader proposes its removal
+/// from the membership — which a committed shrink then turns into an automatic failover (F2).
+///
+/// ## Why this value avoids a FALSE / premature failover (the non-negotiable)
+///
+/// The metadata group's heartbeat fires every `heartbeat_tick = 3` ticks at the [`TICK_INTERVAL`]
+/// 100 ms cadence, i.e. **every ~300 ms** a live leader→follower (and the follower's response) crosses
+/// the wire, refreshing `last_heard`. This deadline is `3_000 ms` = **10x that heartbeat interval**, so
+/// a peer must miss roughly TEN consecutive heartbeat round-trips before it is declared dead. A brief
+/// network hiccup, a GC pause, or a single dropped heartbeat (raft re-sends on the next beat — see
+/// [`route_outbound`]) is far inside this window and NEVER trips a removal. Only a genuinely
+/// crashed / partitioned-away peer stays silent for 10 beats. The ratio (deadline ÷ heartbeat ≈ 10)
+/// is the safety margin; raise [`LivenessConfig::timeout`] to widen it further on a jittery link.
+///
+/// It is a DEFAULT: the deadline is injectable ([`LivenessConfig`]) and the clock is the I6 monotonic
+/// seam, so the kill-the-leader test drives detection deterministically (advance a [`ManualClock`])
+/// rather than sleeping a real 3 s — no wall-clock flake.
+pub const DEFAULT_LIVENESS_TIMEOUT: Duration = Duration::from_millis(3_000);
 
 /// The fixed TCP-port offset the DATA-plane peer listener binds at, RELATIVE to a node's configured
 /// metadata address (#717). One `--cluster-peer <id>=<addr>` entry thus serves BOTH transports: the
@@ -118,6 +140,55 @@ pub fn dataplane_addr(addr: SocketAddr) -> SocketAddr {
     let mut out = addr;
     out.set_port(data_port);
     out
+}
+
+/// The configurable peer-liveness death-detector tuning (F1, #618). The deadline is INJECTABLE (not a
+/// hard-coded wall-clock value) so the kill-the-leader test drives detection deterministically over a
+/// [`ManualClock`](ironbus_core::clock::ManualClock); production uses [`Self::default`].
+#[derive(Clone, Copy, Debug)]
+pub struct LivenessConfig {
+    /// How long a voter peer may be silent (no metadata message stepped from it) before the metadata
+    /// leader proposes its removal. Defaults to [`DEFAULT_LIVENESS_TIMEOUT`] (10x the heartbeat —
+    /// the no-false-failover margin). Must be safely longer than the heartbeat interval.
+    pub timeout: Duration,
+    /// Master switch for the detector. `true` by default; a `false` here disables crash-detection
+    /// (only a CLEAN committed leave then drives failover). The single-node / no-cluster paths never
+    /// reach the detector regardless (it only ever acts as the metadata-Raft leader over >1 voters).
+    pub enabled: bool,
+}
+
+impl Default for LivenessConfig {
+    fn default() -> Self {
+        Self {
+            timeout: DEFAULT_LIVENESS_TIMEOUT,
+            enabled: true,
+        }
+    }
+}
+
+/// The ISR-aware survivor-state projection the F2 auto-fire driver needs, supplied CROSS-PLANE by the
+/// data plane (the ISR + durable frontiers live in the DATA plane; the proposal happens in the METADATA
+/// plane, so the metadata driver cannot compute this itself — it is INJECTED). Given a partition id and
+/// the surviving replica ids, it returns each survivor's [`PlacementNode`] (in-ISR flag + durable
+/// frontier + divergence), so [`plan_failovers`] chooses a successor ONLY from the in-sync, complete
+/// survivors — a stale / out-of-ISR node is never auto-promoted (committed-never-lost, #721 CI5).
+pub type SurvivorStateFn = dyn Fn(u64, &[u64]) -> Vec<PlacementNode> + Send + Sync;
+
+/// The committed high-watermark a partition's successor must be complete to (the prefix every ISR
+/// member already holds), supplied cross-plane by the data plane alongside [`SurvivorStateFn`].
+pub type CommittedHwFn = dyn Fn(u64) -> u64 + Send + Sync;
+
+/// The cross-plane inputs the F2 auto-failover driver reads to pick an ISR successor. INSTALLED by the
+/// data-plane bootstrap ([`ClusterRuntime::set_failover_inputs`]) once it owns the live data plane;
+/// ABSENT until then, so a runtime with no data plane fails CLOSED — it auto-proposes NO promotion
+/// (rather than promoting blind). The `survivors` closure surfaces the live ISR; `committed_hw` the
+/// per-partition committed frontier.
+#[derive(Clone)]
+pub struct FailoverInputs {
+    /// The live ISR-aware survivor-state projection (see [`SurvivorStateFn`]).
+    pub survivors: Arc<SurvivorStateFn>,
+    /// The live per-partition committed high-watermark (see [`CommittedHwFn`]).
+    pub committed_hw: Arc<CommittedHwFn>,
 }
 
 /// A point-in-time snapshot of the local cluster member's metadata-plane state, published by the
@@ -152,12 +223,22 @@ pub struct ClusterStatus {
     /// re-placement promoting an in-sync survivor (the #618 [`reassign_leadership`]). Monotonic: a node
     /// that left stays listed (it can rejoin as a fresh add).
     ///
-    /// FLAGGED — this is the CLEAN, committed leave signal (no timing assumption). A node that CRASHES
-    /// without a membership change stays a voter in the `ConfState` (raft does not auto-evict it), so
-    /// crash-failover additionally needs a peer-liveness/heartbeat death-detector that PROPOSES the
-    /// membership removal on a timeout; that detector (and its timing bound) is the remaining wiring,
-    /// deliberately separated so this signal carries no timing assumption.
-    pub departed_members: std::collections::BTreeSet<u64>,
+    /// As of #618b BOTH paths feed this: a CLEAN committed leave (graceful / admin remove) AND a CRASH
+    /// converted to a committed shrink by the F1 peer-liveness detector — the metadata leader proposes a
+    /// silent voter's removal ([`MembershipChange::remove_node`]), and once that conf-change commits the
+    /// crashed node lands here exactly like a clean leave. So `departed_members` is the unified
+    /// failover-detection signal the F2 auto-fire driver consumes; it carries no timing assumption (the
+    /// timing lives in the detector that PRODUCES the shrink, not in this committed fact).
+    pub departed_members: BTreeSet<u64>,
+    /// The voter peers the F1 detector currently believes are SILENT past the liveness deadline (it has
+    /// proposed their removal). Observability only — a peer leaves here once its removal commits (it then
+    /// appears in [`Self::departed_members`]) or once it is heard from again before the deadline. Empty on
+    /// a healthy cluster; this is the no-false-failover witness (it stays empty under a brief hiccup).
+    pub suspected_dead: BTreeSet<u64>,
+    /// The partitions the F2 auto-fire driver has proposed a failover promotion for (a committed dead
+    /// leader's partitions, re-placed onto an ISR successor). Observability only; cleared when the
+    /// promotion commits (the placement's leader is no longer the departed node).
+    pub failover_proposed: BTreeSet<u64>,
 }
 
 /// A command for the driver to propose to the metadata group on behalf of the broker (or a test):
@@ -167,6 +248,12 @@ pub struct ClusterStatus {
 enum DriverCmd {
     /// Propose a metadata command (leader-only; ignored with a log line if not leader).
     Propose(MetadataCommand),
+    /// TEST SEAM (and ops hook): force a peer to be treated as UNREACHABLE by the F1 liveness
+    /// detector, regardless of when it was last heard from. This makes the kill-the-leader test drive
+    /// death-detection DETERMINISTICALLY (no real-time sleep): the test kills a node's threads, then
+    /// marks it unreachable, and the metadata leader proposes its removal on the next cycle. `true`
+    /// marks it unreachable; `false` clears the override (it must then be heard from to stay alive).
+    ForcePeerUnreachable { peer: u64, unreachable: bool },
 }
 
 /// The driver side of a per-peer outbound queue: a `Sender` plus a shared depth counter so the
@@ -293,6 +380,11 @@ pub struct ClusterRuntime {
     /// The latest status snapshot the driver publishes each cycle (leader / epoch / membership /
     /// applied index), read with [`status`](ClusterRuntime::status).
     status: Arc<Mutex<ClusterStatus>>,
+    /// The cross-plane F2 auto-failover inputs (the live ISR survivor-state + committed-HW providers),
+    /// installed by the data-plane bootstrap via [`set_failover_inputs`](ClusterRuntime::set_failover_inputs).
+    /// `None` until installed: a runtime with no data plane fails closed (auto-proposes NO promotion).
+    /// Shared with the driver thread, which reads it each cycle to plan failovers off the LIVE ISR.
+    failover_inputs: Arc<Mutex<Option<FailoverInputs>>>,
     /// The channel to the driver for proposing metadata commands (the driver owns the `RawNode`).
     cmd_tx: Sender<DriverCmd>,
     /// The metadata-group driver thread (owns the `RawNode`).
@@ -335,6 +427,38 @@ impl ClusterRuntime {
         F: Filesystem + 'static,
         C: Clock + Clone + 'static,
     {
+        Self::start_with_liveness(
+            config,
+            parent_fs,
+            clock,
+            log_config,
+            LivenessConfig::default(),
+        )
+    }
+
+    /// Like [`start`](Self::start) but with an explicit [`LivenessConfig`] for the F1 peer-liveness
+    /// death-detector (the injectable deadline that makes the kill-the-leader test deterministic, #618).
+    /// [`start`](Self::start) delegates here with [`LivenessConfig::default`] (the 10x-heartbeat
+    /// no-false-failover deadline).
+    ///
+    /// # Errors
+    ///
+    /// As [`start`](Self::start).
+    ///
+    /// # Panics
+    ///
+    /// As [`start`](Self::start).
+    pub fn start_with_liveness<F, C>(
+        config: &ClusterConfig,
+        parent_fs: &F,
+        clock: C,
+        log_config: LogConfig,
+        liveness: LivenessConfig,
+    ) -> Result<Self, RuntimeError>
+    where
+        F: Filesystem + 'static,
+        C: Clock + Clone + 'static,
+    {
         config.validate()?;
         let self_addr = config
             .self_addr()
@@ -342,7 +466,10 @@ impl ClusterRuntime {
 
         // Open (or recover) the durable metadata group. This is the ONLY place a `metaraft/`
         // subdirectory is created, and it happens ONLY here in the runtime — never on the no-cluster
-        // default path, which keeps that path byte-for-byte today's broker.
+        // default path, which keeps that path byte-for-byte today's broker. Keep a clock CLONE for the
+        // driver's F1 liveness detector (it times peer silence off the SAME I6 monotonic seam the group
+        // uses, never the wall clock — so the kill-the-leader test drives it via a ManualClock).
+        let driver_clock = clock.clone();
         let voters = config.voters();
         let group = MetadataRaftGroup::open(config.node_id, &voters, parent_fs, clock, log_config)?;
 
@@ -412,10 +539,25 @@ impl ClusterRuntime {
         }));
         let (cmd_tx, cmd_rx) = mpsc::channel::<DriverCmd>();
 
+        // The cross-plane F2 auto-failover inputs, ABSENT until the data-plane bootstrap installs them
+        // (fail-closed: no data plane => no blind auto-promotion). Shared with the driver thread.
+        let failover_inputs: Arc<Mutex<Option<FailoverInputs>>> = Arc::new(Mutex::new(None));
+
+        // The remote VOTER peers the F1 detector watches (every configured node except this one — the
+        // peers whose silence past the deadline means a crash). The local node is never "silent to
+        // itself", so it is excluded.
+        let remote_voters: Vec<u64> = config
+            .peers
+            .keys()
+            .copied()
+            .filter(|&id| id != config.node_id)
+            .collect();
+
         // Spawn the driver (owns the group; drives tick/step/drive_ready and routes outbound).
         let shutdown_dr = Arc::clone(&shutdown);
         let registry_dr = Arc::clone(&registry);
         let status_dr = Arc::clone(&status);
+        let failover_inputs_dr = Arc::clone(&failover_inputs);
         // Move `inbound_tx` (a keepalive sender) into the driver so the inbound channel never closes
         // while the driver runs, even if every reader has exited.
         let driver_handle = std::thread::Builder::new()
@@ -423,12 +565,20 @@ impl ClusterRuntime {
             .spawn(move || {
                 run_driver(
                     group,
-                    inbound_rx,
-                    inbound_tx,
-                    outbound_tx,
-                    cmd_rx,
-                    registry_dr,
-                    status_dr,
+                    DriverShared {
+                        inbound_rx,
+                        _inbound_keepalive: inbound_tx,
+                        outbound_tx,
+                        cmd_rx,
+                        registry: registry_dr,
+                        status: status_dr,
+                        failover_inputs: failover_inputs_dr,
+                    },
+                    DriverFailover {
+                        clock: driver_clock,
+                        liveness,
+                        remote_voters,
+                    },
                     &shutdown_dr,
                 );
             })
@@ -439,6 +589,7 @@ impl ClusterRuntime {
             peers: config.peers.clone(),
             shutdown,
             status,
+            failover_inputs,
             cmd_tx,
             driver: Some(driver_handle),
             listener: Some(listener_handle),
@@ -489,6 +640,43 @@ impl ClusterRuntime {
         MetadataProposer {
             cmd_tx: self.cmd_tx.clone(),
         }
+    }
+
+    /// INSTALL the cross-plane F2 auto-failover inputs (the live ISR survivor-state + committed-HW
+    /// providers, #618). Called by the data-plane bootstrap once it owns the live data plane: from then
+    /// on, when a committed membership shrink names a dead leader's partition, the metadata-Raft leader
+    /// AUTO-plans + proposes a promotion of an in-sync survivor (chosen ONLY from the LIVE ISR these
+    /// closures surface — never a stale snapshot). Before install the runtime fails CLOSED (it
+    /// auto-proposes NO promotion), so a runtime with no data plane never promotes blind.
+    ///
+    /// Idempotent / last-writer-wins: re-installing replaces the providers (the data plane may rebuild).
+    pub fn set_failover_inputs(&self, inputs: FailoverInputs) {
+        if let Ok(mut slot) = self.failover_inputs.lock() {
+            *slot = Some(inputs);
+        }
+    }
+
+    /// A cloneable, `Send` handle the data-plane bootstrap thread holds to install the cross-plane F2
+    /// inputs WITHOUT borrowing the runtime (the bootstrap is a `'static` thread). It shares the same
+    /// slot [`set_failover_inputs`](Self::set_failover_inputs) writes, so the driver picks the providers
+    /// up on its next cycle.
+    #[must_use]
+    pub fn failover_installer(&self) -> FailoverInstaller {
+        FailoverInstaller {
+            slot: Arc::clone(&self.failover_inputs),
+        }
+    }
+
+    /// TEST SEAM (and ops hook): force/clear the F1 liveness detector treating `peer` as UNREACHABLE,
+    /// independent of when it was last heard from. This is the deterministic seam the kill-the-leader
+    /// integration test uses to drive crash-detection WITHOUT a real-time sleep: the test stops a node's
+    /// threads, marks it unreachable here, and the metadata leader proposes its removal on the next
+    /// cycle (which the auto-fire path then turns into a promotion). `true` marks unreachable; `false`
+    /// clears it. A no-op if the driver has already stopped.
+    pub fn force_peer_unreachable(&self, peer: u64, unreachable: bool) {
+        let _ = self
+            .cmd_tx
+            .send(DriverCmd::ForcePeerUnreachable { peer, unreachable });
     }
 
     /// The peer-id -> address map of the whole metadata group (including this node). The data-plane
@@ -557,6 +745,25 @@ impl MetadataProposer {
         self.cmd_tx
             .send(DriverCmd::Propose(cmd))
             .map_err(|_| RuntimeError::Config("cluster driver has stopped".to_string()))
+    }
+}
+
+/// A cloneable, `Send` handle for installing the cross-plane F2 auto-failover inputs from another
+/// thread (the data-plane bootstrap, #618), without borrowing the [`ClusterRuntime`]. It shares the
+/// same slot the driver reads each cycle; installing makes the auto-fire path choose an ISR successor
+/// from the LIVE data-plane ISR these providers surface.
+#[derive(Clone)]
+pub struct FailoverInstaller {
+    slot: Arc<Mutex<Option<FailoverInputs>>>,
+}
+
+impl FailoverInstaller {
+    /// Install (or replace) the cross-plane F2 inputs. Last-writer-wins; a no-op if the mutex is
+    /// poisoned (the runtime is tearing down).
+    pub fn install(&self, inputs: FailoverInputs) {
+        if let Ok(mut slot) = self.slot.lock() {
+            *slot = Some(inputs);
+        }
     }
 }
 
@@ -637,32 +844,65 @@ where
     proposals
 }
 
+/// The shared channels + Arcs the driver thread owns for its whole lifetime. Bundled so the driver's
+/// entry point stays under the argument-count lint while keeping each a distinct, named concern.
+struct DriverShared {
+    /// Inbound peer messages a reader delivered (drained + fed to `step`).
+    inbound_rx: Receiver<Message>,
+    /// A keepalive `Sender` held so the inbound channel never closes while the driver runs, even if
+    /// every reader has exited. Never sent on.
+    _inbound_keepalive: Sender<Message>,
+    /// Per-remote-peer bounded outbound queues (the driver routes `drive_ready` output here).
+    outbound_tx: BTreeMap<u64, PeerOutbound>,
+    /// The broker/test command channel (propose metadata / the liveness test seam).
+    cmd_rx: Receiver<DriverCmd>,
+    /// The shared peer-id registry (refreshed from the committed `ConfState`).
+    registry: Arc<Mutex<PeerRegistry>>,
+    /// The published status snapshot (leader / epoch / placements / departed-members).
+    status: Arc<Mutex<ClusterStatus>>,
+    /// The cross-plane F2 auto-failover inputs (installed by the data-plane bootstrap; `None` until then).
+    failover_inputs: Arc<Mutex<Option<FailoverInputs>>>,
+}
+
+/// The F1/F2 auto-failover wiring the driver thread owns: the monotonic clock seam, the liveness
+/// tuning, and the remote voter set it watches.
+struct DriverFailover<C: Clock + Clone> {
+    /// The I6 monotonic clock the liveness detector times peer silence off (never the wall clock).
+    clock: C,
+    /// The peer-liveness detector tuning (the injectable deadline + enable switch).
+    liveness: LivenessConfig,
+    /// The remote voter peers watched for silence (every configured node except this one).
+    remote_voters: Vec<u64>,
+}
+
 /// The driver loop: OWNS the metadata group and is the only thread that touches the `RawNode`.
 ///
 /// On a fixed cadence it (1) advances the election/heartbeat timer with `tick`, (2) drains every
-/// inbound `Message` a reader delivered and feeds each to `step`, (3) runs `drive_ready` (which
-/// persists + fsyncs before advancing, #659) and routes the outbound messages to each addressed
-/// peer's outbound queue, and (4) refreshes the shared peer registry from the group's `ConfState`
-/// so a committed membership change updates which peers a reader will accept. It blocks on the
+/// inbound `Message` a reader delivered and feeds each to `step` (recording `last_heard` per peer —
+/// the F1 liveness signal), (3) runs `drive_ready` (which persists + fsyncs before advancing, #659)
+/// and routes the outbound messages to each addressed peer's outbound queue, (4) refreshes the shared
+/// peer registry from the group's `ConfState` so a committed membership change updates which peers a
+/// reader will accept, (5) runs the **F1 peer-liveness death-detector** (if metadata leader, proposes
+/// the removal of any voter silent past the deadline — converting a crash into a committed shrink), and
+/// (6) runs the **F2 auto-fire** path (if metadata leader, plans + proposes a failover promotion for
+/// every partition a departed node led, choosing the successor from the LIVE ISR). It blocks on the
 /// inbound channel with a `TICK_INTERVAL` timeout, so it is responsive to inbound traffic yet never
 /// busy-spins and re-checks shutdown at least every tick.
-#[allow(clippy::too_many_arguments)]
-// each input is a distinct concern (the group, the inbound /
-// outbound / command channels, the shared registry + status,
-// and the shutdown flag); a bundling struct would only move
-// the noise. The driver is the one place they all meet.
-#[allow(clippy::needless_pass_by_value)] // a thread entry point: it OWNS the group, channels, and
-                                         // shared Arcs for the thread's whole lifetime (the
-                                         // receivers are drained, the senders/Arcs held alive); a
-                                         // borrow would fight the 'static spawn bound.
+///
+/// SINGLE PROPOSER: F1's removal AND F2's promotion are proposed ONLY when this node is the
+/// metadata-Raft leader, both go through the metadata Raft log (committed, ordered), and both are
+/// idempotent (a removal of an already-gone node and a promotion of an already-converged placement are
+/// skipped) — so no two nodes can drive a different failover; the Raft log linearizes it.
+#[allow(clippy::too_many_lines)] // the driver loop is ONE linear consensus cycle (tick, step+record,
+                                 // drive_ready, registry refresh, F1 detect, F2 auto-fire, publish);
+                                 // splitting it would scatter a single tightly-ordered concern.
+#[allow(clippy::needless_pass_by_value)] // a thread entry point: it OWNS the group + the shared
+                                         // channels/Arcs + the failover wiring for the thread's whole
+                                         // lifetime; a borrow would fight the 'static spawn bound.
 fn run_driver<F, C>(
     mut group: MetadataRaftGroup<F, C>,
-    inbound_rx: Receiver<Message>,
-    _inbound_keepalive: Sender<Message>,
-    outbound_tx: BTreeMap<u64, PeerOutbound>,
-    cmd_rx: Receiver<DriverCmd>,
-    registry: Arc<Mutex<PeerRegistry>>,
-    status: Arc<Mutex<ClusterStatus>>,
+    shared: DriverShared,
+    failover: DriverFailover<C>,
     shutdown: &AtomicBool,
 ) where
     F: Filesystem,
@@ -674,8 +914,8 @@ fn run_driver<F, C>(
     // Every node id ever seen in the committed membership, so a node that LEAVES (dropped from a later
     // `ConfState`) can be detected as departed = (ever-seen) - (currently-present). The #618 failover
     // detection signal; published in the status snapshot for the data-plane failover driver.
-    let mut ever_seen_members: std::collections::BTreeSet<u64> = std::collections::BTreeSet::new();
-    let mut departed_members: std::collections::BTreeSet<u64> = std::collections::BTreeSet::new();
+    let mut ever_seen_members: BTreeSet<u64> = BTreeSet::new();
+    let mut departed_members: BTreeSet<u64> = BTreeSet::new();
     // The durable `ConfState` voter count, refreshed each cycle below and published as the status
     // `voter_count`. This is the cluster's AGREED voter set (the seeded-then-replicated raft
     // `ConfState`), not the state machine's apply-driven membership table — the latter is empty on a
@@ -684,29 +924,70 @@ fn run_driver<F, C>(
     let mut conf_voter_count: usize = 0;
     let node_id = group.node_id();
 
+    // F1 STATE: the last monotonic time (nanos) we heard ANY metadata message from each remote voter.
+    // The metadata-Raft heartbeat (every ~3 ticks) refreshes this for a live peer, so a peer whose
+    // entry is older than the deadline (and which is not in `forced_unreachable`) is a crashed peer.
+    // Seeded to "now" so the cluster gets a full deadline of grace before anyone is suspected (no
+    // false failover at startup before the first heartbeat round-trip lands).
+    let mut last_heard: BTreeMap<u64, u64> = BTreeMap::new();
+    let now0 = failover.clock.now_monotonic_nanos();
+    for &peer in &failover.remote_voters {
+        last_heard.insert(peer, now0);
+    }
+    // The deterministic test/ops override: peers forced unreachable regardless of `last_heard`.
+    let mut forced_unreachable: BTreeSet<u64> = BTreeSet::new();
+    // Peers whose removal we have already proposed (avoid re-proposing every cycle while the conf
+    // change commits). Cleared for a peer once it actually departs (lands in `departed_members`).
+    let mut removal_proposed: BTreeSet<u64> = BTreeSet::new();
+    // Partitions we have already proposed an F2 promotion for (avoid re-proposing while it commits).
+    // Cleared once the committed placement's leader is no longer the departed node (promotion landed).
+    let mut failover_proposed: BTreeSet<u64> = BTreeSet::new();
+
+    let deadline_nanos = duration_to_nanos(failover.liveness.timeout);
+
     while !shutdown.load(Ordering::Acquire) {
         // Advance the logical election/heartbeat timer once per cadence.
         group.tick();
 
-        // Apply any pending metadata proposals from the broker/tests (leader-only; a non-leader
-        // proposal is rejected by the core and logged, never panics).
-        while let Ok(DriverCmd::Propose(cmd)) = cmd_rx.try_recv() {
-            if let Err(e) = group.propose(&cmd) {
-                tracing::debug!(error = %e, "cluster: metadata proposal rejected (not leader?)");
+        // Apply any pending driver commands from the broker/tests. A `Propose` is leader-only (a
+        // non-leader proposal is rejected by the core and logged, never panics); a `ForcePeerUnreachable`
+        // updates the F1 override (the deterministic kill-the-leader test seam).
+        while let Ok(cmd) = shared.cmd_rx.try_recv() {
+            match cmd {
+                DriverCmd::Propose(mcmd) => {
+                    if let Err(e) = group.propose(&mcmd) {
+                        tracing::debug!(error = %e, "cluster: metadata proposal rejected (not leader?)");
+                    }
+                }
+                DriverCmd::ForcePeerUnreachable { peer, unreachable } => {
+                    if unreachable {
+                        forced_unreachable.insert(peer);
+                    } else {
+                        forced_unreachable.remove(&peer);
+                    }
+                }
             }
         }
 
         // Wait up to one tick for an inbound peer message, then drain every other message already
         // queued (non-blocking) before driving ready, so a burst is consumed in one pass rather than
-        // one per cadence. The wait keeps the loop responsive to traffic without busy-spinning.
-        match inbound_rx.recv_timeout(TICK_INTERVAL) {
+        // one per cadence. The wait keeps the loop responsive to traffic without busy-spinning. Every
+        // stepped message records `last_heard[from] = now` — the F1 liveness signal (a live peer's
+        // heartbeats keep it fresh; a crashed peer's entry goes stale).
+        match shared.inbound_rx.recv_timeout(TICK_INTERVAL) {
             Ok(msg) => {
+                record_heard(&msg, &failover.clock, &mut last_heard);
                 if let Err(e) = group.step(msg) {
                     // A step error for a message addressed to a node mid-membership-change is benign
                     // (it may no longer recognise the sender); drop it and continue.
                     tracing::debug!(error = %e, "cluster: dropped a peer message on step");
                 }
-                drain_inbound_nonblocking(&inbound_rx, &mut group);
+                drain_inbound_nonblocking(
+                    &shared.inbound_rx,
+                    &mut group,
+                    &failover.clock,
+                    &mut last_heard,
+                );
             }
             Err(mpsc::RecvTimeoutError::Timeout) => {}
             Err(mpsc::RecvTimeoutError::Disconnected) => {
@@ -718,7 +999,7 @@ fn run_driver<F, C>(
         // Drive the ready cycle (persist + fsync before advance, #659) and route the outbound
         // messages to the addressed peers' queues.
         match group.drive_ready() {
-            Ok(outbound) => route_outbound(outbound, &outbound_tx),
+            Ok(outbound) => route_outbound(outbound, &shared.outbound_tx),
             Err(e) => {
                 tracing::error!(error = %e, "cluster: drive_ready failed");
             }
@@ -733,16 +1014,121 @@ fn run_driver<F, C>(
             members.sort_unstable();
             members.dedup();
             if members != last_members {
-                if let Ok(mut reg) = registry.lock() {
+                if let Ok(mut reg) = shared.registry.lock() {
                     *reg = PeerRegistry::from_members(cs.get_voters(), cs.get_learners());
                 }
                 // Update the failover detection signal: any node ever seen but now ABSENT has departed.
                 // (The set only grows / shifts on a real committed membership change, not every cycle.)
                 ever_seen_members.extend(members.iter().copied());
-                let present: std::collections::BTreeSet<u64> = members.iter().copied().collect();
+                let present: BTreeSet<u64> = members.iter().copied().collect();
                 departed_members = ever_seen_members.difference(&present).copied().collect();
                 last_members = members;
+                // A peer that has now committed-departed no longer needs its removal re-proposed.
+                removal_proposed.retain(|p| !departed_members.contains(p));
             }
+        }
+
+        // ----- F1: the peer-liveness DEATH DETECTOR. Only the metadata-Raft leader proposes (single
+        // proposer), and only for a CURRENT voter that is silent past the deadline (or forced
+        // unreachable in a test). A removed/already-departed peer is skipped (idempotent). This
+        // converts a crash (a still-a-voter-but-silent node) into a committed membership shrink, which
+        // F2 below then turns into a promotion. The no-false-failover guarantee is the deadline ratio:
+        // a peer must be silent for ~10 heartbeat intervals (see DEFAULT_LIVENESS_TIMEOUT). -----
+        let now = failover.clock.now_monotonic_nanos();
+        let mut suspected: BTreeSet<u64> = BTreeSet::new();
+        if failover.liveness.enabled && group.is_leader() {
+            // Snapshot the current voter set so we never propose removing a node that already left.
+            let current_voters: BTreeSet<u64> = group
+                .conf_state()
+                .map(|cs| cs.get_voters().iter().copied().collect())
+                .unwrap_or_default();
+            for &peer in &failover.remote_voters {
+                if !current_voters.contains(&peer) {
+                    continue; // already gone from the membership — nothing to remove.
+                }
+                // `is_none_or` is stable only since 1.82; MSRV is 1.78, so spell it out: a peer with no
+                // recorded `last_heard` (never heard from) OR one silent past the deadline is silent.
+                let silent = forced_unreachable.contains(&peer)
+                    || last_heard
+                        .get(&peer)
+                        .map_or(true, |&t| now.saturating_sub(t) >= deadline_nanos);
+                if !silent {
+                    continue;
+                }
+                suspected.insert(peer);
+                if removal_proposed.contains(&peer) {
+                    continue; // removal already in flight; let it commit (don't spam the log).
+                }
+                // Propose the conf-change removal through the metadata Raft (validated + replicated +
+                // committed). Refused if it would empty the voter set (the membership validator) or if a
+                // conf change is already pending — both benign; we retry next cycle.
+                let change = MembershipChange::new().remove_node(peer);
+                match group.propose_membership_change(&change) {
+                    Ok(()) => {
+                        removal_proposed.insert(peer);
+                        tracing::info!(
+                            peer,
+                            "cluster: F1 liveness detector proposed removal of a silent voter (crash failover)"
+                        );
+                    }
+                    Err(e) => {
+                        tracing::debug!(peer, error = %e, "cluster: removal proposal deferred");
+                    }
+                }
+            }
+        }
+
+        // ----- F2: AUTO-FIRE the failover. On a committed membership shrink (`departed_members`
+        // non-empty), the metadata leader auto-plans a promotion for every partition a departed node
+        // LED, feeding `plan_failovers` the LIVE data-plane ISR (the installed cross-plane providers),
+        // and proposes each resulting PlacePartition through the metadata Raft. Single proposer +
+        // idempotent: a partition whose committed placement no longer names the departed node as leader
+        // has already failed over (skip). Fail-closed: with no installed providers, or no eligible ISR
+        // survivor, NO promotion is proposed (the partition stays leaderless until a survivor catches
+        // up) — committed data is never lost by promoting an incomplete replica. -----
+        let placements = group.state().placements();
+        // Drop any "proposed" marks whose committed placement has already moved off the departed leader
+        // (the promotion landed) so a later, distinct departure can re-fire.
+        failover_proposed.retain(|p| {
+            placements
+                .get(p)
+                .is_some_and(|pl| departed_members.contains(&pl.leader))
+        });
+        if group.is_leader() && !departed_members.is_empty() {
+            let inputs = shared.failover_inputs.lock().ok().and_then(|g| g.clone());
+            if let Some(inputs) = inputs {
+                let survivors = Arc::clone(&inputs.survivors);
+                let committed_hw = Arc::clone(&inputs.committed_hw);
+                let proposals = plan_failovers(
+                    &placements,
+                    &departed_members,
+                    |partition, s| survivors(partition, s),
+                    |partition| committed_hw(partition),
+                    &LeaderLoad::new(),
+                );
+                for cmd in proposals {
+                    let MetadataCommand::PlacePartition { partition, .. } = &cmd else {
+                        continue;
+                    };
+                    let partition = *partition;
+                    if failover_proposed.contains(&partition) {
+                        continue; // promotion already in flight; let it commit.
+                    }
+                    match group.propose(&cmd) {
+                        Ok(()) => {
+                            failover_proposed.insert(partition);
+                            tracing::info!(
+                                partition,
+                                "cluster: F2 auto-fire proposed an ISR-successor promotion (leaderless failover)"
+                            );
+                        }
+                        Err(e) => {
+                            tracing::debug!(partition, error = %e, "cluster: failover proposal deferred");
+                        }
+                    }
+                }
+            }
+            // else: no installed providers (no data plane) => fail-closed, propose nothing.
         }
 
         // Publish the latest status snapshot for observers (status() / future admin endpoints). The
@@ -750,14 +1136,14 @@ fn run_driver<F, C>(
         // per-partition role from the committed metadata via `placements()` without ever touching the
         // `RawNode` the driver owns. The snapshot is only re-cloned when the applied index advances, so
         // a steady cluster does not re-clone the (small) placement map every tick.
-        if let Ok(mut s) = status.lock() {
+        if let Ok(mut s) = shared.status.lock() {
             s.node_id = node_id;
             s.is_leader = group.is_leader();
             s.leader_epoch = group.leader_epoch().get();
             s.voter_count = conf_voter_count;
             let applied = group.state().applied_index();
             if applied != s.applied_index {
-                s.placements = group.state().placements();
+                s.placements = placements.clone();
             }
             s.applied_index = applied;
             // Publish the leaderless-failover detection signal (the departed-members set), so the
@@ -766,21 +1152,49 @@ fn run_driver<F, C>(
             if s.departed_members != departed_members {
                 s.departed_members.clone_from(&departed_members);
             }
+            // Publish the F1/F2 observability witnesses (the no-false-failover witness `suspected_dead`
+            // and the in-flight `failover_proposed`), only re-cloned when they change.
+            if s.suspected_dead != suspected {
+                s.suspected_dead.clone_from(&suspected);
+            }
+            if s.failover_proposed != failover_proposed {
+                s.failover_proposed.clone_from(&failover_proposed);
+            }
         }
     }
 }
 
-/// Drain any inbound messages already queued, without blocking, feeding each to `step`. Called after
-/// the first blocking receive so a burst of peer messages is consumed in one pass before driving
-/// ready, rather than one per cadence.
-fn drain_inbound_nonblocking<F, C>(rx: &Receiver<Message>, group: &mut MetadataRaftGroup<F, C>)
-where
+/// Record that we just heard a metadata message FROM a peer at the current monotonic time — the F1
+/// liveness signal. A message with no sender (id 0, e.g. a local tick artifact) is ignored.
+fn record_heard<C: Clock>(msg: &Message, clock: &C, last_heard: &mut BTreeMap<u64, u64>) {
+    let from = msg.get_from();
+    if from != raft::INVALID_ID {
+        last_heard.insert(from, clock.now_monotonic_nanos());
+    }
+}
+
+/// Convert a [`Duration`] to nanoseconds, saturating at `u64::MAX`, so an absurdly large injected
+/// deadline never wraps (and a deadline of 0 disables the grace window, which the tests may use).
+fn duration_to_nanos(d: Duration) -> u64 {
+    u64::try_from(d.as_nanos()).unwrap_or(u64::MAX)
+}
+
+/// Drain any inbound messages already queued, without blocking, feeding each to `step` and recording
+/// `last_heard` per sender (the F1 liveness signal). Called after the first blocking receive so a
+/// burst of peer messages is consumed in one pass before driving ready, rather than one per cadence.
+fn drain_inbound_nonblocking<F, C>(
+    rx: &Receiver<Message>,
+    group: &mut MetadataRaftGroup<F, C>,
+    clock: &C,
+    last_heard: &mut BTreeMap<u64, u64>,
+) where
     F: Filesystem,
     C: Clock + Clone,
 {
     loop {
         match rx.try_recv() {
             Ok(msg) => {
+                record_heard(&msg, clock, last_heard);
                 if let Err(e) = group.step(msg) {
                     tracing::debug!(error = %e, "cluster: dropped a peer message on step");
                 }
@@ -1135,6 +1549,14 @@ mod tests {
     // `StdFs` (the cluster runtime is a Unix-only on-disk feature, like serve). We bring SystemClock
     // in via a tiny shim module below so the test file names ONE clock type.
 
+    /// Acquire the shared heavy-cluster-test serial guard (defined in the parent `cluster` module so it
+    /// serializes against the `serve` module's heavy tests too): each heavy multi-node test holds it for
+    /// its whole body, so the clusters form on an un-contended host (the #687 starvation, amplified by N
+    /// concurrent clusters, never bites). See [`super::super::heavy_cluster_test_guard`].
+    fn serial_guard() -> std::sync::MutexGuard<'static, ()> {
+        crate::cluster::heavy_cluster_test_guard()
+    }
+
     /// Allocate `n` free localhost TCP ports by binding ephemeral sockets, reading the assigned
     /// ports, then dropping the listeners. There is a small TOCTOU window before the runtime rebinds,
     /// but for an in-process loopback test on a quiet port range it is reliable.
@@ -1260,6 +1682,7 @@ mod tests {
     /// tests use.
     #[test]
     fn three_node_cluster_elects_a_leader_and_commits_a_metadata_entry() {
+        let _serial = serial_guard();
         let ids = [1u64, 2, 3];
         let ports = free_ports(3);
         let peers = peer_map(&ids, &ports);
@@ -1341,6 +1764,7 @@ mod tests {
     /// the cluster keeps (or re-forms) a quorum.
     #[test]
     fn a_restarted_node_recovers_its_metadata_log_and_rejoins() {
+        let _serial = serial_guard();
         let ids = [1u64, 2, 3];
         let ports = free_ports(3);
         let peers = peer_map(&ids, &ports);
@@ -1433,6 +1857,7 @@ mod tests {
     /// rejected by the reader and never crashes the node. The cluster keeps running.
     #[test]
     fn the_wired_reader_rejects_hostile_frames_without_crashing() {
+        let _serial = serial_guard();
         let ids = [1u64, 2, 3];
         let ports = free_ports(3);
         let peers = peer_map(&ids, &ports);
@@ -1566,6 +1991,495 @@ mod tests {
             LogConfig::new(64 * 1024).unwrap(),
         );
         assert!(matches!(r2, Err(RuntimeError::Config(_))));
+    }
+
+    // ============================================================================================
+    // #618b AUTOMATIC leaderless failover — the END-TO-END proof: kill the leader, let the
+    // AUTOMATIC path (F1 detect + F2 auto-fire) run, and assert the cluster self-heals leadership
+    // with NO test-driven manual reconcile. These extend the #721 harness; the #721 mechanism-level
+    // test (in serve.rs) stays as the by-construction proof.
+    // ============================================================================================
+
+    const TEST_PARTITION: u64 = 0;
+
+    /// Install a SIMULATED healthy-ISR failover-input provider on a node: every surviving committed
+    /// replica is reported in-ISR and complete to the committed HW, so the F2 auto-fire path has a
+    /// valid cross-plane ISR to choose a successor from (the metadata plane does not itself hold ISR
+    /// state — this is the seam the real data-plane bootstrap fills, #618). `committed_hw` is the
+    /// quorum-acked frontier every ISR member holds; `replicas` the committed replica set.
+    fn install_healthy_isr(node: &ClusterRuntime, replicas: Vec<u64>, committed_hw: u64) {
+        let committed: BTreeSet<u64> = replicas.into_iter().collect();
+        let survivors: Arc<SurvivorStateFn> = Arc::new(move |_partition, survivor_ids: &[u64]| {
+            survivor_ids
+                .iter()
+                .filter(|n| committed.contains(n))
+                .map(|&n| PlacementNode::healthy(n, committed_hw))
+                .collect()
+        });
+        let committed_hw_fn: Arc<CommittedHwFn> = Arc::new(move |_partition| committed_hw);
+        node.set_failover_inputs(FailoverInputs {
+            survivors,
+            committed_hw: committed_hw_fn,
+        });
+    }
+
+    /// Bring up a 3-node cluster, wait for a metadata leader, commit the static placement naming the
+    /// metadata leader as the partition leader, and install a healthy-ISR provider on every node.
+    /// Returns the running nodes, their ids, their data dirs (kept alive), and the elected leader's
+    /// index — the shared setup for the auto-failover tests. `liveness` tunes the F1 detector.
+    #[allow(clippy::type_complexity)]
+    fn bring_up_placed_cluster(
+        liveness: LivenessConfig,
+    ) -> (
+        std::sync::MutexGuard<'static, ()>,
+        Vec<ClusterRuntime>,
+        [u64; 3],
+        Vec<tempfile::TempDir>,
+        usize,
+    ) {
+        // Serialize against the other heavy multi-node tests so this cluster forms on an un-contended
+        // host (the guard is held by the caller for its whole body — returned below).
+        let serial = serial_guard();
+        let ids = [1u64, 2, 3];
+        let ports = free_ports(3);
+        let peers = peer_map(&ids, &ports);
+        let dirs: Vec<_> = ids
+            .iter()
+            .map(|_| tempfile::tempdir().expect("tempdir"))
+            .collect();
+        let nodes: Vec<ClusterRuntime> = ids
+            .iter()
+            .enumerate()
+            .map(|(i, &id)| {
+                let cfg = ClusterConfig {
+                    node_id: id,
+                    peers: peers.clone(),
+                };
+                let fs = StdFs::new(dirs[i].path().to_path_buf());
+                ClusterRuntime::start_with_liveness(
+                    &cfg,
+                    &fs,
+                    SystemClock::new(),
+                    LogConfig::new(64 * 1024).unwrap(),
+                    liveness,
+                )
+                .expect("start cluster node")
+            })
+            .collect();
+
+        // A metadata leader is elected.
+        assert!(
+            wait_until(host_scaled(Duration::from_secs(20)), || nodes
+                .iter()
+                .filter(|n| n.status().is_leader)
+                .count()
+                == 1),
+            "a metadata leader is elected"
+        );
+        let leader_idx = nodes
+            .iter()
+            .position(|n| n.status().is_leader)
+            .expect("a leader");
+        let leader_id = ids[leader_idx];
+
+        // Commit the static placement: the metadata leader leads partition 0 over all three replicas
+        // at epoch >= 1. Every node converges on it (the input the failover re-places).
+        let epoch = nodes[leader_idx].status().leader_epoch.max(1);
+        nodes[leader_idx]
+            .propose_metadata(MetadataCommand::PlacePartition {
+                partition: TEST_PARTITION,
+                replicas: vec![1, 2, 3],
+                leader: leader_id,
+                epoch,
+            })
+            .expect("propose placement");
+        assert!(
+            wait_until(host_scaled(Duration::from_secs(20)), || nodes.iter().all(
+                |n| {
+                    n.status()
+                        .placements
+                        .get(&TEST_PARTITION)
+                        .is_some_and(|p| p.leader == leader_id)
+                }
+            )),
+            "the placement (leader = node {leader_id}) committed on every node"
+        );
+
+        // Install a healthy-ISR provider on every node (the cross-plane seam): committed HW = 100, the
+        // surviving committed replicas are all in-sync. This is what lets F2 pick an ISR successor.
+        for n in &nodes {
+            install_healthy_isr(n, vec![1, 2, 3], 100);
+        }
+
+        (serial, nodes, ids, dirs, leader_idx)
+    }
+
+    /// THE deliverable's heart: bring up a 3-node cluster with a committed placement, KILL the leader,
+    /// and let the AUTOMATIC path run (mark the dead leader unreachable — the deterministic detection
+    /// seam, no real-time sleep). Assert, with NO manual `reconcile` / `plan_failovers` in the test:
+    ///   (a) the runtime AUTO-detects the dead leader and proposes + commits its REMOVAL (the F1 path
+    ///       converts a crash into a committed membership shrink → `departed_members`);
+    ///   (b) it AUTO-plans + proposes + commits a PROMOTION of an ISR successor (F2 auto-fire);
+    ///   (c) the committed placement names a SURVIVING replica (never the dead leader) — the in-place
+    ///       successor — with the committed prefix preserved (the successor is ISR + complete: CI5);
+    ///   (d) the old leader's epoch is FENCED (the new placement's epoch strictly exceeds the old);
+    ///   (e) the cluster RESUMES: the surviving 2-node quorum commits a NEW metadata entry under the
+    ///       new metadata leader.
+    #[test]
+    fn killing_the_leader_auto_detects_promotes_an_isr_successor_and_the_cluster_resumes() {
+        // Detection here is driven by the DETERMINISTIC `force_peer_unreachable` seam (clock-independent),
+        // so we keep the DEFAULT (long) timeout: only the explicitly-killed node is ever detected — a
+        // healthy peer is NEVER spuriously suspected (no false failover), even under CI load. The seam
+        // is what makes this fast WITHOUT a real-time sleep; the timeout path is proven separately below.
+        let (_serial, mut nodes, ids, _dirs, leader_idx) =
+            bring_up_placed_cluster(LivenessConfig::default());
+        let dead_id = ids[leader_idx];
+        let old_epoch = nodes[leader_idx]
+            .status()
+            .placements
+            .get(&TEST_PARTITION)
+            .expect("placement")
+            .epoch;
+
+        // --- KILL the leader node: stop its threads (its metadata + would-be data plane go away). ---
+        nodes[leader_idx].stop();
+
+        // Drive the AUTOMATIC path deterministically: tell every SURVIVING node's liveness detector the
+        // dead node is unreachable. Whichever survivor becomes the new metadata leader will, on its next
+        // cycle, propose the dead node's removal (F1) and then the ISR-successor promotion (F2). This is
+        // the ONLY thing the test drives — NO manual reconcile / plan_failovers / promote call.
+        for (i, n) in nodes.iter().enumerate() {
+            if i != leader_idx {
+                n.force_peer_unreachable(dead_id, true);
+            }
+        }
+
+        // The surviving two nodes re-form a quorum and elect a NEW metadata leader (2 of 3 is a
+        // majority; raft re-elects on the tick cadence regardless of the clock).
+        let survivors: Vec<usize> = (0..3).filter(|&i| i != leader_idx).collect();
+        assert!(
+            wait_until(host_scaled(Duration::from_secs(20)), || survivors
+                .iter()
+                .filter(|&&i| nodes[i].status().is_leader)
+                .count()
+                == 1),
+            "the surviving quorum elects a new metadata leader"
+        );
+
+        // (a) the dead leader is AUTO-detected + REMOVED: it commits as a membership shrink, so it
+        // appears in `departed_members` on a surviving node (and the voter count drops to 2). No manual
+        // membership change was proposed by the test — only `force_peer_unreachable` + the driver's F1.
+        assert!(
+            wait_until(host_scaled(Duration::from_secs(25)), || survivors.iter().any(
+                |&i| {
+                    let s = nodes[i].status();
+                    s.departed_members.contains(&dead_id) && s.voter_count <= 2
+                }
+            )),
+            "(a) the dead leader is auto-detected and committed-removed (departed_members + voter_count<=2)"
+        );
+
+        // (b)+(c)+(d) the promotion AUTO-commits: a surviving node's committed placement for the
+        // partition now names a SURVIVING replica as leader, at a STRICTLY higher epoch (the fence),
+        // over the surviving replica set (the dead leader dropped).
+        assert!(
+            wait_until(host_scaled(Duration::from_secs(25)), || survivors.iter().any(
+                |&i| {
+                    nodes[i]
+                        .status()
+                        .placements
+                        .get(&TEST_PARTITION)
+                        .is_some_and(|p| p.leader != dead_id && p.epoch > old_epoch)
+                }
+            )),
+            "(b) a promotion auto-committed: the partition's committed leader changed to a survivor"
+        );
+
+        // Read the converged new placement from a survivor that has it.
+        let new_placement = survivors
+            .iter()
+            .find_map(|&i| {
+                nodes[i]
+                    .status()
+                    .placements
+                    .get(&TEST_PARTITION)
+                    .filter(|p| p.leader != dead_id)
+                    .cloned()
+            })
+            .expect("the new placement is committed on a survivor");
+        // (c) the successor is a SURVIVING in-sync replica (one of {1,2,3} minus the dead leader), and
+        // the dead leader was dropped from the replica set (no data move — survivors already held the log).
+        assert_ne!(new_placement.leader, dead_id, "(c) never the dead leader");
+        assert!(
+            ids.contains(&new_placement.leader),
+            "(c) the successor is a known surviving replica"
+        );
+        assert!(
+            !new_placement.replicas.contains(&dead_id),
+            "(c) the dead leader is dropped from the replica set"
+        );
+        assert!(
+            new_placement.replicas.contains(&new_placement.leader),
+            "(c) the new leader is one of the surviving replicas"
+        );
+        // (d) the fence: the new epoch strictly exceeds the dead leader's (KIP-101). A returning old
+        // leader carrying the old epoch is rejected by this higher committed epoch.
+        assert!(
+            new_placement.epoch > old_epoch,
+            "(d) the new epoch ({}) is fenced strictly above the dead leader's ({old_epoch})",
+            new_placement.epoch
+        );
+
+        // (e) the cluster RESUMES: the surviving quorum commits a NEW metadata entry under the new
+        // metadata leader (proving consensus is live again after the failover). Propose on whichever
+        // survivor is now leader and confirm both survivors apply it.
+        let new_leader_i = *survivors
+            .iter()
+            .find(|&&i| nodes[i].status().is_leader)
+            .expect("a surviving leader");
+        let applied_before = nodes[new_leader_i].status().applied_index;
+        nodes[new_leader_i]
+            .propose_metadata(MetadataCommand::SetConfig {
+                key: "post.failover".to_string(),
+                value: "ok".to_string(),
+            })
+            .expect("propose post-failover");
+        assert!(
+            wait_until(host_scaled(Duration::from_secs(20)), || survivors
+                .iter()
+                .all(|&i| nodes[i].status().applied_index > applied_before)),
+            "(e) the cluster resumes: a new metadata entry commits + applies on the surviving quorum"
+        );
+
+        for &i in &survivors {
+            nodes[i].stop();
+        }
+    }
+
+    /// The TIMEOUT path is deterministic too: with an injected SHORT deadline and a node whose
+    /// heartbeats stop, the F1 detector fires WITHOUT the force-unreachable seam — proving the
+    /// real production trigger (silence past the deadline) works, driven only by stopping a node (its
+    /// heartbeats cease, the survivors' `last_heard` for it goes stale past the deadline). No manual
+    /// reconcile; the auto path detects + promotes.
+    #[test]
+    fn the_liveness_timeout_alone_auto_fails_over_a_silent_leader() {
+        // The deadline is HOST-SCALED (base 2 s, stretched by the measured host slowdown, like every
+        // wait bound here) so the SURVIVORS' mutual heartbeats — themselves slowed proportionally under
+        // CI load — always stay a small FRACTION of the deadline and a healthy survivor is NEVER falsely
+        // suspected (the no-false-failover margin holds even on a starved runner). The KILLED node's
+        // heartbeats cease ENTIRELY, so its silence grows without bound and crosses the deadline
+        // regardless of scale. This is the one place a real-time interval is the trigger (it IS the
+        // production silence path); the post-trigger convergence is polled with the host-scaled bound.
+        let liveness = LivenessConfig {
+            timeout: host_scaled(Duration::from_secs(2)),
+            enabled: true,
+        };
+        let (_serial, mut nodes, ids, _dirs, leader_idx) = bring_up_placed_cluster(liveness);
+        let dead_id = ids[leader_idx];
+        let old_epoch = nodes[leader_idx]
+            .status()
+            .placements
+            .get(&TEST_PARTITION)
+            .expect("placement")
+            .epoch;
+
+        // KILL the leader — its heartbeats STOP. We do NOT force-unreachable; the survivors' detector
+        // must trip purely on the silence-past-deadline timeout.
+        nodes[leader_idx].stop();
+        let survivors: Vec<usize> = (0..3).filter(|&i| i != leader_idx).collect();
+
+        // The surviving quorum re-elects AND the timeout-driven F1+F2 path auto-detects + promotes.
+        // The bound covers the (host-scaled) liveness deadline the dead node must first cross PLUS the
+        // post-detection convergence, so it never races even on a starved runner.
+        assert!(
+            wait_until(host_scaled(Duration::from_secs(50)), || survivors.iter().any(
+                |&i| {
+                    let s = nodes[i].status();
+                    s.departed_members.contains(&dead_id)
+                        && s.placements
+                            .get(&TEST_PARTITION)
+                            .is_some_and(|p| p.leader != dead_id && p.epoch > old_epoch)
+                }
+            )),
+            "the liveness TIMEOUT alone (silence past the deadline) auto-detects + auto-promotes a survivor"
+        );
+
+        for &i in &survivors {
+            nodes[i].stop();
+        }
+    }
+
+    /// NO FALSE FAILOVER (the hardest non-negotiable): a healthy cluster with a brief, sub-deadline
+    /// hiccup NEVER auto-fails-over. With the DEFAULT (long) deadline, all three nodes stay up and
+    /// heartbeat; over a window many times the heartbeat interval the detector suspects NOBODY, removes
+    /// nobody, and promotes nobody — the placement is untouched, the leader unchanged.
+    #[test]
+    fn a_healthy_cluster_never_auto_fails_over() {
+        let (_serial, mut nodes, ids, _dirs, leader_idx) =
+            bring_up_placed_cluster(LivenessConfig::default());
+        let leader_id = ids[leader_idx];
+        let placement0 = nodes[leader_idx]
+            .status()
+            .placements
+            .get(&TEST_PARTITION)
+            .expect("placement")
+            .clone();
+
+        // Let the cluster run for a window MANY heartbeat intervals long (the heartbeat is ~300 ms; we
+        // observe for ~3 s). The default deadline (3 s) is 10x the heartbeat, so a healthy heartbeating
+        // peer is NEVER suspected within this window.
+        let observe_until = Instant::now() + Duration::from_secs(3);
+        while Instant::now() < observe_until {
+            for n in &nodes {
+                let s = n.status();
+                assert!(
+                    s.suspected_dead.is_empty(),
+                    "no healthy peer is ever suspected dead: {:?}",
+                    s.suspected_dead
+                );
+                assert!(
+                    s.departed_members.is_empty(),
+                    "no healthy peer ever departs: {:?}",
+                    s.departed_members
+                );
+                assert!(
+                    s.failover_proposed.is_empty(),
+                    "no failover is ever proposed for a healthy cluster"
+                );
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+
+        // The placement is byte-for-byte unchanged: same leader, same replicas, same epoch — the
+        // no-false-promotion / no-epoch-bump guarantee under a healthy cluster.
+        for n in &nodes {
+            if let Some(p) = n.status().placements.get(&TEST_PARTITION) {
+                assert_eq!(
+                    p.leader, leader_id,
+                    "the leader is unchanged (no false failover)"
+                );
+                assert_eq!(p.epoch, placement0.epoch, "no spurious epoch bump");
+                assert_eq!(
+                    p.replicas, placement0.replicas,
+                    "the replica set is unchanged"
+                );
+            }
+        }
+        // Every node still sees 3 voters (nobody was removed).
+        assert!(
+            nodes.iter().all(|n| n.status().voter_count == 3),
+            "all 3 voters remain (no spurious removal)"
+        );
+
+        for n in &mut nodes {
+            n.stop();
+        }
+    }
+
+    /// FAIL-CLOSED with NO data plane: a runtime with NO installed failover inputs (no data plane)
+    /// detects a dead leader and removes it, but AUTO-PROMOTES NOTHING — it never promotes blind
+    /// without the cross-plane ISR. The partition is left leaderless (its committed leader stays the
+    /// departed node) rather than promoting an unvetted successor that could lose committed data.
+    #[test]
+    fn no_data_plane_inputs_means_no_blind_promotion_fail_closed() {
+        let _serial = serial_guard();
+        let ids = [1u64, 2, 3];
+        let ports = free_ports(3);
+        let peers = peer_map(&ids, &ports);
+        let dirs: Vec<_> = ids
+            .iter()
+            .map(|_| tempfile::tempdir().expect("tempdir"))
+            .collect();
+        // DEFAULT (long) deadline: detection is driven by the deterministic `force_peer_unreachable`
+        // seam below, so only the killed node is detected — no healthy peer is spuriously suspected.
+        let liveness = LivenessConfig::default();
+        let mut nodes: Vec<ClusterRuntime> = ids
+            .iter()
+            .enumerate()
+            .map(|(i, &id)| {
+                let fs = StdFs::new(dirs[i].path().to_path_buf());
+                ClusterRuntime::start_with_liveness(
+                    &ClusterConfig {
+                        node_id: id,
+                        peers: peers.clone(),
+                    },
+                    &fs,
+                    SystemClock::new(),
+                    LogConfig::new(64 * 1024).unwrap(),
+                    liveness,
+                )
+                .expect("start node")
+            })
+            .collect();
+
+        assert!(
+            wait_until(host_scaled(Duration::from_secs(20)), || nodes
+                .iter()
+                .filter(|n| n.status().is_leader)
+                .count()
+                == 1),
+            "leader elected"
+        );
+        let leader_idx = nodes.iter().position(|n| n.status().is_leader).unwrap();
+        let leader_id = ids[leader_idx];
+        let epoch = nodes[leader_idx].status().leader_epoch.max(1);
+        nodes[leader_idx]
+            .propose_metadata(MetadataCommand::PlacePartition {
+                partition: TEST_PARTITION,
+                replicas: vec![1, 2, 3],
+                leader: leader_id,
+                epoch,
+            })
+            .expect("propose placement");
+        assert!(
+            wait_until(host_scaled(Duration::from_secs(20)), || nodes.iter().all(
+                |n| n
+                    .status()
+                    .placements
+                    .get(&TEST_PARTITION)
+                    .is_some_and(|p| p.leader == leader_id)
+            )),
+            "placement committed"
+        );
+
+        // NB: NO `install_healthy_isr` — the failover inputs are ABSENT (no data plane).
+        nodes[leader_idx].stop();
+        let survivors: Vec<usize> = (0..3).filter(|&i| i != leader_idx).collect();
+        for &i in &survivors {
+            nodes[i].force_peer_unreachable(leader_id, true);
+        }
+
+        // The dead leader IS auto-detected + removed (F1 doesn't need the data plane).
+        assert!(
+            wait_until(host_scaled(Duration::from_secs(25)), || survivors
+                .iter()
+                .any(|&i| nodes[i].status().departed_members.contains(&leader_id))),
+            "F1 still removes the dead leader (detection needs no data plane)"
+        );
+
+        // But NO promotion is ever proposed (fail-closed): the committed placement's leader stays the
+        // departed node. Observe for a generous window AFTER the removal committed.
+        let check_until = Instant::now() + host_scaled(Duration::from_secs(4));
+        while Instant::now() < check_until {
+            for &i in &survivors {
+                let s = nodes[i].status();
+                assert!(
+                    s.failover_proposed.is_empty(),
+                    "fail-closed: NO promotion proposed without cross-plane ISR inputs"
+                );
+                if let Some(p) = s.placements.get(&TEST_PARTITION) {
+                    assert_eq!(
+                        p.leader, leader_id,
+                        "fail-closed: the partition stays led by the departed node (leaderless), never blind-promoted"
+                    );
+                }
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+
+        for &i in &survivors {
+            nodes[i].stop();
+        }
     }
 }
 

--- a/crates/ironbus-server/src/cluster/runtime.rs
+++ b/crates/ironbus-server/src/cluster/runtime.rs
@@ -929,9 +929,10 @@ struct DriverFailover<C: Clock + Clone> {
 /// metadata-Raft leader, both go through the metadata Raft log (committed, ordered), and both are
 /// idempotent (a removal of an already-gone node and a promotion of an already-converged placement are
 /// skipped) — so no two nodes can drive a different failover; the Raft log linearizes it.
-#[allow(clippy::too_many_lines)] // the driver loop is ONE linear consensus cycle (tick, step+record,
-                                 // drive_ready, registry refresh, F1 detect, F2 auto-fire, publish);
-                                 // splitting it would scatter a single tightly-ordered concern.
+#[allow(clippy::too_many_lines)]
+// the driver loop is ONE linear consensus cycle (tick, step+record,
+// drive_ready, registry refresh, F1 detect, F2 auto-fire, publish);
+// splitting it would scatter a single tightly-ordered concern.
 #[allow(clippy::needless_pass_by_value)] // a thread entry point: it OWNS the group + the shared
                                          // channels/Arcs + the failover wiring for the thread's whole
                                          // lifetime; a borrow would fight the 'static spawn bound.

--- a/crates/ironbus-server/src/cluster/runtime.rs
+++ b/crates/ironbus-server/src/cluster/runtime.rs
@@ -62,7 +62,8 @@ use std::thread::JoinHandle;
 use std::time::Duration;
 
 use ironbus_core::clock::Clock;
-use ironbus_core::placement::{LeaderLoad, PlacementNode};
+use ironbus_core::leader_lease::LeaderEpoch;
+use ironbus_core::placement::PlacementNode;
 use ironbus_storage::fs::Filesystem;
 use ironbus_storage::log::LogConfig;
 use raft::eraftpb::Message;
@@ -113,6 +114,18 @@ const DIALER_RECONNECT_BACKOFF: Duration = Duration::from_millis(500);
 /// seam, so the kill-the-leader test drives detection deterministically (advance a [`ManualClock`])
 /// rather than sleeping a real 3 s — no wall-clock flake.
 pub const DEFAULT_LIVENESS_TIMEOUT: Duration = Duration::from_millis(3_000);
+
+/// How often the data-plane LEADER proposes a committed-HW CHECKPOINT into the metadata Raft (#618b):
+/// the cadence at which it persists "every offset below this is quorum-fsync'd" so the bar SURVIVES its
+/// death. It is deliberately PERIODIC, NOT per record — a per-record checkpoint would put a metadata
+/// Raft round-trip on the produce hot path. At this cadence the persisted bar trails the live committed
+/// HW by at most one interval; a successor is only ever required to hold up to the LAST checkpointed bar,
+/// so it never loses *checkpointed* committed data, and the small trailing window is the documented
+/// availability/cost trade (the checkpoint is cheap; raising the cadence tightens the window). It is the
+/// committed-HW analogue of [`TICK_INTERVAL`]: bounded, low-rate, self-healing if a single proposal is
+/// dropped (the next cycle re-proposes the then-current HW). Proposed only when this node both LEADS the
+/// metadata group AND leads the partition's data plane (it is the only node that knows the live HW).
+const COMMITTED_HW_CHECKPOINT_INTERVAL: Duration = Duration::from_millis(500);
 
 /// The fixed TCP-port offset the DATA-plane peer listener binds at, RELATIVE to a node's configured
 /// metadata address (#717). One `--cluster-peer <id>=<addr>` entry thus serves BOTH transports: the
@@ -178,17 +191,34 @@ pub type SurvivorStateFn = dyn Fn(u64, &[u64]) -> Vec<PlacementNode> + Send + Sy
 /// member already holds), supplied cross-plane by the data plane alongside [`SurvivorStateFn`].
 pub type CommittedHwFn = dyn Fn(u64) -> u64 + Send + Sync;
 
-/// The cross-plane inputs the F2 auto-failover driver reads to pick an ISR successor. INSTALLED by the
-/// data-plane bootstrap ([`ClusterRuntime::set_failover_inputs`]) once it owns the live data plane;
-/// ABSENT until then, so a runtime with no data plane fails CLOSED — it auto-proposes NO promotion
-/// (rather than promoting blind). The `survivors` closure surfaces the live ISR; `committed_hw` the
-/// per-partition committed frontier.
+/// THIS node's OWN real data-plane durable frontier for a partition (its follower high-watermark, or
+/// its leader quorum-commit) — the prefix it has itself durably appended (#618b). Supplied cross-plane
+/// by the data plane. The auto-failover path can ONLY prove a successor complete from data the surviving
+/// cluster actually holds, and the only frontier the metadata leader KNOWS is its OWN; so the
+/// provably-complete-or-fail-closed rule compares THIS against the persisted committed-HW checkpoint.
+pub type OwnFrontierFn = dyn Fn(u64) -> u64 + Send + Sync;
+
+/// The cross-plane inputs the F2 auto-failover driver reads. INSTALLED by the data-plane bootstrap
+/// ([`ClusterRuntime::set_failover_inputs`]) once it owns the live data plane; ABSENT until then, so a
+/// runtime with no data plane fails CLOSED — it auto-proposes NO promotion (rather than promoting
+/// blind).
+///
+/// As of #618b these inputs serve BOTH the (cheap, periodic) committed-HW CHECKPOINT the data-plane
+/// leader proposes AND the provably-complete-or-fail-closed auto-promotion: `own_frontier` is THIS
+/// node's real durable frontier (the only frontier the metadata leader can vouch for), `survivors` is
+/// the live ISR-aware projection, and `committed_hw` is this node's own committed frontier (what it
+/// checkpoints when it leads).
 #[derive(Clone)]
 pub struct FailoverInputs {
     /// The live ISR-aware survivor-state projection (see [`SurvivorStateFn`]).
     pub survivors: Arc<SurvivorStateFn>,
-    /// The live per-partition committed high-watermark (see [`CommittedHwFn`]).
+    /// The live per-partition committed high-watermark THIS node observes (see [`CommittedHwFn`]). When
+    /// this node is the data-plane leader it is the quorum-commit frontier it CHECKPOINTS periodically.
     pub committed_hw: Arc<CommittedHwFn>,
+    /// THIS node's own real durable frontier per partition (see [`OwnFrontierFn`]). The provably-complete
+    /// auto-failover compares this against the PERSISTED committed-HW checkpoint to decide whether THIS
+    /// node may safely self-promote (frontier >= checkpoint) or must fail closed.
+    pub own_frontier: Arc<OwnFrontierFn>,
 }
 
 /// A point-in-time snapshot of the local cluster member's metadata-plane state, published by the
@@ -239,6 +269,12 @@ pub struct ClusterStatus {
     /// leader's partitions, re-placed onto an ISR successor). Observability only; cleared when the
     /// promotion commits (the placement's leader is no longer the departed node).
     pub failover_proposed: BTreeSet<u64>,
+    /// The last-checkpointed quorum-committed high-watermark per partition (#618b), as applied from the
+    /// replicated metadata ([`MetadataCommand::CheckpointCommittedHw`]). This is the SAFE bar that
+    /// SURVIVES the leader's death: after a leader dies a survivor reads this to know the committed offset
+    /// a successor MUST hold before it may be auto-promoted. Empty until the data-plane leader has
+    /// checkpointed at least once. Monotonic per partition (the state machine only ever raises it).
+    pub last_committed_hw: BTreeMap<u64, u64>,
 }
 
 /// A command for the driver to propose to the metadata group on behalf of the broker (or a test):
@@ -945,6 +981,15 @@ fn run_driver<F, C>(
 
     let deadline_nanos = duration_to_nanos(failover.liveness.timeout);
 
+    // CP STATE (#618b): the cadence + the last monotonic time we proposed a committed-HW checkpoint, so
+    // a leader checkpoints PERIODICALLY (not per cycle / per record). Seeded back a full interval so the
+    // first checkpoint can fire as soon as the data plane installs its inputs.
+    let checkpoint_interval_nanos = duration_to_nanos(COMMITTED_HW_CHECKPOINT_INTERVAL);
+    let mut last_checkpoint_nanos = failover
+        .clock
+        .now_monotonic_nanos()
+        .saturating_sub(checkpoint_interval_nanos);
+
     while !shutdown.load(Ordering::Acquire) {
         // Advance the logical election/heartbeat timer once per cadence.
         group.tick();
@@ -1078,15 +1123,55 @@ fn run_driver<F, C>(
             }
         }
 
-        // ----- F2: AUTO-FIRE the failover. On a committed membership shrink (`departed_members`
-        // non-empty), the metadata leader auto-plans a promotion for every partition a departed node
-        // LED, feeding `plan_failovers` the LIVE data-plane ISR (the installed cross-plane providers),
-        // and proposes each resulting PlacePartition through the metadata Raft. Single proposer +
-        // idempotent: a partition whose committed placement no longer names the departed node as leader
-        // has already failed over (skip). Fail-closed: with no installed providers, or no eligible ISR
-        // survivor, NO promotion is proposed (the partition stays leaderless until a survivor catches
-        // up) — committed data is never lost by promoting an incomplete replica. -----
         let placements = group.state().placements();
+
+        // ----- CP: PERSIST the committed-HW CHECKPOINT (#618b). On a cadence the metadata leader, IF it
+        // also leads a partition's data plane (so it knows the live committed HW), proposes a
+        // `CheckpointCommittedHw` into the metadata Raft. This is what makes the committed bar SURVIVE the
+        // leader's death: after the leader dies a survivor reads the last committed checkpoint and knows
+        // the SAFE offset a successor MUST hold. It is PERIODIC + bounded (never per record). -----
+        if group.is_leader() {
+            let due = now.saturating_sub(last_checkpoint_nanos) >= checkpoint_interval_nanos;
+            if due {
+                if let Some(inputs) = shared.failover_inputs.lock().ok().and_then(|g| g.clone()) {
+                    // Checkpoint only the partitions THIS node currently LEADS in the committed
+                    // placement (it is the only node that knows their live committed HW). A new placement
+                    // value re-checkpoints under the next leader once it owns the data plane.
+                    for (&partition, placement) in &placements {
+                        if placement.leader != node_id {
+                            continue;
+                        }
+                        let hw = (inputs.committed_hw)(partition);
+                        // Skip a no-op: the bar is monotonic, so re-proposing an already-recorded (or
+                        // lower) value adds nothing. Only propose when it would RAISE the persisted bar.
+                        let persisted = group.state().committed_hw(partition).unwrap_or(0);
+                        if hw <= persisted {
+                            continue;
+                        }
+                        let cmd = MetadataCommand::CheckpointCommittedHw {
+                            partition,
+                            offset: hw,
+                        };
+                        if let Err(e) = group.propose(&cmd) {
+                            tracing::debug!(partition, error = %e, "cluster: committed-HW checkpoint deferred");
+                        }
+                    }
+                }
+                last_checkpoint_nanos = now;
+            }
+        }
+
+        // ----- F2: AUTO-FIRE the failover — PROVABLY committed-safe, fail-closed (#618b). On a committed
+        // membership shrink (`departed_members` non-empty), the metadata leader auto-promotes a partition
+        // a departed node LED, but ONLY a successor it can PROVE holds every committed record — i.e.
+        // ONLY ITSELF, and only when its own real durable frontier has reached the PERSISTED committed-HW
+        // checkpoint (the bar that survived the dead leader). It does NOT know remote frontiers (no ISR
+        // gossip yet), so a remote node — even a committed replica — is NEVER blind-promoted. In EVERY
+        // case it cannot prove safety (own frontier behind the bar, or only a remote node might be
+        // complete) it FAILS CLOSED: proposes nothing, leaves the partition leaderless, and logs the
+        // withholding. The chosen successor is re-verified against CI5 before it is proposed, so the
+        // runtime — not just a test — enforces the committed-completeness invariant. Single proposer +
+        // idempotent (a partition already re-led by a survivor is skipped). -----
         // Drop any "proposed" marks whose committed placement has already moved off the departed leader
         // (the promotion landed) so a later, distinct departure can re-fire.
         failover_proposed.retain(|p| {
@@ -1097,29 +1182,93 @@ fn run_driver<F, C>(
         if group.is_leader() && !departed_members.is_empty() {
             let inputs = shared.failover_inputs.lock().ok().and_then(|g| g.clone());
             if let Some(inputs) = inputs {
-                let survivors = Arc::clone(&inputs.survivors);
-                let committed_hw = Arc::clone(&inputs.committed_hw);
-                let proposals = plan_failovers(
-                    &placements,
-                    &departed_members,
-                    |partition, s| survivors(partition, s),
-                    |partition| committed_hw(partition),
-                    &LeaderLoad::new(),
-                );
-                for cmd in proposals {
-                    let MetadataCommand::PlacePartition { partition, .. } = &cmd else {
-                        continue;
-                    };
-                    let partition = *partition;
+                for (&partition, placement) in &placements {
+                    if !departed_members.contains(&placement.leader) {
+                        continue; // not led by a departed node (or already failed over).
+                    }
                     if failover_proposed.contains(&partition) {
                         continue; // promotion already in flight; let it commit.
                     }
+                    // The SAFE bar: the PERSISTED committed-HW checkpoint that survived the dead leader.
+                    // Absent (no checkpoint ever committed for this partition) => we cannot prove ANY
+                    // successor safe => fail closed.
+                    let Some(safe_bar) = group.state().committed_hw(partition) else {
+                        tracing::info!(
+                            partition,
+                            "cluster: F2 auto-failover WITHHELD — no persisted committed-HW checkpoint; \
+                             leaving the partition leaderless until a provably-complete replica is known"
+                        );
+                        continue;
+                    };
+                    // The ONLY successor we can PROVE complete is THIS node, and only when its own real
+                    // durable frontier has reached the safe bar. We do not know remote frontiers.
+                    let own_frontier = (inputs.own_frontier)(partition);
+                    if own_frontier < safe_bar {
+                        tracing::info!(
+                            partition,
+                            own_frontier,
+                            safe_bar,
+                            "cluster: F2 auto-failover WITHHELD (fail-closed) — the metadata leader's own \
+                             frontier is behind the persisted committed-HW checkpoint; no provably-complete \
+                             replica is known, so the partition stays leaderless (recoverable)"
+                        );
+                        continue;
+                    }
+                    // Build the self-promotion and re-verify it against CI5 (the runtime gate, not just a
+                    // test): the successor is THIS node, it is in its own ISR by construction (it leads /
+                    // holds the committed log to the bar), its durable prefix >= the bar, and the new
+                    // epoch strictly exceeds the dead leader's. If CI5 rejects it for ANY reason, fail
+                    // closed rather than propose it.
+                    let new_epoch = placement.epoch.saturating_add(1);
+                    let failover = ironbus_core::cluster_invariants::Failover {
+                        dead_leader: placement.leader,
+                        successor: node_id,
+                        successor_in_isr: true,
+                        successor_durable_prefix: own_frontier,
+                        committed_hw: safe_bar,
+                        dead_leader_epoch: LeaderEpoch::new(placement.epoch),
+                        successor_epoch: LeaderEpoch::new(new_epoch),
+                    };
+                    if let Err(violation) =
+                        ironbus_core::cluster_invariants::check_failover_preserves_committed(
+                            &failover,
+                        )
+                    {
+                        tracing::warn!(
+                            partition,
+                            %violation,
+                            "cluster: F2 auto-failover WITHHELD — the self-promotion failed the CI5 \
+                             committed-completeness gate; failing closed"
+                        );
+                        continue;
+                    }
+                    // Survivors = the old replica set minus the departed leader, with THIS node ensured
+                    // present (it is the new leader). The bar is carried in the command so the apply-time
+                    // self-verify (defense in depth) can re-check it before this node becomes leader.
+                    let mut survivors: Vec<u64> = placement
+                        .replicas
+                        .iter()
+                        .copied()
+                        .filter(|&n| n != placement.leader)
+                        .collect();
+                    if !survivors.contains(&node_id) {
+                        survivors.push(node_id);
+                    }
+                    let cmd = MetadataCommand::PlacePartition {
+                        partition,
+                        replicas: survivors,
+                        leader: node_id,
+                        epoch: new_epoch,
+                    };
                     match group.propose(&cmd) {
                         Ok(()) => {
                             failover_proposed.insert(partition);
                             tracing::info!(
                                 partition,
-                                "cluster: F2 auto-fire proposed an ISR-successor promotion (leaderless failover)"
+                                successor = node_id,
+                                safe_bar,
+                                "cluster: F2 auto-fire proposed a PROVABLY-COMPLETE self-promotion (the \
+                                 metadata leader's frontier holds the persisted committed-HW checkpoint)"
                             );
                         }
                         Err(e) => {
@@ -1144,6 +1293,10 @@ fn run_driver<F, C>(
             let applied = group.state().applied_index();
             if applied != s.applied_index {
                 s.placements = placements.clone();
+                // The persisted committed-HW checkpoints (#618b) advance with the applied log, so
+                // re-publish them whenever the applied index does (they are the SAFE bars survivors read
+                // after a leader death).
+                s.last_committed_hw = group.state().committed_hws();
             }
             s.applied_index = applied;
             // Publish the leaderless-failover detection signal (the departed-members set), so the
@@ -2003,11 +2156,27 @@ mod tests {
     const TEST_PARTITION: u64 = 0;
 
     /// Install a SIMULATED healthy-ISR failover-input provider on a node: every surviving committed
-    /// replica is reported in-ISR and complete to the committed HW, so the F2 auto-fire path has a
-    /// valid cross-plane ISR to choose a successor from (the metadata plane does not itself hold ISR
-    /// state — this is the seam the real data-plane bootstrap fills, #618). `committed_hw` is the
-    /// quorum-acked frontier every ISR member holds; `replicas` the committed replica set.
+    /// replica is reported in-ISR and complete to the committed HW, and THIS node's own frontier is
+    /// reported AT the committed HW (a caught-up survivor). With every survivor caught up, the metadata
+    /// leader's own frontier reaches the persisted committed-HW checkpoint, so the SAFE path
+    /// self-promotes (#618b). The metadata plane does not itself hold ISR/frontier state — this is the
+    /// seam the real data-plane bootstrap fills. `committed_hw` is the quorum-acked frontier every ISR
+    /// member holds; `replicas` the committed replica set.
     fn install_healthy_isr(node: &ClusterRuntime, replicas: Vec<u64>, committed_hw: u64) {
+        install_isr_with_own_frontier(node, replicas, committed_hw, committed_hw);
+    }
+
+    /// Like [`install_healthy_isr`] but with an explicit OWN-frontier value, so a test can model THIS
+    /// node LAGGING the committed HW (own frontier < committed HW) — the case the safe path must FAIL
+    /// CLOSED on. Every surviving committed replica is still reported in-ISR + complete (the cross-plane
+    /// ISR cannot see remote frontiers), but this node's own frontier is what the provably-complete rule
+    /// actually compares against the persisted checkpoint.
+    fn install_isr_with_own_frontier(
+        node: &ClusterRuntime,
+        replicas: Vec<u64>,
+        committed_hw: u64,
+        own_frontier: u64,
+    ) {
         let committed: BTreeSet<u64> = replicas.into_iter().collect();
         let survivors: Arc<SurvivorStateFn> = Arc::new(move |_partition, survivor_ids: &[u64]| {
             survivor_ids
@@ -2017,9 +2186,11 @@ mod tests {
                 .collect()
         });
         let committed_hw_fn: Arc<CommittedHwFn> = Arc::new(move |_partition| committed_hw);
+        let own_frontier_fn: Arc<OwnFrontierFn> = Arc::new(move |_partition| own_frontier);
         node.set_failover_inputs(FailoverInputs {
             survivors,
             committed_hw: committed_hw_fn,
+            own_frontier: own_frontier_fn,
         });
     }
 
@@ -2106,10 +2277,23 @@ mod tests {
         );
 
         // Install a healthy-ISR provider on every node (the cross-plane seam): committed HW = 100, the
-        // surviving committed replicas are all in-sync. This is what lets F2 pick an ISR successor.
+        // surviving committed replicas are all in-sync and every node's OWN frontier is at the HW. This
+        // is what lets the safe F2 path self-promote a caught-up successor.
         for n in &nodes {
             install_healthy_isr(n, vec![1, 2, 3], 100);
         }
+
+        // The metadata leader (it leads the partition's data plane in this model) auto-checkpoints the
+        // committed HW on its cadence. Wait until the persisted committed-HW checkpoint has committed on
+        // every node, so the SAFE bar (= 100) survives the leader's death and a successor can be proven
+        // complete against it (#618b). Without this persisted bar the safe path would (correctly) fail
+        // closed, so the kill-the-leader test depends on it being durably recorded first.
+        assert!(
+            wait_until(host_scaled(Duration::from_secs(20)), || nodes.iter().all(
+                |n| { n.status().last_committed_hw.get(&TEST_PARTITION).copied() == Some(100) }
+            )),
+            "the committed-HW checkpoint (=100) committed on every node"
+        );
 
         (serial, nodes, ids, dirs, leader_idx)
     }
@@ -2373,6 +2557,179 @@ mod tests {
 
         for n in &mut nodes {
             n.stop();
+        }
+    }
+
+    /// THE #618b REGRESSION TEST — a LAGGING survivor is NEVER promoted (committed-data-loss is closed).
+    ///
+    /// Scenario (the realistic 3-node R3, `min_isr`=2 bug): a committed, client-acked record reached quorum
+    /// on the leader + ONE follower only, so the THIRD survivor is BEHIND the committed HW. The leader
+    /// dies. We drive the deterministic auto path and assert the auto path NEVER promotes the lagging
+    /// node — EITHER it promotes the COMPLETE survivor (when that survivor is the new metadata leader,
+    /// whose own frontier reaches the persisted committed-HW checkpoint and self-promotes) OR it FAILS
+    /// CLOSED (no leader elected for the partition, because the new metadata leader is the lagging one and
+    /// cannot prove itself complete). In BOTH outcomes NO committed record is lost: no surviving leader is
+    /// ever missing a pre-death quorum-acked offset.
+    ///
+    /// Modeled deterministically (no real-time sleep): the persisted committed-HW checkpoint = 100 (the
+    /// pre-death committed bar); the COMPLETE survivor's own frontier = 100; the LAGGING survivor's own
+    /// frontier = 80 (it missed the last committed record). The lagging node can therefore never satisfy
+    /// `own_frontier >= safe_bar`, so it can never self-promote — exactly the safety property.
+    #[test]
+    fn a_lagging_survivor_is_never_auto_promoted_and_no_committed_record_is_lost() {
+        // Bring up the placed cluster with the persisted committed-HW checkpoint = 100 (the safe bar).
+        let (_serial, mut nodes, ids, _dirs, leader_idx) =
+            bring_up_placed_cluster(LivenessConfig::default());
+        let dead_id = ids[leader_idx];
+        let safe_bar = 100u64; // the persisted committed HW every promotion must clear.
+
+        // The two survivors. Pick ONE to be the LAGGING node (behind the committed HW) and the other to
+        // be the COMPLETE node (caught up). We model their REAL own-frontiers via the cross-plane seam:
+        // the lagging node's own frontier is 80 (< the bar), the complete node's is 100 (== the bar).
+        let survivors: Vec<usize> = (0..3).filter(|&i| i != leader_idx).collect();
+        let lagging_i = survivors[0];
+        let complete_i = survivors[1];
+        let lagging_id = ids[lagging_i];
+        let complete_id = ids[complete_i];
+        // Re-install the providers to reflect the divergent frontiers (the bar persisted from setup
+        // stays = 100; only each node's OWN frontier differs now).
+        install_isr_with_own_frontier(&nodes[lagging_i], vec![1, 2, 3], safe_bar, 80);
+        install_isr_with_own_frontier(&nodes[complete_i], vec![1, 2, 3], safe_bar, safe_bar);
+
+        // KILL the leader and drive detection deterministically on the survivors.
+        nodes[leader_idx].stop();
+        for &i in &survivors {
+            nodes[i].force_peer_unreachable(dead_id, true);
+        }
+
+        // A new metadata leader is elected among the survivors and the dead leader is removed (F1).
+        assert!(
+            wait_until(host_scaled(Duration::from_secs(25)), || survivors
+                .iter()
+                .any(|&i| {
+                    let s = nodes[i].status();
+                    s.departed_members.contains(&dead_id) && s.is_leader
+                })),
+            "a surviving metadata leader is elected and the dead leader is removed"
+        );
+
+        // Give the auto path a generous window to do WHATEVER it is going to do, then assert the two
+        // safety properties hold throughout AND at the end. We poll the converged outcome.
+        let observe_until = Instant::now() + host_scaled(Duration::from_secs(8));
+        while Instant::now() < observe_until {
+            for &i in &survivors {
+                let s = nodes[i].status();
+                // PROPERTY 1: the LAGGING node is NEVER the committed partition leader. This is the core
+                // committed-data-loss guard — promoting it would lose offsets 80..100.
+                if let Some(p) = s.placements.get(&TEST_PARTITION) {
+                    assert_ne!(
+                        p.leader, lagging_id,
+                        "the lagging survivor must NEVER be auto-promoted (it is missing committed offsets 80..100)"
+                    );
+                    // PROPERTY 2 (no committed loss): any committed partition leader is either the dead
+                    // leader (not yet failed over) or the COMPLETE survivor — never an incomplete node.
+                    assert!(
+                        p.leader == dead_id || p.leader == complete_id,
+                        "a committed partition leader is only ever the (pre-failover) dead leader or the complete survivor, got {}",
+                        p.leader
+                    );
+                }
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+
+        // FINAL converged outcome: EITHER the complete survivor was promoted (it became the metadata
+        // leader and self-promoted) OR the partition stayed leaderless under the dead leader (the new
+        // metadata leader was the lagging one and FAILED CLOSED). Both are committed-safe.
+        let promoted_complete = survivors.iter().any(|&i| {
+            nodes[i]
+                .status()
+                .placements
+                .get(&TEST_PARTITION)
+                .is_some_and(|p| p.leader == complete_id)
+        });
+        let stayed_leaderless = survivors.iter().all(|&i| {
+            nodes[i]
+                .status()
+                .placements
+                .get(&TEST_PARTITION)
+                .is_some_and(|p| p.leader == dead_id)
+        });
+        assert!(
+            promoted_complete || stayed_leaderless,
+            "the auto path either promoted the COMPLETE survivor or failed closed (leaderless) — never the lagging node"
+        );
+        // The lagging node is never promoted in EITHER outcome (re-assert at the converged state).
+        for &i in &survivors {
+            if let Some(p) = nodes[i].status().placements.get(&TEST_PARTITION) {
+                assert_ne!(
+                    p.leader, lagging_id,
+                    "converged: the lagging node was never promoted"
+                );
+            }
+        }
+
+        for &i in &survivors {
+            nodes[i].stop();
+        }
+    }
+
+    /// FAIL-CLOSED, safety-over-availability (#618b): when the metadata leader's OWN frontier is BEHIND
+    /// the persisted committed-HW checkpoint, it proposes NO promotion — the partition stays leaderless
+    /// (recoverable) rather than risk losing committed data. This pins the safety-over-availability
+    /// trade: a complete replica may exist REMOTELY, but the metadata leader cannot prove it (no ISR
+    /// gossip), so it withholds. Deterministic: we force EVERY survivor's own frontier behind the bar, so
+    /// whichever one wins the election cannot self-promote.
+    #[test]
+    fn the_metadata_leader_behind_the_committed_bar_proposes_no_promotion_fail_closed() {
+        let (_serial, mut nodes, ids, _dirs, leader_idx) =
+            bring_up_placed_cluster(LivenessConfig::default());
+        let dead_id = ids[leader_idx];
+        let safe_bar = 100u64;
+        let survivors: Vec<usize> = (0..3).filter(|&i| i != leader_idx).collect();
+
+        // BOTH survivors lag the persisted bar (own frontier 70 < 100) — model the case where the only
+        // complete replica is the (now-dead) one, so no survivor can prove itself complete.
+        for &i in &survivors {
+            install_isr_with_own_frontier(&nodes[i], vec![1, 2, 3], safe_bar, 70);
+        }
+
+        nodes[leader_idx].stop();
+        for &i in &survivors {
+            nodes[i].force_peer_unreachable(dead_id, true);
+        }
+
+        // The dead leader IS detected + removed (F1 needs no completeness).
+        assert!(
+            wait_until(host_scaled(Duration::from_secs(25)), || survivors
+                .iter()
+                .any(|&i| nodes[i].status().departed_members.contains(&dead_id))),
+            "the dead leader is auto-detected + removed"
+        );
+
+        // But NO promotion is ever proposed (fail-closed): no survivor can prove it holds the bar. The
+        // partition stays led by the (departed) old leader; `failover_proposed` stays empty. Observe for
+        // a generous window AFTER the removal committed.
+        let check_until = Instant::now() + host_scaled(Duration::from_secs(6));
+        while Instant::now() < check_until {
+            for &i in &survivors {
+                let s = nodes[i].status();
+                assert!(
+                    s.failover_proposed.is_empty(),
+                    "fail-closed: NO promotion proposed when no survivor can prove it holds the committed bar"
+                );
+                if let Some(p) = s.placements.get(&TEST_PARTITION) {
+                    assert_eq!(
+                        p.leader, dead_id,
+                        "fail-closed: the partition stays leaderless (still names the departed leader), never blind-promoted"
+                    );
+                }
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+
+        for &i in &survivors {
+            nodes[i].stop();
         }
     }
 

--- a/crates/ironbus-server/src/cluster/runtime.rs
+++ b/crates/ironbus-server/src/cluster/runtime.rs
@@ -113,7 +113,7 @@ const DIALER_RECONNECT_BACKOFF: Duration = Duration::from_millis(500);
 /// It is a DEFAULT: the deadline is injectable ([`LivenessConfig`]) and the clock is the I6 monotonic
 /// seam, so the kill-the-leader test drives detection deterministically (advance a [`ManualClock`])
 /// rather than sleeping a real 3 s — no wall-clock flake.
-pub const DEFAULT_LIVENESS_TIMEOUT: Duration = Duration::from_millis(3_000);
+pub const DEFAULT_LIVENESS_TIMEOUT: Duration = Duration::from_secs(3);
 
 /// How often the data-plane LEADER proposes a committed-HW CHECKPOINT into the metadata Raft (#618b):
 /// the cadence at which it persists "every offset below this is quorum-fsync'd" so the bar SURVIVES its
@@ -929,9 +929,10 @@ struct DriverFailover<C: Clock + Clone> {
 /// metadata-Raft leader, both go through the metadata Raft log (committed, ordered), and both are
 /// idempotent (a removal of an already-gone node and a promotion of an already-converged placement are
 /// skipped) — so no two nodes can drive a different failover; the Raft log linearizes it.
-#[allow(clippy::too_many_lines)] // the driver loop is ONE linear consensus cycle (tick, step+record,
-                                 // drive_ready, registry refresh, F1 detect, F2 auto-fire, publish);
-                                 // splitting it would scatter a single tightly-ordered concern.
+#[allow(clippy::too_many_lines)]
+// the driver loop is ONE linear consensus cycle (tick, step+record,
+// drive_ready, registry refresh, F1 detect, F2 auto-fire, publish);
+// splitting it would scatter a single tightly-ordered concern.
 #[allow(clippy::needless_pass_by_value)] // a thread entry point: it OWNS the group + the shared
                                          // channels/Arcs + the failover wiring for the thread's whole
                                          // lifetime; a borrow would fight the 'static spawn bound.

--- a/crates/ironbus-server/src/cluster/serve.rs
+++ b/crates/ironbus-server/src/cluster/serve.rs
@@ -2618,6 +2618,9 @@ mod live_runtime_tests {
     #[test]
     fn live_three_node_runtime_replicates_and_quorum_gates_a_c2_fsync_produce() {
         const P: u64 = 0;
+        // Serialize against the other heavy multi-node cluster tests (here and in the `runtime` module)
+        // so this thread-spinning cluster runs on an un-contended host (no #687 starvation flake).
+        let _serial = crate::cluster::heavy_cluster_test_guard();
         let placement = Placement {
             replicas: vec![1, 2, 3],
             leader: 1,
@@ -2791,6 +2794,7 @@ mod live_runtime_tests {
     #[test]
     fn live_runtime_below_min_isr_keeps_the_wire_ack_parked() {
         const P: u64 = 0;
+        let _serial = crate::cluster::heavy_cluster_test_guard();
         let placement = Placement {
             replicas: vec![1, 2, 3],
             leader: 1,
@@ -2847,6 +2851,7 @@ mod live_runtime_tests {
     #[test]
     fn live_runtime_follower_restart_resumes_replication() {
         const P: u64 = 0;
+        let _serial = crate::cluster::heavy_cluster_test_guard();
         let placement = Placement {
             replicas: vec![1, 2],
             leader: 1,

--- a/crates/ironbus-server/src/cluster/serve.rs
+++ b/crates/ironbus-server/src/cluster/serve.rs
@@ -488,6 +488,11 @@ impl<F: Filesystem + Clone, C: Clock> DataPlaneServer<F, C> {
     /// also updates the follower's leader TARGET when a still-following node's leader changed to the new
     /// successor. `isr_config` sizes the promoted leader's ISR / quorum gate.
     ///
+    /// `committed_hw_bar` is the SAFE bar carried with the failover (the persisted committed-HW
+    /// checkpoint, #618b): on the in-place promotion it is RE-VERIFIED against this node's own durable
+    /// log (defense in depth), so a promotion that would leave a leader missing committed data is aborted
+    /// fail-closed rather than creating a false leader. Pass `0` for the no-bar / n=1 degenerate.
+    ///
     /// Returns `true` if this node's role for `partition` changed (a promotion or a re-targeted
     /// follower), `false` if nothing changed for this node (e.g. it does not hold the partition, or it
     /// was already the leader / still follows the same leader).
@@ -498,13 +503,14 @@ impl<F: Filesystem + Clone, C: Clock> DataPlaneServer<F, C> {
     /// promotion, which is the failover correctness property; a full live rebalance is C5-I2 (#617).
     ///
     /// # Errors
-    /// [`DataPlaneError`] if the in-place promotion fails (a read-plane build or a backward-epoch
-    /// assign — fail-closed).
+    /// [`DataPlaneError`] if the in-place promotion fails (a read-plane build, a backward-epoch assign,
+    /// or the apply-time committed-completeness self-verify — all fail-closed).
     pub fn reconcile_placement(
         &mut self,
         partition: u64,
         new_placement: &Placement,
         isr_config: IsrConfig,
+        committed_hw_bar: u64,
     ) -> Result<bool, DataPlaneError> {
         let role = role_for_placement(self.node_id, new_placement);
         match role {
@@ -514,11 +520,14 @@ impl<F: Filesystem + Clone, C: Clock> DataPlaneServer<F, C> {
                     return Ok(false);
                 }
                 // FOLLOWER → LEADER promotion over the held log (no data move), seeding the bumped epoch.
+                // The apply-time committed-completeness self-verify inside `promote_follower_to_leader`
+                // aborts fail-closed if this node's durable log does not cover `committed_hw_bar`.
                 self.seam.controller_mut().promote_follower_to_leader(
                     partition,
                     LeaderEpoch::new(new_placement.epoch),
                     &new_placement.replicas,
                     isr_config,
+                    committed_hw_bar,
                 )?;
                 // This node no longer follows the partition (it leads it now).
                 self.follower_targets.remove(&partition);
@@ -1912,7 +1921,9 @@ mod tests {
         assert_replicated_byte_identical(&succ_bytes_pre, leader_log);
         successor_follower
             .server
-            .reconcile_placement(P, &new_placement, quorum3())
+            // Carry the committed-HW bar (#618b): the apply-time self-verify confirms the promoted node's
+            // own durable log covers it before it becomes leader (it caught up to the full pre-death HW).
+            .reconcile_placement(P, &new_placement, quorum3(), committed_hw)
             .expect("the in-sync follower is promoted to leader in place");
         // (a) it is now the LEADER for the partition.
         assert!(
@@ -2039,10 +2050,11 @@ mod tests {
         let (new_listener, new_addr) = new_leader_addr;
         let new_addr = new_addr.unwrap();
 
-        // The other survivor reconciles too: it stays a follower but re-targets to the successor.
+        // The other survivor reconciles too: it stays a follower but re-targets to the successor. (As a
+        // follower the committed-HW bar is unused, but we pass it for symmetry with the leader path.)
         let changed = other_follower
             .server
-            .reconcile_placement(P, &new_placement, quorum3())
+            .reconcile_placement(P, &new_placement, quorum3(), committed_hw)
             .expect("the other survivor reconciles");
         assert!(changed, "the other survivor re-targeted to the new leader");
         assert_eq!(
@@ -2089,10 +2101,19 @@ mod tests {
 
         // FINAL: the falsifiable #618 invariant (CI5) over the REAL post-failover state — the successor
         // was in the ISR, holds every pre-death committed offset, and carries a strictly-higher epoch.
+        // `successor_in_isr` is DERIVED FROM REAL STATE (no hardcoded shortcut, #618b): a replica is in
+        // the ISR for failover purposes exactly when its durable prefix has reached the committed HW (the
+        // data-plane completeness criterion `place_partition` uses); we read the successor's measured
+        // pre-death durable HW and compute the predicate, rather than asserting it.
+        let successor_in_isr = succ_hw_pre >= committed_hw;
+        assert!(
+            successor_in_isr,
+            "the successor's measured durable HW ({succ_hw_pre}) reached the committed HW ({committed_hw}) — it really is ISR-complete"
+        );
         let failover_state = ironbus_core::cluster_invariants::Failover {
             dead_leader: 1,
             successor,
-            successor_in_isr: true, // it was caught up in phase 1 (an ISR member)
+            successor_in_isr,
             // The successor's TRUE durable prefix: every offset it durably appended as a follower (it
             // caught up to the full pre-death committed HW). The read-plane-served end can lag this by the
             // active (unsealed) tail, but the records are durably HELD — CI5 is about held committed data.

--- a/crates/ironbus-server/src/cluster/state_machine.rs
+++ b/crates/ironbus-server/src/cluster/state_machine.rs
@@ -130,6 +130,15 @@ pub enum MetadataCommand {
     },
     /// Set a cluster-wide configuration key to a value.
     SetConfig { key: String, value: String },
+    /// CHECKPOINT the last-known quorum-committed high-watermark for `partition` into the replicated
+    /// metadata (#618b committed-data-loss fix). The data-plane LEADER proposes this PERIODICALLY (on a
+    /// cadence — NOT per record; cheap + bounded), so the committed bar SURVIVES the leader's death: a
+    /// surviving node reads this checkpoint and knows the SAFE offset a successor MUST hold before it may
+    /// be auto-promoted. `offset` is the committed HW (every offset strictly below it was quorum-fsync'd
+    /// on `min_isr` replicas). It is MONOTONIC per partition in the state machine — a stale/lower
+    /// checkpoint never lowers the bar, so the bar can only ever rise (a successor must always clear the
+    /// highest committed HW the cluster ever durably recorded).
+    CheckpointCommittedHw { partition: u64, offset: u64 },
 }
 
 /// Errors from decoding a [`MetadataCommand`] off a committed log entry's bytes.
@@ -182,6 +191,7 @@ const TAG_REMOVE_NODE: u8 = 2;
 const TAG_ASSIGN_PARTITION: u8 = 3;
 const TAG_SET_CONFIG: u8 = 4;
 const TAG_PLACE_PARTITION: u8 = 5;
+const TAG_CHECKPOINT_COMMITTED_HW: u8 = 6;
 
 impl MetadataCommand {
     /// Encode the command to its canonical little-endian wire bytes.
@@ -231,6 +241,11 @@ impl MetadataCommand {
                 out.push(TAG_SET_CONFIG);
                 push_str(&mut out, key);
                 push_str(&mut out, value);
+            }
+            MetadataCommand::CheckpointCommittedHw { partition, offset } => {
+                out.push(TAG_CHECKPOINT_COMMITTED_HW);
+                out.extend_from_slice(&partition.to_le_bytes());
+                out.extend_from_slice(&offset.to_le_bytes());
             }
         }
         out
@@ -297,6 +312,11 @@ impl MetadataCommand {
                 let key = cur.string()?;
                 let value = cur.string()?;
                 MetadataCommand::SetConfig { key, value }
+            }
+            TAG_CHECKPOINT_COMMITTED_HW => {
+                let partition = cur.u64()?;
+                let offset = cur.u64()?;
+                MetadataCommand::CheckpointCommittedHw { partition, offset }
             }
             other => return Err(DecodeError::UnknownTag(other)),
         };
@@ -377,6 +397,12 @@ pub struct MetadataStateMachine {
     members: BTreeMap<u64, NodeRole>,
     /// partition id -> current placement (leader + epoch).
     placements: BTreeMap<u64, Placement>,
+    /// partition id -> the last-checkpointed quorum-committed high-watermark (#618b). The data-plane
+    /// leader proposes a [`MetadataCommand::CheckpointCommittedHw`] periodically; this is the SAFE bar a
+    /// successor must hold before it may be auto-promoted on a leader death (it SURVIVES the leader's
+    /// death because it is replicated metadata). MONOTONIC per partition (a lower checkpoint never lowers
+    /// the bar), so committed data the cluster once recorded as quorum-fsync'd can never be "forgotten".
+    committed_hw: BTreeMap<u64, u64>,
     /// cluster-wide config key -> value.
     config: BTreeMap<String, String>,
     /// The index of the last entry applied to this state machine (monotonic).
@@ -427,6 +453,14 @@ impl MetadataStateMachine {
             }
             MetadataCommand::SetConfig { key, value } => {
                 self.config.insert(key.clone(), value.clone());
+            }
+            MetadataCommand::CheckpointCommittedHw { partition, offset } => {
+                // MONOTONIC: only ever RAISE the bar. A late/duplicate/stale checkpoint (a lower offset,
+                // e.g. from an out-of-order proposal or a node that briefly read a lower frontier) must
+                // NEVER lower the safe bar a successor has to clear — that would silently re-admit a loss
+                // window. So we keep the maximum committed HW the cluster has ever durably recorded.
+                let entry = self.committed_hw.entry(*partition).or_insert(0);
+                *entry = (*entry).max(*offset);
             }
         }
         self.applied_index = index;
@@ -500,6 +534,23 @@ impl MetadataStateMachine {
     #[must_use]
     pub fn placements(&self) -> BTreeMap<u64, Placement> {
         self.placements.clone()
+    }
+
+    /// The last-checkpointed quorum-committed high-watermark for `partition` (#618b), or `None` if no
+    /// [`MetadataCommand::CheckpointCommittedHw`] has committed for it yet. This is the SAFE bar a
+    /// successor MUST hold before the auto-failover path may promote it — it survives the leader's death
+    /// because it is replicated metadata.
+    #[must_use]
+    pub fn committed_hw(&self, partition: u64) -> Option<u64> {
+        self.committed_hw.get(&partition).copied()
+    }
+
+    /// A snapshot of EVERY partition's last-checkpointed committed high-watermark (#618b), keyed by
+    /// partition id. The driver publishes this each cycle so a surviving node can read the SAFE bar a
+    /// successor must clear AFTER the leader that produced it has died. Empty until a checkpoint commits.
+    #[must_use]
+    pub fn committed_hws(&self) -> BTreeMap<u64, u64> {
+        self.committed_hw.clone()
     }
 
     /// A config value by key.
@@ -694,6 +745,14 @@ mod tests {
                 key: String::new(),
                 value: String::new(),
             },
+            MetadataCommand::CheckpointCommittedHw {
+                partition: 0,
+                offset: 0,
+            },
+            MetadataCommand::CheckpointCommittedHw {
+                partition: 7,
+                offset: 123_456,
+            },
         ];
         for cmd in &cmds {
             let bytes = cmd.encode();
@@ -721,6 +780,57 @@ mod tests {
             MetadataCommand::decode(&buf),
             Err(DecodeError::TrailingBytes)
         );
+    }
+
+    #[test]
+    fn checkpoint_committed_hw_stores_and_is_monotonic() {
+        // The committed-HW checkpoint (#618b) records the SAFE bar a successor must hold. It is stored
+        // per partition and is MONOTONIC: a later, LOWER checkpoint never lowers the bar (it would
+        // silently re-open a loss window), so the bar only ever rises.
+        let mut sm = MetadataStateMachine::new();
+        assert_eq!(sm.committed_hw(0), None, "no checkpoint yet");
+        sm.apply(
+            1,
+            &MetadataCommand::CheckpointCommittedHw {
+                partition: 0,
+                offset: 100,
+            },
+        );
+        assert_eq!(sm.committed_hw(0), Some(100));
+        // A higher checkpoint raises the bar.
+        sm.apply(
+            2,
+            &MetadataCommand::CheckpointCommittedHw {
+                partition: 0,
+                offset: 150,
+            },
+        );
+        assert_eq!(sm.committed_hw(0), Some(150));
+        // A LOWER (stale / out-of-order) checkpoint must NOT lower the bar.
+        sm.apply(
+            3,
+            &MetadataCommand::CheckpointCommittedHw {
+                partition: 0,
+                offset: 120,
+            },
+        );
+        assert_eq!(
+            sm.committed_hw(0),
+            Some(150),
+            "a stale lower checkpoint never lowers the safe bar"
+        );
+        // It is per-partition.
+        sm.apply(
+            4,
+            &MetadataCommand::CheckpointCommittedHw {
+                partition: 9,
+                offset: 42,
+            },
+        );
+        assert_eq!(sm.committed_hw(9), Some(42));
+        assert_eq!(sm.committed_hw(0), Some(150));
+        assert_eq!(sm.committed_hws().get(&0), Some(&150));
+        assert_eq!(sm.committed_hws().get(&9), Some(&42));
     }
 
     #[test]


### PR DESCRIPTION
## What this finishes

PR #721 (C5-I3) landed the failover **mechanism** (`reassign_leadership`, `plan_failovers`, `promote_follower_to_leader`, `reconcile_placement`, CI5) but left it **test-driven**. This makes failover fire **automatically** in the live cluster, proven by killing the leader in a real multi-node test.

The runtime driver (`run_driver` in `cluster/runtime.rs`) — the single thread that owns the metadata `RawNode` — now does both halves:

### F1 — peer-liveness death detector
The driver records `last_heard[peer]` whenever it steps a metadata message from that peer (the metadata-Raft heartbeats/appends **are** the heartbeat — `record_heard` + `drain_inbound_nonblocking`), timed off the I6 monotonic clock. Each cycle, **if this node is the metadata-Raft leader**, any current voter silent past the deadline (or a forced-unreachable test peer) is proposed for removal via `MembershipChange::remove_node` through the metadata Raft (`runtime.rs` F1 block). Once that conf-change commits, the crashed node lands in `departed_members` exactly like a clean leave — a crash is converted into a committed membership shrink.

### F2 — auto-fire
On a committed shrink (`departed_members` non-empty) the metadata leader auto-calls `plan_failovers` for every partition the departed node led, feeding it the **live data-plane ISR** through cross-plane providers (`FailoverInputs` = `SurvivorStateFn` + `CommittedHwFn`) the data-plane bootstrap installs via `FailoverInstaller`/`set_failover_inputs` (`main.rs` `run_dataplane_bootstrap`). Each resulting `PlacePartition` is proposed through the metadata Raft; the existing apply path → `reconcile_placement` promotes the successor in place.

## How each NON-NEGOTIABLE is guaranteed (code pointers)

- **No false / premature failover.** Default deadline `DEFAULT_LIVENESS_TIMEOUT = 3s` = **10x** the ~300ms metadata heartbeat (`heartbeat_tick=3` @ `TICK_INTERVAL=100ms`). A peer must miss ~10 consecutive beats; a single dropped beat (raft re-sends) or a brief hiccup never trips. `last_heard` is seeded to "now" at driver start (full deadline of grace). Proven by `a_healthy_cluster_never_auto_fails_over` (3s window, `suspected_dead`/`departed_members`/`failover_proposed` all stay empty, placement byte-unchanged, 3 voters retained).
- **Single proposer, linearizable.** Both F1's removal and F2's promotion are proposed **only** when `group.is_leader()`, both go through the metadata Raft log. Idempotent: `removal_proposed`/`failover_proposed` suppress re-spam; an already-departed peer / already-converged placement is skipped. No two nodes promote different successors — the Raft log linearizes it.
- **Split-brain / old-leader fence.** The promotion's epoch is `max(placement,dead)+1` (the #721/#694 KIP-101 machinery, unchanged). Proven in the kill test: the new committed epoch strictly exceeds the old (assertion d), and the #721 serve test still proves the old leader's stale-epoch query is fenced.
- **Committed-never-lost (CI5).** F2 feeds `plan_failovers` the **real** live ISR (the installed providers read the data-plane controller's `follower_high_watermark`/`quorum_commit`), so a non-ISR / incomplete survivor is never chosen. Fail-closed: no providers (no data plane) ⇒ no promotion — proven by `no_data_plane_inputs_means_no_blind_promotion_fail_closed`.
- **Single-node byte-identical / single-writer.** All new logic is metadata-plane and cluster-gated; off-cluster nothing is constructed (`serve` only starts a runtime with a `ClusterConfig`). The produce/consume hot path (`session.rs`/`engine.rs`/`actor.rs`) is untouched. The promoted leader's single-writer is the #721 in-place promotion (no data move).
- **Deterministic test, no wall-clock flake.** `LivenessConfig` makes the deadline injectable; `force_peer_unreachable` is a clock-independent detection seam. The kill test uses it (no real-time sleep); the timeout test uses a host-scaled deadline so it never races even under CI starvation.

## The tests (what each proves)

In `cluster/runtime.rs` (real multi-node, `#[cfg(unix)]`, extend the #721 harness):

- **`killing_the_leader_auto_detects_promotes_an_isr_successor_and_the_cluster_resumes`** — THE proof. 3-node cluster, committed placement, **kill the leader**, then drive ONLY the deterministic `force_peer_unreachable` seam (no manual reconcile/plan_failovers/promote). Asserts: (a) auto-detect + committed removal (`departed_members` + voter_count≤2); (b) auto-planned + committed promotion; (c) successor is a surviving ISR replica, dead leader dropped from replicas, committed prefix preserved; (d) epoch fenced strictly above the old; (e) the surviving quorum commits a NEW entry under the new leader. **Proven by killing the leader.**
- **`the_liveness_timeout_alone_auto_fails_over_a_silent_leader`** — the production silence trigger (NO force seam): a stopped node's heartbeats cease and the host-scaled deadline detects it. **Proven by killing the leader.**
- **`a_healthy_cluster_never_auto_fails_over`** — no-false-failover. **Proven by construction + a real healthy cluster.**
- **`no_data_plane_inputs_means_no_blind_promotion_fail_closed`** — F1 removes the dead leader but F2 promotes nothing without cross-plane ISR. **Proven by killing the leader (no data plane installed).**
- The #721 mechanism test is **kept** (the by-construction proof).

Rerun-stability: the kill test ran 5/5 clean; the timeout test 8/8 clean after host-scaling its deadline.

## Gates
- `cargo fmt --all --check` ✅
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` ✅
- `cargo test --workspace --all-features --locked` ✅ green **except** the one known APFS local flake `ironbus-storage … preallocate_reserves_real_blocks_on_a_supporting_fs` (near-full disk — the only-allowed failure)
- io-free-check on ironbus-core ✅ (core untouched); metrics taxonomy untouched
- SPDX `head -3` check ✅ (no new files); MSRV 1.78 ✅ (no new deps; `is_none_or` avoided as it is 1.82+)

## Scope / deferred (flagged honestly)
- **Client-side `NOT_LEADER` redirect** (a reconnecting client producing to the new leader) is a SEPARATE follow-on (the client-awareness story). This PR proves the SERVER auto-heals leadership; the data-plane followers re-point replication to the new leader.
- **Multi-partition / full ISR gossip.** The cross-plane survivor-state provider reports THIS node's own real frontier and treats remote committed replicas as ISR-complete to the committed HW (sound for the single default partition, where the surviving committed replicas that caught up ARE the ISR). Distinguishing a remote survivor that lagged out of the ISR before the crash needs ISR gossip across the data plane → #693. Flagged in `main.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVWp2H2txnKGru4q2twxM3