### PR TITLE
feat(cluster): client cluster-awareness — NOT_LEADER produce redirect + follower-read consume over the wire

### DIFF
--- a/crates/ironbus-cli/src/main.rs
+++ b/crates/ironbus-cli/src/main.rs
@@ -6210,11 +6210,25 @@ fn run_dataplane_bootstrap(
     // the shared slot so every per-connection produce path (which captured the slot at serve start)
     // reaches it: from now on a clustered `C2-fsync` led produce's wire `PubAck` is withheld until
     // quorum-fsync. Before this fill, the produce path acked immediately (the brief bootstrap window).
-    let mut dp_runtime = match DataPlaneRuntime::start_with_client_gate(
+    // The node-id -> CLIENT-address advertise map for the #735 `NOT_LEADER` leader HINT. There is no
+    // per-peer client-address config today (`--cluster-peer` carries only the metadata address; a peer's
+    // CLIENT listener `--addr` is not advertised), so this is EMPTY in production for now: the `NOT_LEADER`
+    // redirect still fires correctly (a client on a non-leader is redirected before any append/ack), but
+    // with NO concrete hint — the client re-tries its own configured peer set to find the leader. A
+    // `--cluster-peer-client <id>=<addr>` advertise that fills this hint is the flagged follow-up (#735).
+    let leader_client_addrs: std::collections::BTreeMap<u64, std::net::SocketAddr> =
+        std::collections::BTreeMap::new();
+    // Start the runtime with the client gate AND the #735 client cluster-awareness wiring: the (currently
+    // empty) leader-hint advertise map and the shared metadata status snapshot (the follower-read
+    // committed-HW safe-watermark source). The status handle is what lets a FOLLOWER serve committed reads
+    // over the wire (without it the follower-read fails closed to a 0 safe bar).
+    let mut dp_runtime = match DataPlaneRuntime::start_with_client_gate_aware(
         server,
         self_data_addr,
         &peer_data_addrs,
         configured_level,
+        leader_client_addrs,
+        std::sync::Arc::clone(status),
     ) {
         Ok(r) => r,
         Err(e) => {
@@ -6617,7 +6631,11 @@ fn run_broker<F: Filesystem + Clone + 'static>(
                                      // struct would only move the noise, not remove it.
                                      // GENERIC over the engine's Filesystem (#443), like `run_broker`: the disk and memory storage
                                      // backends share the one health-server wiring, monomorphized by the same static dispatch.
-fn start_health_server<F: Filesystem + 'static>(
+                                     // `F: Clone` since the engine handle is used as an `EngineAccess` by `serve_health`, and the
+                                     // `EngineAccess` impl for `EngineHandle` carries `F: Clone` (the #735 follower-read consume override
+                                     // builds a read plane over a follower's owned log). The shipped filesystems are all `Clone`, so this is
+                                     // no real constraint — it just matches the serve loop, which already requires `F: Clone`.
+fn start_health_server<F: Filesystem + Clone + 'static>(
     config: &ServeConfig,
     health_addr: Option<&str>,
     health_bind: Option<HealthBindDecision>,

--- a/crates/ironbus-client/src/lib.rs
+++ b/crates/ironbus-client/src/lib.rs
@@ -28,13 +28,13 @@ use ironbus_core::types::RecordFlags;
 use ironbus_proto::frame::{decode_frame, encode_frame, FrameDecode, FrameError, FrameType};
 use ironbus_proto::message::{
     decode_dead_letter, decode_deliver, decode_deliver_batch, decode_gap_marker, decode_info,
-    decode_produce_confirm, decode_pub_ack, decode_stream_info_response, decode_truncated,
-    encode_ack, encode_connect, encode_cumulative_ack, encode_fetch, encode_pub, encode_pub_to,
-    encode_stream_commit, encode_stream_declare, encode_stream_fetch, encode_stream_info,
-    encode_sub, encode_sub_to, produce_confirm_status, AckBody, AckLevel, AckOp, BodyError,
-    ConnectBody, ConsumeTier, CumulativeAckBody, DeliverBody, FetchBody, PubBody, PubToBody,
-    StreamCommitBody, StreamDeclareBody, StreamFetchBody, StreamInfoBody, SubBody, SubToBody,
-    PUB_FLAG_ACK_LEVEL_MASK, PUB_FLAG_ACK_LEVEL_SHIFT,
+    decode_not_leader, decode_produce_confirm, decode_pub_ack, decode_stream_info_response,
+    decode_truncated, encode_ack, encode_connect, encode_cumulative_ack, encode_fetch, encode_pub,
+    encode_pub_to, encode_stream_commit, encode_stream_declare, encode_stream_fetch,
+    encode_stream_info, encode_sub, encode_sub_to, produce_confirm_status, AckBody, AckLevel,
+    AckOp, BodyError, ConnectBody, ConsumeTier, CumulativeAckBody, DeliverBody, FetchBody, PubBody,
+    PubToBody, StreamCommitBody, StreamDeclareBody, StreamFetchBody, StreamInfoBody, SubBody,
+    SubToBody, PUB_FLAG_ACK_LEVEL_MASK, PUB_FLAG_ACK_LEVEL_SHIFT,
 };
 use std::io::{self, Read, Write};
 use std::net::{TcpStream, ToSocketAddrs};
@@ -59,6 +59,17 @@ pub enum ClientError {
     BadResponse(&'static str),
     /// The connection closed before a complete response arrived.
     Closed,
+    /// The server REDIRECTED a produce: the node this client is connected to holds a clustered replica
+    /// role for the target partition but is NOT its current leader (#735), so the produce was NOT
+    /// appended/acked here — it must go to the leader. `leader_hint` is the current leader's CLIENT
+    /// address when the server knew it (`Some`), or `None` (mid-failover, or no advertised client address),
+    /// in which case the caller re-discovers the leader from its own known peers. A RECOVERABLE error: the
+    /// connection stays usable (the client can keep producing once it reconnects to the leader); see
+    /// [`Client::produce_to_leader`] for the transparent reconnect/retry helper.
+    NotLeader {
+        /// The current leader's CLIENT address to reconnect to, or `None` when the server did not know it.
+        leader_hint: Option<String>,
+    },
     /// A delivered payload carried the `COMPRESSED` flag but could not be decompressed back to
     /// the original bytes (#430): an unknown codec (e.g. a `zstd` record read by this pure-Rust
     /// client), a dictionary this client cannot resolve (`PoisonUnresolvedDict`; the client
@@ -112,6 +123,10 @@ impl core::fmt::Display for ClientError {
                     "delivered payload at offset {offset} failed decompression: {source}"
                 )
             }
+            ClientError::NotLeader { leader_hint } => match leader_hint {
+                Some(addr) => write!(f, "not leader: produce to the leader at {addr}"),
+                None => write!(f, "not leader: the current leader is unknown"),
+            },
         }
     }
 }
@@ -400,11 +415,15 @@ pub enum ProgressOutcome {
 /// One produce reply, classified: the single decode point shared by the half-duplex
 /// [`Client::produce_window`] drain and the [`Client::produce_stream`] reader thread (#458), so
 /// the two paths can never drift on the reply contract.
+#[derive(Debug)]
 enum PubReply {
     Acked(u64),
     Duplicate(u64),
     ServerErr(String),
     Pong,
+    /// A cluster `NotLeader` redirect (#735): the produce landed on a non-leader replica of the
+    /// partition and was NOT appended/acked; the leader's CLIENT-address hint (or `None` when unknown).
+    NotLeader(Option<String>),
 }
 
 /// One coalesced write's byte budget for [`Client::produce_stream`] (#458): large enough to
@@ -490,6 +509,20 @@ fn drain_stream_replies(
                 f.server_errors += 1;
                 if f.first_server_err.is_none() {
                     f.first_server_err = Some(msg);
+                }
+            }
+            // A cluster NotLeader redirect (#735) mid-stream: this node is not the leader, so these
+            // streamed produces did NOT land. Surface it like a server error (the first one is reported),
+            // so the caller learns the stream went to the wrong node and re-streams to the leader. Counted
+            // as done so the writer's window does not stall waiting on a reply that will never ack.
+            PubReply::NotLeader(hint) => {
+                f.done += 1;
+                f.server_errors += 1;
+                if f.first_server_err.is_none() {
+                    f.first_server_err = Some(match hint {
+                        Some(addr) => format!("not leader: produce to the leader at {addr}"),
+                        None => "not leader: the current leader is unknown".to_string(),
+                    });
                 }
             }
             // The terminal marker: the server's FIFO frame order guarantees every prior
@@ -596,6 +629,20 @@ fn confirm_outcome(status: u8) -> ConfirmOutcome {
     }
 }
 
+/// Decode a `NotLeader` redirect body (#735) into the typed [`ClientError::NotLeader`] with the leader
+/// hint (an empty hint -> `None`). A malformed body falls back to a `None` hint rather than a parse error,
+/// so a redirect is always actionable (the client re-tries its known peers).
+fn not_leader_error(body: &[u8]) -> ClientError {
+    let leader_hint = decode_not_leader(body).ok().and_then(|r| {
+        if r.leader_hint.is_empty() {
+            None
+        } else {
+            Some(r.leader_hint.to_string())
+        }
+    });
+    ClientError::NotLeader { leader_hint }
+}
+
 fn classify_pub_reply(ty: FrameType, body: &[u8]) -> Result<PubReply, ClientError> {
     match ty {
         FrameType::PubAck => {
@@ -612,6 +659,18 @@ fn classify_pub_reply(ty: FrameType, body: &[u8]) -> Result<PubReply, ClientErro
         }
         FrameType::Err => Ok(PubReply::ServerErr(String::from_utf8_lossy(body).into())),
         FrameType::Pong => Ok(PubReply::Pong),
+        // A cluster NotLeader redirect (#735): decode the leader hint (an empty hint -> `None`). The
+        // produce was NOT appended/acked here; the caller reconnects/retries to the leader.
+        FrameType::NotLeader => {
+            let redirect = decode_not_leader(body)
+                .map_err(|_| ClientError::BadResponse("malformed NotLeader redirect body"))?;
+            let hint = if redirect.leader_hint.is_empty() {
+                None
+            } else {
+                Some(redirect.leader_hint.to_string())
+            };
+            Ok(PubReply::NotLeader(hint))
+        }
         other => Err(ClientError::Unexpected(other)),
     }
 }
@@ -948,6 +1007,55 @@ impl Client {
         self.produce_dedup(message).map(|ack| ack.offset)
     }
 
+    /// Produce `message`, transparently following a cluster [`ClientError::NotLeader`] redirect (#735) to
+    /// the leader. On a non-cluster broker (or when already connected to the leader) this is exactly
+    /// [`Client::produce`]: one produce, no extra work. In a cluster, if the connected node is NOT the
+    /// leader of the partition, the server replies `NotLeader` with the current leader's CLIENT-address
+    /// hint; this RECONNECTS this client to the hinted leader (using `config` for the handshake, so the
+    /// negotiated capabilities are preserved) and RETRIES the produce there — so a client connected to the
+    /// wrong node (e.g. after a failover moved leadership) recovers automatically. Bounded by
+    /// `max_redirects` reconnects (a small value like 3 is ample; it guards against a redirect loop / a
+    /// rebalance storm).
+    ///
+    /// A `NotLeader` with NO hint (`leader_hint == None` — the server did not yet know the leader, e.g.
+    /// mid-failover) is returned to the caller UNCHANGED (this helper cannot guess an address): the caller
+    /// re-tries its own known peers. Every other error (a real server `Err`, a transport error) is
+    /// returned unchanged. On success the client REMAINS connected to the leader, so subsequent produces
+    /// go straight there.
+    ///
+    /// # Errors
+    /// Returns [`ClientError::NotLeader`] when the redirect carried no hint, or when `max_redirects`
+    /// reconnects were exhausted (the last redirect is surfaced); a [`ClientError`] on a reconnect failure
+    /// or any non-redirect produce error.
+    pub fn produce_to_leader(
+        &mut self,
+        message: &PubBody<'_>,
+        config: &ClientConfig,
+        max_redirects: u32,
+    ) -> Result<u64, ClientError> {
+        let mut attempts = 0;
+        loop {
+            match self.produce(message) {
+                Ok(offset) => return Ok(offset),
+                Err(ClientError::NotLeader { leader_hint }) => {
+                    // No hint, or redirect budget exhausted: surface the redirect for the caller to handle
+                    // (re-discover the leader from its own peers). Never loop unbounded.
+                    match leader_hint {
+                        Some(addr) if attempts < max_redirects => {
+                            // Reconnect to the hinted leader (preserving the handshake-negotiated
+                            // capabilities), then retry the produce there. A reconnect failure surfaces as
+                            // the connect error.
+                            *self = Client::connect_with(addr.as_str(), config)?;
+                            attempts += 1;
+                        }
+                        other => return Err(ClientError::NotLeader { leader_hint: other }),
+                    }
+                }
+                Err(e) => return Err(e),
+            }
+        }
+    }
+
     /// Produces a message and returns the full [`ProduceAck`]: the assigned (or, on a dedup hit, the
     /// ORIGINAL) offset plus the `duplicate` indication (#33). When `message.dedup` is `Some`, the
     /// publish opts into the broker's effectively-once dedup window; if the `msg_id` was already seen
@@ -994,6 +1102,10 @@ impl Client {
             (FrameType::Err, body) => {
                 Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
             }
+            // A cluster NotLeader redirect (#735): this node is not the leader, so the produce did NOT
+            // land here. Surface the typed `NotLeader` error (with the leader hint) so the caller can
+            // reconnect/retry to the leader; the connection stays usable. `produce_to_leader` automates it.
+            (FrameType::NotLeader, body) => Err(not_leader_error(&body)),
             (other, _) => Err(ClientError::Unexpected(other)),
         }
     }
@@ -1268,6 +1380,14 @@ impl Client {
                 PubReply::ServerErr(msg) => {
                     if first_err.is_none() {
                         first_err = Some(ClientError::Server(msg));
+                    }
+                }
+                // A cluster NotLeader redirect (#735): this node is not the leader, so the windowed
+                // produces did NOT land. Remember it as the first error (with the leader hint); the drain
+                // continues so the connection stays framed, then the call returns the typed redirect.
+                PubReply::NotLeader(leader_hint) => {
+                    if first_err.is_none() {
+                        first_err = Some(ClientError::NotLeader { leader_hint });
                     }
                 }
                 PubReply::Pong => return Err(ClientError::Unexpected(FrameType::Pong)),
@@ -2781,6 +2901,14 @@ impl PipelinedProducer<'_> {
                 PubReply::ServerErr(msg) => {
                     if first_err.is_none() {
                         first_err = Some(ClientError::Server(msg));
+                    }
+                }
+                // A cluster NotLeader redirect (#735): the pipelined produces did NOT land on this
+                // non-leader node. Remember the typed redirect (with the leader hint) as the first error;
+                // the drain continues so the connection stays framed.
+                PubReply::NotLeader(leader_hint) => {
+                    if first_err.is_none() {
+                        first_err = Some(ClientError::NotLeader { leader_hint });
                     }
                 }
                 PubReply::Pong => return Err(ClientError::Unexpected(FrameType::Pong)),
@@ -6060,5 +6188,49 @@ mod tests {
         drop(conn);
         shutdown.store(true, Ordering::Release);
         serve_handle.join().unwrap();
+    }
+
+    // ---- #735 client NOT_LEADER redirect classification ----------------------------------------
+
+    #[test]
+    fn a_not_leader_frame_classifies_as_a_redirect_with_the_leader_hint() {
+        use ironbus_proto::message::{encode_not_leader, NotLeaderBody};
+        // A NotLeader frame carrying a concrete leader hint classifies as a redirect to that address.
+        let mut body = Vec::new();
+        encode_not_leader(
+            &NotLeaderBody {
+                leader_hint: "127.0.0.1:9002",
+            },
+            &mut body,
+        )
+        .unwrap();
+        match classify_pub_reply(FrameType::NotLeader, &body).unwrap() {
+            PubReply::NotLeader(Some(addr)) => assert_eq!(addr, "127.0.0.1:9002"),
+            other => panic!("expected a NotLeader redirect with a hint, got {other:?}"),
+        }
+        // The single-produce path surfaces it as the typed ClientError::NotLeader with the hint.
+        match not_leader_error(&body) {
+            ClientError::NotLeader {
+                leader_hint: Some(addr),
+            } => assert_eq!(addr, "127.0.0.1:9002"),
+            other => panic!("expected ClientError::NotLeader with a hint, got {other}"),
+        }
+    }
+
+    #[test]
+    fn a_hintless_not_leader_frame_classifies_as_a_redirect_with_no_hint() {
+        use ironbus_proto::message::{encode_not_leader, NotLeaderBody};
+        // An EMPTY leader hint (the server did not yet know the leader) classifies as a redirect with no
+        // hint — the caller re-discovers the leader from its own peers.
+        let mut body = Vec::new();
+        encode_not_leader(&NotLeaderBody { leader_hint: "" }, &mut body).unwrap();
+        match classify_pub_reply(FrameType::NotLeader, &body).unwrap() {
+            PubReply::NotLeader(None) => {}
+            other => panic!("expected a hintless NotLeader redirect, got {other:?}"),
+        }
+        match not_leader_error(&body) {
+            ClientError::NotLeader { leader_hint: None } => {}
+            other => panic!("expected a hintless ClientError::NotLeader, got {other}"),
+        }
     }
 }

--- a/crates/ironbus-client/src/lib.rs
+++ b/crates/ironbus-client/src/lib.rs
@@ -6233,4 +6233,440 @@ mod tests {
             other => panic!("expected a hintless ClientError::NotLeader, got {other}"),
         }
     }
+
+    // ---------------------------------------------------------------------------------------------
+    // #735 (V2 client cluster-awareness): a REAL client connection is transparently routed —
+    //   A. a produce to a NON-leader node is answered NOT_LEADER + a leader hint, and the client
+    //      retries to the leader where the produce succeeds (quorum-acked);
+    //   B. a consume from a FOLLOWER node serves committed records over the wire, never past the
+    //      safe watermark.
+    // ---------------------------------------------------------------------------------------------
+
+    /// A handle to one in-process broker spun up for the #735 tests: its address + the shared gate (so a
+    /// test can drive a follower's quorum-fsync report, like the runtime's follower thread), plus the
+    /// shutdown flag and serve thread.
+    #[cfg(unix)]
+    #[allow(dead_code)]
+    struct ClusterBroker {
+        addr: std::net::SocketAddr,
+        gate: Arc<ironbus_server::cluster::ClientAckGate<InMemoryFs, SystemClock>>,
+        shutdown: Arc<AtomicBool>,
+        serve: std::thread::JoinHandle<()>,
+    }
+
+    #[cfg(unix)]
+    impl ClusterBroker {
+        fn stop(self) {
+            self.shutdown.store(true, Ordering::Release);
+            self.serve.join().unwrap();
+        }
+    }
+
+    /// The shared engine config for the #735 brokers (sync durability, a generous credit).
+    #[cfg(unix)]
+    fn cluster_test_engine_config() -> EngineConfig {
+        EngineConfig {
+            log: LogConfig::default(),
+            lease: LeaseConfig::default(),
+            delivery: DeliveryConfig::new(5, false, vec![]).unwrap(),
+            max_in_flight: 16,
+            consumer_credit: 256,
+            consumer_credit_bytes: 0,
+            checkpoint_interval: 1024,
+            max_retained_bytes: 0,
+            max_age_ms: 0,
+            max_messages: 0,
+            max_groups: DEFAULT_MAX_GROUPS,
+            group_idle_evict_ms: DEFAULT_GROUP_IDLE_EVICT_MS,
+            ram_ceiling_bytes: 0,
+            disk_full_policy: DiskFullPolicy::DropNew,
+            dedup: ironbus_core::dedup::DedupConfig::default(),
+            durability_level: ironbus_server::engine::DurabilityLevel::Sync,
+            flush_interval_ms: 0,
+            flush_max_bytes: 0,
+            codel_target_ms: 0,
+            codel_interval_ms: 0,
+            retry_budget_ratio_per_million: 0,
+            retry_budget_window_ms: 0,
+            fire_and_forget_msg_rate: 0,
+            fire_and_forget_byte_rate: 0,
+            fire_and_forget_refill_ms: 0,
+            egress_limit: 0,
+            wal_fsync_headroom_bytes: 0,
+            compression: ironbus_core::compress::Codec::None,
+            default_message_ttl_ms: 0,
+            dead_letter_exchange: None,
+            dead_letter_expired: false,
+        }
+    }
+
+    /// Build one clustered broker for partition 0 of `{1,2,3}` (`min_isr = 2`). When `lead` is true this
+    /// node LEADS (so a produce here is quorum-gated, never redirected); when false it FOLLOWS (leader is
+    /// node 2) over a replica log pre-seeded by replicating `seed_records` from a leader plane, so a real
+    /// client consume here serves committed records. `leader_client_addr` is advertised as node 2's CLIENT
+    /// address (the `NOT_LEADER` hint). The follower's committed-HW status covers the whole replicated
+    /// prefix.
+    #[cfg(unix)]
+    #[allow(clippy::too_many_lines)] // one cohesive broker-build helper (leader or follower role + wiring)
+    fn start_cluster_broker(
+        lead: bool,
+        leader_client_addr: Option<std::net::SocketAddr>,
+        seed_records: u32,
+    ) -> ClusterBroker {
+        use ironbus_server::actor::EngineHandle;
+        use ironbus_server::cluster::{
+            ClientAckGate, ClusterAckLevel, ClusterStatus, DataPlaneController, DataPlaneServer,
+            IsrConfig, ProduceAckSeam,
+        };
+        use ironbus_storage::log::{Append, Log};
+        use std::collections::BTreeMap;
+        use std::sync::{Mutex, OnceLock};
+
+        let engine = Engine::open(
+            InMemoryFs::new(),
+            SystemClock::new(),
+            cluster_test_engine_config(),
+        )
+        .unwrap();
+
+        let isr = IsrConfig {
+            min_isr: 2,
+            max_lag_records: 0,
+        };
+        let self_id = if lead { 1 } else { 3 };
+        let mut controller = DataPlaneController::new(self_id);
+        let mut committed_hw = 0u64;
+        if lead {
+            let leader_log: &'static mut Log<InMemoryFs, SystemClock> = Box::leak(Box::new(
+                Log::open(InMemoryFs::new(), SystemClock::new(), LogConfig::default()).unwrap(),
+            ));
+            controller.start_leader(
+                C2_PARTITION,
+                Arc::new(leader_log.read_plane().unwrap()),
+                ironbus_core::epoch_cache::EpochCache::new(),
+                &[1, 2, 3],
+                isr,
+            );
+        } else {
+            // Seed a leader plane, then replicate it into this node's follower log (the in-process
+            // catch-up the dataplane tests use), so the follower holds a committed prefix to serve.
+            let small = LogConfig {
+                max_segment_bytes: 256,
+                max_total_bytes: 0,
+                ..LogConfig::default()
+            };
+            let leader_log: &'static mut Log<InMemoryFs, SystemClock> = Box::leak(Box::new(
+                Log::open(InMemoryFs::new(), SystemClock::new(), small).unwrap(),
+            ));
+            for i in 0..seed_records {
+                leader_log
+                    .append(&Append {
+                        timestamp_ms: 7,
+                        flags: ironbus_core::types::RecordFlags::EMPTY,
+                        key: b"",
+                        headers: b"",
+                        payload: format!("c735-{i:02}").as_bytes(),
+                    })
+                    .unwrap();
+            }
+            leader_log.sync().unwrap();
+            let plane = Arc::new(leader_log.read_plane().unwrap());
+            let mut served_end = 0u64;
+            loop {
+                let raw = plane
+                    .read_range_raw(ironbus_core::types::Offset::new(served_end), 1_000, None)
+                    .unwrap();
+                let next = raw.run.next_offset.get();
+                if next <= served_end {
+                    break;
+                }
+                served_end = next;
+            }
+            committed_hw = served_end;
+            let mut leader_ctrl: DataPlaneController<InMemoryFs, SystemClock> =
+                DataPlaneController::new(2);
+            leader_ctrl.start_leader(
+                C2_PARTITION,
+                Arc::clone(&plane),
+                ironbus_core::epoch_cache::EpochCache::new(),
+                &[1, 2, 3],
+                isr,
+            );
+            controller.start_follower(
+                C2_PARTITION,
+                Log::open(InMemoryFs::new(), SystemClock::new(), small).unwrap(),
+            );
+            for _ in 0..(served_end + 8) {
+                if controller.follower_high_watermark(C2_PARTITION).unwrap() >= served_end {
+                    break;
+                }
+                let req = controller
+                    .make_fetch_request(C2_PARTITION, 8, 4096)
+                    .unwrap();
+                let resp = leader_ctrl.serve_fetch(C2_PARTITION, &req).unwrap();
+                controller
+                    .apply_fetch_response(C2_PARTITION, &resp)
+                    .unwrap();
+            }
+        }
+
+        let mut server = DataPlaneServer::new(self_id, ProduceAckSeam::new(controller));
+        if !lead {
+            server.set_follower_target(C2_PARTITION, 2);
+        }
+        let mut addrs: BTreeMap<u64, std::net::SocketAddr> = BTreeMap::new();
+        if let Some(a) = leader_client_addr {
+            addrs.insert(2, a);
+        }
+        let mut status = ClusterStatus::default();
+        status.last_committed_hw.insert(C2_PARTITION, committed_hw);
+        let gate = Arc::new(
+            ClientAckGate::new(Arc::new(Mutex::new(server)), ClusterAckLevel::C2Fsync)
+                .with_leader_client_addrs(addrs)
+                .with_status_handle(Arc::new(Mutex::new(status))),
+        );
+
+        let slot: ironbus_server::actor::ClientAckSlot<InMemoryFs, SystemClock> =
+            Arc::new(OnceLock::new());
+        slot.set(Arc::clone(&gate)).ok();
+        let (handle_engine, _actor): (EngineHandle<InMemoryFs, SystemClock>, _) =
+            spawn_actor(engine, DEFAULT_CHANNEL_BOUND);
+        let handle_engine = handle_engine.with_client_ack_slot(slot);
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let serve = std::thread::spawn({
+            let shutdown = Arc::clone(&shutdown);
+            move || {
+                let clock = SystemClock::new();
+                let beacon =
+                    ironbus_server::liveness::LivenessBeacon::new(clock.now_monotonic_nanos());
+                serve(&listener, &handle_engine, &shutdown, 16, &clock, &beacon).unwrap();
+            }
+        });
+        ClusterBroker {
+            addr,
+            gate,
+            shutdown,
+            serve,
+        }
+    }
+
+    /// Drive a follower quorum-fsync report on `gate` until it RELEASES a parked C2-fsync ack (or a
+    /// deadline) — standing in for the data-plane runtime's follower thread, on a side thread so a client
+    /// can await its quorum-gated `PubAck`.
+    #[cfg(unix)]
+    fn spawn_quorum_releaser(
+        gate: Arc<ironbus_server::cluster::ClientAckGate<InMemoryFs, SystemClock>>,
+    ) -> std::thread::JoinHandle<()> {
+        std::thread::spawn(move || {
+            let deadline = std::time::Instant::now() + Duration::from_secs(5);
+            while std::time::Instant::now() < deadline {
+                if gate.on_follower_report(
+                    C2_PARTITION,
+                    &ironbus_server::cluster::AckReplicatedBody {
+                        follower_id: 2,
+                        fsynced_offset: 1,
+                    },
+                ) > 0
+                {
+                    return;
+                }
+                std::thread::sleep(Duration::from_millis(5));
+            }
+        })
+    }
+
+    /// A: a real client produces to a NON-leader node, gets `NOT_LEADER` + the leader hint, transparently
+    /// retries to the leader where the produce SUCCEEDS and is quorum-acked (#720). The end-to-end #735
+    /// half-A proof over real sockets.
+    #[cfg(unix)]
+    #[test]
+    fn a_real_client_redirects_a_not_leader_produce_to_the_leader_and_succeeds() {
+        let leader = start_cluster_broker(true, None, 0);
+        let follower = start_cluster_broker(false, Some(leader.addr), 0);
+
+        let mut client = Client::connect(follower.addr).unwrap();
+        let msg = PubBody {
+            flags: 0,
+            timestamp_ms: 0,
+            key: b"",
+            headers: b"",
+            dedup: None,
+            fire_and_forget: false,
+            payload: b"to-the-leader",
+        };
+        // A bare produce on the FOLLOWER gets a typed NotLeader redirect carrying the leader's address.
+        match client.produce(&msg) {
+            Err(ClientError::NotLeader { leader_hint }) => {
+                assert_eq!(
+                    leader_hint.as_deref(),
+                    Some(leader.addr.to_string().as_str()),
+                    "the redirect carries the current leader's client address as the hint"
+                );
+            }
+            other => panic!("expected a NotLeader redirect from the follower, got {other:?}"),
+        }
+
+        // produce_to_leader follows the hint: it reconnects to the leader and retries there, where the
+        // C2-fsync ack is quorum-gated (#719) — release it on a side thread.
+        let releaser = spawn_quorum_releaser(Arc::clone(&leader.gate));
+        let offset = client
+            .produce_to_leader(&msg, &ClientConfig::default(), 3)
+            .expect("the produce succeeds on the leader after the redirect");
+        assert_eq!(offset, 0, "the leader assigned the durable offset 0");
+        releaser.join().unwrap();
+
+        leader.stop();
+        follower.stop();
+    }
+
+    /// A no-false-NOT_LEADER guard: a produce to the actual LEADER proceeds (quorum-gated), never a
+    /// redirect.
+    #[cfg(unix)]
+    #[test]
+    fn a_real_client_produce_to_the_leader_is_not_redirected() {
+        let leader = start_cluster_broker(true, None, 0);
+        let mut client = Client::connect(leader.addr).unwrap();
+        let releaser = spawn_quorum_releaser(Arc::clone(&leader.gate));
+        let offset = client
+            .produce(&PubBody {
+                flags: 0,
+                timestamp_ms: 0,
+                key: b"",
+                headers: b"",
+                dedup: None,
+                fire_and_forget: false,
+                payload: b"on-the-leader",
+            })
+            .expect("a produce to the leader proceeds (never a NotLeader redirect)");
+        assert_eq!(offset, 0, "the leader assigned offset 0 (no redirect)");
+        releaser.join().unwrap();
+        leader.stop();
+    }
+
+    /// B: a real client CONSUMES committed records from a FOLLOWER node over the wire (a Tier-S
+    /// `StreamFetch`), byte-faithfully, never past the safe watermark. The end-to-end #735 half-B proof.
+    #[cfg(unix)]
+    #[test]
+    fn a_real_client_consumes_committed_records_from_a_follower_over_the_wire() {
+        use ironbus_proto::message::{encode_stream_fetch, StreamFetchBody};
+        const N: u32 = 12;
+        let follower = start_cluster_broker(false, None, N);
+
+        let cfg = ClientConfig {
+            understands_streaming: true,
+            ..ClientConfig::default()
+        };
+        let mut conn = raw_connect_with(follower.addr, &cfg);
+
+        let mut body = Vec::new();
+        encode_stream_fetch(
+            &StreamFetchBody {
+                start_offset: 0,
+                max_records: 1_000,
+                max_bytes: 0,
+            },
+            &mut body,
+        );
+        conn.write_frame(FrameType::StreamFetch, &body);
+
+        let mut payloads: Vec<Vec<u8>> = Vec::new();
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            assert!(
+                std::time::Instant::now() <= deadline,
+                "follower-read response did not terminate"
+            );
+            match conn.next_frame() {
+                Some((FrameType::Deliver, b)) => {
+                    let d = ironbus_proto::message::decode_deliver(&b).unwrap();
+                    payloads.push(d.payload.to_vec());
+                }
+                Some((FrameType::FlowEnd, _)) => break,
+                Some((other, _)) => {
+                    panic!("unexpected frame in a follower-read response: {other:?}")
+                }
+                // A read-timeout with no whole frame yet: loop and re-check the deadline.
+                None => {}
+            }
+        }
+        assert!(
+            !payloads.is_empty(),
+            "the follower served committed records over the wire (not vacuously empty)"
+        );
+        assert!(
+            payloads.len() <= N as usize,
+            "the follower never serves more than the committed prefix"
+        );
+        for (i, p) in payloads.iter().enumerate() {
+            assert_eq!(
+                p.as_slice(),
+                format!("c735-{i:02}").as_bytes(),
+                "follower-read payload {i} is byte-faithful"
+            );
+        }
+
+        drop(conn);
+        follower.stop();
+    }
+
+    /// A raw connection with an explicit handshake `config` (so a test can advertise Tier-S streaming).
+    #[cfg(unix)]
+    fn raw_connect_with(addr: std::net::SocketAddr, config: &ClientConfig) -> RawConn {
+        use ironbus_proto::message::{encode_connect, ConnectBody};
+        let stream = std::net::TcpStream::connect(addr).unwrap();
+        stream
+            .set_read_timeout(Some(Duration::from_millis(500)))
+            .unwrap();
+        let mut conn = RawConn {
+            stream,
+            buf: Vec::new(),
+        };
+        let mut body = Vec::new();
+        encode_connect(
+            &ConnectBody {
+                understands_streaming: config.understands_streaming,
+                ..ConnectBody::default()
+            },
+            &mut body,
+        );
+        conn.write_frame(FrameType::Connect, &body);
+        let (ty, _b) = conn.next_frame().expect("Info handshake reply");
+        assert_eq!(ty, FrameType::Info);
+        conn
+    }
+
+    /// Byte-identical guarantee (#735 non-negotiable 1): a NON-cluster broker's produce + consume hot
+    /// path is unchanged — a produce returns a normal `PubAck` (NEVER a `NotLeader` redirect), and the
+    /// record round-trips byte-faithfully on consume. The non-cluster `start_server` broker builds NO
+    /// `ClientAckGate`, so `cluster_produce_routing`/`cluster_follower_consume` take their cheap default
+    /// (`Local` / `None`) and the produce + consume paths are the existing ones.
+    #[test]
+    fn a_non_cluster_produce_and_consume_is_never_redirected_or_follower_routed() {
+        let (addr, shutdown, handle) = start_server();
+        let mut c = Client::connect(addr).unwrap();
+        // A produce on a non-cluster broker returns a normal PubAck offset — never a NotLeader redirect.
+        let offset = c
+            .produce(&PubBody {
+                flags: 0,
+                timestamp_ms: 0,
+                key: b"",
+                headers: b"",
+                dedup: None,
+                fire_and_forget: false,
+                payload: b"single-node",
+            })
+            .expect("a non-cluster produce returns a PubAck, never a NotLeader redirect");
+        assert_eq!(offset, 0, "the single-node broker assigned offset 0");
+        // The consume round-trips the record byte-faithfully through the normal (non-follower) path.
+        let messages = c.fetch(10).unwrap().messages;
+        assert_eq!(messages.len(), 1, "the record is consumed normally");
+        assert_eq!(messages[0].offset, 0);
+        assert_eq!(messages[0].payload.as_slice(), b"single-node");
+        drop(c);
+        shutdown.store(true, Ordering::Release);
+        handle.join().unwrap();
+    }
 }

--- a/crates/ironbus-proto/src/frame.rs
+++ b/crates/ironbus-proto/src/frame.rs
@@ -383,6 +383,22 @@ pub enum FrameType {
     /// byte-for-byte unchanged. The geo leaf layer (`crate::cluster::leaf` in `ironbus-server`) is its
     /// only encoder/decoder.
     LeafPush,
+    /// CLUSTER `NotLeader` produce REDIRECT (#735, V2-C-client-awareness, wire tag 42). The server's
+    /// reply to a `Pub`/`PubTo`/`PubSubject` that landed on a node which holds a CLUSTERED replica role
+    /// for the target partition but is NOT its current leader: the produce is redirected BEFORE any local
+    /// append or ack, so a client connected to the wrong node (e.g. after a failover moved leadership)
+    /// learns the CURRENT leader and transparently reconnects/retries there. It carries a LEADER HINT —
+    /// the committed leader's CLIENT-facing address — so the client need not re-discover it. It is an
+    /// ADDITIVE, server→client tag a single-node broker NEVER emits (the redirect path is cluster-gated):
+    /// an off-cluster produce is byte-for-byte today's `PubAck`/`Err`, so this tag never appears on a
+    /// non-cluster wire. A client that does not understand the tag treats it as an unknown frame (a
+    /// `ClientError`), exactly the forward-compatible skip the envelope already guarantees; tags 1-41 are
+    /// byte-for-byte unchanged. Body: a [`crate::message::NotLeaderBody`] — `body_version: u8`, then the
+    /// leader-hint address as a u16-length-prefixed UTF-8 string (EMPTY when the current leader's client
+    /// address is not yet known, e.g. mid-failover; the client then re-discovers / retries its known
+    /// peers). The session layer (`crate::session` in `ironbus-server`) and the client are its only
+    /// encoder/decoder.
+    NotLeader,
 }
 
 impl FrameType {
@@ -431,6 +447,7 @@ impl FrameType {
             FrameType::SegmentFingerprints => 39,
             FrameType::MirrorPull => 40,
             FrameType::LeafPush => 41,
+            FrameType::NotLeader => 42,
         }
     }
 
@@ -480,6 +497,7 @@ impl FrameType {
             39 => FrameType::SegmentFingerprints,
             40 => FrameType::MirrorPull,
             41 => FrameType::LeafPush,
+            42 => FrameType::NotLeader,
             _ => return None,
         })
     }
@@ -612,7 +630,7 @@ mod tests {
     use super::*;
     use proptest::prelude::*;
 
-    const ALL_TYPES: [FrameType; 41] = [
+    const ALL_TYPES: [FrameType; 42] = [
         FrameType::Connect,
         FrameType::Info,
         FrameType::Ping,
@@ -654,6 +672,7 @@ mod tests {
         FrameType::SegmentFingerprints,
         FrameType::MirrorPull,
         FrameType::LeafPush,
+        FrameType::NotLeader,
     ];
 
     #[test]
@@ -713,6 +732,7 @@ mod tests {
         assert_eq!(FrameType::SegmentFingerprints.as_u8(), 39);
         assert_eq!(FrameType::MirrorPull.as_u8(), 40);
         assert_eq!(FrameType::LeafPush.as_u8(), 41);
+        assert_eq!(FrameType::NotLeader.as_u8(), 42);
     }
 
     #[test]
@@ -730,7 +750,8 @@ mod tests {
         // verbs; 38 is the cluster OffsetForLeaderEpoch divergence-query (#599, V2-C2-I4); 39 is the
         // cluster SegmentFingerprints divergence-advertisement (#611, V2-C4-I1); 40 is the
         // cross-cluster MirrorPull (#623, V2-C7-I1); 41 is the edge leaf-spoke LeafPush write-through
-        // (#625, V2-C7-I3); 42 is now the next-free (still unknown) tag, so it frames but is not known.
+        // (#625, V2-C7-I3); 42 is the cluster NotLeader produce-redirect (#735); 43 is now the next-free
+        // (still unknown) tag, so it frames but is not known.
         assert_eq!(FrameType::from_u8(37), Some(FrameType::AckReplicated));
         assert_eq!(
             FrameType::from_u8(38),
@@ -739,7 +760,8 @@ mod tests {
         assert_eq!(FrameType::from_u8(39), Some(FrameType::SegmentFingerprints));
         assert_eq!(FrameType::from_u8(40), Some(FrameType::MirrorPull));
         assert_eq!(FrameType::from_u8(41), Some(FrameType::LeafPush));
-        assert_eq!(FrameType::from_u8(42), None);
+        assert_eq!(FrameType::from_u8(42), Some(FrameType::NotLeader));
+        assert_eq!(FrameType::from_u8(43), None);
         for ty in [
             FrameType::BindSubject,
             FrameType::PubSubject,
@@ -782,7 +804,7 @@ mod tests {
         // 37 is the cluster AckReplicated report (#593); 38 is the cluster OffsetForLeaderEpoch
         // divergence-query (#599); 39 is the cluster SegmentFingerprints divergence-advertisement
         // (#611); 40 is the cross-cluster MirrorPull (#623); 41 is the edge leaf-spoke LeafPush (#625);
-        // 42 is the next-free (still unknown) tag.
+        // 42 is the cluster NotLeader produce-redirect (#735); 43 is the next-free (still unknown) tag.
         assert_eq!(FrameType::from_u8(37), Some(FrameType::AckReplicated));
         assert_eq!(
             FrameType::from_u8(38),
@@ -791,7 +813,8 @@ mod tests {
         assert_eq!(FrameType::from_u8(39), Some(FrameType::SegmentFingerprints));
         assert_eq!(FrameType::from_u8(40), Some(FrameType::MirrorPull));
         assert_eq!(FrameType::from_u8(41), Some(FrameType::LeafPush));
-        assert_eq!(FrameType::from_u8(42), None);
+        assert_eq!(FrameType::from_u8(42), Some(FrameType::NotLeader));
+        assert_eq!(FrameType::from_u8(43), None);
         for ty in [
             FrameType::StreamDeclare,
             FrameType::StreamInfo,
@@ -868,8 +891,9 @@ mod tests {
         // 37 is the cluster AckReplicated report (#593, V2-C2-I2); 38 is the cluster
         // OffsetForLeaderEpoch divergence-query (#599, V2-C2-I4); 39 is the cluster SegmentFingerprints
         // divergence-advertisement (#611, V2-C4-I1); 40 is the cross-cluster MirrorPull (#623,
-        // V2-C7-I1); 41 is the edge leaf-spoke LeafPush write-through (#625, V2-C7-I3); 42 is now the
-        // next-free (still unknown) tag, so it frames but is not a known type. (Tags 27 = cluster-peer
+        // V2-C7-I1); 41 is the edge leaf-spoke LeafPush write-through (#625, V2-C7-I3); 42 is the
+        // cluster NotLeader produce-redirect (#735); 43 is now the next-free (still unknown) tag, so it
+        // frames but is not a known type. (Tags 27 = cluster-peer
         // Raft #667; 28-31 = the stream-addressed verbs #588; 32-33 = the cluster replication-fetch
         // verbs #590; 34-36 = the subject-routing verbs #585.)
         assert_eq!(FrameType::from_u8(37), Some(FrameType::AckReplicated));
@@ -880,7 +904,8 @@ mod tests {
         assert_eq!(FrameType::from_u8(39), Some(FrameType::SegmentFingerprints));
         assert_eq!(FrameType::from_u8(40), Some(FrameType::MirrorPull));
         assert_eq!(FrameType::from_u8(41), Some(FrameType::LeafPush));
-        assert_eq!(FrameType::from_u8(42), None);
+        assert_eq!(FrameType::from_u8(42), Some(FrameType::NotLeader));
+        assert_eq!(FrameType::from_u8(43), None);
         for ty in [FrameType::StreamFetch, FrameType::StreamCommit] {
             let mut buf = Vec::new();
             encode_frame(ty, b"\x07\x08", &mut buf).unwrap();
@@ -907,8 +932,9 @@ mod tests {
         // 37 is the cluster AckReplicated report (#593, V2-C2-I2); 38 is the cluster
         // OffsetForLeaderEpoch divergence-query (#599, V2-C2-I4); 39 is the cluster SegmentFingerprints
         // divergence-advertisement (#611, V2-C4-I1); 40 is the cross-cluster MirrorPull (#623,
-        // V2-C7-I1); 41 is the edge leaf-spoke LeafPush write-through (#625, V2-C7-I3); 42 is now the
-        // next-free (still unknown) tag, so it frames but is not a known type. (Tags 27 = cluster-peer
+        // V2-C7-I1); 41 is the edge leaf-spoke LeafPush write-through (#625, V2-C7-I3); 42 is the
+        // cluster NotLeader produce-redirect (#735); 43 is now the next-free (still unknown) tag, so it
+        // frames but is not a known type. (Tags 27 = cluster-peer
         // Raft #667; 28-31 = the stream-addressed verbs #588; 32-33 = the cluster replication-fetch
         // verbs #590; 34-36 = the subject-routing verbs #585.)
         assert_eq!(FrameType::from_u8(37), Some(FrameType::AckReplicated));
@@ -919,7 +945,8 @@ mod tests {
         assert_eq!(FrameType::from_u8(39), Some(FrameType::SegmentFingerprints));
         assert_eq!(FrameType::from_u8(40), Some(FrameType::MirrorPull));
         assert_eq!(FrameType::from_u8(41), Some(FrameType::LeafPush));
-        assert_eq!(FrameType::from_u8(42), None);
+        assert_eq!(FrameType::from_u8(42), Some(FrameType::NotLeader));
+        assert_eq!(FrameType::from_u8(43), None);
         let mut buf = Vec::new();
         encode_frame(FrameType::DeliverBatch, b"\x09\x0a", &mut buf).unwrap();
         match decode_frame(&buf).unwrap() {
@@ -1114,7 +1141,7 @@ mod tests {
         /// An unknown type tag still decodes at the envelope level (forward compatibility):
         /// the body and length are recovered; only `from_u8` reports it unknown.
         #[test]
-        fn an_unknown_type_tag_still_frames(tag in 42u8..=255, body in prop::collection::vec(any::<u8>(), 0..256)) {
+        fn an_unknown_type_tag_still_frames(tag in 43u8..=255, body in prop::collection::vec(any::<u8>(), 0..256)) {
             let frame_len = 1u32 + u32::try_from(body.len()).unwrap();
             let mut buf = frame_len.to_le_bytes().to_vec();
             buf.push(tag);

--- a/crates/ironbus-proto/src/message.rs
+++ b/crates/ironbus-proto/src/message.rs
@@ -4844,7 +4844,10 @@ mod tests {
         for hint in ["127.0.0.1:9000", "[::1]:7000", ""] {
             let mut buf = Vec::new();
             encode_not_leader(&NotLeaderBody { leader_hint: hint }, &mut buf).unwrap();
-            assert_eq!(buf[0], NOT_LEADER_BODY_VERSION, "version byte leads the body");
+            assert_eq!(
+                buf[0], NOT_LEADER_BODY_VERSION,
+                "version byte leads the body"
+            );
             let decoded = decode_not_leader(&buf).unwrap();
             assert_eq!(decoded.leader_hint, hint);
         }

--- a/crates/ironbus-proto/src/message.rs
+++ b/crates/ironbus-proto/src/message.rs
@@ -1050,6 +1050,65 @@ pub fn decode_produce_confirm(body: &[u8]) -> Result<ProduceConfirmBody, BodyErr
     Ok(ProduceConfirmBody { offset, status })
 }
 
+/// The version of the [`crate::frame::FrameType::NotLeader`] redirect body (#735). Version `1` is the
+/// first (and only) layout: a `body_version: u8` followed by the leader-hint address as a
+/// u16-length-prefixed UTF-8 string. The version byte lets a future field be appended after the address
+/// without a new frame tag (an old reader stops at the address it knows). A NON-cluster broker NEVER
+/// emits this frame, so it never appears on a single-node wire.
+pub const NOT_LEADER_BODY_VERSION: u8 = 1;
+
+/// A cluster `NotLeader` produce-redirect body (the [`crate::frame::FrameType::NotLeader`] frame, #735):
+/// the server tells a producer that the node it produced to is NOT the current leader of the target
+/// (clustered) partition, carrying a LEADER HINT — the current committed leader's CLIENT-facing address —
+/// so the client transparently reconnects/retries to the leader. The redirect happens BEFORE any local
+/// append or ack, so a redirected produce is never acked by the wrong node (no double-append, no false
+/// ack).
+///
+/// Layout (version-prefixed, forward-compatible): `body_version: u8` ([`NOT_LEADER_BODY_VERSION`]), then
+/// the `leader_hint` address as a u16-length-prefixed UTF-8 string. The hint is EMPTY (a zero-length
+/// string) when the current leader's client address is not yet known to this node (e.g. mid-failover, or
+/// the leader has not advertised a client address); the client then falls back to re-discovering the
+/// leader from its own known peer set.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NotLeaderBody<'a> {
+    /// The current leader's CLIENT-facing address (e.g. `"127.0.0.1:9000"`), or the EMPTY string when
+    /// this node does not yet know it. Borrowed from the decoded frame body (UTF-8 validated by the
+    /// caller — the bytes are taken verbatim here so the codec stays panic-free and allocation-free).
+    pub leader_hint: &'a str,
+}
+
+/// Encodes a `NotLeader` body onto the end of `out`: the version byte then the u16-length-prefixed
+/// leader-hint address.
+///
+/// # Errors
+/// Returns [`BodyError::FieldTooLarge`] if `leader_hint` exceeds the `u16` wire field limit (an address
+/// is far shorter, so this is unreachable in practice).
+pub fn encode_not_leader(redirect: &NotLeaderBody<'_>, out: &mut Vec<u8>) -> Result<(), BodyError> {
+    out.push(NOT_LEADER_BODY_VERSION);
+    push_var(out, redirect.leader_hint.as_bytes())
+}
+
+/// Decodes a `NotLeader` body: the version byte then the u16-length-prefixed leader-hint address. The
+/// `body_version` is NOT rejected if unknown (a future version is forward-compatible: the v1 address
+/// field is still read, and any appended bytes past it are tolerated and ignored), so a newer server's
+/// extended redirect still routes an older client. The address must be valid UTF-8 (an address always
+/// is); a non-UTF-8 hint is a [`BodyError::Truncated`]-class malformed body.
+///
+/// # Errors
+/// Returns a [`BodyError`] on a short body (no version byte / a length field exceeding the body) or a
+/// non-UTF-8 leader-hint.
+pub fn decode_not_leader(body: &[u8]) -> Result<NotLeaderBody<'_>, BodyError> {
+    let mut r = Reader::new(body);
+    // Read and discard the version byte: v1 is the only layout, but an unknown future version still
+    // carries the v1 address field first, so we stay forward-compatible by reading the field regardless.
+    let _body_version = r.u8()?;
+    let hint_bytes = r.var()?;
+    // Trailing bytes past the v1 address are a FUTURE version's appended fields: tolerated and ignored
+    // (no `at_end` check), so a newer server's extended redirect still decodes here.
+    let leader_hint = core::str::from_utf8(hint_bytes).map_err(|_| BodyError::Truncated)?;
+    Ok(NotLeaderBody { leader_hint })
+}
+
 /// The version of the `Connect`/`Info` handshake body framing (#292, refs #275, #65, #11). The
 /// handshake bodies were EMPTY before this; version `1` is the first non-empty layout. It is the
 /// handshake-BODY version, distinct from the (still un-wired) `wire_protocol_version` integer #71/#11
@@ -4778,5 +4837,41 @@ mod tests {
         huge.extend_from_slice(&u16::try_from(2usize).unwrap().to_le_bytes());
         huge.extend_from_slice(&claimed.to_le_bytes());
         assert_eq!(decode_pub_subject(&huge), Err(BodyError::BadLength));
+    }
+
+    #[test]
+    fn not_leader_round_trips_the_leader_hint() {
+        for hint in ["127.0.0.1:9000", "[::1]:7000", ""] {
+            let mut buf = Vec::new();
+            encode_not_leader(&NotLeaderBody { leader_hint: hint }, &mut buf).unwrap();
+            assert_eq!(buf[0], NOT_LEADER_BODY_VERSION, "version byte leads the body");
+            let decoded = decode_not_leader(&buf).unwrap();
+            assert_eq!(decoded.leader_hint, hint);
+        }
+    }
+
+    #[test]
+    fn not_leader_tolerates_a_future_version_and_trailing_fields() {
+        // A future version byte still carries the v1 address field first, and appended bytes past it are
+        // tolerated (forward-compatible): an older client still routes a newer server's extended redirect.
+        let mut buf = Vec::new();
+        buf.push(NOT_LEADER_BODY_VERSION + 7);
+        push_var(&mut buf, b"10.0.0.5:9000").unwrap();
+        buf.extend_from_slice(b"FUTURE-APPENDED-FIELD"); // a v2 field an old reader ignores
+        let decoded = decode_not_leader(&buf).unwrap();
+        assert_eq!(decoded.leader_hint, "10.0.0.5:9000");
+    }
+
+    #[test]
+    fn not_leader_fails_closed_on_malformed_input() {
+        // Empty body -> Truncated (no version byte). A declared length past the body -> Truncated, never
+        // an over-read. A non-UTF-8 hint -> Truncated (an address is always UTF-8).
+        assert_eq!(decode_not_leader(&[]), Err(BodyError::Truncated));
+        let mut short = vec![NOT_LEADER_BODY_VERSION];
+        short.extend_from_slice(&5u16.to_le_bytes()); // claims 5 bytes, none follow
+        assert_eq!(decode_not_leader(&short), Err(BodyError::Truncated));
+        let mut bad_utf8 = vec![NOT_LEADER_BODY_VERSION];
+        push_var(&mut bad_utf8, &[0xff, 0xfe]).unwrap();
+        assert_eq!(decode_not_leader(&bad_utf8), Err(BodyError::Truncated));
     }
 }

--- a/crates/ironbus-server/src/actor.rs
+++ b/crates/ironbus-server/src/actor.rs
@@ -41,8 +41,9 @@ use ironbus_storage::log::Append;
 use std::sync::mpsc::{sync_channel, Receiver, SyncSender};
 use std::sync::{Arc, Mutex, OnceLock};
 
-use crate::cluster::client_ack::ClientAckGate;
-use crate::cluster::dataplane::AckDisposition;
+use crate::cluster::client_ack::{ClientAckGate, ClusterProduceRouting};
+use crate::cluster::dataplane::{AckDisposition, FollowerReadOutcome};
+use crate::cluster::read_consistency::ReadTier;
 use ironbus_core::keyshared::MemberId;
 
 /// The default bound on the actor command channel: the most produce/engine commands that may be
@@ -740,9 +741,48 @@ pub trait EngineAccess<F: Filesystem, C: Clock> {
     /// overrides it to clear the gate's outbox entry when the cluster slot is filled. Called from the
     /// connection-cleanup path, like #497's `drop_l2_confirms`.
     fn drop_client_acks(&self, _member: MemberId) {}
+
+    /// The cluster PRODUCE-ROUTING decision (#735, the `NOT_LEADER` redirect): called by the produce path
+    /// BEFORE any local append/ack. The DEFAULT impl returns [`ClusterProduceRouting::Local`] (a
+    /// SINGLE-NODE / no-cluster broker — proceed exactly as today, with ZERO work: no lock, no allocation,
+    /// the byte-identical hot path). [`EngineHandle`] overrides it to consult the shared
+    /// [`ClientAckGate`](crate::cluster::client_ack::ClientAckGate) ONLY when the cluster slot is filled (a
+    /// clustered serve past bootstrap); even then it returns `Local` unless this node provably holds a
+    /// clustered replica role for the partition it does NOT lead, in which case it returns
+    /// [`ClusterProduceRouting::Redirect`] with the current leader's CLIENT-address hint. NEVER a false
+    /// `NOT_LEADER` on the leader or on a non-clustered partition.
+    fn cluster_produce_routing(&self, _partition: u64) -> ClusterProduceRouting {
+        ClusterProduceRouting::Local
+    }
+
+    /// Serve a CLUSTER FOLLOWER-READ consume (#735, half B) from this node's follower read plane via the
+    /// #723 read-consistency tiers, fail-closed by the SAFE committed watermark. The DEFAULT impl returns
+    /// `None` (SINGLE-NODE / no-cluster: there is no follower role — serve the consume the normal way,
+    /// with ZERO work). [`EngineHandle`] overrides it to consult the gate ONLY when the cluster slot is
+    /// filled; it returns `None` unless this node FOLLOWS the partition (the leader / no-role case uses the
+    /// normal path), else `Some(outcome)` — the served zero-copy bytes or a confirm-with-leader signal.
+    /// The committed-HW safe-watermark bar is sourced internally by the gate from the metadata status, so
+    /// the caller need not know it.
+    fn cluster_follower_consume(
+        &self,
+        _partition: u64,
+        _tier: ReadTier,
+        _from: Offset,
+        _max_records: usize,
+        _max_bytes: Option<usize>,
+    ) -> Option<FollowerReadOutcome> {
+        None
+    }
 }
 
-impl<F: Filesystem + 'static, C: Clock + Clone + 'static> EngineAccess<F, C>
+// `F: Clone` is required by the follower-read consume override (#735, half B): the gate's
+// `serve_follower_consume` builds a read plane over the follower's owned replica log (the #621
+// `serve_follower_read` lives in the `F: Filesystem + Clone` impl). Every PRODUCTION path that uses an
+// `EngineHandle` as an `EngineAccess` already carries `F: Clone` (the serve loop in `server.rs` requires
+// it for `session.process`), and the shipped filesystems (`InMemoryFs`/`StdFs`) are all `Clone`, so this
+// adds no real constraint; the CLI/bench helpers that hold a non-`Clone` `EngineHandle` use only its
+// inherent methods, not this trait impl.
+impl<F: Filesystem + Clone + 'static, C: Clock + Clone + 'static> EngineAccess<F, C>
     for EngineHandle<F, C>
 {
     fn produce(&self, append: OwnedAppend) -> Result<ProduceOutcome, ActorGone> {
@@ -814,6 +854,37 @@ impl<F: Filesystem + 'static, C: Clock + Clone + 'static> EngineAccess<F, C>
 
     fn drop_client_acks(&self, member: MemberId) {
         EngineHandle::drop_client_acks(self, member);
+    }
+
+    fn cluster_produce_routing(&self, partition: u64) -> ClusterProduceRouting {
+        // SINGLE-NODE / no-cluster / pre-bootstrap: `client_ack_gate` is `None`, so this returns `Local`
+        // with ZERO work (no lock, no alloc) and the produce path proceeds exactly as today — the
+        // byte-identical hot path. Only a clustered serve past bootstrap reaches the gate, which itself
+        // returns `Local` for a led / no-role partition and `Redirect` only for a non-led replica role.
+        match self.client_ack_gate() {
+            Some(gate) => gate.produce_routing(partition),
+            None => ClusterProduceRouting::Local,
+        }
+    }
+
+    fn cluster_follower_consume(
+        &self,
+        partition: u64,
+        tier: ReadTier,
+        from: Offset,
+        max_records: usize,
+        max_bytes: Option<usize>,
+    ) -> Option<FollowerReadOutcome> {
+        // SINGLE-NODE / no-cluster / pre-bootstrap: no gate, so this returns `None` with ZERO work and the
+        // consume serves through the normal (local-engine) path — byte-identical. Only a clustered serve
+        // past bootstrap reaches the gate, which returns `None` unless this node FOLLOWS the partition.
+        self.client_ack_gate()?.serve_follower_consume(
+            partition,
+            tier,
+            from,
+            max_records,
+            max_bytes,
+        )
     }
 }
 

--- a/crates/ironbus-server/src/cluster/client_ack.rs
+++ b/crates/ironbus-server/src/cluster/client_ack.rs
@@ -625,9 +625,6 @@ mod tests {
 
     // ---- #735 half A: the NOT_LEADER produce-routing decision ------------------------------------
 
-    use std::collections::BTreeMap;
-    use std::net::SocketAddr;
-
     /// A follower [`ClientAckGate`] for node 1 FOLLOWING partition 0 (leader is node `leader_id`), built
     /// over a fresh empty replica log. The follower target names `leader_id` so `produce_routing` finds
     /// the leader to redirect to. The optional `(leader_id, addr)` advertise entries fill the leader hint.
@@ -688,12 +685,58 @@ mod tests {
     }
 
     #[test]
+    fn produce_routing_after_a_failover_redirects_to_the_new_leader() {
+        // FAILOVER RECOVERY (#735, composes with #720/#722): node 1 starts as the LEADER of partition 0
+        // (a produce proceeds locally). Then leadership MOVES to node 2 (a committed placement change):
+        // node 1 becomes a FOLLOWER of node 2. A produce on the OLD leader now redirects to the NEW
+        // leader's advertised client address — the client recovers automatically.
+        let new_leader_addr: SocketAddr = "127.0.0.1:9002".parse().unwrap();
+        // Build a node-1 LEADER gate that ALSO advertises node 2's client address (for after the failover).
+        let mut controller = DataPlaneController::new(1);
+        controller.start_leader(
+            P,
+            leader_plane(),
+            ironbus_core::epoch_cache::EpochCache::new(),
+            &[1, 2, 3],
+            quorum3(),
+        );
+        let seam = ProduceAckSeam::new(controller);
+        let server = Arc::new(Mutex::new(DataPlaneServer::new(1, seam)));
+        let gate = ClientAckGate::new(Arc::clone(&server), ClusterAckLevel::C2Fsync)
+            .with_leader_client_addrs([(2, new_leader_addr)].into_iter().collect());
+        // BEFORE the failover: node 1 leads, so a produce proceeds locally (no false NOT_LEADER).
+        assert_eq!(gate.produce_routing(P), ClusterProduceRouting::Local);
+
+        // FAILOVER: leadership moves to node 2. Apply it to the SAME shared server the gate reads: node 1
+        // stops leading and becomes a follower of node 2 (exactly the role transition a committed
+        // re-placement drives).
+        {
+            let mut srv = server.lock().unwrap();
+            assert!(srv.seam_mut().controller_mut().stop_partition(P));
+            srv.seam_mut().controller_mut().start_follower(
+                P,
+                Log::open(InMemoryFs::new(), ManualClock::new(), LogConfig::default()).unwrap(),
+            );
+            srv.set_follower_target(P, 2);
+        }
+
+        // AFTER the failover: a produce on the OLD leader redirects to the NEW leader (node 2).
+        assert_eq!(
+            gate.produce_routing(P),
+            ClusterProduceRouting::Redirect {
+                leader_hint: Some(new_leader_addr),
+            },
+            "after leadership moves, the old leader redirects to the new leader"
+        );
+    }
+
+    #[test]
     fn produce_routing_with_no_role_for_the_partition_is_local() {
         // Node 1 leads partition 0 but the produce names a DIFFERENT partition it holds no role for (the
         // bootstrap window / a non-clustered partition): proceed LOCALLY — never a false NOT_LEADER on a
         // partition this node is not a clustered replica of.
-        let gate = leader_gate(1);
         const OTHER_PARTITION: u64 = 7;
+        let gate = leader_gate(1);
         assert_eq!(
             gate.produce_routing(OTHER_PARTITION),
             ClusterProduceRouting::Local,

--- a/crates/ironbus-server/src/cluster/client_ack.rs
+++ b/crates/ironbus-server/src/cluster/client_ack.rs
@@ -622,4 +622,265 @@ mod tests {
             "a disconnect drops the undrained released acks (no outbox leak)"
         );
     }
+
+    // ---- #735 half A: the NOT_LEADER produce-routing decision ------------------------------------
+
+    use std::collections::BTreeMap;
+    use std::net::SocketAddr;
+
+    /// A follower [`ClientAckGate`] for node 1 FOLLOWING partition 0 (leader is node `leader_id`), built
+    /// over a fresh empty replica log. The follower target names `leader_id` so `produce_routing` finds
+    /// the leader to redirect to. The optional `(leader_id, addr)` advertise entries fill the leader hint.
+    fn follower_gate_with_addrs(
+        leader_id: u64,
+        addrs: &[(u64, SocketAddr)],
+    ) -> ClientAckGate<InMemoryFs, ManualClock> {
+        let mut controller = DataPlaneController::new(1);
+        let replica_log =
+            Log::open(InMemoryFs::new(), ManualClock::new(), LogConfig::default()).unwrap();
+        controller.start_follower(P, replica_log);
+        let seam = ProduceAckSeam::new(controller);
+        let mut server = DataPlaneServer::new(1, seam);
+        // Name the leader to redirect to (the follower fetch target the produce-routing reads).
+        server.set_follower_target(P, leader_id);
+        let map: BTreeMap<u64, SocketAddr> = addrs.iter().copied().collect();
+        ClientAckGate::new(Arc::new(Mutex::new(server)), ClusterAckLevel::C2Fsync)
+            .with_leader_client_addrs(map)
+    }
+
+    #[test]
+    fn produce_routing_redirects_a_non_led_partition_with_the_leader_hint() {
+        // Node 1 FOLLOWS partition 0 (leader node 2). A produce here must REDIRECT to node 2's advertised
+        // client address — the NOT_LEADER hint — never appended/acked locally.
+        let leader_addr: SocketAddr = "127.0.0.1:9002".parse().unwrap();
+        let gate = follower_gate_with_addrs(2, &[(2, leader_addr)]);
+        assert_eq!(
+            gate.produce_routing(P),
+            ClusterProduceRouting::Redirect {
+                leader_hint: Some(leader_addr),
+            },
+            "a non-led produce redirects to the current leader's advertised client address"
+        );
+    }
+
+    #[test]
+    fn produce_routing_redirects_with_no_hint_when_the_leader_addr_is_unknown() {
+        // Same follower role, but NO advertised address for the leader: still REDIRECT (the mechanism is
+        // load-bearing), just with no hint — the client re-tries its known peers.
+        let gate = follower_gate_with_addrs(2, &[]);
+        assert_eq!(
+            gate.produce_routing(P),
+            ClusterProduceRouting::Redirect { leader_hint: None },
+            "the redirect fires even with no advertised leader address (no hint)"
+        );
+    }
+
+    #[test]
+    fn produce_routing_on_the_leader_is_local_never_a_false_not_leader() {
+        // Node 1 LEADS partition 0: the produce proceeds LOCALLY (the #720 quorum gate applies) — NEVER a
+        // false NOT_LEADER on the leader.
+        let gate = leader_gate(1);
+        assert_eq!(
+            gate.produce_routing(P),
+            ClusterProduceRouting::Local,
+            "the leader proceeds locally, never a false NOT_LEADER"
+        );
+    }
+
+    #[test]
+    fn produce_routing_with_no_role_for_the_partition_is_local() {
+        // Node 1 leads partition 0 but the produce names a DIFFERENT partition it holds no role for (the
+        // bootstrap window / a non-clustered partition): proceed LOCALLY — never a false NOT_LEADER on a
+        // partition this node is not a clustered replica of.
+        let gate = leader_gate(1);
+        const OTHER_PARTITION: u64 = 7;
+        assert_eq!(
+            gate.produce_routing(OTHER_PARTITION),
+            ClusterProduceRouting::Local,
+            "a partition this node holds no role for proceeds locally (no false NOT_LEADER)"
+        );
+    }
+
+    // ---- #735 half B: the follower-read consume routing ------------------------------------------
+
+    /// A small segment cap so a handful of records rolls to multiple segments (the follower's read plane
+    /// serves the SEALED prefix).
+    fn small_config() -> LogConfig {
+        LogConfig {
+            max_segment_bytes: 256,
+            max_total_bytes: 0,
+            ..LogConfig::default()
+        }
+    }
+
+    fn rec(payload: &[u8]) -> ironbus_storage::log::Append<'_> {
+        ironbus_storage::log::Append {
+            timestamp_ms: 7,
+            flags: ironbus_core::types::RecordFlags::EMPTY,
+            key: b"",
+            headers: b"",
+            payload,
+        }
+    }
+
+    /// Build a FOLLOWER gate (node 2 following partition 0, leader node 1) whose replica log has been
+    /// caught up to a leader holding `n` records, plus a status snapshot whose committed-HW covers the
+    /// whole replicated prefix. Returns the gate and the served-end the leader's read plane reaches (the
+    /// committed bar). The follower then serves committed records LOCALLY off its own read plane.
+    fn caught_up_follower_gate(n: u32) -> (ClientAckGate<InMemoryFs, ManualClock>, u64) {
+        // Seed the leader log + read plane. Leaked as `&'static mut` so the read plane's `Arc` lifetime is
+        // `'static` for the test (the same leaked-log pattern the serve.rs cluster tests use) while the
+        // appends/sync below still have the `&mut` they need.
+        let leader_log: &'static mut Log<InMemoryFs, ManualClock> = Box::leak(Box::new(
+            Log::open(InMemoryFs::new(), ManualClock::new(), small_config()).unwrap(),
+        ));
+        for i in 0..n {
+            leader_log
+                .append(&rec(format!("c6-{i:02}").as_bytes()))
+                .unwrap();
+        }
+        leader_log.sync().unwrap();
+        let plane = Arc::new(leader_log.read_plane().unwrap());
+        // The sealed-served end (the prefix the follower converges to).
+        let mut served_end = 0u64;
+        loop {
+            let raw = plane
+                .read_range_raw(Offset::new(served_end), 1_000, None)
+                .unwrap();
+            let next = raw.run.next_offset.get();
+            if next <= served_end {
+                break;
+            }
+            served_end = next;
+        }
+        // The leader controller (to serve fetches from) and the follower controller (to catch up).
+        let mut leader: DataPlaneController<InMemoryFs, ManualClock> = DataPlaneController::new(1);
+        leader.start_leader(
+            P,
+            Arc::clone(&plane),
+            ironbus_core::epoch_cache::EpochCache::new(),
+            &[1, 2],
+            quorum3(),
+        );
+        let mut follower = DataPlaneController::new(2);
+        follower.start_follower(
+            P,
+            Log::open(InMemoryFs::new(), ManualClock::new(), small_config()).unwrap(),
+        );
+        for _ in 0..(served_end + 8) {
+            if follower.follower_high_watermark(P).unwrap() >= served_end {
+                break;
+            }
+            let req = follower.make_fetch_request(P, 8, 4096).unwrap();
+            let resp = leader.serve_fetch(P, &req).unwrap();
+            follower.apply_fetch_response(P, &resp).unwrap();
+        }
+        // Wrap the follower controller in a gate with a status snapshot whose committed-HW covers the
+        // served prefix (a checkpoint has caught up), so the safe watermark admits the whole prefix.
+        let seam = ProduceAckSeam::new(follower);
+        let server = DataPlaneServer::new(2, seam);
+        let mut status = super::super::runtime::ClusterStatus::default();
+        status.last_committed_hw.insert(P, served_end);
+        let gate = ClientAckGate::new(Arc::new(Mutex::new(server)), ClusterAckLevel::C2Fsync)
+            .with_status_handle(Arc::new(Mutex::new(status)));
+        (gate, served_end)
+    }
+
+    /// Decode a follower-read run into (offset, payload), re-validating each frame's CRC.
+    fn decode_run(run: &ironbus_storage::segment::RawByteRun) -> Vec<(u64, Vec<u8>)> {
+        let mut out = Vec::new();
+        let mut cursor = 0usize;
+        let mut offset = run.first_offset.get();
+        while cursor < run.bytes.len() {
+            let (view, consumed) = ironbus_core::codec::decode(&run.bytes[cursor..]).unwrap();
+            out.push((offset, view.payload.to_vec()));
+            offset += 1;
+            cursor += consumed;
+        }
+        out
+    }
+
+    #[test]
+    fn serve_follower_consume_serves_committed_records_from_a_follower() {
+        let (gate, served_end) = caught_up_follower_gate(30);
+        assert!(served_end > 0, "the follower replicated a committed prefix");
+        // The follower serves the committed prefix LOCALLY off its own read plane.
+        let mut from = Offset::ZERO;
+        let mut total = 0u64;
+        let mut guard = 0u32;
+        loop {
+            guard += 1;
+            assert!(guard < 10_000, "follower-read chain failed to terminate");
+            let outcome = gate
+                .serve_follower_consume(P, ReadTier::FollowerCommitted, from, usize::MAX, None)
+                .expect("a follower returns Some(outcome)");
+            let run = match outcome {
+                FollowerReadOutcome::Served(r) => r.run,
+                FollowerReadOutcome::ConfirmWithLeader { .. } => panic!("expected a local serve"),
+            };
+            let recs = decode_run(&run);
+            for (off, _payload) in &recs {
+                assert!(
+                    *off < served_end,
+                    "served offset {off} past the committed bar {served_end}"
+                );
+            }
+            if recs.is_empty() {
+                break;
+            }
+            total += recs.len() as u64;
+            let next = run.next_offset.get();
+            if next <= from.get() {
+                break;
+            }
+            from = Offset::new(next);
+        }
+        assert!(
+            total > 0,
+            "the follower served committed records locally (not vacuously empty)"
+        );
+        assert!(
+            total <= served_end,
+            "the follower never serves past the committed bar"
+        );
+    }
+
+    #[test]
+    fn serve_follower_consume_fails_closed_with_no_committed_hw() {
+        // SAME caught-up follower, but NO status handle -> the committed-HW bar is unknown -> the safe
+        // watermark is 0 -> the follower serves NOTHING (fail-closed), never a stale/uncommitted read.
+        let (gate, _served_end) = caught_up_follower_gate(30);
+        // Rebuild the gate WITHOUT a status handle by routing through a fresh gate over the same server.
+        let server = Arc::clone(gate.server());
+        let no_hw_gate = ClientAckGate::new(server, ClusterAckLevel::C2Fsync);
+        let outcome = no_hw_gate
+            .serve_follower_consume(
+                P,
+                ReadTier::FollowerCommitted,
+                Offset::ZERO,
+                usize::MAX,
+                None,
+            )
+            .expect("a follower returns Some(outcome)");
+        match outcome {
+            FollowerReadOutcome::Served(r) => assert_eq!(
+                r.run.record_count, 0,
+                "with no known committed HW the follower serves NOTHING (fail-closed)"
+            ),
+            FollowerReadOutcome::ConfirmWithLeader { .. } => {
+                panic!("a clean read with no HW serves nothing, not a confirm")
+            }
+        }
+    }
+
+    #[test]
+    fn serve_follower_consume_on_the_leader_is_none() {
+        // A LEADER returns `None` (the caller serves the normal leader path), never the follower-read.
+        let gate = leader_gate(1);
+        assert!(
+            gate.serve_follower_consume(P, ReadTier::FollowerCommitted, Offset::ZERO, 8, None)
+                .is_none(),
+            "the leader uses the normal consume path, not the follower-read"
+        );
+    }
 }

--- a/crates/ironbus-server/src/cluster/client_ack.rs
+++ b/crates/ironbus-server/src/cluster/client_ack.rs
@@ -40,16 +40,19 @@
 //! cluster-gated branch is skipped, and the immediate ack-after-local-fsync path is byte-for-byte
 //! today's, with ZERO added work, latency, or allocation. The gate is a no-op without a cluster.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
+use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 
 use ironbus_core::clock::Clock;
 use ironbus_core::keyshared::MemberId;
+use ironbus_core::types::Offset;
 use ironbus_storage::fs::Filesystem;
 
 use super::ack_level::ClusterAckLevel;
-use super::dataplane::AckDisposition;
+use super::dataplane::{AckDisposition, FollowerReadOutcome};
 use super::isr::AckReplicatedBody;
+use super::read_consistency::ReadTier;
 use super::serve::DataPlaneServer;
 
 /// The fixed partition the broker's DEFAULT-stream log maps to in a clustered serve (#717/#719).
@@ -57,6 +60,33 @@ use super::serve::DataPlaneServer;
 /// client produce-ack gate routes every produce to it. Multi-partition routing (a produce to the right
 /// partition leader's seam) is the #693 multi-partition engine — FLAGGED, out of scope here.
 pub const DEFAULT_PARTITION: u64 = 0;
+
+/// How a clustered produce to `partition` should be ROUTED at the wire level (#735, the `NOT_LEADER`
+/// redirect, half A). The output of [`ClientAckGate::produce_routing`]: the produce path consults it
+/// BEFORE any local append/ack and either proceeds locally (as today) or short-circuits with a typed
+/// `NOT_LEADER` redirect carrying the current leader's CLIENT address.
+///
+/// A NON-cluster broker never builds a [`ClientAckGate`], so the produce path never calls this and the
+/// single-node hot path is byte-for-byte unchanged.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ClusterProduceRouting {
+    /// PROCEED with the local produce exactly as today: this node either LEADS the partition (the #720
+    /// quorum gate then applies), or holds no clustered role for it (the brief bootstrap window, or a
+    /// partition that is not clustered) — in which case the local engine is authoritative and a redirect
+    /// would be a FALSE `NOT_LEADER`. The fail-safe default: never redirect unless this node provably holds
+    /// a clustered replica role it does not lead.
+    Local,
+    /// REDIRECT: this node holds a clustered REPLICA role for the partition but is NOT its current leader,
+    /// so the produce must go to the leader. The produce path writes a `NOT_LEADER` frame carrying
+    /// `leader_hint` (the current committed leader's CLIENT address, or `None` when this node does not yet
+    /// know it — mid-failover, or no advertised client address) and does NOT append/ack locally. The
+    /// client reconnects/retries to the leader (or, with no hint, re-tries its known peers).
+    Redirect {
+        /// The current leader's CLIENT-facing address, or `None` when unknown (the client falls back to
+        /// re-discovering the leader from its own configured peer set).
+        leader_hint: Option<SocketAddr>,
+    },
+}
 
 /// The shared client produce-ack gate (#719): the seam (via the shared
 /// [`DataPlaneServer`](super::serve::DataPlaneServer)) plus the per-connection released-ack outbox.
@@ -79,6 +109,20 @@ pub struct ClientAckGate<F: Filesystem, C: Clock> {
     /// in release (offset) order. The runtime deposits here on quorum-fsync; the owning connection
     /// drains here on its own pass. Empty for any connection with nothing released-pending.
     outbox: Mutex<HashMap<u64, Vec<Vec<u8>>>>,
+    /// The node-id -> CLIENT-facing address advertise map (#735), the source of the `NOT_LEADER` leader
+    /// HINT. When this node holds a non-leader replica role for a partition, the produce path looks up the
+    /// current leader's node id (via the shared server's follower target) and maps it here to the address
+    /// the client should reconnect to. EMPTY when no client addresses are advertised (the redirect still
+    /// fires, but with no hint — the client re-tries its own known peers). Immutable after construction
+    /// (the committed placement is static this phase; #693 dynamic re-placement is the flagged follow-up).
+    leader_client_addrs: BTreeMap<u64, SocketAddr>,
+    /// The shared metadata-plane status snapshot (#722/#735, half B): the source of the per-partition
+    /// committed-HW bar (`last_committed_hw`) the follower-read safe watermark `min(own_flushed,
+    /// known_committed_hw)` clamps to. `None` when no status handle was installed (the in-process tests
+    /// that drive the follower-read directly pass the HW explicitly): the follower-read then fails CLOSED
+    /// to a `0` committed bar (serve nothing) rather than risk a stale read. Read under a brief lock, never
+    /// across a socket write.
+    status: Option<Arc<Mutex<super::runtime::ClusterStatus>>>,
 }
 
 impl<F: Filesystem, C: Clock> ClientAckGate<F, C> {
@@ -93,7 +137,43 @@ impl<F: Filesystem, C: Clock> ClientAckGate<F, C> {
             server,
             configured_level,
             outbox: Mutex::new(HashMap::new()),
+            leader_client_addrs: BTreeMap::new(),
+            status: None,
         }
+    }
+
+    /// Install the node-id -> CLIENT-address advertise map (#735) used to fill the `NOT_LEADER` leader
+    /// HINT, returning the gate. Each entry maps a cluster node id to the address a CLIENT should dial to
+    /// reach that node's broker (its `--addr` listener). The redirect mechanism works with an EMPTY map
+    /// (the client re-tries its known peers); a populated map lets the redirect carry a concrete hint so
+    /// the client reconnects straight to the leader. Builder-style so the runtime can supply it at
+    /// construction (a non-cluster broker never builds the gate, so this never runs off-cluster).
+    #[must_use]
+    pub fn with_leader_client_addrs(mut self, addrs: BTreeMap<u64, SocketAddr>) -> Self {
+        self.leader_client_addrs = addrs;
+        self
+    }
+
+    /// Install the shared metadata-plane status snapshot (#735, half B), returning the gate. The
+    /// follower-read consume reads the per-partition committed-HW bar (`last_committed_hw`) from it for the
+    /// SAFE watermark `min(own_flushed, known_committed_hw)`. Without it the follower-read fails CLOSED
+    /// (a `0` committed bar — serve nothing — until a checkpoint is known), so installing it is what makes
+    /// a follower actually serve committed records. Builder-style; a non-cluster broker never builds the
+    /// gate, so this never runs off-cluster.
+    #[must_use]
+    pub fn with_status_handle(mut self, status: Arc<Mutex<super::runtime::ClusterStatus>>) -> Self {
+        self.status = Some(status);
+        self
+    }
+
+    /// The per-partition committed-HW bar this node has applied from the replicated metadata (#722) — the
+    /// `known_committed_hw` the follower-read safe watermark clamps to. Reads the shared status snapshot
+    /// (a brief lock); `None` when no status handle is installed or no checkpoint has committed for the
+    /// partition yet (the follower-read then fails closed to a `0` safe bar — serve nothing).
+    fn known_committed_hw(&self, partition: u64) -> Option<u64> {
+        let status = self.status.as_ref()?;
+        let snapshot = status.lock().ok()?;
+        snapshot.last_committed_hw.get(&partition).copied()
     }
 
     /// The serve-wide configured cluster ack level this gate holds produces to (#696).
@@ -181,6 +261,50 @@ impl<F: Filesystem, C: Clock> ClientAckGate<F, C> {
         }
     }
 
+    /// The cluster PRODUCE-ROUTING decision for `partition` (#735, the `NOT_LEADER` redirect, half A):
+    /// called by the produce path BEFORE any local append or ack. Returns:
+    ///
+    /// * [`ClusterProduceRouting::Local`] — PROCEED locally (byte-for-byte today's path) when this node
+    ///   LEADS the partition (the #720 quorum gate then applies on the local produce), OR holds NO
+    ///   clustered role for it (the brief bootstrap window before the placement commits here, or a
+    ///   non-clustered partition). The fail-safe default — NEVER a false `NOT_LEADER` on the leader, and
+    ///   never a redirect on a partition this node is authoritative for.
+    /// * [`ClusterProduceRouting::Redirect`] — this node holds a clustered REPLICA (follower) role for the
+    ///   partition but is NOT the leader, so the produce must be redirected to the current leader. The
+    ///   hint is the leader's CLIENT address from [`Self::with_leader_client_addrs`] (mapped from the
+    ///   follower's committed leader-target node id), or `None` when unknown.
+    ///
+    /// Locks the shared server briefly (the SAME `Arc<Mutex<DataPlaneServer>>` the runtime drives), never
+    /// across a socket write. A poisoned lock fails SAFE to [`ClusterProduceRouting::Local`] (proceed
+    /// locally rather than wrongly redirect a produce on a teardown edge — the local engine's own append
+    /// stays authoritative and no false `NOT_LEADER` is emitted).
+    #[must_use]
+    pub fn produce_routing(&self, partition: u64) -> ClusterProduceRouting {
+        let Ok(srv) = self.server.lock() else {
+            // Teardown edge (poisoned lock): proceed locally. The local engine append is authoritative;
+            // we never emit a false `NOT_LEADER` here.
+            return ClusterProduceRouting::Local;
+        };
+        // LEADER of this partition: proceed locally exactly as today (the #720 quorum gate applies on the
+        // produce). This is checked FIRST so a leader NEVER gets a false `NOT_LEADER`.
+        if srv.seam().controller().is_leader(partition) {
+            return ClusterProduceRouting::Local;
+        }
+        // NOT the leader. Only REDIRECT when this node provably holds a clustered FOLLOWER role for the
+        // partition (it is a replica that does not lead). If it holds no role at all — the bootstrap
+        // window, or a partition that is not clustered here — proceed LOCALLY (the local engine is
+        // authoritative; a redirect would be a false `NOT_LEADER`). `follower_leader` is `Some` exactly when
+        // this node follows the partition, and it names the current committed leader to redirect to.
+        match srv.follower_leader(partition) {
+            Some(leader_id) => {
+                let leader_hint = self.leader_client_addrs.get(&leader_id).copied();
+                ClusterProduceRouting::Redirect { leader_hint }
+            }
+            // No clustered role for this partition (bootstrap / non-clustered): proceed locally.
+            None => ClusterProduceRouting::Local,
+        }
+    }
+
     /// Feed a follower's [`AckReplicatedBody`] for `partition` into the gate (driven by the runtime's
     /// follower-report path) and DEPOSIT each released wire `PubAck` into its OWNER connection's outbox,
     /// in offset order, for that connection to flush on its own pass. Below `min_isr` releases NOTHING
@@ -235,6 +359,63 @@ impl<F: Filesystem, C: Clock> ClientAckGate<F, C> {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         outbox.remove(&member.get());
+    }
+}
+
+// The FOLLOWER-READ consume serve (#735, half B) needs `F: Clone`: the follower read plane is built over
+// the follower's owned replica log (the #621 `DataPlaneController::serve_follower_read` lives in the
+// `F: Filesystem + Clone` impl block). A SEPARATE impl block keeps the rest of the gate — and the
+// no-cluster path — on the looser `F: Filesystem` bound; nothing on the single-node path links this.
+impl<F: Filesystem + Clone, C: Clock> ClientAckGate<F, C> {
+    /// Serve a CLUSTER FOLLOWER-READ consume of `[from, from + max_records)` for `partition` at `tier`
+    /// (#735, half B), LOCALLY from this node's follower read plane via the #723 read-consistency tiers
+    /// ([`DataPlaneController::serve_follower_read`](super::dataplane::DataPlaneController::serve_follower_read)).
+    /// The committed-HW bar is read from the installed status snapshot ([`Self::with_status_handle`]); the
+    /// serve is fail-closed by the SAFE watermark `min(own_flushed, known_committed_hw)` (a `0` bar when no
+    /// checkpoint is known), so a follower NEVER serves a record past the committed bar.
+    ///
+    /// Returns `None` when this node holds NO follower role for the partition (it is the leader, or holds
+    /// no role): the caller then serves the consume through the normal (leader/local-engine) path. Returns
+    /// `Some(outcome)` when this node follows the partition: either the served zero-copy bytes
+    /// ([`FollowerReadOutcome::Served`]) or a [`FollowerReadOutcome::ConfirmWithLeader`] signal for a
+    /// latest/dirty read above the safe watermark.
+    ///
+    /// Locks the shared server briefly, never across a socket write. A poisoned lock fails SAFE to `None`
+    /// (the caller serves through the normal path rather than risk a stale follower read).
+    #[must_use]
+    pub fn serve_follower_consume(
+        &self,
+        partition: u64,
+        tier: ReadTier,
+        from: Offset,
+        max_records: usize,
+        max_bytes: Option<usize>,
+    ) -> Option<FollowerReadOutcome> {
+        // The committed-HW bar from the replicated metadata (#722): the SAFE watermark clamps to it.
+        // Read BEFORE the server lock (its own brief lock), and `None` when unknown -> the serve fails
+        // closed to a `0` safe bar (serve nothing) rather than risk a stale read.
+        let known_committed_hw = self.known_committed_hw(partition);
+        let Ok(srv) = self.server.lock() else {
+            return None;
+        };
+        // Only a FOLLOWER serves a follower read. A leader / no-role partition returns `None` so the
+        // caller uses the normal consume path (the single-writer / leader read plane), never this.
+        if !srv.seam().controller().is_follower(partition) {
+            return None;
+        }
+        // A serve fault (IO) or a role race maps to `None` (the caller serves the normal path) — never a
+        // panic on the serve path and never an unsafe stale serve.
+        srv.seam()
+            .controller()
+            .serve_follower_read(
+                partition,
+                tier,
+                known_committed_hw,
+                from,
+                max_records,
+                max_bytes,
+            )
+            .ok()
     }
 }
 

--- a/crates/ironbus-server/src/cluster/mod.rs
+++ b/crates/ironbus-server/src/cluster/mod.rs
@@ -286,7 +286,7 @@ pub mod state_machine;
 pub mod transport;
 
 pub use ack_level::{ClusterAckLevel, ClusterAckLevelMetrics};
-pub use client_ack::ClientAckGate;
+pub use client_ack::{ClientAckGate, ClusterProduceRouting};
 pub use dataplane::{
     decode_dataplane_frame, role_for_placement, AckDisposition, AckToken, DataPlaneAction,
     DataPlaneController, DataPlaneError, DataPlaneFrame, FollowerReadOutcome, PlacementRole,

--- a/crates/ironbus-server/src/cluster/serve.rs
+++ b/crates/ironbus-server/src/cluster/serve.rs
@@ -660,6 +660,22 @@ const DATAPLANE_POLL: Duration = Duration::from_millis(100);
 /// [`ClusterRuntime`](super::runtime::ClusterRuntime)). With no cluster config NOTHING here is
 /// constructed — no server, no listener, no thread, no data frame — and the broker's produce/consume
 /// hot path is byte-for-byte today's.
+/// The client-gate construction inputs threaded into [`DataPlaneRuntime::start_inner`] (#719/#735): the
+/// configured cluster ack level (#719) plus the #735 client cluster-awareness wiring — the node-id ->
+/// CLIENT-address advertise map (the `NOT_LEADER` leader hint) and the shared metadata status snapshot (the
+/// follower-read committed-HW safe-watermark source). `None` for a runtime started without a client gate
+/// (the in-process tests / the observability serve).
+struct ClientGateConfig {
+    /// The serve-wide configured cluster ack level the produce-ack gate holds produces to (#719/#696).
+    configured_level: super::ack_level::ClusterAckLevel,
+    /// The node-id -> CLIENT-address advertise map for the `NOT_LEADER` leader hint (#735); empty means the
+    /// redirect carries no hint (the client re-tries its known peers).
+    leader_client_addrs: BTreeMap<u64, SocketAddr>,
+    /// The shared metadata status snapshot the follower-read reads the committed-HW bar from (#735, half
+    /// B); `None` fails the follower-read closed (serve nothing) until a checkpoint is known.
+    status: Option<Arc<Mutex<super::runtime::ClusterStatus>>>,
+}
+
 pub struct DataPlaneRuntime<F: Filesystem, C: Clock> {
     /// The shared, `Send` data-plane server every peer thread drives under a short per-frame lock.
     server: Arc<Mutex<DataPlaneServer<F, C>>>,
@@ -755,19 +771,56 @@ where
             server,
             self_data_addr,
             peer_data_addrs,
-            Some(configured_level),
+            Some(ClientGateConfig {
+                configured_level,
+                leader_client_addrs: BTreeMap::new(),
+                status: None,
+            }),
         )
     }
 
-    /// The shared work of [`Self::start`] / [`Self::start_with_client_gate`]: when `client_level` is
-    /// `Some`, a [`ClientAckGate`](super::client_ack::ClientAckGate) is built around the wrapped server
-    /// Arc and the leader-side readers release through it (`AckRelease::Gate`); when `None`, the readers
-    /// drive the seam directly and drop the released bytes (`AckRelease::ServerOnly`).
+    /// Like [`Self::start_with_client_gate`], but ALSO supplies the #735 client cluster-awareness wiring:
+    /// the node-id -> CLIENT-address advertise map (the `NOT_LEADER` leader HINT) and the shared metadata
+    /// status snapshot (the follower-read committed-HW safe-watermark source). With an empty advertise map
+    /// the `NOT_LEADER` redirect still fires (the client re-tries its known peers); without a status handle a
+    /// follower-read fails closed (serves nothing) until a committed-HW checkpoint is known.
+    ///
+    /// # Errors
+    /// As [`Self::start`].
+    ///
+    /// # Panics
+    /// As [`Self::start`].
+    pub fn start_with_client_gate_aware(
+        server: DataPlaneServer<F, C>,
+        self_data_addr: SocketAddr,
+        peer_data_addrs: &BTreeMap<u64, SocketAddr>,
+        configured_level: super::ack_level::ClusterAckLevel,
+        leader_client_addrs: BTreeMap<u64, SocketAddr>,
+        status: Arc<Mutex<super::runtime::ClusterStatus>>,
+    ) -> io::Result<Self> {
+        Self::start_inner(
+            server,
+            self_data_addr,
+            peer_data_addrs,
+            Some(ClientGateConfig {
+                configured_level,
+                leader_client_addrs,
+                status: Some(status),
+            }),
+        )
+    }
+
+    /// The shared work of [`Self::start`] / [`Self::start_with_client_gate`] /
+    /// [`Self::start_with_client_gate_aware`]: when `client_cfg` is `Some`, a
+    /// [`ClientAckGate`](super::client_ack::ClientAckGate) is built around the wrapped server Arc (with the
+    /// #735 leader-hint advertise map + status handle) and the leader-side readers release through it
+    /// (`AckRelease::Gate`); when `None`, the readers drive the seam directly and drop the released bytes
+    /// (`AckRelease::ServerOnly`).
     fn start_inner(
         server: DataPlaneServer<F, C>,
         self_data_addr: SocketAddr,
         peer_data_addrs: &BTreeMap<u64, SocketAddr>,
-        client_level: Option<super::ack_level::ClusterAckLevel>,
+        client_cfg: Option<ClientGateConfig>,
     ) -> io::Result<Self> {
         // Bind the data-plane peer listener BEFORE spawning anything, so a bind failure is synchronous
         // (no half-started runtime). Non-blocking so the accept loop polls the shutdown flag.
@@ -777,14 +830,18 @@ where
         let follower_partitions = server.follower_partitions();
         let server = Arc::new(Mutex::new(server));
         let shutdown = Arc::new(AtomicBool::new(false));
-        // Build the client produce-ack gate around the SAME server Arc when a configured level was given
-        // (#719). The gate and every leader-side reader share this one Arc, so the seam's parked state is
-        // one source of truth.
-        let client_gate = client_level.map(|level| {
-            Arc::new(super::client_ack::ClientAckGate::new(
-                Arc::clone(&server),
-                level,
-            ))
+        // Build the client produce-ack gate around the SAME server Arc when a config was given (#719/#735).
+        // The gate and every leader-side reader share this one Arc, so the seam's parked state is one
+        // source of truth. The #735 wiring (the `NOT_LEADER` leader-hint advertise map + the follower-read
+        // committed-HW status handle) is layered on via the gate's builders.
+        let client_gate = client_cfg.map(|cfg| {
+            let mut gate =
+                super::client_ack::ClientAckGate::new(Arc::clone(&server), cfg.configured_level)
+                    .with_leader_client_addrs(cfg.leader_client_addrs);
+            if let Some(status) = cfg.status {
+                gate = gate.with_status_handle(status);
+            }
+            Arc::new(gate)
         });
         let release = match &client_gate {
             Some(g) => AckRelease::Gate(Arc::clone(g)),

--- a/crates/ironbus-server/src/session.rs
+++ b/crates/ironbus-server/src/session.rs
@@ -19,6 +19,8 @@
 use crate::actor::{
     ActorGone, EngineAccess, OwnedAppend, OwnedDedup, ProduceOutcome, ProduceSubmission,
 };
+use crate::cluster::dataplane::FollowerReadOutcome;
+use crate::cluster::read_consistency::ReadTier;
 use crate::engine::{
     AckResult, Engine, EngineError, NackResult, Poll, ProgressResult, StreamBatch, StreamRawBatch,
 };
@@ -39,11 +41,11 @@ use ironbus_proto::message::{
     decode_pub, decode_pub_subject, decode_pub_to, decode_stream_commit, decode_stream_declare,
     decode_stream_fetch, decode_stream_info, decode_sub, decode_sub_subject, decode_sub_to,
     encode_dead_letter, encode_deliver, encode_deliver_batch, encode_gap_marker, encode_info,
-    encode_produce_confirm, encode_pub_ack, encode_stream_info_response, encode_truncated,
-    gap_reason, parse_connect_auth, produce_confirm_status, pub_ack_level, AckLevel, AckOp,
-    ConsumeTier, CreditAdvert, DeadLetterBody, DeliverBatchHeader, DeliverBody, GapMarkerBody,
-    InfoBody, ProduceConfirmBody, PubAckBody, StreamInfoResponseBody, TruncatedBody,
-    DEAD_LETTER_MAX_DELIVER, PUB_WIRE_ONLY_FLAGS,
+    encode_not_leader, encode_produce_confirm, encode_pub_ack, encode_stream_info_response,
+    encode_truncated, gap_reason, parse_connect_auth, produce_confirm_status, pub_ack_level,
+    AckLevel, AckOp, ConsumeTier, CreditAdvert, DeadLetterBody, DeliverBatchHeader, DeliverBody,
+    GapMarkerBody, InfoBody, NotLeaderBody, ProduceConfirmBody, PubAckBody, StreamInfoResponseBody,
+    TruncatedBody, DEAD_LETTER_MAX_DELIVER, PUB_WIRE_ONLY_FLAGS,
 };
 use ironbus_storage::fs::Filesystem;
 use ironbus_storage::log::Append;
@@ -1033,6 +1035,30 @@ impl Session {
         // existing parked-ack path is unchanged.
         let level0 = matches!(ack_level, AckLevel::NoAck);
         let fire_and_forget = level0;
+        // CLUSTER `NOT_LEADER` PRODUCE REDIRECT (#735, half A): on a clustered serve, if this node holds a
+        // replica role for the partition but is NOT its current leader, the produce must go to the leader
+        // — redirect it BEFORE any local append/ack, so it is never acked by the wrong node (no
+        // double-append, no false ack; the client retries to the leader where the #720 quorum gate
+        // applies). SINGLE-NODE / no-cluster is BYTE-IDENTICAL: `cluster_produce_routing` returns
+        // `Local` via a cheap default (no gate, no lock, no alloc), so this whole branch is skipped and
+        // the produce path is byte-for-byte today's. NEVER a false `NOT_LEADER` on the leader (it returns
+        // `Local`) or on a non-clustered / pre-bootstrap partition (also `Local`). The default-stream log
+        // maps to the cluster default partition; multi-partition routing is the flagged #693 follow-up.
+        if let crate::cluster::client_ack::ClusterProduceRouting::Redirect { leader_hint } =
+            engine.cluster_produce_routing(crate::cluster::client_ack::DEFAULT_PARTITION)
+        {
+            // Preserve the wire reply order: flush the earlier pipelined produces' acks FIRST (exactly
+            // like every other pre-submit return in this function), THEN the redirect.
+            drain_parked(engine, member_id, parked, out)?;
+            // A LEVEL-0 (fire-and-forget) produce expects NO reply by contract: drop it silently (the
+            // record is simply not appended on this wrong node — the QoS-0 producer accepts loss and will
+            // re-fire to the leader on its own). An at-least-once produce gets the typed `NOT_LEADER` frame
+            // carrying the leader hint so the client transparently reconnects/retries to the leader.
+            if !fire_and_forget {
+                reply_not_leader(out, leader_hint);
+            }
+            return Ok(());
+        }
         // Enforce the dedup id length caps (#33) at the wire boundary, BEFORE the bytes cross into
         // owned storage. The `producer_id` keys the per-producer window map and the `msg_id` keys the
         // per-window ring; both are wire-supplied and attacker-chosen (up to the 64 KiB wire field
@@ -2100,6 +2126,32 @@ impl Session {
         let start = Offset::new(req.start_offset);
         let group = self.subscription.clone();
         let member = self.member_id;
+        // CLUSTER FOLLOWER-READ over the wire (#735, half B): if this node FOLLOWS the partition, serve the
+        // Tier-S streaming fetch from its OWN follower read plane via the #723 read-consistency tiers —
+        // fail-closed by the SAFE committed watermark `min(own_flushed, known_committed_hw)`, so a follower
+        // NEVER serves a record past the committed bar (CRAQ committed reads off a replica). This is the
+        // lease-FREE, cursor-FREE Tier-S contract, which is exactly the stateless follower-read shape (the
+        // follower serves via the read plane and never writes — single-writer preserved). SINGLE-NODE /
+        // no-cluster is BYTE-IDENTICAL: `cluster_follower_consume` returns `None` via a cheap default (no
+        // gate), so this branch is skipped and the normal (leader/local-engine) Tier-S path runs unchanged.
+        // A `Some` outcome means this node follows the partition: serve from the follower run (or, for a
+        // latest/dirty read above the safe bar, reply an empty batch — never a speculative unconfirmed
+        // serve; the dirty-tier leader confirm over the wire is the flagged follow-up).
+        if let Some(outcome) = engine.cluster_follower_consume(
+            crate::cluster::client_ack::DEFAULT_PARTITION,
+            ReadTier::FollowerCommitted,
+            start,
+            want,
+            max_bytes,
+        ) {
+            let delivered = Self::serve_follower_read_outcome(outcome, out);
+            // Terminate with the SAME FlowEnd a leader Tier-S batch uses, so the client frames a
+            // follower-read response exactly like any other streaming batch. No keep-up auto-tune on the
+            // follower path (the credit window is the leader engine's concern); a follower-read just serves
+            // its committed prefix.
+            reply(out, FrameType::FlowEnd, &delivered.to_le_bytes());
+            return Ok(());
+        }
         // A consumer that advertised the DeliverBatch capability (#541) takes the RAW-FRAMED batch path:
         // a contiguous run ships as ONE `DeliverBatch` (the on-disk frame bytes verbatim, sendfile-ready
         // for #658) instead of N per-record `Deliver` frames, with no broker re-encode of the sealed run.
@@ -2131,6 +2183,54 @@ impl Session {
         // client frames the streaming batch exactly like a Fetch batch.
         reply(out, FrameType::FlowEnd, &delivered.to_le_bytes());
         Ok(())
+    }
+
+    /// Emit a CLUSTER FOLLOWER-READ outcome (#735, half B) as per-record `Deliver` frames, returning the
+    /// number of records written. The follower serves the committed prefix from its OWN read plane as a
+    /// zero-copy [`RawSealedRead`] run; this decodes each CRC-framed record (re-validating the header AND
+    /// body CRC via [`ironbus_core::codec::decode`] — fail-closed, a torn/corrupt frame stops the run
+    /// rather than shipping a bad byte) into the SAME `Deliver` wire shape a leader Tier-S serve uses.
+    /// Generation `0` (lease-free, like every Tier-S delivery): a follower-read consumer commits by offset,
+    /// never by a fencing token. A [`FollowerReadOutcome::ConfirmWithLeader`] (a latest/dirty read above
+    /// the safe watermark) serves NOTHING here — never a speculative unconfirmed serve; the over-the-wire
+    /// dirty-tier leader confirm is the flagged follow-up.
+    fn serve_follower_read_outcome(outcome: FollowerReadOutcome, out: &mut Vec<u8>) -> u32 {
+        let run = match outcome {
+            FollowerReadOutcome::Served(read) => read.run,
+            // A latest/dirty read above the safe watermark: do NOT speculatively serve unconfirmed bytes.
+            // Serve nothing (an empty batch); the client re-reads / the wire dirty-tier confirm is the
+            // flagged follow-up.
+            FollowerReadOutcome::ConfirmWithLeader { .. } => return 0,
+        };
+        let mut delivered = 0u32;
+        let mut cursor = 0usize;
+        let mut offset = run.first_offset.get();
+        while cursor < run.bytes.len() {
+            // Re-validate and decode each stored frame (header + body CRC). A torn/corrupt frame is
+            // fail-closed: stop the run here rather than ship a bad record (never a blind-trusted byte).
+            let Ok((view, consumed)) = ironbus_core::codec::decode(&run.bytes[cursor..]) else {
+                break;
+            };
+            let msg = DeliverBody {
+                offset,
+                // Lease-free Tier-S follower-read: generation 0, commit-by-offset (no fencing token).
+                generation: 0,
+                flags: view.flags.bits(),
+                timestamp_ms: view.timestamp_ms,
+                key: view.key,
+                headers: view.headers,
+                payload: view.payload,
+            };
+            let mut frame_body = Vec::new();
+            if encode_deliver(&msg, &mut frame_body).is_err() {
+                break;
+            }
+            reply(out, FrameType::Deliver, &frame_body);
+            delivered += 1;
+            offset += 1;
+            cursor += consumed;
+        }
+        delivered
     }
 
     /// The per-record half of [`Session::handle_stream_fetch`] (the consumer did NOT advertise
@@ -3346,6 +3446,24 @@ fn reply_pub_ack(out: &mut Vec<u8>, frame_type: FrameType, offset: Offset) {
         &mut body,
     );
     reply(out, frame_type, &body);
+}
+
+/// Emits a cluster `NotLeader` produce-redirect reply (#735): the current leader's CLIENT-address hint
+/// (or the EMPTY string when this node does not yet know it), via the shared [`encode_not_leader`] codec
+/// so the wire body cannot drift from the proto definition. Written ONLY on a clustered serve when a
+/// produce lands on a non-leader replica of the partition (see [`ClusterProduceRouting::Redirect`]); a
+/// single-node broker never reaches this. The encode is infallible for an address (well under the u16
+/// field cap); on the unreachable over-cap error it falls back to an empty hint so the redirect still
+/// fires (the client re-tries its known peers) rather than panicking on the serve path (#11).
+fn reply_not_leader(out: &mut Vec<u8>, leader_hint: Option<std::net::SocketAddr>) {
+    let hint = leader_hint.map(|a| a.to_string()).unwrap_or_default();
+    let mut body = Vec::new();
+    if encode_not_leader(&NotLeaderBody { leader_hint: &hint }, &mut body).is_err() {
+        body.clear();
+        // Unreachable for a real address; emit an empty-hint redirect rather than panic.
+        let _ = encode_not_leader(&NotLeaderBody { leader_hint: "" }, &mut body);
+    }
+    reply(out, FrameType::NotLeader, &body);
 }
 
 /// Writes one Level-2 `ProduceConfirm` frame (#497) for a ready terminal: the durable offset plus the


### PR DESCRIPTION
## What

Client cluster-awareness over the wire (#735) — the last clustering piece: a real client connected to ANY cluster node is transparently routed.

**A. `NotLeader` produce redirect.** When a client `Pub`s to a node that is NOT the leader of the (clustered) default partition, the server returns a typed `NotLeader` frame carrying the CURRENT leader's CLIENT address (a leader hint), BEFORE any local append/ack. The client transparently reconnects/retries to the leader (`Client::produce_to_leader`). A client on the wrong node (e.g. after a failover moved leadership) recovers automatically.

**B. Follower-read consume over the wire.** A Tier-S `StreamFetch` (lease-free, cursor-free) on a FOLLOWER node is served from that node's own read plane via the #723 read-consistency tiers, fail-closed by the safe committed watermark `min(own_flushed, known_committed_hw)`. A real client can now CONSUME committed records from a follower over the wire (not just via the in-process controller as #723/#725 left it).

Both halves are cluster-gated behind the same `Option` slot that gives the #719 byte-identical single-node guarantee.

## Design

- **Wire:** new `FrameType::NotLeader` (tag 42) + `NotLeaderBody` codec (`crates/ironbus-proto/`): version byte + u16-length-prefixed leader-hint address (empty when unknown), forward-compatible.
- **Server seam:** `ClientAckGate` (the #719 per-connection cluster seam) gains `produce_routing(partition) -> ClusterProduceRouting` (Local / Redirect{leader_hint}) and `serve_follower_consume(...)`, both reading the shared `Arc<Mutex<DataPlaneServer>>` (the role source of truth). The leader hint maps the committed leader node id (from the follower target) through a node-id->client-addr advertise map; the committed-HW bar comes from the shared metadata status snapshot. `crates/ironbus-server/src/cluster/client_ack.rs`.
- **EngineAccess:** new `cluster_produce_routing` (default `Local`) + `cluster_follower_consume` (default `None`), so the non-cluster hot path is a cheap bool short-circuit. `crates/ironbus-server/src/actor.rs`.
- **Session:** `handle_pub` short-circuits with `NotLeader` before submit; `handle_stream_fetch` routes a follower-read through the gate. `crates/ironbus-server/src/session.rs`.
- **Client:** `ClientError::NotLeader { leader_hint }`, classified across every produce-reply path; `Client::produce_to_leader(msg, config, max_redirects)` follows the hint. `crates/ironbus-client/src/lib.rs`.

## How each non-negotiable is guaranteed (code pointers)

1. **Single-node byte-identical.** `cluster_produce_routing`/`cluster_follower_consume` default to `Local`/`None` with zero work (no gate, no lock, no alloc) — `actor.rs:746,768`; the `EngineHandle` overrides short-circuit on `client_ack_gate().is_none()` — `actor.rs:858,872`. Both session branches are skipped off-cluster — `session.rs:1047` (produce), `session.rs:2140` (consume). Proven by `a_non_cluster_produce_and_consume_is_never_redirected_or_follower_routed`.
2. **NotLeader only when actually not the leader.** `produce_routing` checks `is_leader` FIRST (-> Local), and only `Redirect`s when `follower_leader(partition)` is Some (a held replica role that does not lead); no role -> Local — `client_ack.rs` (`produce_routing`). Proven by `produce_routing_on_the_leader_is_local_never_a_false_not_leader`, `produce_routing_with_no_role_for_the_partition_is_local`, and `a_real_client_produce_to_the_leader_is_not_redirected`.
3. **No committed-data / ack regression.** The redirect is BEFORE any local append/ack (`handle_pub`, before the L0/L1/L2 submit) — `session.rs:1047`. The client retries to the leader where the #720 quorum gate applies. Proven by `a_real_client_redirects_a_not_leader_produce_to_the_leader_and_succeeds` (the redirected produce is quorum-acked on the leader).
4. **Follower-read safety.** `serve_follower_consume` reads the committed-HW from the metadata status; the #723 `serve_follower_read` clamps to `min(own_flushed, known_committed_hw)`, fail-closed to 0 when unknown — `client_ack.rs` (`serve_follower_consume`/`known_committed_hw`). Proven by `serve_follower_consume_fails_closed_with_no_committed_hw` and `a_real_client_consumes_committed_records_from_a_follower_over_the_wire` (byte-faithful, never past the bar).
5. **Single-writer preserved.** The follower serves via the read plane only (`serve_follower_read`), never writes; the redirect never appends. No new log writer.

## Tests (what they prove)

Real-socket (loopback) end-to-end, `#[cfg(unix)]`:
- `a_real_client_redirects_a_not_leader_produce_to_the_leader_and_succeeds` — client on a follower gets `NotLeader` + hint, `produce_to_leader` reconnects to the leader, produce succeeds + quorum-acked (#720).
- `a_real_client_produce_to_the_leader_is_not_redirected` — no-false-`NotLeader`.
- `a_real_client_consumes_committed_records_from_a_follower_over_the_wire` — Tier-S follower-read serves committed records byte-faithfully.
- `a_non_cluster_produce_and_consume_is_never_redirected_or_follower_routed` — byte-identical single-node.

Gate unit tests: `produce_routing_*` (redirect-with-hint / no-hint / leader-Local / no-role-Local / **after-a-failover**), `serve_follower_consume_*` (serves / fails-closed-no-HW / None-on-leader). Client classification: `a_not_leader_frame_classifies_*`. Proto: `not_leader_round_trips_*`, forward-compat, fail-closed.

All new tests run 5x-stable on this macOS rig.

## Deferred (flagged)

- **Leader-hint advertise map is empty in production** — `--cluster-peer` carries only the metadata address; a peer's CLIENT `--addr` is not advertised, so the redirect fires correctly but with no concrete hint (the client re-tries its known peers). A `--cluster-peer-client <id>=<addr>` advertise that fills the hint is the follow-up. (Tests exercise the hint end-to-end via a populated map.)
- **Multi-partition routing** (different partitions -> different leaders) is #693; this PR targets the default/single-stream partition (the `NotLeader` mechanism generalizes).
- **Dirty-tier (latest) follower-read over the wire** — a `ConfirmWithLeader` serves nothing (never speculative); the wire HW-confirm is a follow-up.
- **Tier-W follower consume** — only Tier-S `StreamFetch` is routed to the follower-read (the lease-free, stateless shape that matches the read-plane contract).
- **Apples-to-apples wire-to-wire consume re-bench (C8)** and the two-OS-process end-to-end validation need #636 hardware (the macOS rig stalls multi-process per #726).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVWp2H2txnKGru4q2twxM3
