### PR TITLE
feat(cluster): reads that scale with replicas — leader-lease local + CRAQ follower committed reads (#620, #621, #622)

### DIFF
--- a/crates/ironbus-server/src/cluster/dataplane.rs
+++ b/crates/ironbus-server/src/cluster/dataplane.rs
@@ -119,10 +119,15 @@ use ironbus_core::types::Offset;
 use ironbus_proto::frame::FrameType;
 use ironbus_storage::fs::Filesystem;
 use ironbus_storage::log::Log;
-use ironbus_storage::read_plane::ReadPlane;
+use ironbus_storage::read_plane::{RawSealedRead, ReadPlane};
+use ironbus_storage::segment::RawByteRun;
 
 use super::ack_level::ClusterAckLevel;
 use super::isr::{AckReplicatedBody, IsrConfig, IsrTracker, QuorumAckGate};
+use super::read_consistency::{
+    classify_follower_read, classify_leader_local_read, follower_safe_watermark,
+    FollowerReadDecision, LeaderReadDecision, ReadTier,
+};
 use super::replication::{
     DivergenceTruncation, EpochAwareFollower, FetchRecordsBody, FetchResponseBody, Follower,
     OffsetForLeaderEpochBody, OffsetForLeaderEpochResponse, ReadPlaneLeader, ReplicationError,
@@ -165,6 +170,15 @@ pub enum DataPlaneError {
         /// The committed-HW bar the successor had to hold (and did not).
         committed_hw: u64,
     },
+    /// A LEADER-LEASE LINEARIZABLE LOCAL read (#620, [`DataPlaneController::serve_leader_local_read`])
+    /// was requested but the leaseholder's lease is in DOUBT (expired, or this node is on a stale epoch /
+    /// is not the current leaseholder). The read is REFUSED fail-closed rather than risk a stale local
+    /// read — the caller falls back to a read-index/quorum confirm or returns unavailable. This is the
+    /// #694/#722 soundness fence: no serving-as-leader on a stale epoch.
+    LeaseNotValid {
+        /// The partition whose lease was in doubt.
+        partition: u64,
+    },
 }
 
 impl core::fmt::Display for DataPlaneError {
@@ -190,6 +204,11 @@ impl core::fmt::Display for DataPlaneError {
                 "partition {partition} failover aborted (fail-closed): this node's durable frontier \
                  {durable_frontier} is behind the committed-HW bar {committed_hw}; it is missing \
                  committed data and must not become leader"
+            ),
+            DataPlaneError::LeaseNotValid { partition } => write!(
+                f,
+                "partition {partition} leader-lease local read refused (fail-closed): the leader lease \
+                 is in doubt (expired / stale epoch); not serving a stale local read"
             ),
         }
     }
@@ -490,6 +509,80 @@ impl<F: Filesystem, C: Clock> DataPlaneController<F, C> {
                 needed: "leader",
             }),
             None => Err(DataPlaneError::UnknownPartition { partition }),
+        }
+    }
+
+    // ---- C6 reads: leader-lease linearizable local read + the HW-version query the dirty tier needs --
+
+    /// The leader's CURRENT committed high-watermark for `partition` — the read plane's flushed frontier,
+    /// the SAME committed offset [`ReadPlaneLeader::high_watermark`] advertises (#654/#715). This is the
+    /// answer to a follower's "latest/dirty" HW-VERSION query (#621, [`ReadTier::FollowerLatest`]): a
+    /// follower wanting data above its known safe watermark asks the leader for this offset (NOT the
+    /// data), then serves the confirmed prefix locally. Leader-only; `None` for a follower / absent
+    /// partition (a follower never answers an authoritative committed-HW query).
+    #[must_use]
+    pub fn leader_committed_hw(&self, partition: u64) -> Option<u64> {
+        match self.roles.get(&partition) {
+            Some(PartitionRole::Leader { plane, .. }) => Some(plane.flushed()),
+            _ => None,
+        }
+    }
+
+    /// Serve a LEADER-LEASE LINEARIZABLE LOCAL read of `[from, from + max_records)` for `partition` from
+    /// the leader's OWN off-actor read plane — a 0-RTT linearizable read with NO quorum round (#620).
+    /// Leader-only.
+    ///
+    /// `lease_valid` is the leaseholder's lease-validity bit at the CURRENT monotonic time and epoch —
+    /// exactly [`MetadataRaftGroup::can_act_as_leader`](super::metadata_group::MetadataRaftGroup::can_act_as_leader)
+    /// (a held, unexpired lease under the current epoch). The serve path is SOUND by the #694/#722 fence:
+    /// if the lease is in doubt the leader REFUSES the local read ([`DataPlaneError::LeaseNotValid`])
+    /// rather than risk a stale read — the caller falls back to a read-index/quorum confirm or returns
+    /// unavailable. No serving-as-leader on a stale epoch.
+    ///
+    /// On a valid lease the read is served zero-copy from the leader's read plane via
+    /// [`ReadPlane::read_range_raw`] (the SAME machinery the leader serves fetches from), bounded by the
+    /// leader's flushed frontier (the linearizable committed prefix), `max_records`, and the optional
+    /// `max_bytes`.
+    ///
+    /// # Errors
+    /// [`DataPlaneError::UnknownPartition`] if this node holds no role for `partition`;
+    /// [`DataPlaneError::WrongRole`] if it is a follower; [`DataPlaneError::LeaseNotValid`] if the lease
+    /// is in doubt (the soundness fence — never a stale local read);
+    /// [`DataPlaneError::Replication`] on a serve fault.
+    pub fn serve_leader_local_read(
+        &self,
+        partition: u64,
+        lease_valid: bool,
+        from: Offset,
+        max_records: usize,
+        max_bytes: Option<usize>,
+    ) -> Result<RawSealedRead, DataPlaneError> {
+        let plane = match self.roles.get(&partition) {
+            Some(PartitionRole::Leader { plane, .. }) => plane,
+            Some(PartitionRole::Follower { .. }) => {
+                return Err(DataPlaneError::WrongRole {
+                    partition,
+                    needed: "leader",
+                })
+            }
+            None => return Err(DataPlaneError::UnknownPartition { partition }),
+        };
+        let leader_flushed = plane.flushed();
+        // The wanted exclusive end: `from + max_records`, saturated. `usize::MAX` records means "as much
+        // as is linearizable", clamped to the flushed frontier by the classifier.
+        let wanted_end = Offset::new(from.get().saturating_add(max_records as u64));
+        match classify_leader_local_read(lease_valid, from, wanted_end, leader_flushed) {
+            // The SOUNDNESS FENCE: an in-doubt lease refuses the local read (never a stale read).
+            LeaderReadDecision::Refuse => Err(DataPlaneError::LeaseNotValid { partition }),
+            LeaderReadDecision::Nothing => Ok(empty_raw_read(from)),
+            LeaderReadDecision::ServeLocal { from, .. } => {
+                // The classifier already clamped to the flushed frontier; the read plane re-applies the
+                // SAME flushed bound internally (its frontier is the hard exclusive bound), so a record
+                // at/past the linearizable prefix is never returned. Zero-copy raw serve.
+                plane
+                    .read_range_raw(from, max_records, max_bytes)
+                    .map_err(|e| DataPlaneError::Replication(ReplicationError::Storage(e)))
+            }
         }
     }
 
@@ -916,6 +1009,144 @@ impl<F: Filesystem + Clone, C: Clock> DataPlaneController<F, C> {
         drop(log);
         self.start_leader(partition, plane, epochs, replica_ids, isr_config);
         Ok(())
+    }
+
+    // ---- C6 FOLLOWER reads (#621/#622): CRAQ committed-local + the dirty-tier leader confirm --------
+
+    /// The SAFE committed watermark a FOLLOWER of `partition` may serve reads up to (#621): `min(its own
+    /// read-plane flushed frontier, the KNOWN committed HW)` — the bar BOTH durably-held-here AND
+    /// committed-on-a-quorum (see [`crate::cluster::read_consistency::follower_safe_watermark`]). A
+    /// follower NEVER serves a record at or past this. Follower-only; `None` for a leader / absent
+    /// partition.
+    ///
+    /// `known_committed_hw` is the last [`CheckpointCommittedHw`](super::state_machine::MetadataCommand::CheckpointCommittedHw)
+    /// bar this node has applied from the replicated metadata (#722) — read by the caller from
+    /// [`committed_hw`](super::state_machine::MetadataStateMachine::committed_hw); pass `None` when no
+    /// checkpoint has committed yet (the safe bar is then 0 — fail closed).
+    ///
+    /// # Errors
+    /// [`DataPlaneError::Replication`] if the follower's read plane cannot be built (an IO fault).
+    pub fn follower_safe_read_watermark(
+        &self,
+        partition: u64,
+        known_committed_hw: Option<u64>,
+    ) -> Result<Option<u64>, DataPlaneError> {
+        match self.roles.get(&partition) {
+            Some(PartitionRole::Follower { follower }) => {
+                // The follower's OWN durably-replicated, CRC-revalidated flushed prefix.
+                let own_flushed = follower.follower().read_plane()?.flushed();
+                Ok(Some(follower_safe_watermark(
+                    own_flushed,
+                    known_committed_hw,
+                )))
+            }
+            _ => Ok(None),
+        }
+    }
+
+    /// Serve a CRAQ-style FOLLOWER read of `[from, from + max_records)` for `partition` at `tier`,
+    /// LOCALLY from the follower's OWN off-actor read plane (#621/#622) — zero-copy, no leader data
+    /// round-trip. Follower-only.
+    ///
+    /// `known_committed_hw` is the committed-HW bar this node has applied from the replicated metadata
+    /// (#722). The serve is fail-closed by the safe watermark (`min(own_flushed, known_committed_hw)`):
+    ///
+    /// * [`ReadTier::FollowerCommitted`] (clean): serves the committed prefix `<=` the safe watermark
+    ///   locally; a read starting in the uncommitted tail serves an empty run.
+    /// * [`ReadTier::FollowerLatest`] (dirty): if the wanted range is already provably committed-and-held
+    ///   it serves locally; if it reaches ABOVE the safe watermark it returns
+    ///   [`FollowerReadOutcome::ConfirmWithLeader`] (the caller does the HW-version query via
+    ///   [`leader_committed_hw`](Self::leader_committed_hw), updates `known_committed_hw`, and re-serves)
+    ///   — NEVER speculatively serving unconfirmed bytes.
+    /// * [`ReadTier::LeaderLocal`] on a follower escalates to the dirty-tier confirm (never a stale local
+    ///   serve).
+    ///
+    /// The served bytes are the SAME zero-copy [`RawByteRun`] the read plane hands a leader fetch (#542):
+    /// arc-swapped sealed-segment byte ranges, no user-space copy. The read plane re-applies its own
+    /// flushed bound internally, and the safe-watermark clamp bounds it further to the committed prefix,
+    /// so a record at/past the safe watermark is never returned.
+    ///
+    /// # Errors
+    /// [`DataPlaneError::UnknownPartition`] if this node holds no role; [`DataPlaneError::WrongRole`] if
+    /// it is a leader; [`DataPlaneError::Replication`] on a serve fault.
+    pub fn serve_follower_read(
+        &self,
+        partition: u64,
+        tier: ReadTier,
+        known_committed_hw: Option<u64>,
+        from: Offset,
+        max_records: usize,
+        max_bytes: Option<usize>,
+    ) -> Result<FollowerReadOutcome, DataPlaneError> {
+        let follower = match self.roles.get(&partition) {
+            Some(PartitionRole::Follower { follower }) => follower,
+            Some(PartitionRole::Leader { .. }) => {
+                return Err(DataPlaneError::WrongRole {
+                    partition,
+                    needed: "follower",
+                })
+            }
+            None => return Err(DataPlaneError::UnknownPartition { partition }),
+        };
+        let plane = follower.follower().read_plane()?;
+        let safe = follower_safe_watermark(plane.flushed(), known_committed_hw);
+        let wanted_end = Offset::new(from.get().saturating_add(max_records as u64));
+        match classify_follower_read(tier, from, wanted_end, safe) {
+            FollowerReadDecision::Nothing => Ok(FollowerReadOutcome::Served(empty_raw_read(from))),
+            FollowerReadDecision::ConfirmWithLeader { current_safe } => {
+                Ok(FollowerReadOutcome::ConfirmWithLeader { current_safe })
+            }
+            FollowerReadDecision::ServeLocal { from, serve_up_to } => {
+                // The classifier clamped `serve_up_to` to the safe watermark. Bound the read-plane read
+                // by `serve_up_to - from` records so it never serves past the committed bar. The read
+                // plane ALSO clamps to its own flushed frontier (the hard exclusive bound), so the two
+                // bounds together never return a record at/past `min(own_flushed, known_committed_hw)`.
+                let safe_records = usize::try_from(serve_up_to.get().saturating_sub(from.get()))
+                    .unwrap_or(usize::MAX)
+                    .min(max_records);
+                if safe_records == 0 {
+                    return Ok(FollowerReadOutcome::Served(empty_raw_read(from)));
+                }
+                let run = plane
+                    .read_range_raw(from, safe_records, max_bytes)
+                    .map_err(|e| DataPlaneError::Replication(ReplicationError::Storage(e)))?;
+                Ok(FollowerReadOutcome::Served(run))
+            }
+        }
+    }
+}
+
+/// The outcome of [`DataPlaneController::serve_follower_read`] (#621): either the zero-copy bytes served
+/// locally, or a signal that the "latest/dirty" read must CONFIRM the leader's current committed HW
+/// before it can serve above the follower's known safe watermark.
+#[derive(Debug)]
+pub enum FollowerReadOutcome {
+    /// The follower served `[from, ...)` LOCALLY from its read plane (committed-and-held bytes,
+    /// zero-copy). May be an empty run (nothing safe to serve at this position/tier yet).
+    Served(RawSealedRead),
+    /// The read reaches ABOVE the follower's known safe watermark: the caller must query the leader's
+    /// current committed HW (a tiny HW-version query, [`DataPlaneController::leader_committed_hw`] in the
+    /// in-process test, an `OffsetForLeaderEpoch`-style HW frame over the wire in a real serve), update
+    /// `known_committed_hw`, and re-serve. NEVER serve unconfirmed bytes speculatively.
+    ConfirmWithLeader {
+        /// The follower's CURRENT safe watermark (the clean prefix it could serve right now without
+        /// confirmation).
+        current_safe: Offset,
+    },
+}
+
+/// An empty zero-copy [`RawSealedRead`] anchored at `from` — what a read serves when nothing is safe to
+/// return at this position/tier (the request is empty, the start is past the safe watermark, or a
+/// leader-lease read has an exhausted range). Mirrors the read plane's own empty-run shape.
+fn empty_raw_read(from: Offset) -> RawSealedRead {
+    RawSealedRead {
+        run: RawByteRun {
+            bytes: bytes::Bytes::new(),
+            first_offset: from,
+            record_count: 0,
+            next_offset: from,
+        },
+        fallback_from: None,
     }
 }
 
@@ -2186,5 +2417,473 @@ mod tests {
             other => panic!("expected an already-committed fast release, got {other:?}"),
         }
         assert_eq!(seam.parked_len(), 0, "nothing remains withheld");
+    }
+
+    // ---- C6 reads (#620/#621/#622): leader-lease local + CRAQ follower committed reads -------------
+
+    use super::{FollowerReadOutcome, ReadTier};
+
+    /// Decode a zero-copy raw run into `(offset, payload)` pairs the way a consumer that received the
+    /// run would — full `codec::decode` (header + body CRC), so a served run is integrity-checkable
+    /// end-to-end (the C6 zero-copy delivery, #622, reuses the read-plane raw run verbatim).
+    fn decode_run(run: &ironbus_storage::segment::RawByteRun) -> Vec<(u64, Vec<u8>)> {
+        let mut out = Vec::new();
+        let mut cursor = 0usize;
+        let mut offset = run.first_offset.get();
+        while cursor < run.bytes.len() {
+            let (view, consumed) = ironbus_core::codec::decode(&run.bytes[cursor..])
+                .expect("every shipped C6 follower-read frame passes header AND body CRC");
+            out.push((offset, view.payload.to_vec()));
+            offset += 1;
+            cursor += consumed;
+        }
+        assert_eq!(out.len() as u64, run.record_count);
+        out
+    }
+
+    /// Catch `follower` up to the leader's read-plane-served prefix over the in-process fetch path, then
+    /// return that served end (the offset the follower durably holds up to).
+    fn catch_follower_up(
+        leader: &mut DataPlaneController<InMemoryFs, ManualClock>,
+        follower: &mut DataPlaneController<InMemoryFs, ManualClock>,
+        partition: u64,
+        served_end: u64,
+        rounds: u64,
+    ) {
+        for _ in 0..rounds {
+            if follower.follower_high_watermark(partition).unwrap() >= served_end {
+                break;
+            }
+            let req = follower.make_fetch_request(partition, 8, 4096).unwrap();
+            let resp = leader.serve_fetch(partition, &req).unwrap();
+            follower.apply_fetch_response(partition, &resp).unwrap();
+        }
+    }
+
+    /// THE C6 follower-read SAFETY test (#621 non-negotiable 1): a follower whose FLUSHED prefix is
+    /// BEYOND the known committed HW serves only `<= committed HW`, NEVER the uncommitted tail. The
+    /// follower replicates a leader's whole sealed prefix (its own flushed frontier is the served end),
+    /// but we hand it a committed-HW bar STRICTLY BELOW that — the safe watermark is the bar, and the
+    /// clean read serves nothing past it.
+    #[test]
+    #[allow(clippy::too_many_lines)] // one coherent safety scenario (replicate, set a low bar, chain-read)
+    fn a_follower_serves_only_up_to_the_committed_hw_never_the_uncommitted_tail() {
+        const P: u64 = 0;
+        let mut leader_log = open_log(InMemoryFs::new(), small_config());
+        for i in 0..30u32 {
+            leader_log
+                .append(&rec(format!("c6-{i:02}").as_bytes()))
+                .unwrap();
+        }
+        leader_log.sync().unwrap();
+        let plane = leader_plane(&leader_log);
+        let served_end = plane_served_end(&plane);
+        assert!(
+            served_end >= 10,
+            "need a healthy sealed prefix (got {served_end})"
+        );
+
+        let mut leader = DataPlaneController::new(1);
+        leader.start_leader(P, Arc::clone(&plane), EpochCache::new(), &[1, 2], quorum3());
+        let mut follower = DataPlaneController::new(2);
+        follower.start_follower(P, open_log(InMemoryFs::new(), small_config()));
+        catch_follower_up(&mut leader, &mut follower, P, served_end, served_end + 8);
+        let own_flushed = follower.follower_high_watermark(P).unwrap();
+        assert!(
+            own_flushed >= served_end,
+            "the follower durably holds the served prefix (own_flushed={own_flushed})"
+        );
+
+        // The committed HW is STRICTLY BELOW the follower's flushed prefix: [committed_hw, own_flushed)
+        // is an uncommitted (still epoch-truncatable) tail the follower happens to hold.
+        let committed_hw = served_end / 2;
+        assert!(committed_hw > 0 && committed_hw < own_flushed);
+
+        // The SAFE watermark is the committed HW (the MIN), so a CLEAN read for everything serves only
+        // [0, committed_hw) — never a record at/past committed_hw.
+        assert_eq!(
+            follower
+                .follower_safe_read_watermark(P, Some(committed_hw))
+                .unwrap(),
+            Some(committed_hw),
+        );
+        // CHAIN clean reads across the whole prefix (the read plane serves one sealed segment per raw
+        // read). EVERY served record must be strictly BELOW the committed HW — never the uncommitted tail
+        // [committed_hw, own_flushed). The chain must serve SOMETHING (not vacuously empty) and stop
+        // exactly at the bar, never crossing it.
+        let mut from = Offset::ZERO;
+        let mut served_any = false;
+        let mut guard = 0u32;
+        loop {
+            guard += 1;
+            assert!(guard < 10_000, "follower-read chain failed to terminate");
+            let outcome = follower
+                .serve_follower_read(
+                    P,
+                    ReadTier::FollowerCommitted,
+                    Some(committed_hw),
+                    from,
+                    usize::MAX,
+                    None,
+                )
+                .unwrap();
+            let run = match outcome {
+                FollowerReadOutcome::Served(r) => r,
+                FollowerReadOutcome::ConfirmWithLeader { .. } => {
+                    panic!("expected a local serve, not a confirm")
+                }
+            };
+            let records = decode_run(&run.run);
+            for (off, _payload) in &records {
+                assert!(
+                    *off < committed_hw,
+                    "served offset {off} at/past the committed HW {committed_hw} (the uncommitted tail!)"
+                );
+            }
+            if records.is_empty() {
+                break;
+            }
+            served_any = true;
+            let next = run.run.next_offset.get();
+            assert!(
+                next <= committed_hw,
+                "the served run crossed the committed HW (next={next} > {committed_hw})"
+            );
+            if next <= from.get() {
+                break;
+            }
+            from = Offset::new(next);
+        }
+        assert!(
+            served_any,
+            "the follower served the committed prefix locally (not vacuously empty)"
+        );
+        // The clean chain stopped exactly at the committed bar: a read STARTING at the bar serves nothing.
+        let at_bar = follower
+            .serve_follower_read(
+                P,
+                ReadTier::FollowerCommitted,
+                Some(committed_hw),
+                Offset::new(committed_hw),
+                usize::MAX,
+                None,
+            )
+            .unwrap();
+        match at_bar {
+            FollowerReadOutcome::Served(r) => {
+                assert_eq!(
+                    r.run.record_count, 0,
+                    "a clean read at the committed bar serves nothing"
+                );
+            }
+            FollowerReadOutcome::ConfirmWithLeader { .. } => {
+                panic!("a clean read at the committed bar serves an empty run, not a confirm")
+            }
+        }
+    }
+
+    /// THE C6 follower-read CORRECTNESS test (#621/#622): a follower serves COMMITTED records LOCALLY,
+    /// BYTE-IDENTICAL to the leader's, with NO leader round-trip — the CRAQ clean tier + zero-copy
+    /// delivery. The committed HW covers the whole served prefix here (the steady state once a checkpoint
+    /// caught up), so the clean read serves the full committed prefix from the follower's own read plane.
+    #[test]
+    fn a_follower_serves_committed_records_locally_byte_identical_to_the_leader() {
+        const P: u64 = 0;
+        let mut leader_log = open_log(InMemoryFs::new(), small_config());
+        for i in 0..30u32 {
+            leader_log
+                .append(&rec(format!("c6-{i:02}").as_bytes()))
+                .unwrap();
+        }
+        leader_log.sync().unwrap();
+        let plane = leader_plane(&leader_log);
+        let served_end = plane_served_end(&plane);
+
+        let mut leader = DataPlaneController::new(1);
+        leader.start_leader(P, Arc::clone(&plane), EpochCache::new(), &[1, 2], quorum3());
+        let mut follower = DataPlaneController::new(2);
+        follower.start_follower(P, open_log(InMemoryFs::new(), small_config()));
+        catch_follower_up(&mut leader, &mut follower, P, served_end, served_end + 8);
+
+        // The committed HW covers the whole served prefix (a checkpoint has caught up). CHAIN the clean
+        // read across the whole committed prefix off the FOLLOWER's own read plane (one sealed segment
+        // per raw read), collecting (offset, payload).
+        let collect_committed =
+            |c: &DataPlaneController<InMemoryFs, ManualClock>| -> Vec<(u64, Vec<u8>)> {
+                let mut out = Vec::new();
+                let mut from = Offset::ZERO;
+                let mut guard = 0u32;
+                loop {
+                    guard += 1;
+                    assert!(guard < 10_000, "chain failed to terminate");
+                    let outcome = c
+                        .serve_follower_read(
+                            P,
+                            ReadTier::FollowerCommitted,
+                            Some(served_end),
+                            from,
+                            usize::MAX,
+                            None,
+                        )
+                        .unwrap();
+                    let run = match outcome {
+                        FollowerReadOutcome::Served(r) => r,
+                        FollowerReadOutcome::ConfirmWithLeader { .. } => {
+                            panic!("expected a local serve, not a confirm")
+                        }
+                    };
+                    let recs = decode_run(&run.run);
+                    if recs.is_empty() {
+                        break;
+                    }
+                    let next = run.run.next_offset.get();
+                    out.extend(recs);
+                    if next <= from.get() {
+                        break;
+                    }
+                    from = Offset::new(next);
+                }
+                out
+            };
+        let follower_records = collect_committed(&follower);
+        assert!(
+            !follower_records.is_empty(),
+            "the follower served committed records locally"
+        );
+
+        // BYTE-IDENTICAL to the leader: chain the LEADER's read plane over the same prefix and compare
+        // every (offset, payload). The follower's bytes are its OWN replica's page cache (zero-copy), and
+        // they decode to the same records as the leader's — real CRAQ committed reads off a replica.
+        let mut leader_records: Vec<(u64, Vec<u8>)> = Vec::new();
+        let mut from = Offset::ZERO;
+        while from.get() < served_end {
+            let leader_run = plane
+                .read_range_raw(from, usize::MAX, None)
+                .expect("leader read plane serves");
+            let recs = decode_run(&leader_run.run);
+            if recs.is_empty() {
+                break;
+            }
+            let next = leader_run.run.next_offset.get();
+            leader_records.extend(recs);
+            if next <= from.get() {
+                break;
+            }
+            from = Offset::new(next);
+        }
+        // The follower serves its OWN SEALED page-cache prefix, which is a byte-identical PREFIX of the
+        // leader's committed prefix (the follower's last replicated segment may not have sealed yet — its
+        // read plane, like the leader's, serves only the sealed prefix). So the follower's served records
+        // are byte-identical to the leader's at the same offsets, and the follower covers a non-trivial
+        // chunk (real committed reads off the replica), but it need not cover the leader's still-active
+        // tail (FLAGGED, the same active-tail lag the leader-fetch path has).
+        assert!(
+            follower_records.len() <= leader_records.len(),
+            "the follower never serves MORE than the leader's committed prefix"
+        );
+        assert!(
+            follower_records.len() * 2 >= leader_records.len(),
+            "the follower served a healthy committed prefix off its own read plane (got {}, leader {})",
+            follower_records.len(),
+            leader_records.len()
+        );
+        for (f, l) in follower_records.iter().zip(leader_records.iter()) {
+            assert_eq!(f.0, l.0, "offset mismatch leader vs follower");
+            assert_eq!(
+                f.1, l.1,
+                "payload byte mismatch leader vs follower at offset {}",
+                f.0
+            );
+        }
+    }
+
+    /// THE C6 dirty-tier test (#621): a "latest" read ABOVE the follower's known safe watermark CONFIRMS
+    /// the leader's current committed HW (a HW-version query) before serving — never speculatively
+    /// serving unconfirmed bytes — and after the confirm it serves the now-confirmed prefix locally.
+    #[test]
+    fn a_latest_follower_read_above_the_safe_watermark_confirms_with_the_leader_then_serves() {
+        const P: u64 = 0;
+        let mut leader_log = open_log(InMemoryFs::new(), small_config());
+        for i in 0..30u32 {
+            leader_log
+                .append(&rec(format!("c6-{i:02}").as_bytes()))
+                .unwrap();
+        }
+        leader_log.sync().unwrap();
+        let plane = leader_plane(&leader_log);
+        let served_end = plane_served_end(&plane);
+
+        let mut leader = DataPlaneController::new(1);
+        leader.start_leader(P, Arc::clone(&plane), EpochCache::new(), &[1, 2], quorum3());
+        let mut follower = DataPlaneController::new(2);
+        follower.start_follower(P, open_log(InMemoryFs::new(), small_config()));
+        catch_follower_up(&mut leader, &mut follower, P, served_end, served_end + 8);
+
+        // The follower KNOWS only a low committed HW (a stale checkpoint). A "latest" read STARTING AT
+        // that known-safe bar has nothing committed to serve from there with current knowledge, so it
+        // must CONFIRM the leader's current HW first — never speculatively serving the unconfirmed tail.
+        let stale_known = served_end / 3;
+        assert!(stale_known > 0 && stale_known < served_end);
+        let outcome = follower
+            .serve_follower_read(
+                P,
+                ReadTier::FollowerLatest,
+                Some(stale_known),
+                Offset::new(stale_known),
+                usize::MAX,
+                None,
+            )
+            .unwrap();
+        let current_safe = match outcome {
+            FollowerReadOutcome::ConfirmWithLeader { current_safe } => current_safe,
+            FollowerReadOutcome::Served(_) => {
+                panic!("a latest read at/above the known bar must confirm, not serve")
+            }
+        };
+        assert_eq!(
+            current_safe.get(),
+            stale_known,
+            "the clean prefix is the known-safe bar"
+        );
+
+        // The caller does the tiny HW-VERSION query to the leader (NOT the data) — the leader's current
+        // committed HW. The follower updates its known HW and re-serves: now the previously-unconfirmed
+        // prefix is confirmed-committed, so it serves locally.
+        let leader_hw = leader
+            .leader_committed_hw(P)
+            .expect("leader answers the HW query");
+        assert!(
+            leader_hw >= served_end,
+            "the leader's committed HW covers the served prefix"
+        );
+        let reserved = follower
+            .serve_follower_read(
+                P,
+                ReadTier::FollowerLatest,
+                Some(leader_hw),
+                Offset::new(stale_known),
+                usize::MAX,
+                None,
+            )
+            .unwrap();
+        let run = match reserved {
+            FollowerReadOutcome::Served(r) => r,
+            FollowerReadOutcome::ConfirmWithLeader { .. } => {
+                panic!("after the confirm the follower serves locally, not another confirm")
+            }
+        };
+        assert!(
+            run.run.record_count > 0,
+            "the confirmed prefix is served locally after the HW confirm"
+        );
+        // Every served record is at/above where we resumed and strictly below the confirmed HW.
+        for (off, _) in decode_run(&run.run) {
+            assert!(off >= stale_known && off < leader_hw);
+        }
+    }
+
+    /// A follower is NOT an authoritative committed-HW source: `leader_committed_hw` returns `None` on a
+    /// follower (only the leader answers the dirty-tier HW-version query), and `serve_leader_local_read`
+    /// / `serve_follower_read` reject the wrong role.
+    #[test]
+    fn role_gating_for_the_c6_read_apis() {
+        const P: u64 = 0;
+        let mut leader_log = open_log(InMemoryFs::new(), small_config());
+        for i in 0..10u32 {
+            leader_log
+                .append(&rec(format!("g-{i}").as_bytes()))
+                .unwrap();
+        }
+        leader_log.sync().unwrap();
+        let plane = leader_plane(&leader_log);
+        let mut leader = DataPlaneController::<InMemoryFs, ManualClock>::new(1);
+        leader.start_leader(P, Arc::clone(&plane), EpochCache::new(), &[1, 2], quorum3());
+        let mut follower = DataPlaneController::new(2);
+        follower.start_follower(P, open_log(InMemoryFs::new(), small_config()));
+
+        // A follower never answers an authoritative committed-HW query.
+        assert_eq!(follower.leader_committed_hw(P), None);
+        assert!(leader.leader_committed_hw(P).is_some());
+        // A follower-read on a LEADER is a wrong-role error.
+        assert!(matches!(
+            leader.serve_follower_read(
+                P,
+                ReadTier::FollowerCommitted,
+                Some(5),
+                Offset::ZERO,
+                8,
+                None
+            ),
+            Err(DataPlaneError::WrongRole {
+                needed: "follower",
+                ..
+            })
+        ));
+        // A leader-local read on a FOLLOWER is a wrong-role error.
+        assert!(matches!(
+            follower.serve_leader_local_read(P, true, Offset::ZERO, 8, None),
+            Err(DataPlaneError::WrongRole {
+                needed: "leader",
+                ..
+            })
+        ));
+        // An unknown partition is a typed error on both.
+        assert!(matches!(
+            leader.serve_leader_local_read(99, true, Offset::ZERO, 8, None),
+            Err(DataPlaneError::UnknownPartition { partition: 99 })
+        ));
+    }
+
+    /// THE C6 leader-lease LOCAL-read test (#620): a VALID leaseholder serves a 0-RTT linearizable read
+    /// LOCALLY from its own read plane; an EXPIRED/INVALID lease does NOT serve a stale local read — it
+    /// REFUSES fail-closed (the #694/#722 soundness fence).
+    #[test]
+    fn a_valid_leaseholder_serves_a_local_linearizable_read_an_invalid_lease_refuses() {
+        const P: u64 = 0;
+        let mut leader_log = open_log(InMemoryFs::new(), small_config());
+        for i in 0..20u32 {
+            leader_log
+                .append(&rec(format!("ll-{i:02}").as_bytes()))
+                .unwrap();
+        }
+        leader_log.sync().unwrap();
+        let plane = leader_plane(&leader_log);
+        let served_end = plane_served_end(&plane);
+        assert!(served_end > 0);
+        let mut leader = DataPlaneController::<InMemoryFs, ManualClock>::new(1);
+        leader.start_leader(P, Arc::clone(&plane), EpochCache::new(), &[1], {
+            IsrConfig {
+                min_isr: 1,
+                max_lag_records: 0,
+            }
+        });
+
+        // VALID lease: serve a linearizable read LOCALLY from the leader's own read plane (no quorum
+        // round). The served bytes decode to the leader's committed records, byte-identical.
+        let outcome = leader
+            .serve_leader_local_read(P, true, Offset::ZERO, usize::MAX, None)
+            .expect("a valid leaseholder serves locally");
+        let local = decode_run(&outcome.run);
+        assert!(
+            !local.is_empty(),
+            "the leaseholder served records locally with no quorum round"
+        );
+        let plane_run = plane
+            .read_range_raw(Offset::ZERO, usize::MAX, None)
+            .unwrap();
+        let plane_records = decode_run(&plane_run.run);
+        for (a, b) in local.iter().zip(plane_records.iter()) {
+            assert_eq!(
+                a, b,
+                "the local linearizable read is byte-identical to the leader's read plane"
+            );
+        }
+
+        // INVALID lease (in doubt — expired / stale epoch): REFUSE, never a stale local read.
+        let refused = leader.serve_leader_local_read(P, false, Offset::ZERO, usize::MAX, None);
+        assert!(
+            matches!(refused, Err(DataPlaneError::LeaseNotValid { partition: P })),
+            "an in-doubt lease refuses the local read (the #694/#722 soundness fence), got {refused:?}"
+        );
     }
 }

--- a/crates/ironbus-server/src/cluster/mod.rs
+++ b/crates/ironbus-server/src/cluster/mod.rs
@@ -272,6 +272,7 @@ pub mod membership;
 pub mod metadata_group;
 pub mod metadata_storage;
 pub mod placement;
+pub mod read_consistency;
 pub mod replication;
 pub mod runtime;
 pub mod serve;
@@ -282,7 +283,8 @@ pub use ack_level::{ClusterAckLevel, ClusterAckLevelMetrics};
 pub use client_ack::ClientAckGate;
 pub use dataplane::{
     decode_dataplane_frame, role_for_placement, AckDisposition, AckToken, DataPlaneAction,
-    DataPlaneController, DataPlaneError, DataPlaneFrame, PlacementRole, ProduceAckSeam,
+    DataPlaneController, DataPlaneError, DataPlaneFrame, FollowerReadOutcome, PlacementRole,
+    ProduceAckSeam,
 };
 pub use divergence::{
     compare_fingerprints, execute_resync, fingerprint_log, plan_resync, quarantine_and_resync,
@@ -300,6 +302,10 @@ pub use metadata_storage::{MetadataLogStorage, MetadataStorageError, METADATA_SU
 pub use placement::{
     decide_placement, placement_command, placement_node_from, reassign_leadership, FailoverOutcome,
     PlacementOutcome,
+};
+pub use read_consistency::{
+    classify_follower_read, classify_leader_local_read, follower_safe_watermark,
+    FollowerReadDecision, LeaderReadDecision, ReadTier,
 };
 pub use replication::{
     ApplyOutcome, DivergenceTruncation, EpochAwareFollower, FetchRecordsBody, FetchResponseBody,

--- a/crates/ironbus-server/src/cluster/read_consistency.rs
+++ b/crates/ironbus-server/src/cluster/read_consistency.rs
@@ -1,0 +1,507 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! Cluster READ-consistency tiers: reads that scale with replicas (V2-C6, #620/#621/#622).
+//!
+//! This is the PURE, IO-free heart of the C6 read story — the watermark math + the read-tier
+//! classification that the [`dataplane`](super::dataplane) controller wires onto the off-actor read
+//! plane. It holds NO log, NO clock, and does NO IO (exactly like
+//! [`ironbus_core::cluster_invariants`]): the caller supplies the offsets / the lease-validity bit and
+//! gets back a fail-closed decision. That keeps the load-bearing correctness argument unit-testable
+//! against constructed states without standing up a cluster.
+//!
+//! ## The three read-consistency tiers
+//!
+//! Where C1-C5 made the cluster committed-safe (consensus, replication, quorum-fsync ack,
+//! committed-safe failover), C6 turns "where you read" into a principled CHOICE — not a stale-read
+//! bug. There are three tiers, ordered weakest-coupling-to-the-leader to strongest:
+//!
+//! * **[`ReadTier::FollowerCommitted`] (CRAQ "clean", #621):** a FOLLOWER serves a read LOCALLY — with
+//!   NO round-trip to the leader — for any offset at or below its SAFE committed watermark. Read
+//!   throughput therefore scales ~linearly with replicas (CRAQ): every replica can serve committed
+//!   reads. The safe watermark is the load-bearing bound (below).
+//! * **[`ReadTier::FollowerLatest`] (CRAQ "dirty", #621):** a read ABOVE the follower's known safe
+//!   watermark needs the leader's CURRENT committed HW before it can be served — a tiny HW-VERSION
+//!   query (not the data) to the leader confirms how far the follower may serve, then the follower
+//!   serves the now-confirmed prefix LOCALLY (still zero-copy, still no data round-trip). This turns a
+//!   stale-follower-read (a NATS bug class) into a strongly-consistent latest read.
+//! * **[`ReadTier::LeaderLocal`] (leader-lease linearizable, #620):** the LEASEHOLDER serves a
+//!   linearizable read LOCALLY from its own read plane with NO quorum round (0-RTT linearizable read),
+//!   valid ONLY while its leader lease is live at the current epoch (the [`#722`](super) fence). If the
+//!   lease is in doubt it does NOT serve a stale local read — it refuses ([`LeaderReadDecision::Refuse`]).
+//!
+//! ## The follower SAFE watermark (the non-negotiable, #621 correctness 1)
+//!
+//! A follower must NEVER serve a record past the committed bar it can prove it holds. That bar is the
+//! MIN of two independently-trustworthy quantities — [`follower_safe_watermark`]:
+//!
+//! 1. its OWN read plane's [`flushed`](ironbus_storage::read_plane::ReadPlane::flushed) frontier — the
+//!    durably-replicated, CRC-revalidated, non-divergent prefix it actually holds (a follower's
+//!    [`Log::append`](ironbus_storage::log::Log::append) path gives I1-I4: CRC, longest-valid-prefix
+//!    recovery, and the C2-I4/C4 epoch truncation can only ever LOWER it, never expose an uncommitted
+//!    record); AND
+//! 2. the KNOWN committed HW — the [`CheckpointCommittedHw`](super::state_machine::MetadataCommand::CheckpointCommittedHw)
+//!    bar the metadata plane replicated (#722): every offset strictly below it was quorum-fsync'd on
+//!    `min_isr` replicas, so it can never be rolled back by a KIP-101 epoch truncation.
+//!
+//! The MIN is safe because BOTH conditions must hold for an offset to be servable: the follower must
+//! durably hold it (1) AND the cluster must have committed it (2). Taking the min means an offset above
+//! EITHER bar is withheld. An uncommitted tail the follower happens to hold (flushed but not yet
+//! quorum-committed — it can still be epoch-truncated) is excluded by (2); a committed offset the
+//! follower has not yet replicated is excluded by (1). Serving `<= min(...)` is exactly the CRAQ clean
+//! tier.
+//!
+//! ## Single-node / no-cluster
+//!
+//! Nothing here is constructed off-cluster: the [`dataplane`](super::dataplane) controller (which owns
+//! these decisions) is built ONLY on a clustered serve, so the single-node consume path never reaches
+//! this module — it is zero non-cluster cost BY CONSTRUCTION.
+
+use ironbus_core::types::Offset;
+
+/// The committed read-consistency tier a CONSUMER (or a routing client) asks for. The data plane maps a
+/// requested tier + the local role to a concrete serve decision ([`classify_follower_read`] /
+/// [`LeaderReadDecision`]).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ReadTier {
+    /// CRAQ "clean": serve any committed offset (`<=` the follower's SAFE committed watermark) LOCALLY,
+    /// no leader round-trip. The throughput-scaling tier (#621).
+    FollowerCommitted,
+    /// CRAQ "dirty": a read that may reach ABOVE the follower's known safe watermark — confirm the
+    /// leader's current committed HW (a tiny HW-version query, NOT the data) before serving the
+    /// now-confirmed prefix locally (#621). Strongly-consistent latest read.
+    FollowerLatest,
+    /// Leader-lease linearizable: the leaseholder serves a 0-RTT linearizable read from its own read
+    /// plane while its lease is live at the current epoch (#620).
+    LeaderLocal,
+}
+
+/// The SAFE committed watermark a follower may serve reads up to: `min(own_flushed, known_committed_hw)`
+/// — the bar BOTH durably-held-here AND committed-on-a-quorum. A follower NEVER serves a record at or
+/// past this (the per-record bound is `< watermark`, exactly as the read plane's flushed frontier is the
+/// exclusive read bound). See the module docs for why the MIN is the safe bar.
+///
+/// `own_flushed` is the follower's read-plane flushed frontier (its durably-replicated, CRC-revalidated,
+/// non-divergent prefix). `known_committed_hw` is the last [`CheckpointCommittedHw`](super::state_machine::MetadataCommand::CheckpointCommittedHw)
+/// bar the follower has applied from the replicated metadata (#722); pass `None` when no checkpoint has
+/// committed yet, in which case the safe bar is `0` (serve nothing — fail closed — until the cluster has
+/// recorded a committed HW the follower can trust).
+#[must_use]
+pub fn follower_safe_watermark(own_flushed: u64, known_committed_hw: Option<u64>) -> u64 {
+    match known_committed_hw {
+        // BOTH bars must admit the offset: take the MIN. An uncommitted tail (held but not yet
+        // quorum-committed) is cut by the committed-HW bar; a committed offset not yet replicated here
+        // is cut by the follower's own flushed frontier.
+        Some(hw) => own_flushed.min(hw),
+        // No committed-HW checkpoint has been replicated yet: fail closed. The follower has no proof any
+        // offset is quorum-committed, so it serves NOTHING locally — a latest read confirms with the
+        // leader (the dirty tier), and a clean read simply finds nothing safe yet.
+        None => 0,
+    }
+}
+
+/// The outcome of classifying a FOLLOWER read request against its safe watermark — the pure decision the
+/// data plane acts on (#621). It NEVER admits an offset the follower cannot prove is committed-and-held.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FollowerReadDecision {
+    /// Serve `[from, serve_up_to)` LOCALLY from the follower's read plane — no leader round-trip. The
+    /// CRAQ clean serve: every offset in the range is at or below the follower's safe committed
+    /// watermark. `serve_up_to` is the exclusive upper bound (it equals the safe watermark clamped to
+    /// the request's wanted end), so the follower serves only committed-and-held records.
+    ServeLocal {
+        /// The first offset to serve (the request's `from`).
+        from: Offset,
+        /// The exclusive upper bound to serve up to (`<= follower_safe_watermark`). Records at or past
+        /// this are NOT served locally.
+        serve_up_to: Offset,
+    },
+    /// The read reaches ABOVE the follower's known safe watermark (a "latest/dirty" read): the data
+    /// plane must CONFIRM the leader's current committed HW (a tiny HW-version query) before serving the
+    /// confirmed prefix. Carries the follower's current safe watermark so the caller knows the clean
+    /// prefix it could serve immediately without confirmation.
+    ConfirmWithLeader {
+        /// The follower's CURRENT safe watermark (the clean prefix servable without confirmation). The
+        /// caller queries the leader for a HW at or above this, then re-classifies.
+        current_safe: Offset,
+    },
+    /// Nothing to serve from this request at this tier (the request is empty, or `from` is already at or
+    /// past the safe watermark on a CLEAN-only request). Not an error — the caller serves an empty run.
+    Nothing,
+}
+
+/// Classify a FOLLOWER read of `[from, wanted_end)` at `tier` against the follower's `safe_watermark`
+/// (= [`follower_safe_watermark`]). PURE and fail-closed — it never admits an offset above the proven
+/// committed bar.
+///
+/// * [`ReadTier::FollowerCommitted`] (clean): serve `[from, min(wanted_end, safe_watermark))` locally,
+///   or [`FollowerReadDecision::Nothing`] if `from` is already at/past the safe watermark.
+/// * [`ReadTier::FollowerLatest`] (dirty): if the wanted range stays at or below the safe watermark it
+///   is served locally exactly like the clean tier (no confirmation needed); only if it reaches ABOVE
+///   the safe watermark does it return [`FollowerReadDecision::ConfirmWithLeader`] so the caller does the
+///   HW-version query first — NEVER speculatively serving unconfirmed bytes.
+/// * [`ReadTier::LeaderLocal`] on a FOLLOWER is a wrong-tier request: a follower cannot serve a
+///   leader-lease linearizable read, so it degrades to the strongly-consistent latest path
+///   ([`FollowerReadDecision::ConfirmWithLeader`]) rather than serving stale local data.
+///
+/// `wanted_end` is the exclusive upper bound the request wants (e.g. `from + max_records`, saturated);
+/// pass `u64::MAX`-saturated for "as much as is safe".
+#[must_use]
+pub fn classify_follower_read(
+    tier: ReadTier,
+    from: Offset,
+    wanted_end: Offset,
+    safe_watermark: u64,
+) -> FollowerReadDecision {
+    let from_raw = from.get();
+    let wanted = wanted_end.get();
+    // An empty or backwards request serves nothing (a degenerate `from >= wanted_end`).
+    if wanted <= from_raw {
+        return FollowerReadDecision::Nothing;
+    }
+    match tier {
+        ReadTier::FollowerCommitted => {
+            // Clean: serve only the prefix at or below the safe watermark.
+            if from_raw >= safe_watermark {
+                FollowerReadDecision::Nothing
+            } else {
+                FollowerReadDecision::ServeLocal {
+                    from,
+                    serve_up_to: Offset::new(wanted.min(safe_watermark)),
+                }
+            }
+        }
+        ReadTier::FollowerLatest => {
+            // Dirty: serve what is PROVABLY committed-and-held right now, and round-trip to confirm the
+            // leader's current HW ONLY when `from` is already at/past the known safe watermark — i.e. the
+            // follower would otherwise return EMPTY but the caller wants the LATEST. This is the CRAQ
+            // dirty semantics: never serve unconfirmed bytes, but never round-trip when there is a clean
+            // committed prefix to serve from `from` either.
+            //
+            // * `from < safe_watermark`: serve `[from, min(wanted, safe_watermark))` LOCALLY — the clean
+            //   committed prefix from the requested position, exactly like the clean tier. (If the caller
+            //   wants strictly newer-than-safe data it re-reads from the new position, which then lands in
+            //   the confirm branch.)
+            // * `from >= safe_watermark`: the follower has nothing committed to serve from here with its
+            //   current knowledge, so it CONFIRMS the leader's current HW before serving — never
+            //   speculatively serving the unconfirmed tail.
+            if from_raw < safe_watermark {
+                FollowerReadDecision::ServeLocal {
+                    from,
+                    serve_up_to: Offset::new(wanted.min(safe_watermark)),
+                }
+            } else {
+                FollowerReadDecision::ConfirmWithLeader {
+                    current_safe: Offset::new(safe_watermark),
+                }
+            }
+        }
+        // A leader-lease linearizable read cannot be served by a follower; do NOT serve stale local
+        // data — escalate to the strongly-consistent latest path (confirm with the leader).
+        ReadTier::LeaderLocal => FollowerReadDecision::ConfirmWithLeader {
+            current_safe: Offset::new(safe_watermark),
+        },
+    }
+}
+
+/// The outcome of asking whether the LEASEHOLDER may serve a leader-lease linearizable LOCAL read
+/// (#620). Sound by the #694/#722 fence: a leader on a stale epoch / lapsed lease must NOT serve.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LeaderReadDecision {
+    /// Serve `[from, serve_up_to)` LOCALLY from the leader's own read plane — a 0-RTT linearizable read.
+    /// The lease is live at the current epoch, so the leader's committed prefix IS the linearizable
+    /// state. `serve_up_to` is the leader's read-plane flushed frontier clamped to the wanted end.
+    ServeLocal {
+        /// The first offset to serve.
+        from: Offset,
+        /// The exclusive upper bound (`<=` the leader's flushed frontier).
+        serve_up_to: Offset,
+    },
+    /// Nothing to serve (empty request, or `from` is already at/past the leader's flushed frontier).
+    Nothing,
+    /// REFUSE the local read: the lease is in doubt (expired, or this node is not the current
+    /// leaseholder / is on a stale epoch). Serving locally would risk a stale read, so the leader does
+    /// NOT serve — the caller falls back to a read-index/quorum confirm or returns unavailable. This is
+    /// the soundness fence: no serving-as-leader on a stale epoch.
+    Refuse,
+}
+
+/// Decide whether the LEASEHOLDER may serve a leader-lease linearizable LOCAL read of `[from,
+/// wanted_end)` (#620). `lease_valid` is the leaseholder's lease-validity bit at the current monotonic
+/// time and epoch — exactly [`can_act_as_leader`](super::metadata_group::MetadataRaftGroup::can_act_as_leader)
+/// for the metadata leader, or the per-partition equivalent (a held, unexpired lease under the current
+/// epoch). `leader_flushed` is the leader's read-plane flushed frontier (its committed/linearizable
+/// prefix).
+///
+/// Returns [`LeaderReadDecision::Refuse`] when the lease is NOT valid — never a stale local read.
+/// Otherwise serves `[from, min(wanted_end, leader_flushed))` from the leader's own read plane.
+#[must_use]
+pub fn classify_leader_local_read(
+    lease_valid: bool,
+    from: Offset,
+    wanted_end: Offset,
+    leader_flushed: u64,
+) -> LeaderReadDecision {
+    // The SOUNDNESS FENCE: a leader whose lease is in doubt must not serve a local read. No
+    // serving-as-leader on a stale epoch (the #694/#722 fence).
+    if !lease_valid {
+        return LeaderReadDecision::Refuse;
+    }
+    let from_raw = from.get();
+    let wanted = wanted_end.get();
+    if wanted <= from_raw || from_raw >= leader_flushed {
+        return LeaderReadDecision::Nothing;
+    }
+    LeaderReadDecision::ServeLocal {
+        from,
+        serve_up_to: Offset::new(wanted.min(leader_flushed)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- the SAFE watermark = min(own_flushed, known_committed_hw) (#621 correctness 1) ----------
+
+    #[test]
+    fn safe_watermark_is_the_min_of_own_flushed_and_known_committed_hw() {
+        // The committed HW is BELOW the follower's flushed prefix: the follower holds an uncommitted
+        // tail (flushed but not yet quorum-committed). The safe bar is the committed HW — the
+        // uncommitted tail is NEVER servable (it could still be epoch-truncated).
+        assert_eq!(follower_safe_watermark(100, Some(80)), 80);
+        // The follower has not yet replicated the whole committed prefix: the safe bar is its own
+        // flushed frontier — it cannot serve an offset it does not durably hold.
+        assert_eq!(follower_safe_watermark(60, Some(80)), 60);
+        // Equal: the whole flushed prefix is committed.
+        assert_eq!(follower_safe_watermark(80, Some(80)), 80);
+    }
+
+    #[test]
+    fn no_committed_hw_checkpoint_yet_serves_nothing_fail_closed() {
+        // With no replicated committed-HW checkpoint the follower has NO proof any offset is
+        // quorum-committed, so the safe bar is 0 (serve nothing locally — fail closed).
+        assert_eq!(follower_safe_watermark(100, None), 0);
+        assert_eq!(follower_safe_watermark(0, None), 0);
+    }
+
+    /// THE safety property: a follower whose FLUSHED prefix is BEYOND the known committed HW serves only
+    /// `<= committed HW` — never the uncommitted tail. This is the constructed-state form of the
+    /// integration safety test.
+    #[test]
+    fn a_follower_ahead_of_the_committed_hw_never_serves_the_uncommitted_tail() {
+        let own_flushed = 100; // the follower durably holds [0,100)
+        let committed_hw = 70; // but only [0,70) is quorum-committed
+        let safe = follower_safe_watermark(own_flushed, Some(committed_hw));
+        assert_eq!(safe, 70);
+        // A clean read asking for everything serves ONLY up to the committed HW (70), never to 100.
+        match classify_follower_read(
+            ReadTier::FollowerCommitted,
+            Offset::ZERO,
+            Offset::new(u64::MAX),
+            safe,
+        ) {
+            FollowerReadDecision::ServeLocal { from, serve_up_to } => {
+                assert_eq!(from, Offset::ZERO);
+                assert_eq!(
+                    serve_up_to,
+                    Offset::new(70),
+                    "never serves the uncommitted tail [70,100)"
+                );
+            }
+            other => panic!("expected a local serve up to the committed HW, got {other:?}"),
+        }
+        // A read STARTING in the uncommitted tail serves nothing clean.
+        assert_eq!(
+            classify_follower_read(
+                ReadTier::FollowerCommitted,
+                Offset::new(85),
+                Offset::new(100),
+                safe,
+            ),
+            FollowerReadDecision::Nothing,
+        );
+    }
+
+    // ---- CRAQ clean tier (FollowerCommitted) ----------------------------------------------------
+
+    #[test]
+    fn clean_tier_serves_the_committed_prefix_locally() {
+        let safe = follower_safe_watermark(50, Some(50));
+        match classify_follower_read(
+            ReadTier::FollowerCommitted,
+            Offset::new(10),
+            Offset::new(30),
+            safe,
+        ) {
+            FollowerReadDecision::ServeLocal { from, serve_up_to } => {
+                assert_eq!(from, Offset::new(10));
+                assert_eq!(
+                    serve_up_to,
+                    Offset::new(30),
+                    "the whole wanted range is committed"
+                );
+            }
+            other => panic!("expected a local serve, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn clean_tier_clamps_the_serve_to_the_safe_watermark() {
+        let safe = follower_safe_watermark(50, Some(40)); // safe = 40
+        match classify_follower_read(
+            ReadTier::FollowerCommitted,
+            Offset::new(30),
+            Offset::new(60),
+            safe,
+        ) {
+            FollowerReadDecision::ServeLocal { serve_up_to, .. } => {
+                assert_eq!(
+                    serve_up_to,
+                    Offset::new(40),
+                    "clamped to the safe watermark"
+                );
+            }
+            other => panic!("expected a clamped local serve, got {other:?}"),
+        }
+    }
+
+    // ---- CRAQ dirty tier (FollowerLatest) -------------------------------------------------------
+
+    #[test]
+    fn dirty_tier_serves_the_committed_prefix_from_within_the_safe_watermark() {
+        let safe = follower_safe_watermark(100, Some(100));
+        // `from` is below the safe watermark: serve the committed prefix locally with NO confirmation.
+        assert_eq!(
+            classify_follower_read(
+                ReadTier::FollowerLatest,
+                Offset::new(10),
+                Offset::new(90),
+                safe,
+            ),
+            FollowerReadDecision::ServeLocal {
+                from: Offset::new(10),
+                serve_up_to: Offset::new(90),
+            },
+        );
+    }
+
+    #[test]
+    fn dirty_tier_clamps_a_within_range_serve_to_the_safe_watermark_no_confirm() {
+        let safe = follower_safe_watermark(50, Some(50)); // safe = 50
+                                                          // `from` (40) is below the safe watermark, but the wanted range reaches above it: serve the clean
+                                                          // committed prefix [40,50) LOCALLY (never the unconfirmed [50,80)) with no round-trip. The caller
+                                                          // that wants strictly-newer data re-reads from 50, which then confirms.
+        assert_eq!(
+            classify_follower_read(
+                ReadTier::FollowerLatest,
+                Offset::new(40),
+                Offset::new(80),
+                safe,
+            ),
+            FollowerReadDecision::ServeLocal {
+                from: Offset::new(40),
+                serve_up_to: Offset::new(50),
+            },
+        );
+    }
+
+    #[test]
+    fn dirty_tier_confirms_with_the_leader_when_from_is_at_or_past_the_safe_watermark() {
+        let safe = follower_safe_watermark(50, Some(50)); // safe = 50
+                                                          // `from` (50) is AT the safe watermark: the follower has nothing committed to serve from here, so
+                                                          // it confirms the leader's current HW before serving — never speculatively serving [50,80).
+        assert_eq!(
+            classify_follower_read(
+                ReadTier::FollowerLatest,
+                Offset::new(50),
+                Offset::new(80),
+                safe,
+            ),
+            FollowerReadDecision::ConfirmWithLeader {
+                current_safe: Offset::new(50),
+            },
+        );
+    }
+
+    #[test]
+    fn a_follower_never_serves_a_leader_local_tier_request_stale() {
+        // A LeaderLocal request landing on a follower must NOT serve stale local data; it escalates to
+        // the strongly-consistent latest path (confirm with the leader).
+        let safe = follower_safe_watermark(50, Some(50));
+        assert_eq!(
+            classify_follower_read(ReadTier::LeaderLocal, Offset::ZERO, Offset::new(40), safe,),
+            FollowerReadDecision::ConfirmWithLeader {
+                current_safe: Offset::new(50),
+            },
+        );
+    }
+
+    #[test]
+    fn an_empty_or_backwards_request_serves_nothing() {
+        let safe = 100;
+        for tier in [
+            ReadTier::FollowerCommitted,
+            ReadTier::FollowerLatest,
+            ReadTier::LeaderLocal,
+        ] {
+            assert_eq!(
+                classify_follower_read(tier, Offset::new(10), Offset::new(10), safe),
+                FollowerReadDecision::Nothing,
+                "an empty request serves nothing at {tier:?}"
+            );
+            assert_eq!(
+                classify_follower_read(tier, Offset::new(20), Offset::new(10), safe),
+                FollowerReadDecision::Nothing,
+                "a backwards request serves nothing at {tier:?}"
+            );
+        }
+    }
+
+    // ---- leader-lease linearizable LOCAL read (#620) --------------------------------------------
+
+    #[test]
+    fn a_valid_leaseholder_serves_a_local_linearizable_read() {
+        // The lease is live: the leader serves [from, min(wanted, flushed)) locally with no quorum round.
+        assert_eq!(
+            classify_leader_local_read(true, Offset::new(10), Offset::new(40), 100),
+            LeaderReadDecision::ServeLocal {
+                from: Offset::new(10),
+                serve_up_to: Offset::new(40),
+            },
+        );
+        // Clamped to the leader's flushed frontier (never serves past its committed prefix).
+        assert_eq!(
+            classify_leader_local_read(true, Offset::new(10), Offset::new(200), 100),
+            LeaderReadDecision::ServeLocal {
+                from: Offset::new(10),
+                serve_up_to: Offset::new(100),
+            },
+        );
+    }
+
+    #[test]
+    fn an_invalid_lease_refuses_the_local_read_never_serving_stale() {
+        // The lease is in doubt (expired / not the leaseholder / stale epoch): REFUSE — never a stale
+        // local read. This is the #694/#722 soundness fence.
+        assert_eq!(
+            classify_leader_local_read(false, Offset::ZERO, Offset::new(40), 100),
+            LeaderReadDecision::Refuse,
+        );
+        // Even a fully-committed range is refused while the lease is invalid.
+        assert_eq!(
+            classify_leader_local_read(false, Offset::ZERO, Offset::new(10), 100),
+            LeaderReadDecision::Refuse,
+        );
+    }
+
+    #[test]
+    fn a_valid_leaseholder_with_an_exhausted_range_serves_nothing() {
+        // The lease is valid but `from` is already at/past the flushed frontier: nothing to serve.
+        assert_eq!(
+            classify_leader_local_read(true, Offset::new(100), Offset::new(120), 100),
+            LeaderReadDecision::Nothing,
+        );
+        assert_eq!(
+            classify_leader_local_read(true, Offset::new(10), Offset::new(10), 100),
+            LeaderReadDecision::Nothing,
+        );
+    }
+}

--- a/crates/ironbus-server/src/cluster/replication.rs
+++ b/crates/ironbus-server/src/cluster/replication.rs
@@ -840,6 +840,30 @@ impl<F: Filesystem, C: Clock> Follower<F, C> {
     }
 }
 
+// The C6 FOLLOWER-READ path (#621/#622) builds an `Arc`-shared, off-actor [`ReadPlane`] over the
+// follower's OWN replica log — the SAME zero-copy machinery the leader serves through (#654/#715). It
+// needs `F: Clone` (the read plane clones the filesystem handle behind an `Arc` so the plane can read the
+// immutable sealed files concurrently with the follower's writer), so it is a SEPARATE impl block (the
+// rest of the follower keeps the looser `F: Filesystem` bound; the single-node path links neither).
+impl<F: Filesystem + Clone, C: Clock> Follower<F, C> {
+    /// Build an `Arc`-shared, off-actor [`ReadPlane`] over the follower's OWN replica log — the C6
+    /// zero-copy follower-read source (#622). A FOLLOWER serves committed reads from this plane EXACTLY
+    /// as a leader serves fetches from its plane: arc-swapped sealed segments out of its own page cache,
+    /// no user-space copy, no append-actor round-trip. The follower NEVER writes a log through this — it
+    /// only READS the immutable sealed bytes; the follower's single ingest writer stays the sole writer.
+    ///
+    /// The plane's [`flushed`](ReadPlane::flushed) frontier is the follower's durably-replicated,
+    /// CRC-revalidated prefix; a C6 follower read clamps it further to the KNOWN committed HW (the safe
+    /// watermark, [`crate::cluster::read_consistency::follower_safe_watermark`]) so it never serves an
+    /// uncommitted / epoch-truncatable record.
+    ///
+    /// # Errors
+    /// Returns [`ReplicationError::Storage`] if the read plane cannot be built (an underlying IO fault).
+    pub fn read_plane(&self) -> Result<ReadPlane<F>, ReplicationError> {
+        Ok(self.log.read_plane()?)
+    }
+}
+
 /// The typed, REPORTED outcome of a leader-epoch divergence reconciliation (C2-I4, #599) — never a
 /// silent drop. When a follower adopts a (possibly-new) leader and finds its uncommitted tail
 /// diverges from the leader's lineage, [`EpochAwareFollower::reconcile_with_leader`] truncates to the

--- a/crates/ironbus-server/src/cluster/serve.rs
+++ b/crates/ironbus-server/src/cluster/serve.rs
@@ -2960,4 +2960,271 @@ mod live_runtime_tests {
         f_rt2.stop();
         leader_rt.stop();
     }
+
+    // ---- C6 (#620/#621/#622): a CONSUMER reads committed data FROM A FOLLOWER over the live runtime ---
+
+    /// Decode a zero-copy raw run into `(offset, payload)` pairs via the full `codec::decode` (header +
+    /// body CRC) — the consumer-side half of a C6 follower read: the served bytes are integrity-checkable
+    /// end-to-end (#622 zero-copy delivery reuses the read-plane raw run verbatim).
+    fn decode_run(run: &ironbus_storage::segment::RawByteRun) -> Vec<(u64, Vec<u8>)> {
+        let mut out = Vec::new();
+        let mut cursor = 0usize;
+        let mut offset = run.first_offset.get();
+        while cursor < run.bytes.len() {
+            let (view, consumed) = ironbus_core::codec::decode(&run.bytes[cursor..])
+                .expect("every C6 follower-served frame passes header AND body CRC");
+            out.push((offset, view.payload.to_vec()));
+            offset += 1;
+            cursor += consumed;
+        }
+        out
+    }
+
+    /// THE C6 HEADLINE (#621/#622): a real 3-node serve cluster over real loopback sockets, where a
+    /// CONSUMER reads COMMITTED records FROM A FOLLOWER (not the leader) and gets BYTE-IDENTICAL committed
+    /// data — the CRAQ committed-local read that makes read throughput scale with replicas — AND a read
+    /// ABOVE the committed HW is NOT served stale (it confirms with the leader; never speculative).
+    ///
+    /// The leader + two followers each run their OWN `DataPlaneRuntime` (the SAME construct `run_broker`
+    /// spawns) on their own threads over real sockets; the runtimes' threads do the replication. Once a
+    /// follower has caught up, we read FROM THAT FOLLOWER's replica via the C6 serve path and verify:
+    ///   1. the follower serves committed records LOCALLY (its own read plane, zero-copy);
+    ///   2. those bytes are byte-identical to the leader's over the same committed prefix;
+    ///   3. a "latest" read STARTING AT the follower's known committed bar does NOT serve the
+    ///      uncommitted/unknown tail stale — it asks the leader to confirm the current HW first.
+    #[test]
+    fn live_three_node_runtime_a_consumer_reads_committed_data_from_a_follower_craq() {
+        use crate::cluster::dataplane::FollowerReadOutcome;
+        use crate::cluster::read_consistency::ReadTier;
+
+        const P: u64 = 0;
+        // Serialize against the other heavy multi-node tests so this thread-spinning cluster forms on an
+        // un-contended host (the #687 starvation guard).
+        let _serial = crate::cluster::heavy_cluster_test_guard();
+        let placement = Placement {
+            replicas: vec![1, 2, 3],
+            leader: 1,
+            epoch: 5,
+        };
+        let placements: BTreeMap<u64, Placement> = [(P, placement)].into_iter().collect();
+        let data_addrs: BTreeMap<u64, SocketAddr> = [1u64, 2, 3]
+            .into_iter()
+            .map(|id| (id, SocketAddr::from((Ipv4Addr::LOCALHOST, free_port()))))
+            .collect();
+
+        // The LEADER (node 1): 25 records produced + fsync'd; serves through the off-actor read plane.
+        let leader_dir = tempfile::tempdir().expect("leader dir");
+        let leader_log = leaked_disk_leader(leader_dir.path(), 25);
+        let leader_pl = disk_leader_plane(leader_log);
+        let served_end = plane_served_end(&leader_pl);
+        assert!(
+            served_end > 0,
+            "the read plane serves a non-empty committed prefix"
+        );
+
+        let leader_server = DataPlaneServer::from_placements(
+            1,
+            &placements,
+            quorum3(),
+            |p| (p == P).then(|| Arc::clone(&leader_pl)),
+            &DiskReplicaLogs {
+                root: leader_dir.path().to_path_buf(),
+            },
+            |_| EpochCache::new(),
+        )
+        .expect("leader server builds");
+        let mut leader_rt =
+            DataPlaneRuntime::start(leader_server, data_addrs[&1], &data_addrs).expect("leader rt");
+
+        // The two FOLLOWERS (nodes 2 + 3), each its own runtime + replica log + threads dialing node 1.
+        let f2_dir = tempfile::tempdir().expect("f2 dir");
+        let f3_dir = tempfile::tempdir().expect("f3 dir");
+        let mk_follower = |id: u64, root: std::path::PathBuf| {
+            DataPlaneServer::from_placements(
+                id,
+                &placements,
+                quorum3(),
+                |_| None,
+                &DiskReplicaLogs { root },
+                |_| EpochCache::new(),
+            )
+            .expect("follower server builds")
+        };
+        let mut f2_rt = DataPlaneRuntime::start(
+            mk_follower(2, f2_dir.path().to_path_buf()),
+            data_addrs[&2],
+            &data_addrs,
+        )
+        .expect("f2 rt");
+        let mut f3_rt = DataPlaneRuntime::start(
+            mk_follower(3, f3_dir.path().to_path_buf()),
+            data_addrs[&3],
+            &data_addrs,
+        )
+        .expect("f3 rt");
+
+        // Wait until follower 2 has caught up to the leader's committed prefix over the LIVE transport.
+        let f2_hw = || {
+            f2_rt
+                .server()
+                .lock()
+                .unwrap()
+                .seam()
+                .controller()
+                .follower_high_watermark(P)
+                .unwrap_or(0)
+        };
+        assert!(
+            wait_until(Duration::from_secs(30), || f2_hw() >= served_end),
+            "follower 2 caught up over the live runtime (hw={}, served_end={served_end})",
+            f2_hw()
+        );
+
+        // The committed HW the cluster has recorded: with a 2-of-3 quorum met (the leader + follower 2
+        // both hold the served prefix) the committed HW covers it. In a real serve this is the replicated
+        // `CheckpointCommittedHw` bar; here we read the leader's live quorum-commit, which is exactly that
+        // bar (the highest offset min_isr replicas have all fsync'd).
+        let committed_hw = wait_until(Duration::from_secs(15), || {
+            leader_rt
+                .server()
+                .lock()
+                .unwrap()
+                .seam()
+                .controller()
+                .quorum_commit(P)
+                .unwrap_or(0)
+                >= served_end
+        })
+        .then_some(served_end)
+        .expect("the cluster committed the served prefix on a 2-of-3 quorum");
+
+        // (1) + (2): a CONSUMER reads COMMITTED records FROM FOLLOWER 2 (NOT the leader), LOCALLY off the
+        // follower's own read plane, and gets BYTE-IDENTICAL bytes to the leader's committed prefix. Chain
+        // the clean read across the prefix (one sealed segment per raw read).
+        let mut follower_records: Vec<(u64, Vec<u8>)> = Vec::new();
+        {
+            let f2 = f2_rt.server().lock().unwrap();
+            let ctrl = f2.seam().controller();
+            let mut from = ironbus_core::types::Offset::ZERO;
+            let mut guard = 0u32;
+            loop {
+                guard += 1;
+                assert!(guard < 10_000, "follower-read chain failed to terminate");
+                let outcome = ctrl
+                    .serve_follower_read(
+                        P,
+                        ReadTier::FollowerCommitted,
+                        Some(committed_hw),
+                        from,
+                        usize::MAX,
+                        None,
+                    )
+                    .expect("the follower serves a committed read locally");
+                let run = match outcome {
+                    FollowerReadOutcome::Served(r) => r,
+                    FollowerReadOutcome::ConfirmWithLeader { .. } => {
+                        panic!("a clean committed read serves locally, not a confirm")
+                    }
+                };
+                let recs = decode_run(&run.run);
+                if recs.is_empty() {
+                    break;
+                }
+                // SAFETY: every served offset is strictly below the committed HW (never the uncommitted
+                // tail) — the non-negotiable for a follower read.
+                for (off, _) in &recs {
+                    assert!(
+                        *off < committed_hw,
+                        "follower served offset {off} at/past committed HW"
+                    );
+                }
+                let next = run.run.next_offset.get();
+                follower_records.extend(recs);
+                if next <= from.get() {
+                    break;
+                }
+                from = ironbus_core::types::Offset::new(next);
+            }
+        }
+        assert!(
+            !follower_records.is_empty(),
+            "the consumer read committed records FROM THE FOLLOWER (CRAQ committed-local read)"
+        );
+
+        // The leader's committed prefix, decoded over the same range (the byte-identity oracle).
+        let mut leader_records: Vec<(u64, Vec<u8>)> = Vec::new();
+        {
+            let mut from = ironbus_core::types::Offset::ZERO;
+            while from.get() < served_end {
+                let run = leader_pl
+                    .read_range_raw(from, usize::MAX, None)
+                    .expect("leader read plane serves");
+                let recs = decode_run(&run.run);
+                if recs.is_empty() {
+                    break;
+                }
+                let next = run.run.next_offset.get();
+                leader_records.extend(recs);
+                if next <= from.get() {
+                    break;
+                }
+                from = ironbus_core::types::Offset::new(next);
+            }
+        }
+        // The follower's served records are byte-identical to the leader's at the same offsets (a
+        // byte-identical PREFIX — the follower's last replicated segment may not have sealed yet, the same
+        // active-tail lag the leader-fetch path has; FLAGGED).
+        assert!(
+            !follower_records.is_empty() && follower_records.len() <= leader_records.len(),
+            "the follower never serves more than the leader's committed prefix"
+        );
+        for (f, l) in follower_records.iter().zip(leader_records.iter()) {
+            assert_eq!(
+                f.0, l.0,
+                "offset mismatch leader vs follower over the live runtime"
+            );
+            assert_eq!(
+                f.1, l.1,
+                "payload byte mismatch leader vs follower at offset {} over the live runtime",
+                f.0
+            );
+        }
+
+        // (3): a "latest" read STARTING AT the follower's served prefix end (above its known-committed
+        // bar if we feed it a STALE lower known HW) is NOT served stale — it asks the leader to CONFIRM
+        // the current HW first, never speculatively serving the unconfirmed tail.
+        {
+            let f2 = f2_rt.server().lock().unwrap();
+            let ctrl = f2.seam().controller();
+            // Feed a STALE known HW BELOW the served prefix and read starting AT it: the latest read must
+            // confirm with the leader rather than serve the unknown-committed region stale.
+            let stale_known = committed_hw / 2;
+            let outcome = ctrl
+                .serve_follower_read(
+                    P,
+                    ReadTier::FollowerLatest,
+                    Some(stale_known),
+                    ironbus_core::types::Offset::new(stale_known),
+                    usize::MAX,
+                    None,
+                )
+                .expect("the follower classifies a latest read");
+            match outcome {
+                FollowerReadOutcome::ConfirmWithLeader { current_safe } => {
+                    assert_eq!(
+                        current_safe.get(),
+                        stale_known,
+                        "a latest read above the known bar confirms with the leader (never stale)"
+                    );
+                }
+                FollowerReadOutcome::Served(_) => {
+                    panic!("a latest read above the known committed bar must NOT serve stale local data")
+                }
+            }
+        }
+
+        leader_rt.stop();
+        f2_rt.stop();
+        f3_rt.stop();
+    }
 }


### PR DESCRIPTION
## What this is (V2-C6: cluster reads that scale with replicas)

On top of the committed-safe cluster (consensus, replication, quorum-fsync ack, committed-safe failover), this PR makes **where you read** a principled, strongly-consistent CHOICE — not a stale-read bug. Three read-consistency tiers, all reusing the existing off-actor zero-copy `ReadPlane`:

| Tier | Who serves | Round-trip | Issue |
|---|---|---|---|
| **`LeaderLocal`** (leader-lease linearizable) | the leaseholder, from its own read plane | **0-RTT** | #620 |
| **`FollowerCommitted`** (CRAQ "clean") | any follower, for `<= safe HW`, LOCALLY | **0-RTT** | #621 |
| **`FollowerLatest`** (CRAQ "dirty") | a follower, after a tiny HW-version confirm to the leader | 1 small HW query, then local | #621 |
| zero-copy delivery | followers serve via `ReadPlane::read_range_raw` (sealed-segment byte ranges) | — | #622 |

Follower committed reads scale read throughput ~linearly with replicas (CRAQ); the dirty tier turns a stale-follower-read (a NATS bug class) into a strongly-consistent latest read.

## Design

- **New pure, IO-free `cluster::read_consistency` module** — the load-bearing correctness math, unit-testable against constructed states without a cluster:
  - `follower_safe_watermark(own_flushed, known_committed_hw) = min(...)` (the safe bar).
  - `classify_follower_read(tier, from, wanted_end, safe)` → serve-local / confirm-with-leader / nothing.
  - `classify_leader_local_read(lease_valid, ...)` → serve-local / refuse / nothing.
- **`DataPlaneController` serve methods** (reuse the off-actor `ReadPlane`, never a second writer):
  - `serve_leader_local_read` — lease-gated linearizable local read; **refuses fail-closed** on an in-doubt lease.
  - `leader_committed_hw` — the leader's flushed frontier; the dirty-tier HW-version answer (leader-only).
  - `follower_safe_read_watermark` + `serve_follower_read` — CRAQ clean + dirty-confirm, zero-copy.
- **`Follower::read_plane()`** (in a `F: Clone` impl) builds the off-actor plane over the follower's OWN replica log — a follower serves from its own page cache and never writes a log.

## How each non-negotiable is guaranteed (code pointers)

1. **A follower NEVER serves past its SAFE committed watermark** — `follower_safe_watermark = min(own_flushed, known_committed_hw)` (`read_consistency.rs`). `serve_follower_read` bounds the read-plane read to `serve_up_to - from` records AND the read plane re-applies its own flushed frontier internally, so both bounds together never return a record at/past `min(...)`. *Proven by a real multi-node test + a controller safety test (a follower whose flushed prefix is BEYOND the committed HW serves only `<= HW`).*
2. **Leader-lease read is sound** — `classify_leader_local_read` returns `Refuse` (→ `DataPlaneError::LeaseNotValid`) whenever `lease_valid` is false (expired / stale epoch / not the leaseholder). No serving-as-leader on a stale epoch (the #694/#722 fence). The `lease_valid` bit is exactly `MetadataRaftGroup::can_act_as_leader` (monotonic-clock, current epoch). *Proven by a controller test (valid serves byte-identical; invalid refuses).*
3. **Dirty read confirms before serving** — `classify_follower_read(FollowerLatest, ...)` returns `ConfirmWithLeader` when `from >= safe_watermark`; the caller does the HW-version query (`leader_committed_hw`), updates `known_committed_hw`, and only then re-serves. Never speculative. *Proven by a controller test + the integration test.*
4. **Single-node byte-identical & single-writer** — the cluster controller (which owns all C6 decisions) is constructed ONLY on a clustered serve, so `session.rs`/`engine.rs` consume hot path is unchanged (zero non-cluster cost, by construction). Followers serve via the read plane (Arc, off-actor) and never write a log; the single append actor stays the only writer.
5. **Zero-copy preserved** — follower + leader-local delivery go through `ReadPlane::read_range_raw` (sealed-segment byte ranges), not a user-space copy. The served frames decode end-to-end (header + body CRC) in tests.

## Read-consistency tiers (summary)

- `FollowerCommitted`: serve `[from, min(wanted, safe_watermark))` locally.
- `FollowerLatest`: serve the clean prefix locally; confirm with the leader only when `from` is at/past the known safe watermark (would otherwise return empty but the caller wants the latest).
- `LeaderLocal`: serve `[from, min(wanted, leader_flushed))` locally iff the lease is valid; else refuse.

## Tests + what they prove

- `live_three_node_runtime_a_consumer_reads_committed_data_from_a_follower_craq` (real 3-node `#[cfg(unix)]`, `DataPlaneRuntime` over loopback sockets): a **consumer reads committed data FROM A FOLLOWER**, byte-identical to the leader, AND a read above the committed HW is **not served stale** (confirms with the leader). Reuses the `heavy_cluster_test_guard` serial guard + `wait_until` (deterministic, no fixed-deadline flake). **Reran 5/5 stable.**
- `a_follower_serves_only_up_to_the_committed_hw_never_the_uncommitted_tail` — a follower whose flushed prefix is BEYOND the committed HW serves only `<= HW`.
- `a_follower_serves_committed_records_locally_byte_identical_to_the_leader` — CRAQ clean + zero-copy byte-identity.
- `a_latest_follower_read_above_the_safe_watermark_confirms_with_the_leader_then_serves` — dirty tier confirm-then-serve.
- `a_valid_leaseholder_serves_a_local_linearizable_read_an_invalid_lease_refuses` — #620 serve/refuse.
- `role_gating_for_the_c6_read_apis` — wrong-role / unknown-partition fail closed; a follower never answers an authoritative committed-HW query.
- 13 `read_consistency` unit tests for `min(...)` and every tier classification.

## Deferred / honest caveats

- **Active-tail lag (FLAGGED, by construction):** a follower serves its SEALED page-cache prefix, a byte-identical PREFIX of the leader's committed prefix; its last replicated segment may not have sealed yet (the same active-tail lag the leader-fetch path has). Not a correctness gap.
- **Client-side read routing** is minimal here (the controller serve methods PROVE a follower can serve a committed read); a rich "read from the nearest replica" client policy and the `session.rs`/`engine.rs` consume-path wiring of the tier selection are follow-on (the consume hot path is deliberately untouched to keep single-node byte-identical).
- **Multi-partition routing** → #693. Full CRAQ chain-ordering beyond committed-`<=HW` + the dirty HW-version confirm is deferred.

## Gates (all pass)

- `cargo fmt --all --check`: clean
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`: clean
- `cargo test --workspace --all-features --locked`: green except the allowed APFS `preallocate_reserves_real_blocks_on_a_supporting_fs` local flake (ironbus-server lib: 715 passed / 0 failed)
- io-free-check on ironbus-core: ok; SPDX local check: miss=0; no metrics touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVWp2H2txnKGru4q2twxM3