### PR TITLE
feat(cluster): cross-cluster domain namespace — address streams by <domain>/<stream> (#624)

### DIFF
--- a/crates/ironbus-cli/src/main.rs
+++ b/crates/ironbus-cli/src/main.rs
@@ -95,7 +95,10 @@ use ironbus_server::cluster::{
     IsrConfig, MetadataCommand, MetadataProposer, MirrorApplier, OriginCursorStore, Placement,
     ReplicaLogFactory, RuntimeError, GEO_POLL,
 };
-use ironbus_server::cluster::{ClusterConfig, GeoConfig, GeoMode, GeoOrigin, GeoStreamConfig};
+use ironbus_server::cluster::{
+    ClusterConfig, Domain, DomainRef, DomainResolver, GeoConfig, GeoMode, GeoOrigin,
+    GeoStreamConfig,
+};
 use std::io::{self, Read, Write};
 use std::path::Path;
 use std::process::ExitCode;
@@ -1969,6 +1972,17 @@ struct ServeFlags {
     /// `--source <local>=<addr1>/<stream1>,<addr2>/<stream2>,...` declares a local stream that FANS IN one
     /// or more remote origin streams. Raw strings parsed after collection. Empty = the non-geo default.
     sources: Vec<String>,
+    /// This cluster's stable cross-cluster DOMAIN / cluster-id (#624, V2-C7-I2), from
+    /// `--cluster-domain <id>`. `None` (no flag) = the non-namespaced default: a `@domain/stream`
+    /// reference cannot be a self-reference (there is no own domain), and behavior is exactly today's.
+    /// Validated into a [`ironbus_server::cluster::Domain`] after collection (a malformed id is a typed
+    /// usage error). CLI-only and singular.
+    cluster_domain: Option<String>,
+    /// Repeatable remote-domain LINK specs (#624): each `--cluster-link <domain>=<addr>` maps a remote
+    /// cluster's domain to its geo-pull endpoint address, the ONLY way a `@domain/stream` origin resolves
+    /// to a dial address (no auto-discovery). Raw `domain=addr` strings, validated after collection. Empty
+    /// = no remote domains configured. CLI-only and repeatable, like `--cluster-peer`.
+    cluster_links: Vec<String>,
     /// The TLS server certificate chain file (#629, V2-M7): a PEM path. RESERVED, NOT YET HONORED
     /// (#107): the TLS 1.3 handshake (rustls) is not wired (no allowed crypto provider), so a set value
     /// is a fail-closed startup REFUSAL rather than an accepted cert that would imply encryption this
@@ -2197,6 +2211,18 @@ fn collect_serve_flags(args: &[String]) -> Result<ServeFlags, CliError> {
             // read-only single-origin replica; `--source` is a fan-in of one or more origins.
             "--mirror" => f.mirrors.push(take_value("--mirror", args, &mut i)?),
             "--source" => f.sources.push(take_value("--source", args, &mut i)?),
+            // The cross-cluster NAMESPACE (#624): this cluster's own domain + the remote-domain link
+            // table, so a `--mirror`/`--source` origin can be a stable `@<domain>/<stream>` reference, not
+            // only a raw `host:port` address. Validated after collection (a malformed domain/link is a
+            // typed usage error). `--cluster-domain` is singular; `--cluster-link` is repeatable like
+            // `--cluster-peer`. NOTE: distinct from the numeric `--cluster-id` (this node's raft id).
+            "--cluster-domain" => {
+                f.cluster_domain = Some(take_value("--cluster-domain", args, &mut i)?);
+            }
+            "--cluster-link" => {
+                f.cluster_links
+                    .push(take_value("--cluster-link", args, &mut i)?);
+            }
             "--visibility-timeout-ms" => {
                 f.visibility_ms = Some(take_number("--visibility-timeout-ms", args, &mut i)?);
             }
@@ -2705,10 +2731,17 @@ fn parse_serve_flags_with_env_and_reader(
             f.cluster_join_as_learner,
             &f.cluster_pending_learners,
         )?,
-        // The cross-cluster GEO config (#623): empty (no `--mirror`/`--source`) is the non-geo default —
-        // NO geo plane, byte-for-byte today's broker. A malformed spec is a typed usage error here,
-        // fail-closed before any side effect.
-        geo: parse_geo_config(&f.mirrors, &f.sources)?,
+        // The cross-cluster GEO config (#623) + the DOMAIN NAMESPACE (#624): empty (no
+        // `--mirror`/`--source`) is the non-geo default — NO geo plane, byte-for-byte today's broker. The
+        // domain resolver (`--cluster-domain` + `--cluster-link`) resolves any `@<domain>/<stream>` origin
+        // reference to a concrete address at parse time, so the downstream pull plane is unchanged; a raw
+        // `<addr>/<stream>` origin never touches the namespace (the back-compat path). A malformed
+        // spec/domain/link is a typed usage error here, fail-closed before any side effect.
+        geo: parse_geo_config(
+            &f.mirrors,
+            &f.sources,
+            &build_domain_resolver(f.cluster_domain.as_deref(), &f.cluster_links)?,
+        )?,
         // Transport security material + auth references + pre-auth DoS knobs (#629/#631/#633): paths
         // resolved with flag > env > default; the bind guard + StrictModes + identity-table load run
         // at `cmd_serve` (after the bind is classified). The DoS knobs take their safe defaults.
@@ -3084,6 +3117,53 @@ fn parse_cluster_peer(spec: &str) -> Result<(u64, std::net::SocketAddr), CliErro
     Ok((id, addr))
 }
 
+/// Builds the cross-cluster DOMAIN [`DomainResolver`] (#624, V2-C7-I2) from `--cluster-domain` (this
+/// cluster's own domain) + the repeated `--cluster-link <domain>=<addr>` flags, or an EMPTY resolver when
+/// none are given (the non-namespaced default; a `@domain/stream` reference then resolves to nothing).
+/// Fail-closed: a malformed own-domain, a malformed link spec, an empty link address, or a duplicate link
+/// domain is a typed usage error before any side effect.
+///
+/// The own domain is OPTIONAL: it only changes self-reference handling (a `@<own>/stream` reference is a
+/// typed error rather than a remote dial). The link table is the ONLY source of a remote dial address (no
+/// auto-discovery), so an unconfigured domain in a reference is a typed error at resolution time.
+fn build_domain_resolver(
+    cluster_domain: Option<&str>,
+    cluster_links: &[String],
+) -> Result<DomainResolver, CliError> {
+    let own = match cluster_domain {
+        Some(id) => Some(Domain::parse(id).map_err(|e| {
+            CliError::Usage(format!("invalid `--cluster-domain` value `{id}`: {e}"))
+        })?),
+        None => None,
+    };
+    let mut resolver = DomainResolver::new(own);
+    let mut seen: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    for spec in cluster_links {
+        let (domain_str, addr) = spec.split_once('=').ok_or_else(|| {
+            CliError::Usage(format!(
+                "`--cluster-link` must be `<domain>=<addr>` (e.g. `--cluster-link east=10.0.0.1:7500`), \
+                 got `{spec}`"
+            ))
+        })?;
+        let domain = Domain::parse(domain_str).map_err(|e| {
+            CliError::Usage(format!("invalid `--cluster-link` domain in `{spec}`: {e}"))
+        })?;
+        if addr.is_empty() {
+            return Err(CliError::Usage(format!(
+                "`--cluster-link` endpoint address is empty in `{spec}`"
+            )));
+        }
+        if !seen.insert(domain.as_str().to_string()) {
+            return Err(CliError::Usage(format!(
+                "`--cluster-link` domain `{domain}` is declared more than once (in `{spec}`); each \
+                 remote domain maps to exactly one endpoint"
+            )));
+        }
+        resolver.add_link(domain, addr.to_string());
+    }
+    Ok(resolver)
+}
+
 /// Builds the validated cross-cluster [`GeoConfig`] (#623, V2-C7-I1) from the repeated `--mirror` /
 /// `--source` specs, or an EMPTY config when none are given (the non-geo default). Fail-closed: a
 /// malformed spec, an empty local name, a duplicate local stream across mirror/source, or an origin spec
@@ -3091,13 +3171,23 @@ fn parse_cluster_peer(spec: &str) -> Result<(u64, std::net::SocketAddr), CliErro
 ///
 /// `--mirror <local>=<origin-addr>/<origin-stream>` (exactly ONE origin, read-only).
 /// `--source <local>=<addr1>/<stream1>,<addr2>/<stream2>,...` (one or more origins, fan-in).
-fn parse_geo_config(mirrors: &[String], sources: &[String]) -> Result<GeoConfig, CliError> {
+///
+/// Each origin is EITHER a raw `<addr>/<stream>` (the #623/#728 back-compat path) OR a domain-QUALIFIED
+/// `@<domain>/<stream>` reference (#624). A domain reference is resolved through `resolver` to its
+/// configured endpoint address at parse time, so it flows into the SAME [`GeoOrigin`] a raw reference does
+/// and the downstream pull plane is unchanged. A self-domain / unconfigured-domain reference is a typed
+/// usage error here (fail-closed, no silent leakage).
+fn parse_geo_config(
+    mirrors: &[String],
+    sources: &[String],
+    resolver: &DomainResolver,
+) -> Result<GeoConfig, CliError> {
     let mut streams = Vec::new();
     let mut seen_local: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
 
     for spec in mirrors {
         let (local, origins_str) = split_geo_spec("--mirror", spec)?;
-        let origins = parse_geo_origins("--mirror", spec, origins_str)?;
+        let origins = parse_geo_origins("--mirror", spec, origins_str, resolver)?;
         if origins.len() != 1 {
             return Err(CliError::Usage(format!(
                 "`--mirror` declares exactly ONE origin (a read-only single-origin replica); use \
@@ -3119,7 +3209,7 @@ fn parse_geo_config(mirrors: &[String], sources: &[String]) -> Result<GeoConfig,
 
     for spec in sources {
         let (local, origins_str) = split_geo_spec("--source", spec)?;
-        let origins = parse_geo_origins("--source", spec, origins_str)?;
+        let origins = parse_geo_origins("--source", spec, origins_str, resolver)?;
         if origins.is_empty() {
             return Err(CliError::Usage(format!(
                 "`--source` needs at least one `<addr>/<stream>` origin (in `{spec}`)"
@@ -3158,34 +3248,62 @@ fn split_geo_spec<'a>(flag: &str, spec: &'a str) -> Result<(String, &'a str), Cl
     Ok((local.to_string(), origins))
 }
 
-/// Parse a comma-separated list of `<addr>/<stream>` origin specs into [`GeoOrigin`]s. Fail-closed on a
-/// missing `/`, an empty addr, or an over-long origin stream name.
-fn parse_geo_origins(flag: &str, spec: &str, origins: &str) -> Result<Vec<GeoOrigin>, CliError> {
+/// Parse a comma-separated list of origin specs into [`GeoOrigin`]s, where each is EITHER a raw
+/// `<addr>/<stream>` (the back-compat #623/#728 path) OR a domain-qualified `@<domain>/<stream>` reference
+/// (#624) resolved through `resolver`. Fail-closed on a missing `/`, an empty addr, an over-long origin
+/// stream name, or a domain reference that is a self-reference / names an unconfigured domain.
+///
+/// The first byte CLASSIFIES the origin with no guesswork: a leading `@` is a domain reference (it never
+/// appears in a raw `host:port`); anything else is a raw address. Both produce the same [`GeoOrigin`]
+/// `{ addr, stream }`, so the downstream pull plane never sees a domain.
+fn parse_geo_origins(
+    flag: &str,
+    spec: &str,
+    origins: &str,
+    resolver: &DomainResolver,
+) -> Result<Vec<GeoOrigin>, CliError> {
     let mut out = Vec::new();
     for one in origins.split(',') {
-        // Split at the FIRST `/` so the addr keeps its `host:port` and the stream is the remainder (a
-        // stream name may itself contain no `/`, which the engine's name rule already enforces).
-        let (addr, stream) = one.split_once('/').ok_or_else(|| {
+        // CLASSIFY: a `@<domain>/<stream>` reference (#624) resolves through the link table to a concrete
+        // address; a raw `<addr>/<stream>` (no `@`) takes the historical path. `DomainRef::parse` returns
+        // `Ok(None)` for a non-`@` spec, so the match cleanly separates the two without re-checking the
+        // sigil here.
+        let maybe_ref = DomainRef::parse(one).map_err(|e| {
             CliError::Usage(format!(
-                "`{flag}` origin must be `<addr>/<stream>` (e.g. `10.0.0.1:7500/orders`), got `{one}` \
-                 in `{spec}`"
+                "`{flag}` domain reference `{one}` (in `{spec}`): {e}"
             ))
         })?;
-        if addr.is_empty() {
-            return Err(CliError::Usage(format!(
-                "`{flag}` origin address is empty in `{one}` (in `{spec}`)"
-            )));
-        }
+        let (addr, stream) = if let Some(reference) = maybe_ref {
+            // A domain reference resolves ONLY through the explicit `--cluster-link` table (no
+            // auto-discovery): a self-reference or an unconfigured domain is a typed usage error.
+            resolver.resolve(&reference).map_err(|e| {
+                CliError::Usage(format!(
+                    "`{flag}` cannot resolve domain reference `{one}` (in `{spec}`): {e}"
+                ))
+            })?
+        } else {
+            // The raw-address path, unchanged: split at the FIRST `/` so the addr keeps its
+            // `host:port` and the stream is the remainder.
+            let (addr, stream) = one.split_once('/').ok_or_else(|| {
+                CliError::Usage(format!(
+                    "`{flag}` origin must be `<addr>/<stream>` or `@<domain>/<stream>` (e.g. \
+                     `10.0.0.1:7500/orders` or `@east/orders`), got `{one}` in `{spec}`"
+                ))
+            })?;
+            if addr.is_empty() {
+                return Err(CliError::Usage(format!(
+                    "`{flag}` origin address is empty in `{one}` (in `{spec}`)"
+                )));
+            }
+            (addr.to_string(), stream.to_string())
+        };
         if stream.len() > ironbus_server::cluster::MAX_ORIGIN_STREAM_LEN {
             return Err(CliError::Usage(format!(
                 "`{flag}` origin stream name `{stream}` is over the {}-byte cap (in `{spec}`)",
                 ironbus_server::cluster::MAX_ORIGIN_STREAM_LEN
             )));
         }
-        out.push(GeoOrigin {
-            addr: addr.to_string(),
-            stream: stream.to_string(),
-        });
+        out.push(GeoOrigin { addr, stream });
     }
     Ok(out)
 }
@@ -14853,6 +14971,178 @@ mod tests {
                 "the rejection must explain the durable-disk requirement: {m}"
             ),
             other => panic!("expected a Usage error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_domain_qualified_origin_resolves_through_the_link_table() {
+        // `--cluster-domain` + `--cluster-link` let a `--mirror`/`--source` origin be a stable
+        // `@<domain>/<stream>` reference; it resolves at parse time to the configured endpoint, flowing
+        // into the SAME GeoOrigin a raw address would (the downstream pull plane never sees a domain).
+        let parsed = parse_serve_flags(&serve_args(&[
+            "--cluster-domain",
+            "home",
+            "--cluster-link",
+            "east=10.0.0.1:7500",
+            "--cluster-link",
+            "west=10.0.0.2:7500",
+            "--mirror",
+            "mirror-orders=@east/orders",
+            "--source",
+            "events=@east/a,@west/b",
+        ]))
+        .unwrap();
+        assert_eq!(parsed.geo.streams.len(), 2);
+        match &parsed.geo.streams[0].mode {
+            GeoMode::Mirror(o) => {
+                assert_eq!(
+                    o.addr, "10.0.0.1:7500",
+                    "@east resolved to its link address"
+                );
+                assert_eq!(o.stream, "orders");
+            }
+            GeoMode::Source(_) => panic!("expected a mirror, got a source"),
+        }
+        match &parsed.geo.streams[1].mode {
+            GeoMode::Source(os) => {
+                assert_eq!(os.len(), 2);
+                assert_eq!(os[0].addr, "10.0.0.1:7500");
+                assert_eq!(os[0].stream, "a");
+                assert_eq!(os[1].addr, "10.0.0.2:7500");
+                assert_eq!(os[1].stream, "b");
+            }
+            GeoMode::Mirror(_) => panic!("expected a source, got a mirror"),
+        }
+    }
+
+    #[test]
+    fn a_raw_address_and_a_domain_reference_can_be_mixed_in_one_source() {
+        // Back-compat + namespace coexist: a source can fan in a RAW `<addr>/<stream>` (the #623/#728
+        // path) AND a `@<domain>/<stream>` reference, in any order.
+        let parsed = parse_serve_flags(&serve_args(&[
+            "--cluster-link",
+            "east=10.0.0.1:7500",
+            "--source",
+            "events=10.9.9.9:7500/raw,@east/named",
+        ]))
+        .unwrap();
+        match &parsed.geo.streams[0].mode {
+            GeoMode::Source(os) => {
+                assert_eq!(os[0].addr, "10.9.9.9:7500", "the raw origin is untouched");
+                assert_eq!(os[0].stream, "raw");
+                assert_eq!(os[1].addr, "10.0.0.1:7500", "the @east origin resolved");
+                assert_eq!(os[1].stream, "named");
+            }
+            GeoMode::Mirror(_) => panic!("expected a source"),
+        }
+    }
+
+    #[test]
+    fn a_self_domain_reference_is_a_typed_usage_error() {
+        // A `@<own-domain>/...` reference is rejected fail-closed (a self-mirror is not a valid topology).
+        let e = parse_serve_flags(&serve_args(&[
+            "--cluster-domain",
+            "home",
+            "--mirror",
+            "m=@home/orders",
+        ]))
+        .unwrap_err();
+        match e {
+            CliError::Usage(m) => assert!(
+                m.contains("home") && m.contains("own"),
+                "the rejection must name the self-referenced domain: {m}"
+            ),
+            other => panic!("expected a Usage error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn an_unconfigured_domain_reference_is_a_typed_usage_error_no_leakage() {
+        // A `@<domain>/...` with NO `--cluster-link` is rejected (never auto-discovered): no silent
+        // cross-domain leakage to an unconfigured address.
+        let e = parse_serve_flags(&serve_args(&["--mirror", "m=@nowhere/orders"])).unwrap_err();
+        match e {
+            CliError::Usage(m) => assert!(
+                m.contains("nowhere") && m.contains("cluster-link"),
+                "the rejection must name the unknown domain + the link flag: {m}"
+            ),
+            other => panic!("expected a Usage error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_malformed_cluster_domain_or_link_is_a_typed_usage_error() {
+        // An uppercase own-domain (outside the [a-z0-9-] grammar) is rejected.
+        assert!(matches!(
+            parse_serve_flags(&serve_args(&["--cluster-domain", "Home"])),
+            Err(CliError::Usage(_))
+        ));
+        // A link with no `=`.
+        assert!(matches!(
+            parse_serve_flags(&serve_args(&["--cluster-link", "no-equals"])),
+            Err(CliError::Usage(_))
+        ));
+        // A link with an empty address.
+        assert!(matches!(
+            parse_serve_flags(&serve_args(&["--cluster-link", "east="])),
+            Err(CliError::Usage(_))
+        ));
+        // A duplicate link domain.
+        assert!(matches!(
+            parse_serve_flags(&serve_args(&[
+                "--cluster-link",
+                "east=a:1",
+                "--cluster-link",
+                "east=b:2",
+            ])),
+            Err(CliError::Usage(_))
+        ));
+    }
+
+    #[test]
+    fn a_local_stream_and_a_remote_domain_stream_do_not_collide_at_the_cli() {
+        // The NAMESPACE-collision guarantee at the CLI: a LOCAL mirror named `s` (raw origin) and a
+        // REMOTE `@east/s` origin are distinct — the local name is `s`, and `@east/s` resolves to east's
+        // address with origin stream `s`. No collision between local `s` and remote east/s.
+        let parsed = parse_serve_flags(&serve_args(&[
+            "--cluster-link",
+            "east=10.0.0.1:7500",
+            "--mirror",
+            "s=10.0.0.9:7500/s",
+            "--mirror",
+            "from-east=@east/s",
+        ]))
+        .unwrap();
+        // Two distinct local streams.
+        let locals: Vec<&str> = parsed
+            .geo
+            .streams
+            .iter()
+            .map(|st| st.local_stream.as_str())
+            .collect();
+        assert_eq!(locals, vec!["s", "from-east"]);
+        // The remote `@east/s` resolved to east, origin stream `s` — a different endpoint than local `s`.
+        match &parsed.geo.streams[1].mode {
+            GeoMode::Mirror(o) => {
+                assert_eq!(o.addr, "10.0.0.1:7500");
+                assert_eq!(o.stream, "s");
+            }
+            GeoMode::Source(_) => panic!("expected a mirror"),
+        }
+    }
+
+    #[test]
+    fn a_raw_mirror_still_works_with_no_domain_flags() {
+        // BACK-COMPAT: a raw-address mirror (the #623/#728 path) parses identically with NO
+        // `--cluster-domain`/`--cluster-link`, byte-for-byte the pre-#624 behavior.
+        let parsed =
+            parse_serve_flags(&serve_args(&["--mirror", "m=10.0.0.1:7500/orders"])).unwrap();
+        match &parsed.geo.streams[0].mode {
+            GeoMode::Mirror(o) => {
+                assert_eq!(o.addr, "10.0.0.1:7500");
+                assert_eq!(o.stream, "orders");
+            }
+            GeoMode::Source(_) => panic!("expected a mirror"),
         }
     }
 

--- a/crates/ironbus-server/src/cluster/domain.rs
+++ b/crates/ironbus-server/src/cluster/domain.rs
@@ -1,0 +1,494 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! Cross-cluster DOMAIN namespace / cluster-id (V2-C7-I2, #624) — address a stream across a cluster
+//! boundary by a STABLE `<domain>/<stream>` name, not only a raw `host:port` address.
+//!
+//! This is the NAMESPACE the cross-cluster primitives build on: the geo mirror/source plane (#623,
+//! [`geo`](super::geo)) today addresses a remote ORIGIN by a raw `host:port` address, which is brittle —
+//! a topology that names "the `east` cluster's `orders` stream" must hard-code `east`'s current node
+//! address, and re-wire every reference when that address changes. This module gives each cluster a
+//! stable, configured **domain** (a.k.a. cluster-id) and a small RESOLUTION table that maps a remote
+//! domain to its configured geo-pull endpoint, so a reference can be the stable `<domain>/<stream>` that
+//! survives an address change. The edge leaf-spoke topology (#625) and gateway federation (#626) are
+//! SEPARATE issues built ON this namespace; they are NOT pulled in here, but the [`Domain`] type and the
+//! [`DomainResolver`] resolution API are the clean primitive they reuse.
+//!
+//! ## The [`Domain`] grammar (restricted, validated, fail-closed)
+//!
+//! A domain is a DNS-label-like restricted id: `[a-z0-9]([a-z0-9-]*[a-z0-9])?`, 1..=[`MAX_DOMAIN_LEN`]
+//! (63) bytes. Concretely:
+//!
+//! * lowercase ASCII letters, ASCII digits, and the hyphen `-`;
+//! * it must NOT be empty and must NOT exceed 63 bytes;
+//! * it must NOT start or end with a hyphen (so a domain is never confusable with a flag/option, and the
+//!   `<domain>/<stream>` split is unambiguous).
+//!
+//! The charset is restricted on PURPOSE: a domain is an identity that appears in config, logs, and (later)
+//! a federation wire, so it is held to a small, case-stable, path-safe, shell-safe alphabet. A malformed
+//! domain is REJECTED with a typed [`DomainError`] — fail-closed, never silently lower-cased / truncated /
+//! guessed at.
+//!
+//! ## Local vs remote is UNAMBIGUOUS (no cross-domain collision)
+//!
+//! A LOCAL stream `s` and a REMOTE `east/s` are DISTINCT: the remote one is always domain-QUALIFIED, so
+//! the domain prefix disambiguates and a cross-domain name collision is IMPOSSIBLE. A reference that names
+//! THIS cluster's OWN domain ([`DomainResolver::own`]) is a SELF-reference; [`DomainResolver::resolve`]
+//! returns a typed [`DomainError::SelfReference`] for it (a cross-cluster mirror/source of your own
+//! cluster is not a meaningful topology — use the local stream directly), so a self-domain reference can
+//! never silently turn into a remote dial.
+//!
+//! ## No silent cross-domain leakage (the security non-negotiable)
+//!
+//! [`DomainResolver::resolve`] resolves a remote domain ONLY through the EXPLICITLY-configured link table
+//! (`--cluster-link <domain>=<addr>`): an UNCONFIGURED domain is a typed [`DomainError::UnknownDomain`],
+//! never an auto-discovered / guessed address. There is NO discovery path — a domain reference can only
+//! ever resolve to an endpoint the operator wrote down. This is the [`geo`](super::geo) plane's
+//! "connect only to a configured endpoint" guarantee, lifted to the namespace.
+//!
+//! ## Opt-in + zero-cost when unused (back-compat)
+//!
+//! Nothing here constructs unless a `--cluster-domain` / `--cluster-link` / a `@domain/stream` reference is
+//! configured. The raw-address geo path (#623/#728) is UNCHANGED: an origin given as a raw `host:port`
+//! address never touches this module, and a broker with no geo config at all has no [`Domain`], no
+//! resolver, and the byte-for-byte single-node behavior. The namespace is a CONFIG-TIME resolution layer:
+//! a `@domain/stream` reference resolves to the very same [`GeoOrigin`](super::geo::GeoOrigin) `{ addr,
+//! stream }` a raw reference produces, so the entire downstream pull plane (link, applier, cursor) is
+//! untouched.
+
+use std::collections::BTreeMap;
+
+/// The hard maximum length, in bytes, of a [`Domain`]. 63 mirrors the DNS label limit: a domain is a
+/// stable, restricted, path-/shell-safe identity, so it is held to the same small ceiling. A longer id is
+/// rejected fail-closed before any allocation.
+pub const MAX_DOMAIN_LEN: usize = 63;
+
+/// A typed DOMAIN error. Every malformed-domain and every resolution failure is one of these — the layer
+/// NEVER panics, NEVER lower-cases / truncates / guesses a malformed id, and NEVER resolves a domain to an
+/// unconfigured address. Fail-closed on every bad input.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DomainError {
+    /// The domain id was empty (`--cluster-domain ` with no value, or an empty `<domain>` in a reference).
+    Empty,
+    /// The domain id exceeded [`MAX_DOMAIN_LEN`] bytes.
+    TooLong {
+        /// The byte length seen.
+        len: usize,
+    },
+    /// The domain id carried a byte outside the restricted grammar `[a-z0-9-]` (e.g. an uppercase letter,
+    /// a dot, a slash, whitespace, or any non-ASCII byte).
+    BadChar {
+        /// The offending byte.
+        byte: u8,
+    },
+    /// The domain id started or ended with a hyphen (`-east` / `east-`), which the grammar forbids so a
+    /// domain is never confusable with a flag and the `<domain>/<stream>` split is unambiguous.
+    HyphenEdge,
+    /// A `@<domain>/<stream>` reference named THIS cluster's OWN domain — a self-reference, which is not a
+    /// meaningful cross-cluster topology (use the local stream directly). Carries the self domain.
+    SelfReference {
+        /// The cluster's own domain that was self-referenced.
+        domain: String,
+    },
+    /// A `@<domain>/<stream>` reference named a domain with NO configured `--cluster-link` endpoint. Resolved
+    /// fail-closed (never auto-discovered) so a domain reference can only reach an explicitly-configured
+    /// remote. Carries the unknown domain.
+    UnknownDomain {
+        /// The domain that had no configured link.
+        domain: String,
+    },
+}
+
+impl core::fmt::Display for DomainError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            DomainError::Empty => write!(f, "domain id is empty"),
+            DomainError::TooLong { len } => {
+                write!(f, "domain id is {len} bytes, over the {MAX_DOMAIN_LEN}-byte cap")
+            }
+            DomainError::BadChar { byte } => write!(
+                f,
+                "domain id has an illegal byte {byte:#04x}; the grammar is [a-z0-9-] \
+                 (lowercase ASCII letters, digits, hyphen)"
+            ),
+            DomainError::HyphenEdge => {
+                write!(f, "domain id must not start or end with a hyphen")
+            }
+            DomainError::SelfReference { domain } => write!(
+                f,
+                "domain reference names this cluster's OWN domain `{domain}`; a cross-cluster \
+                 mirror/source of your own cluster is not a valid topology (use the local stream)"
+            ),
+            DomainError::UnknownDomain { domain } => write!(
+                f,
+                "domain `{domain}` has no configured `--cluster-link <domain>=<addr>` endpoint; a \
+                 domain reference resolves only to an explicitly-configured remote (never auto-discovered)"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for DomainError {}
+
+/// A VALIDATED cross-cluster domain (a.k.a. cluster-id): a stable, restricted-charset identity for a
+/// cluster within a cross-cluster topology. The ONLY constructor ([`Domain::parse`]) enforces the grammar,
+/// so an existing `Domain` is ALWAYS well-formed — a typed proof that the id is one of `[a-z0-9-]`,
+/// 1..=[`MAX_DOMAIN_LEN`] bytes, no hyphen edge. This is the clean primitive the geo namespace, the edge
+/// leaf-spoke (#625), and the federation (#626) all address streams by.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Domain(String);
+
+impl Domain {
+    /// Parse + VALIDATE a domain id against the grammar, fail-closed.
+    ///
+    /// The grammar is `[a-z0-9]([a-z0-9-]*[a-z0-9])?`, 1..=[`MAX_DOMAIN_LEN`] (63) bytes: lowercase ASCII
+    /// letters / digits / hyphen, non-empty, no leading or trailing hyphen. A single character `a`–`z` /
+    /// `0`–`9` is the minimal valid domain.
+    ///
+    /// # Errors
+    /// [`DomainError::Empty`] for an empty id, [`DomainError::TooLong`] over the cap,
+    /// [`DomainError::BadChar`] for any byte outside `[a-z0-9-]`, [`DomainError::HyphenEdge`] for a leading
+    /// or trailing hyphen — never a silent normalization.
+    pub fn parse(id: &str) -> Result<Domain, DomainError> {
+        if id.is_empty() {
+            return Err(DomainError::Empty);
+        }
+        if id.len() > MAX_DOMAIN_LEN {
+            return Err(DomainError::TooLong { len: id.len() });
+        }
+        // Validate the bytes directly: the grammar is ASCII-only, so a byte scan is exact (a multi-byte
+        // UTF-8 sequence's lead/continuation bytes are all > 0x7f, caught by the charset check below).
+        for &b in id.as_bytes() {
+            let ok = b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-';
+            if !ok {
+                return Err(DomainError::BadChar { byte: b });
+            }
+        }
+        // No hyphen edge (checked on the raw bytes; ASCII so byte == char here).
+        if id.starts_with('-') || id.ends_with('-') {
+            return Err(DomainError::HyphenEdge);
+        }
+        Ok(Domain(id.to_string()))
+    }
+
+    /// The validated domain id as a string slice.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl core::fmt::Display for Domain {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// A parsed `@<domain>/<stream>` domain-QUALIFIED reference: the validated remote domain plus the origin
+/// stream name within it. This is the cross-cluster, NAMESPACE twin of a raw `<addr>/<stream>` origin — it
+/// names the remote by a STABLE domain, not a node address. Resolved to a concrete
+/// [`GeoOrigin`](super::geo::GeoOrigin) by a [`DomainResolver`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DomainRef {
+    /// The validated remote domain (the cluster the stream lives in).
+    pub domain: Domain,
+    /// The origin stream name within that domain (empty = the remote's default stream).
+    pub stream: String,
+}
+
+/// The on-wire / on-CLI SIGIL that marks a domain-QUALIFIED origin reference (`@east/orders`), so it is
+/// UNAMBIGUOUSLY distinguished from a raw `host:port` origin address (`10.0.0.1:7500/orders`). A raw
+/// address always carries a `host:port`; a domain reference always leads with `@`. The two grammars cannot
+/// overlap (a raw `host:port` never starts with `@`, and a domain `[a-z0-9-]` never contains a `:` or a
+/// `.`-bearing host), so a reference is classified by its first byte with zero guesswork.
+pub const DOMAIN_REF_SIGIL: char = '@';
+
+impl DomainRef {
+    /// Parse a `@<domain>/<stream>` reference. Returns `Ok(None)` if `spec` is NOT a domain reference (it
+    /// does not lead with [`DOMAIN_REF_SIGIL`]) — the caller then treats it as a raw `<addr>/<stream>`
+    /// origin (the back-compat path). Returns `Ok(Some(_))` for a well-formed reference, or a typed error
+    /// for a malformed one.
+    ///
+    /// The split is at the FIRST `/` after the sigil, so the stream remainder may itself be empty (the
+    /// remote's default stream); the domain segment is validated by [`Domain::parse`].
+    ///
+    /// # Errors
+    /// [`DomainError`] (via [`Domain::parse`]) if the domain segment is malformed, or [`DomainError::Empty`]
+    /// if the reference is just `@` / `@/stream` (an empty domain). A missing `/` is treated as the whole
+    /// remainder being the domain and an empty stream (the default stream).
+    pub fn parse(spec: &str) -> Result<Option<DomainRef>, DomainError> {
+        let Some(rest) = spec.strip_prefix(DOMAIN_REF_SIGIL) else {
+            return Ok(None); // not a domain reference; the caller uses the raw-address path
+        };
+        // Split at the FIRST `/`: `@east/orders` -> ("east", "orders"); `@east` -> ("east", "") (the
+        // remote's default stream). A domain never contains a `/` (the grammar forbids it), so the first
+        // `/` is unambiguously the domain/stream boundary.
+        let (domain_part, stream) = match rest.split_once('/') {
+            Some((d, s)) => (d, s),
+            None => (rest, ""),
+        };
+        let domain = Domain::parse(domain_part)?;
+        Ok(Some(DomainRef {
+            domain,
+            stream: stream.to_string(),
+        }))
+    }
+}
+
+/// The cross-cluster DOMAIN RESOLVER: this cluster's OWN domain (optional) plus the explicit
+/// `domain -> geo-pull endpoint address` link table, the ONLY way a `@<domain>/<stream>` reference becomes
+/// a concrete dial address. Built from `--cluster-domain` + the repeatable `--cluster-link
+/// <domain>=<addr>` flags.
+///
+/// EMPTY (no own domain, no links) is the default: nothing constructs and no reference can resolve (a
+/// `@domain/stream` reference with an empty resolver is an [`DomainError::UnknownDomain`]) — the namespace
+/// is opt-in. The resolver is the reusable resolution API the edge leaf-spoke (#625) and federation (#626)
+/// build on.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct DomainResolver {
+    /// This cluster's OWN domain, if `--cluster-domain` was set. A `@<own>/...` reference resolves to a
+    /// typed [`DomainError::SelfReference`] (a self-mirror is not a valid topology).
+    own: Option<Domain>,
+    /// The explicit `remote-domain -> geo-pull endpoint address` table (`--cluster-link <domain>=<addr>`).
+    /// Sorted (a `BTreeMap`) for a deterministic surface. The ONLY source of a remote address; an
+    /// unconfigured domain never resolves (no auto-discovery).
+    links: BTreeMap<Domain, String>,
+}
+
+impl DomainResolver {
+    /// A fresh resolver with an optional own-domain and NO links. Links are added with [`add_link`].
+    #[must_use]
+    pub fn new(own: Option<Domain>) -> DomainResolver {
+        DomainResolver {
+            own,
+            links: BTreeMap::new(),
+        }
+    }
+
+    /// This cluster's own domain, if configured.
+    #[must_use]
+    pub fn own(&self) -> Option<&Domain> {
+        self.own.as_ref()
+    }
+
+    /// True if NOTHING is configured (no own domain, no links) — the opt-in default; no reference can
+    /// resolve.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.own.is_none() && self.links.is_empty()
+    }
+
+    /// Add (or replace) the `domain -> addr` link for a remote domain. A later add for the same domain
+    /// replaces the earlier address (last-writer-wins), so a repeated `--cluster-link` is well-defined.
+    pub fn add_link(&mut self, domain: Domain, addr: String) {
+        self.links.insert(domain, addr);
+    }
+
+    /// The configured geo-pull endpoint address for `domain`, or `None` if no link is configured.
+    #[must_use]
+    pub fn link(&self, domain: &Domain) -> Option<&str> {
+        self.links.get(domain).map(String::as_str)
+    }
+
+    /// Resolve a `@<domain>/<stream>` reference to a concrete `(addr, stream)` — the EXACT shape a raw
+    /// `<addr>/<stream>` origin produces, so the resolved reference flows into the very same
+    /// [`GeoOrigin`](super::geo::GeoOrigin) and the downstream pull plane is unchanged.
+    ///
+    /// Resolution is fail-closed and EXPLICIT-ONLY:
+    /// * a reference to THIS cluster's own domain is a typed [`DomainError::SelfReference`];
+    /// * a reference to a domain with NO configured `--cluster-link` is a typed
+    ///   [`DomainError::UnknownDomain`] — never an auto-discovered address (no silent cross-domain leakage);
+    /// * otherwise the configured link address + the reference's stream are returned.
+    ///
+    /// # Errors
+    /// [`DomainError::SelfReference`] or [`DomainError::UnknownDomain`] per the above.
+    pub fn resolve(&self, reference: &DomainRef) -> Result<(String, String), DomainError> {
+        if self.own.as_ref() == Some(&reference.domain) {
+            return Err(DomainError::SelfReference {
+                domain: reference.domain.as_str().to_string(),
+            });
+        }
+        match self.links.get(&reference.domain) {
+            Some(addr) => Ok((addr.clone(), reference.stream.clone())),
+            None => Err(DomainError::UnknownDomain {
+                domain: reference.domain.as_str().to_string(),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_domains_parse() {
+        for id in [
+            "east",
+            "west-2",
+            "a",
+            "0",
+            "cluster-id-99",
+            "x".repeat(MAX_DOMAIN_LEN).as_str(),
+        ] {
+            let d = Domain::parse(id).unwrap_or_else(|e| panic!("`{id}` should parse: {e}"));
+            assert_eq!(d.as_str(), id);
+        }
+    }
+
+    #[test]
+    fn empty_domain_is_rejected() {
+        assert_eq!(Domain::parse(""), Err(DomainError::Empty));
+    }
+
+    #[test]
+    fn over_long_domain_is_rejected() {
+        let id = "a".repeat(MAX_DOMAIN_LEN + 1);
+        assert_eq!(
+            Domain::parse(&id),
+            Err(DomainError::TooLong {
+                len: MAX_DOMAIN_LEN + 1
+            })
+        );
+    }
+
+    #[test]
+    fn bad_chars_are_rejected_fail_closed() {
+        // Uppercase, dot, slash, space, colon, underscore, and a non-ASCII byte are all outside [a-z0-9-].
+        for (id, byte) in [
+            ("East", b'E'),
+            ("ea.st", b'.'),
+            ("ea/st", b'/'),
+            ("ea st", b' '),
+            ("ea:st", b':'),
+            ("ea_st", b'_'),
+        ] {
+            assert_eq!(
+                Domain::parse(id),
+                Err(DomainError::BadChar { byte }),
+                "`{id}` should be rejected at byte {byte:#x}"
+            );
+        }
+        // A non-ASCII byte (the first byte of a multi-byte UTF-8 char) is rejected by the charset scan.
+        match Domain::parse("éast") {
+            Err(DomainError::BadChar { .. }) => {}
+            other => panic!("non-ASCII domain should be a BadChar, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn hyphen_edges_are_rejected() {
+        assert_eq!(Domain::parse("-east"), Err(DomainError::HyphenEdge));
+        assert_eq!(Domain::parse("east-"), Err(DomainError::HyphenEdge));
+        // A lone hyphen is a hyphen edge (both ends), rejected.
+        assert_eq!(Domain::parse("-"), Err(DomainError::HyphenEdge));
+        // An interior hyphen is fine.
+        assert!(Domain::parse("ea-st").is_ok());
+    }
+
+    #[test]
+    fn a_raw_address_is_not_a_domain_reference() {
+        // No `@` sigil => not a domain ref; the caller uses the raw-address path (back-compat).
+        assert_eq!(DomainRef::parse("10.0.0.1:7500/orders").unwrap(), None);
+        assert_eq!(DomainRef::parse("orders").unwrap(), None);
+    }
+
+    #[test]
+    fn a_domain_reference_parses() {
+        let r = DomainRef::parse("@east/orders").unwrap().unwrap();
+        assert_eq!(r.domain.as_str(), "east");
+        assert_eq!(r.stream, "orders");
+        // `@east` with no `/` => the remote's default stream (empty).
+        let r = DomainRef::parse("@east").unwrap().unwrap();
+        assert_eq!(r.domain.as_str(), "east");
+        assert_eq!(r.stream, "");
+        // `@east/` => an explicit empty stream too.
+        let r = DomainRef::parse("@east/").unwrap().unwrap();
+        assert_eq!(r.stream, "");
+    }
+
+    #[test]
+    fn a_malformed_domain_reference_is_rejected() {
+        // Just the sigil => empty domain.
+        assert_eq!(DomainRef::parse("@"), Err(DomainError::Empty));
+        assert_eq!(DomainRef::parse("@/orders"), Err(DomainError::Empty));
+        // A bad domain char in a reference is surfaced.
+        assert!(matches!(
+            DomainRef::parse("@East/orders"),
+            Err(DomainError::BadChar { .. })
+        ));
+    }
+
+    #[test]
+    fn resolve_uses_only_the_configured_link_no_leakage() {
+        let mut r = DomainResolver::new(Some(Domain::parse("home").unwrap()));
+        r.add_link(Domain::parse("east").unwrap(), "10.0.0.1:7500".to_string());
+
+        // A configured remote resolves to its explicit address + the reference's stream.
+        let reference = DomainRef::parse("@east/orders").unwrap().unwrap();
+        assert_eq!(
+            r.resolve(&reference).unwrap(),
+            ("10.0.0.1:7500".to_string(), "orders".to_string())
+        );
+
+        // An UNCONFIGURED domain never resolves (no auto-discovery / no leakage).
+        let reference = DomainRef::parse("@west/orders").unwrap().unwrap();
+        assert_eq!(
+            r.resolve(&reference),
+            Err(DomainError::UnknownDomain {
+                domain: "west".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn a_self_domain_reference_is_a_typed_error() {
+        let r = DomainResolver::new(Some(Domain::parse("home").unwrap()));
+        let reference = DomainRef::parse("@home/orders").unwrap().unwrap();
+        assert_eq!(
+            r.resolve(&reference),
+            Err(DomainError::SelfReference {
+                domain: "home".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn local_stream_and_remote_domain_stream_are_distinct() {
+        // The NAMESPACE collision guarantee: a local stream `s` and a remote `east/s` never collide,
+        // because the remote is always domain-QUALIFIED (the `@east/` prefix). A raw `s` is not a domain
+        // reference at all; `@east/s` is, and it resolves to a DIFFERENT (remote) endpoint.
+        let mut r = DomainResolver::new(Some(Domain::parse("home").unwrap()));
+        r.add_link(Domain::parse("east").unwrap(), "10.0.0.1:7500".to_string());
+
+        assert_eq!(
+            DomainRef::parse("s").unwrap(),
+            None,
+            "a bare local name is not a domain ref"
+        );
+        let remote = DomainRef::parse("@east/s").unwrap().unwrap();
+        let (addr, stream) = r.resolve(&remote).unwrap();
+        assert_eq!((addr.as_str(), stream.as_str()), ("10.0.0.1:7500", "s"));
+        // The remote's stream name `s` is the SAME string as a hypothetical local `s`, yet they address
+        // different things: local `s` is this broker's log; `@east/s` dials east. No collision.
+    }
+
+    #[test]
+    fn last_writer_wins_for_a_repeated_link() {
+        let mut r = DomainResolver::new(None);
+        r.add_link(Domain::parse("east").unwrap(), "a:1".to_string());
+        r.add_link(Domain::parse("east").unwrap(), "b:2".to_string());
+        assert_eq!(r.link(&Domain::parse("east").unwrap()), Some("b:2"));
+    }
+
+    #[test]
+    fn an_empty_resolver_resolves_nothing() {
+        let r = DomainResolver::default();
+        assert!(r.is_empty());
+        let reference = DomainRef::parse("@east/orders").unwrap().unwrap();
+        assert_eq!(
+            r.resolve(&reference),
+            Err(DomainError::UnknownDomain {
+                domain: "east".to_string()
+            })
+        );
+    }
+}

--- a/crates/ironbus-server/src/cluster/geo.rs
+++ b/crates/ironbus-server/src/cluster/geo.rs
@@ -1669,6 +1669,51 @@ mod tests {
         assert_eq!(cfg.read_only_streams(), vec!["m".to_string()]);
         assert!(!cfg.is_empty());
     }
+
+    #[test]
+    fn a_domain_resolved_origin_drives_a_byte_faithful_mirror() {
+        use super::super::domain::{Domain, DomainRef, DomainResolver};
+
+        // The NAMESPACE (#624) ties to the geo plane (#623): a `@<domain>/<stream>` reference resolves
+        // through the link table to the SAME `(addr, stream)` a raw origin produces, so the resolved
+        // GeoOrigin drives the geo pull plane EXACTLY as a raw one — byte-faithfully.
+        let mut resolver = DomainResolver::new(Some(Domain::parse("home").unwrap()));
+        resolver.add_link(Domain::parse("east").unwrap(), "10.0.0.1:7500".to_string());
+
+        let reference = DomainRef::parse("@east/orders").unwrap().unwrap();
+        let (addr, stream) = resolver.resolve(&reference).unwrap();
+        let origin = GeoOrigin { addr, stream };
+        assert_eq!(origin.addr, "10.0.0.1:7500");
+        assert_eq!(origin.stream, "orders");
+        // The resolved origin's durable cursor key is stable (domain resolution did not change the geo
+        // identity contract): it is the `<addr>/<stream>` the cursor store keys on.
+        assert_eq!(origin.cursor_key(), "10.0.0.1:7500/orders");
+
+        // Drive an in-process mirror over an origin log USING the resolved origin's stream, and confirm
+        // it converges byte-faithfully — the resolved namespace reference behaves identically to a raw
+        // one through the whole apply path.
+        let mut origin_log =
+            Log::open(InMemoryFs::new(), ManualClock::new(), small_config()).unwrap();
+        for i in 0..30u32 {
+            origin_log
+                .append(&rec(format!("o-{i:02}").as_bytes()))
+                .unwrap();
+        }
+        origin_log.sync().unwrap();
+        let served = plane_served_end(&origin_log);
+
+        let mut app = applier(InMemoryFs::new());
+        let key = origin.cursor_key();
+        let applied = drain_into(&mut app, &origin_log, &key);
+        assert_eq!(
+            applied, served,
+            "the domain-resolved mirror applied the sealed prefix"
+        );
+        let recs = app.log().read_from(Offset::new(0), 100).unwrap();
+        for (i, r) in recs.iter().enumerate() {
+            assert_eq!(r.payload.as_ref(), format!("o-{i:02}").as_bytes());
+        }
+    }
 }
 
 /// The REAL two-"cluster" integration tests (#623): an ORIGIN serve and a separate MIRROR / SOURCE serve

--- a/crates/ironbus-server/src/cluster/mod.rs
+++ b/crates/ironbus-server/src/cluster/mod.rs
@@ -266,6 +266,7 @@ pub mod ack_level;
 pub mod client_ack;
 pub mod dataplane;
 pub mod divergence;
+pub mod domain;
 pub mod eligibility;
 pub mod geo;
 pub mod isr;
@@ -291,6 +292,9 @@ pub use divergence::{
     compare_fingerprints, execute_resync, fingerprint_log, plan_resync, quarantine_and_resync,
     DivergenceDetected, DivergenceError, DivergenceField, DivergenceReport, ResyncBounds,
     ResyncPlan, ResyncReport, SegmentFingerprint, SegmentFingerprints, MAX_FINGERPRINTS,
+};
+pub use domain::{
+    Domain, DomainError, DomainRef, DomainResolver, DOMAIN_REF_SIGIL, MAX_DOMAIN_LEN,
 };
 pub use eligibility::{
     eligible_leaders, evaluate_eligibility, is_eligible_leader, replica_state_from,


### PR DESCRIPTION
## What & why (#624, V2-C7-I2)

Adds the cross-cluster **NAMESPACE** the geo mirror/source plane (#623/#728) and the later edge leaf-spoke (#625) / gateway federation (#626) build on. Today a geo origin is addressed by a raw `host:port` — brittle: a topology that names "the `east` cluster's `orders` stream" must hard-code east's current node address and re-wire on every address change. This gives each cluster a stable, validated **domain** (a.k.a. cluster-id) and a small resolution table, so a mirror/source origin can be the stable `@<domain>/<stream>` that survives an address change.

This is the namespace + domain-qualified addressing **for mirror/source only**. #625 and #626 are SEPARATE and are NOT pulled in — but the `Domain` type + `DomainResolver` resolution API are the clean primitive they reuse.

## Design

**`Domain` type + grammar** (`crates/ironbus-server/src/cluster/domain.rs`)
- Grammar: `[a-z0-9]([a-z0-9-]*[a-z0-9])?`, 1..=63 bytes (DNS-label-like): lowercase ASCII letters/digits/hyphen, non-empty, no leading/trailing hyphen.
- `Domain::parse` is the only constructor; it validates fail-closed with a typed `DomainError` (`Empty` / `TooLong` / `BadChar` / `HyphenEdge`) — never lower-cases, truncates, or guesses.

**Domain-qualified reference + the `@` sigil**
- `DomainRef::parse("@east/orders")` → `{ domain: east, stream: orders }`. The leading `@` sigil unambiguously distinguishes a domain reference from a raw `host:port` address — the two grammars cannot overlap (a raw `host:port` never starts with `@`; a domain `[a-z0-9-]` never contains `:`/`.`). `DomainRef::parse` returns `Ok(None)` for a non-`@` spec, so the raw-address path is taken with zero guesswork.

**Resolution** (`DomainResolver`)
- `--cluster-domain <id>` = this cluster's own domain (optional). `--cluster-link <domain>=<addr>` = the explicit `domain → geo-pull endpoint` table.
- `resolve(&DomainRef)` is fail-closed and explicit-only: a self-domain reference → `SelfReference`; an unconfigured domain → `UnknownDomain` (no auto-discovery). It returns the same `(addr, stream)` a raw origin produces, so a `@domain/stream` reference flows into the very same `GeoOrigin` and the **entire downstream pull plane is unchanged**.

**Where the domain lives — serve config, not cluster metadata (justified).** The geo plane is independent of the metadata-Raft cluster (it needs only `--storage disk`, not a cluster). Forcing the domain into cluster metadata would wrongly couple the namespace to running a metadata quorum. The simplest correct home is the serve-config value, resolved at parse time. **Follow-up (flagged):** propagating a cluster's own domain through cluster metadata so all nodes agree on it is deferred to #625/#626, which need cross-node domain agreement.

## How each non-negotiable is guaranteed (code pointers)

1. **Domain validated + stable, fail-closed** — `Domain::parse` (`domain.rs`), typed `DomainError`; CLI surfaces it as a `CliError::Usage` in `build_domain_resolver` / `parse_geo_origins` (`ironbus-cli/src/main.rs`).
2. **Local vs remote unambiguous, no collision** — a remote is always `@`-qualified (`DOMAIN_REF_SIGIL`); a bare local name is never a domain ref (`DomainRef::parse` → `None`). Local `s` and remote `@east/s` resolve to different endpoints. A self-domain ref is `SelfReference` (`DomainResolver::resolve`).
3. **Back-compat + zero-cost when unused** — nothing constructs without `--cluster-domain`/`--cluster-link`/a `@` reference; a raw-address origin never touches `domain.rs`; `cmd_serve` signature is unchanged (resolution is parse-time only, so no windows-arity change). Diff is confined to `domain.rs`, geo.rs **tests only**, `mod.rs` exports, and the CLI config parser — no engine/storage/produce/consume hot-path change.
4. **No silent cross-domain leakage** — `DomainResolver::resolve` resolves ONLY through the explicit link table; an unconfigured domain is `UnknownDomain`. There is no discovery path.

## Tests (all deterministic, no wall-clock)

`domain.rs` unit (13): `valid_domains_parse`, `empty_domain_is_rejected`, `over_long_domain_is_rejected`, `bad_chars_are_rejected_fail_closed`, `hyphen_edges_are_rejected`, `a_raw_address_is_not_a_domain_reference`, `a_domain_reference_parses`, `a_malformed_domain_reference_is_rejected`, `resolve_uses_only_the_configured_link_no_leakage`, `a_self_domain_reference_is_a_typed_error`, `local_stream_and_remote_domain_stream_are_distinct`, `last_writer_wins_for_a_repeated_link`, `an_empty_resolver_resolves_nothing`.

geo integration (1): `a_domain_resolved_origin_drives_a_byte_faithful_mirror` — a resolved `@east/orders` origin drives the geo pull plane byte-faithfully, identical to a raw origin.

CLI parse (7): `a_domain_qualified_origin_resolves_through_the_link_table`, `a_raw_address_and_a_domain_reference_can_be_mixed_in_one_source`, `a_self_domain_reference_is_a_typed_usage_error`, `an_unconfigured_domain_reference_is_a_typed_usage_error_no_leakage`, `a_malformed_cluster_domain_or_link_is_a_typed_usage_error`, `a_local_stream_and_a_remote_domain_stream_do_not_collide_at_the_cli`, `a_raw_mirror_still_works_with_no_domain_flags`.

All 21 new tests pass; reran 5x stable. Full workspace `cargo test --workspace --all-features --locked` green (48/48 result lines, including the geo live-wire tests; the APFS preallocate test passed too).

## Gates
- `cargo fmt --all --check`: pass
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`: pass
- `cargo test --workspace --all-features --locked`: pass
- io-free-check on ironbus-core: pass
- SPDX header check: miss=0
- Public-repo hygiene grep on the diff: clean

## Deferred (honest)
- #625 (edge leaf-spoke) and #626 (gateway federation) are SEPARATE — not pulled in; the namespace is built to be usable by them (clean `Domain` + `DomainResolver`).
- Propagating a cluster's own domain through cluster metadata (so all nodes agree without each operator setting `--cluster-domain` consistently) is deferred to #625/#626.
- No wire frame added (no new frame tag needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVWp2H2txnKGru4q2twxM3