### PR TITLE
feat(cluster): metadata Raft log snapshot + compaction — bounded metadata log + snapshot-based catch-up (#660)

### DIFF
--- a/crates/ironbus-server/src/cluster/metadata_group.rs
+++ b/crates/ironbus-server/src/cluster/metadata_group.rs
@@ -249,9 +249,20 @@ impl<F: Filesystem, C: Clock + Clone> MetadataRaftGroup<F, C> {
             leadership.observe(recovered_term, false, clock.now_monotonic_nanos());
         }
 
+        // RESTORE the application state machine from the durable SNAPSHOT (#660), if one was
+        // recovered: the snapshot is the committed metadata cut at its index, and the retained log
+        // TAIL above it folds on top through the normal ready/apply cycle the caller drives next.
+        // So a node restarting from {snapshot + tail} re-derives the EXACT committed state a full
+        // log replay would (#660 non-negotiable 1). A group with no snapshot starts with a fresh SM
+        // and recovers entirely from the log, exactly as before.
+        let state = match node.store().snapshot_state_bytes() {
+            Some(bytes) if !bytes.is_empty() => MetadataStateMachine::restore_from_snapshot(&bytes)?,
+            _ => MetadataStateMachine::new(),
+        };
+
         Ok(Self {
             node,
-            state: MetadataStateMachine::new(),
+            state,
             clock,
             leadership,
         })
@@ -517,14 +528,16 @@ impl<F: Filesystem, C: Clock + Clone> MetadataRaftGroup<F, C> {
         // 1. Outbound messages to peers (none at n=1) — collected for the caller.
         let mut outbound = ready.take_messages();
 
-        // 2. Apply a snapshot if present (handled for safety; not produced in the n=1 flows).
-        //    A snapshot replaces the durable log prefix; that is C1-I2's compaction follow-up,
-        //    so for now we surface it as an error rather than silently dropping it (the
-        //    metadata group's current flows never emit one).
+        // 2. APPLY A RECEIVED SNAPSHOT if present (#660 snapshot-based catch-up): a far-behind
+        //    follower/learner that raft-rs decided to catch up via snapshot transfer gets the
+        //    leader's point-in-time snapshot here. We DURABLY persist it (fsync) and install it into
+        //    storage (clearing the log prefix it subsumes), then RESTORE the application state
+        //    machine from the snapshot's DATA bytes. The replicated log TAIL above the snapshot then
+        //    arrives as normal committed entries (steps 3/8) and folds on top — no gap, no dup, no
+        //    replay of pre-snapshot entries.
         if !ready.snapshot().is_empty() {
-            return Err(GroupError::Raft(raft::Error::Store(
-                raft::StorageError::SnapshotTemporarilyUnavailable,
-            )));
+            let snapshot = ready.snapshot().clone();
+            self.install_snapshot(&snapshot)?;
         }
 
         // 3. Apply committed entries that came with this Ready (after a snapshot, or once
@@ -582,6 +595,103 @@ impl<F: Filesystem, C: Clock + Clone> MetadataRaftGroup<F, C> {
         self.refresh_leadership();
 
         Ok(outbound)
+    }
+
+    /// Install a snapshot RECEIVED from the leader (#660): durably persist it + install it into the
+    /// storage (clearing the subsumed log prefix), then RESTORE the application state machine from
+    /// the snapshot's DATA. A STALE snapshot (below our durable first index) is ignored — we already
+    /// hold that state and a newer tail, so re-installing would regress committed state.
+    ///
+    /// The state machine is restored from the snapshot's bytes ONLY when the snapshot actually
+    /// installs (it advances us); the membership view is also refreshed from the installed
+    /// `ConfState` so the SM's voter/learner table tracks the snapshot's membership.
+    fn install_snapshot(&mut self, snapshot: &raft::eraftpb::Snapshot) -> Result<(), GroupError> {
+        let installed = self.node.mut_store().install_received_snapshot(snapshot)?;
+        if !installed {
+            // Stale snapshot: keep our newer committed state. (raft-rs only sends a snapshot to a
+            // behind node, so this is defensive.)
+            return Ok(());
+        }
+        let meta = snapshot.get_metadata();
+        // RESTORE the application state machine from the snapshot's DATA (the serialized committed
+        // metadata cut). An empty data payload is only ever produced by the legacy/no-data path,
+        // which the storage never serves now (it returns SnapshotTemporarilyUnavailable instead), so
+        // a non-empty install always carries a full SM cut.
+        if snapshot.data.is_empty() {
+            // No SM bytes: keep the membership from the ConfState but leave the SM otherwise empty
+            // at the snapshot index (defensive; not produced by this storage's snapshot()).
+            self.state = MetadataStateMachine::new();
+        } else {
+            self.state = MetadataStateMachine::restore_from_snapshot(&snapshot.data)?;
+        }
+        // Track the snapshot's membership in the SM (the ConfState is the durable membership).
+        self.state.set_membership(
+            meta.index,
+            meta.get_conf_state().get_voters(),
+            meta.get_conf_state().get_voters_outgoing(),
+            meta.get_conf_state().get_learners(),
+            meta.get_conf_state().get_learners_next(),
+        );
+        Ok(())
+    }
+
+    /// The committed metadata-log index that has been APPLIED to this node's state machine. A
+    /// snapshot may be taken at or below this index (every entry up to it is durably applied).
+    #[must_use]
+    pub fn applied_index(&self) -> u64 {
+        self.state.applied_index()
+    }
+
+    /// The index of the last durable snapshot/compaction (0 before any). Every metadata log entry
+    /// at or below it is subsumed by the durable snapshot; the retained log is the tail above it.
+    #[must_use]
+    pub fn snapshot_index(&self) -> u64 {
+        self.node.store().snapshot_index()
+    }
+
+    /// The number of metadata log entries RETAINED above the last snapshot (the live, un-compacted
+    /// tail). The driver uses this as the bounded log-size signal for its snapshot cadence: when the
+    /// retained tail grows past a threshold, it snapshots + compacts to bound the log (#660). Reads
+    /// the durable storage's first/last index, never the wall clock.
+    #[must_use]
+    pub fn retained_log_len(&self) -> u64 {
+        let store = self.node.store();
+        let last = store.last_index().unwrap_or(0);
+        let first = store.first_index().unwrap_or(1);
+        // first_index is last_index + 1 for an empty (fully-compacted) log, so saturate.
+        last.saturating_add(1).saturating_sub(first)
+    }
+
+    /// CREATE a metadata snapshot at the current applied index and COMPACT the log up to it (#660),
+    /// IF the applied frontier has advanced past the last snapshot (else a no-op). The snapshot
+    /// captures the EXACT committed state machine at `applied_index` BEFORE the log prefix is
+    /// truncated, so a node restarting from snapshot+tail holds the identical committed state, and a
+    /// far-behind learner can be caught up from the snapshot + tail.
+    ///
+    /// Returns `true` if a snapshot was created (the log was compacted), `false` if it was a no-op
+    /// (nothing new to snapshot). Safe to call on any cadence; it only does work when the applied
+    /// frontier has moved.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GroupError::Storage`] if the snapshot fails to persist durably or the compaction
+    /// fails, or [`GroupError::Raft`] if the applied index's term cannot be read.
+    pub fn create_snapshot(&mut self) -> Result<bool, GroupError> {
+        let applied = self.state.applied_index();
+        // Only snapshot a committed+applied index strictly above the last snapshot. raft-rs never
+        // compacts past the applied index, so this is always safe.
+        if applied <= self.node.store().snapshot_index() {
+            return Ok(false);
+        }
+        // The term of the entry at the applied index (the snapshot's term). It must be a present log
+        // entry (applied <= committed <= last_index), so `term` resolves it.
+        let term = self.node.store().term(applied)?;
+        // Serialize the EXACT committed state machine at the applied index.
+        let data = self.state.snapshot();
+        self.node
+            .mut_store()
+            .create_snapshot_and_compact(applied, term, &data)?;
+        Ok(true)
     }
 
     /// Fold a batch of committed entries into the state machine. A leader's empty no-op entry
@@ -1235,18 +1345,45 @@ mod tests {
     impl Mesh {
         /// Build a mesh of `voters`, each a group that knows the full voter set.
         fn new(voters: &[u64]) -> Self {
+            Self::with_segment_cap(voters, 64 * 1024)
+        }
+
+        /// Build a mesh whose nodes use a specific log segment cap, so a small cap forces several
+        /// sealed segments (and thus reclaimable prefix segments under compaction, #660).
+        fn with_segment_cap(voters: &[u64], segment_cap: u64) -> Self {
             let mut nodes = std::collections::BTreeMap::new();
             for &id in voters {
                 // Each node gets its OWN fs (its own durable metaraft/ image).
                 let fs = InMemoryFs::new();
-                let group =
-                    MetadataRaftGroup::open(id, voters, &fs, ManualClock::new(), log_config())
-                        .expect("open mesh node");
+                let group = MetadataRaftGroup::open(
+                    id,
+                    voters,
+                    &fs,
+                    ManualClock::new(),
+                    LogConfig::new(segment_cap).expect("valid segment cap"),
+                )
+                .expect("open mesh node");
                 // Leak the fs into the group's storage lifetime: the group owns its log, and the
                 // InMemoryFs is reference-counted internally, so we just drop our handle.
                 nodes.insert(id, group);
             }
             Self { nodes }
+        }
+
+        /// Add a new node to the mesh as a non-voting LEARNER joining an EXISTING cluster of
+        /// `existing_voters` (#617): it opens via `open_as_learner`, so it follows the quorum but
+        /// never campaigns (no term disruption) and back-fills by replication / snapshot transfer.
+        fn add_learner_node(&mut self, id: u64, existing_voters: &[u64], segment_cap: u64) {
+            let fs = InMemoryFs::new();
+            let group = MetadataRaftGroup::open_as_learner(
+                id,
+                existing_voters,
+                &fs,
+                ManualClock::new(),
+                LogConfig::new(segment_cap).expect("valid segment cap"),
+            )
+            .expect("open learner node");
+            self.nodes.insert(id, group);
         }
 
         /// Tick every node once (drives election timers).
@@ -1285,13 +1422,24 @@ mod tests {
         }
 
         /// Run the mesh to a fixed point: repeatedly tick (to drive heartbeats / re-broadcasts)
-        /// and pump messages until a full pass routes nothing and no node has pending work. The
-        /// per-pass pump is itself iterated so a message produced by one node's `step` is drained
+        /// and pump messages until the mesh has been QUIESCED for several consecutive idle rounds.
+        /// The per-pass pump is itself iterated so a message produced by one node's `step` is drained
         /// and routed in the same pass — important so a leader's just-appended entry (e.g. the
-        /// auto-appended LEAVE-JOINT conf change) replicates and commits within `run`. Bounded by
-        /// generous fuel so a bug cannot hang the test.
+        /// auto-appended LEAVE-JOINT conf change) replicates and commits within `run`.
+        ///
+        /// It does NOT break on the FIRST idle round: a multi-phase catch-up (notably SNAPSHOT
+        /// transfer to a freshly-added learner, #660) spans several heartbeat intervals — the leader
+        /// probes on a `heartbeat_tick` cadence, the learner rejects, the leader backs off and sends
+        /// a snapshot, the learner installs it and acks, then the tail replicates — with idle rounds
+        /// in between while waiting for the next heartbeat tick. Requiring a run of consecutive idle
+        /// rounds (well past `heartbeat_tick`) before stopping lets the whole negotiation complete,
+        /// while the outer fuel cap still bounds a genuinely stuck mesh.
         fn run(&mut self) {
-            for _ in 0..1024 {
+            // Idle rounds needed to conclude the mesh has truly settled: comfortably more than
+            // `heartbeat_tick` (3) so a between-heartbeat lull is never mistaken for completion.
+            const QUIET_ROUNDS_TO_SETTLE: u32 = 12;
+            let mut consecutive_idle: u32 = 0;
+            for _ in 0..2048 {
                 self.tick_all();
                 // Drain-and-route to a local fixed point before the next tick.
                 let mut progressed = false;
@@ -1305,7 +1453,12 @@ mod tests {
                     }
                 }
                 if self.quiesced() && !progressed {
-                    break;
+                    consecutive_idle += 1;
+                    if consecutive_idle >= QUIET_ROUNDS_TO_SETTLE {
+                        break;
+                    }
+                } else {
+                    consecutive_idle = 0;
                 }
             }
         }
@@ -1569,5 +1722,173 @@ mod tests {
             .expect("propose from local data");
         settle(&mut group);
         assert_eq!(learners_of(&group), vec![2]);
+    }
+
+    // --- #660: metadata log snapshot + compaction at the GROUP layer. ---
+
+    /// THE GROUP-LAYER COMMITTED-STATE-PRESERVED TEST (#660 non-negotiable 1): commit many metadata
+    /// commands on a single-node group, SNAPSHOT + COMPACT, and confirm (a) the log is BOUNDED (its
+    /// retained tail collapses, snapshot_index rises), (b) the live state is unchanged, and (c) a
+    /// REOPEN over the same durable image (a restart) recovers the IDENTICAL committed state from the
+    /// snapshot + the (empty/short) tail — equal to a full replay.
+    #[test]
+    fn snapshot_and_compaction_bounds_the_log_and_survives_reopen() {
+        let fs = InMemoryFs::new();
+        let expected_placements;
+        {
+            // A small segment so the many entries roll into several sealed segments (so compaction
+            // can reclaim whole prefix segments).
+            let mut group = MetadataRaftGroup::open(
+                1,
+                &[1],
+                &fs,
+                ManualClock::new(),
+                LogConfig::new(512).unwrap(),
+            )
+            .expect("open");
+            group.campaign().expect("campaign");
+            settle(&mut group);
+            assert!(group.is_leader());
+
+            // Commit a batch of placement + config commands so the log grows well past one segment.
+            for p in 0..30u64 {
+                group
+                    .propose(&MetadataCommand::AssignPartition {
+                        partition: p,
+                        leader: 1,
+                        epoch: 1,
+                    })
+                    .expect("propose");
+                settle(&mut group);
+            }
+            let applied_before = group.applied_index();
+            assert!(applied_before > 30, "many entries committed + applied");
+            assert_eq!(group.snapshot_index(), 0, "no snapshot yet");
+            let tail_before = group.retained_log_len();
+            assert!(tail_before > 20, "the log is long before compaction");
+
+            // SNAPSHOT + COMPACT at the applied index.
+            let created = group.create_snapshot().expect("create snapshot");
+            assert!(created, "a snapshot was created");
+            assert_eq!(
+                group.snapshot_index(),
+                applied_before,
+                "snapshot taken at the applied index"
+            );
+            assert!(
+                group.retained_log_len() < tail_before,
+                "the retained log shrank ({} < {tail_before})",
+                group.retained_log_len()
+            );
+
+            // The live state is unchanged by compaction.
+            for p in 0..30u64 {
+                assert_eq!(
+                    group.state().placement(p),
+                    Some(Placement::leader_only(1, 1)),
+                    "placement {p} survives compaction"
+                );
+            }
+            expected_placements = group.state().placements();
+
+            // A second snapshot with no new applied entries is a no-op.
+            assert!(
+                !group.create_snapshot().expect("noop snapshot"),
+                "snapshotting an unchanged applied frontier is a no-op"
+            );
+        }
+
+        // REOPEN over the same durable image (a restart): recovery installs the snapshot, then folds
+        // the (empty) tail. The committed state is IDENTICAL — equal to a full replay.
+        let mut reopened = MetadataRaftGroup::open(
+            1,
+            &[1],
+            &fs,
+            ManualClock::new(),
+            LogConfig::new(512).unwrap(),
+        )
+        .expect("reopen");
+        settle(&mut reopened);
+        assert_eq!(
+            reopened.state().placements(),
+            expected_placements,
+            "the committed metadata state survives snapshot + compaction + restart"
+        );
+        assert!(
+            reopened.snapshot_index() >= 30,
+            "the durable snapshot was recovered"
+        );
+    }
+
+    /// THE SNAPSHOT-CATCH-UP TEST on a REAL multi-node mesh (#660 non-negotiable 4): a far-behind
+    /// LEARNER that joins AFTER the leader has compacted its log receives a SNAPSHOT, installs it,
+    /// then applies the replicated log TAIL and converges to the leader's committed metadata state —
+    /// no gap, no dup, no replay of pre-snapshot entries. This is the #617/#724 fast-learner-join
+    /// scenario the issue calls out: the prefix the learner needs is GONE from the leader's log, so
+    /// snapshot transfer is the ONLY way to catch it up. A learner never campaigns, so there is no
+    /// term-disruption (the realistic catch-up shape, unlike an isolated voter).
+    #[test]
+    fn a_far_behind_learner_catches_up_via_snapshot_transfer_on_a_mesh() {
+        const CAP: u64 = 512; // small segments so compaction reclaims whole prefix segments
+        let mut mesh = Mesh::with_segment_cap(&[1, 2, 3], CAP);
+        mesh.elect(1);
+        let leader = mesh.leader().expect("leader");
+
+        // Commit a long run of commands across the 3 voters.
+        for p in 0..40u64 {
+            mesh.nodes
+                .get_mut(&leader)
+                .unwrap()
+                .propose(&MetadataCommand::AssignPartition {
+                    partition: p,
+                    leader,
+                    epoch: 1,
+                })
+                .expect("propose");
+            mesh.run();
+        }
+
+        // Add node 4 as a LEARNER through a committed conf change, so the leader knows to replicate
+        // to it. (It is not yet in the mesh transport, so it does not actually replicate yet.)
+        mesh.change_on_leader(&MembershipChange::new().add_learner(4))
+            .expect("add learner 4");
+
+        // SNAPSHOT + COMPACT on every voter, so the prefix the learner needs is physically GONE
+        // from the leader's retained log — the only way to catch the learner up is a snapshot.
+        for &id in &[1u64, 2u64, 3u64] {
+            let _ = mesh.nodes.get_mut(&id).unwrap().create_snapshot();
+        }
+        assert!(
+            mesh.nodes[&leader].snapshot_index() >= 40,
+            "the leader compacted past the entries the learner is missing"
+        );
+        let expected = mesh.nodes[&leader].state().placements();
+        assert_eq!(expected.len(), 40);
+
+        // NOW bring the learner online (it joins the mesh transport). It opens far behind (genesis),
+        // and the leader's first index is past its next index, so raft-rs must send a SNAPSHOT.
+        mesh.add_learner_node(4, &[1, 2, 3], CAP);
+        assert!(
+            mesh.nodes[&4].state().placements().is_empty(),
+            "the joining learner has none of the committed placements yet"
+        );
+
+        mesh.run();
+
+        assert_eq!(
+            mesh.nodes[&4].state().placements(),
+            expected,
+            "the far-behind learner converged to the leader's committed state via snapshot catch-up"
+        );
+        assert!(
+            mesh.nodes[&4].snapshot_index() > 0,
+            "the learner installed a snapshot (it did not replay the whole log)"
+        );
+        // No gap / no dup: the learner's applied index reached the leader's committed bar.
+        assert_eq!(
+            mesh.nodes[&4].applied_index(),
+            mesh.nodes[&leader].applied_index(),
+            "the learner's applied frontier matches the leader's (no gap, no dup)"
+        );
     }
 }

--- a/crates/ironbus-server/src/cluster/metadata_group.rs
+++ b/crates/ironbus-server/src/cluster/metadata_group.rs
@@ -256,7 +256,9 @@ impl<F: Filesystem, C: Clock + Clone> MetadataRaftGroup<F, C> {
         // log replay would (#660 non-negotiable 1). A group with no snapshot starts with a fresh SM
         // and recovers entirely from the log, exactly as before.
         let state = match node.store().snapshot_state_bytes() {
-            Some(bytes) if !bytes.is_empty() => MetadataStateMachine::restore_from_snapshot(&bytes)?,
+            Some(bytes) if !bytes.is_empty() => {
+                MetadataStateMachine::restore_from_snapshot(&bytes)?
+            }
             _ => MetadataStateMachine::new(),
         };
 
@@ -1728,7 +1730,7 @@ mod tests {
 
     /// THE GROUP-LAYER COMMITTED-STATE-PRESERVED TEST (#660 non-negotiable 1): commit many metadata
     /// commands on a single-node group, SNAPSHOT + COMPACT, and confirm (a) the log is BOUNDED (its
-    /// retained tail collapses, snapshot_index rises), (b) the live state is unchanged, and (c) a
+    /// retained tail collapses, `snapshot_index` rises), (b) the live state is unchanged, and (c) a
     /// REOPEN over the same durable image (a restart) recovers the IDENTICAL committed state from the
     /// snapshot + the (empty/short) tail — equal to a full replay.
     #[test]

--- a/crates/ironbus-server/src/cluster/metadata_storage.rs
+++ b/crates/ironbus-server/src/cluster/metadata_storage.rs
@@ -560,6 +560,23 @@ impl<F: Filesystem, C: Clock> MetadataLogStorage<F, C> {
             .snapshot_index
     }
 
+    /// The serialized state-machine bytes of the durable snapshot (#660), if one is installed (its
+    /// index is `> 0`). The group calls this at open to RESTORE its application state machine from
+    /// the recovered snapshot BEFORE folding the retained log tail on top, so the recovered
+    /// committed state equals a full replay. `None` when no snapshot is installed (a fresh or
+    /// never-compacted group recovers purely from the log).
+    #[must_use]
+    pub fn snapshot_state_bytes(&self) -> Option<Vec<u8>> {
+        let core = self
+            .core
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if core.snapshot_index == 0 {
+            return None;
+        }
+        Some(core.snapshot_data.clone())
+    }
+
     /// CREATE + persist a metadata snapshot at `index` carrying the serialized state-machine
     /// `data`, then COMPACT the log up to it (#660). This is the leader/driver-cadence path: the
     /// caller passes the bytes of its applied [`MetadataStateMachine::snapshot`](crate::cluster::state_machine::MetadataStateMachine::snapshot)

--- a/crates/ironbus-server/src/cluster/metadata_storage.rs
+++ b/crates/ironbus-server/src/cluster/metadata_storage.rs
@@ -235,7 +235,13 @@ impl Core {
     /// Refuses (returns `false`) a STALE snapshot whose index is below our current first index — we
     /// already hold that state and a newer tail, so installing it would REGRESS committed state
     /// (the `SnapshotOutOfDate` guard). The caller surfaces this fail-closed.
-    fn apply_snapshot(&mut self, index: u64, term: u64, conf_state: ConfState, data: Vec<u8>) -> bool {
+    fn apply_snapshot(
+        &mut self,
+        index: u64,
+        term: u64,
+        conf_state: ConfState,
+        data: Vec<u8>,
+    ) -> bool {
         if self.first_index() > index {
             return false; // stale snapshot: we already have this and more.
         }
@@ -345,7 +351,9 @@ impl<F: Filesystem, C: Clock> MetadataLogStorage<F, C> {
             let file = if fs.exists(SNAPSHOT_CHECKPOINT).map_err(StorageError::Io)? {
                 fs.open(SNAPSHOT_CHECKPOINT).map_err(StorageError::Io)?
             } else {
-                let file = fs.create_new(SNAPSHOT_CHECKPOINT).map_err(StorageError::Io)?;
+                let file = fs
+                    .create_new(SNAPSHOT_CHECKPOINT)
+                    .map_err(StorageError::Io)?;
                 fs.sync_dir().map_err(StorageError::Io)?; // the new file's dir entry must be durable
                 file
             };
@@ -625,14 +633,7 @@ impl<F: Filesystem, C: Clock> MetadataLogStorage<F, C> {
             .clone();
 
         // (1) Build + DURABLY persist the snapshot BEFORE dropping any log prefix.
-        let mut snapshot = Snapshot::default();
-        snapshot.data = bytes::Bytes::copy_from_slice(data);
-        {
-            let meta = snapshot.mut_metadata();
-            meta.index = index;
-            meta.term = term;
-            meta.set_conf_state(conf_state);
-        }
+        let snapshot = build_snapshot(index, term, conf_state, data);
         let snapshot_bytes = snapshot.write_to_bytes()?;
         self.snapshot_checkpoint.write(&snapshot_bytes)?;
 
@@ -712,26 +713,21 @@ impl<F: Filesystem, C: Clock> MetadataLogStorage<F, C> {
     fn reclaim_log_prefix(&mut self, snapshot_index: u64) -> Result<(), MetadataStorageError> {
         // Find the protect floor: the lowest IronBus offset of a record that must be RETAINED.
         // Anything strictly below this floor is fully superseded and may be reaped.
-        let records = self
-            .log
-            .read_from(Offset::ZERO, usize::MAX)?;
+        let records = self.log.read_from(Offset::ZERO, usize::MAX)?;
         let mut protect_floor: Option<u64> = None;
         for record in &records {
             let headers = record.headers.as_ref();
             let Some(&kind) = headers.first() else {
                 continue;
             };
-            let retain = match kind {
-                // An ENTRY record is retained iff its raft index is strictly above the snapshot.
-                // The (index, term) are in the header right after the kind byte (LE u64 each).
-                KIND_ENTRY => entry_index_from_header(headers).is_some_and(|idx| idx > snapshot_index),
-                // Conservatively retain ALL state records: the latest one is load-bearing and the
-                // checkpoint-record bytes are tiny, so never reap a segment holding one. (After the
-                // snapshot the group rewrites a fresh STATE record on its next ready cycle, so old
-                // ones drain out of the active segment naturally over time.)
-                KIND_STATE => true,
-                _ => true,
-            };
+            // An ENTRY record is retained iff its raft index is strictly above the snapshot (its
+            // (index, term) are in the header right after the kind byte, LE u64 each). EVERY other
+            // record kind — a STATE checkpoint (the latest is load-bearing; the bytes are tiny) or
+            // any unknown kind — is retained conservatively, so a segment holding one is never
+            // reaped. (After the snapshot the group rewrites a fresh STATE record on its next ready
+            // cycle, so old ones drain out of the active segment naturally over time.)
+            let retain = kind != KIND_ENTRY
+                || entry_index_from_header(headers).is_some_and(|idx| idx > snapshot_index);
             if retain {
                 let off = record.offset.get();
                 protect_floor = Some(protect_floor.map_or(off, |f| f.min(off)));
@@ -748,6 +744,21 @@ impl<F: Filesystem, C: Clock> MetadataLogStorage<F, C> {
         self.log.reap_to_size(1, floor)?;
         Ok(())
     }
+}
+
+/// Build a raft `Snapshot` from its parts (#660): the `data` (serialized state-machine bytes) plus
+/// the `(index, term, conf_state)` metadata. Centralizes the construction so the `mut_metadata`
+/// dance is written once.
+fn build_snapshot(index: u64, term: u64, conf_state: ConfState, data: &[u8]) -> Snapshot {
+    let mut snapshot = Snapshot {
+        data: bytes::Bytes::copy_from_slice(data),
+        ..Snapshot::default()
+    };
+    let meta = snapshot.mut_metadata();
+    meta.index = index;
+    meta.term = term;
+    meta.set_conf_state(conf_state);
+    snapshot
 }
 
 /// Read an `KIND_ENTRY` record's raft index from its header without decoding the protobuf payload.
@@ -938,13 +949,12 @@ impl<F: Filesystem, C: Clock> Storage for MetadataLogStorage<F, C> {
         // If we have a durable data-bearing snapshot at or above the requested index, serve it
         // verbatim (its data is the consistent cut at `snapshot_index`).
         if core.snapshot_index >= request_index && core.snapshot_index > 0 {
-            let mut snapshot = Snapshot::default();
-            snapshot.data = bytes::Bytes::copy_from_slice(&core.snapshot_data);
-            let meta = snapshot.mut_metadata();
-            meta.index = core.snapshot_index;
-            meta.term = core.snapshot_term;
-            meta.set_conf_state(core.conf_state.clone());
-            return Ok(snapshot);
+            return Ok(build_snapshot(
+                core.snapshot_index,
+                core.snapshot_term,
+                core.conf_state.clone(),
+                &core.snapshot_data,
+            ));
         }
         // Otherwise we have no fresh-enough DATA-bearing snapshot to serve; ask raft-rs to retry,
         // by which point the driver's snapshot cadence will have created one covering this index.
@@ -1353,7 +1363,7 @@ mod tests {
                 .create_snapshot_and_compact(6, 3, &sm_bytes("idx6"))
                 .expect("snapshot+compact");
             // The on-disk log still holds all 10 records (single segment, not reaped).
-            assert_eq!(storage.log().durable_record_count() >= 10, true);
+            assert!(storage.log().durable_record_count() >= 10);
         }
 
         // Reopen: the snapshot installs (index 6), and the log replay's pre-snapshot entries (1..=6)
@@ -1416,9 +1426,11 @@ mod tests {
         // Corrupt the snapshot checkpoint file in the metaraft/ subdir (flip bytes across BOTH
         // slots so neither validates) — a torn snapshot.
         let meta_fs = fs.subdir(METADATA_SUBDIR).expect("metaraft subdir");
-        let file = meta_fs.open(SNAPSHOT_CHECKPOINT).expect("open snapshot ckpt");
+        let file = meta_fs
+            .open(SNAPSHOT_CHECKPOINT)
+            .expect("open snapshot ckpt");
         let mut raw = file.snapshot();
-        for b in raw.iter_mut() {
+        for b in &mut raw {
             *b ^= 0xff;
         }
         file.write_all_at(&raw, 0).expect("write corrupted");
@@ -1441,15 +1453,15 @@ mod tests {
         {
             let mut storage = open(&fs, &[1]);
             // A snapshot arriving from a leader at index 30, term 5.
-            let mut snapshot = Snapshot::default();
-            snapshot.data = bytes::Bytes::copy_from_slice(&sm_bytes("recv30"));
-            {
-                let meta = snapshot.mut_metadata();
-                meta.index = 30;
-                meta.term = 5;
-                meta.set_conf_state(conf_state(vec![1, 2, 3], vec![4]));
-            }
-            let installed = storage.install_received_snapshot(&snapshot).expect("install");
+            let snapshot = build_snapshot(
+                30,
+                5,
+                conf_state(vec![1, 2, 3], vec![4]),
+                &sm_bytes("recv30"),
+            );
+            let installed = storage
+                .install_received_snapshot(&snapshot)
+                .expect("install");
             assert!(installed);
             assert_eq!(storage.snapshot_index(), 30);
             assert_eq!(
@@ -1479,21 +1491,16 @@ mod tests {
 
     /// A STALE received snapshot (index below our current first index — we already hold that and a
     /// newer tail) is REFUSED, never regressing committed state (#660 non-negotiable 1,
-    /// fail-closed): the `first_index() > index` `SnapshotOutOfDate` guard, matching MemStorage.
+    /// fail-closed): the `first_index() > index` `SnapshotOutOfDate` guard, matching `MemStorage`.
     #[test]
     fn a_stale_received_snapshot_is_refused() {
         let fs = InMemoryFs::new();
         let mut storage = open(&fs, &[1]);
         // First install a snapshot at index 10, so our first index is 11.
-        let mut newer = Snapshot::default();
-        newer.data = bytes::Bytes::copy_from_slice(&sm_bytes("idx10"));
-        {
-            let meta = newer.mut_metadata();
-            meta.index = 10;
-            meta.term = 2;
-            meta.set_conf_state(conf_state(vec![1], vec![]));
-        }
-        assert!(storage.install_received_snapshot(&newer).expect("install newer"));
+        let newer = build_snapshot(10, 2, conf_state(vec![1], vec![]), &sm_bytes("idx10"));
+        assert!(storage
+            .install_received_snapshot(&newer)
+            .expect("install newer"));
         assert_eq!(storage.first_index().unwrap(), 11);
 
         // A LATER-arriving snapshot at index 5 is stale: it is below our first index (11).

--- a/crates/ironbus-server/src/cluster/metadata_storage.rs
+++ b/crates/ironbus-server/src/cluster/metadata_storage.rs
@@ -46,16 +46,28 @@
 //! supersedes an earlier one, and any raft index above a later batch's tail is dropped — the
 //! last writer for each suffix wins, deterministically, from bytes alone.
 //!
-//! ## Compaction / snapshot
+//! ## Compaction / snapshot (#660)
 //!
-//! `snapshot()` is implemented per raft-rs's contract: a metadata snapshot at the committed
-//! index carrying the current `ConfState` (the metadata state-machine bytes are filled in by
-//! a later checkpoint issue; an empty-data snapshot is valid for the in-cluster
-//! leader-establishment path the metadata group uses). Log COMPACTION (physically reclaiming
-//! the superseded/applied prefix of the metadata log) reuses the storage crate's existing
-//! retention, but driving it from the applied index is deferred to a focused follow-up
-//! (see the module note in the PR); this issue ships the durable append + recover + truncate
-//! core, which is the load-bearing part.
+//! `snapshot()` serves a raft-rs snapshot at the committed index carrying the current `ConfState`
+//! AND the serialized metadata state-machine bytes (in `Snapshot.data`), so a far-behind learner
+//! receives a complete point-in-time cut instead of the whole log. The snapshot is persisted
+//! durably to a DUAL-SLOT CRC checkpoint
+//! ([`MetadataSnapshotCheckpoint`](ironbus_storage::checkpoint::MetadataSnapshotCheckpoint)) in the
+//! `metaraft/` subdirectory — the same crash-safe discipline as the cursor/attempts/producer-seq
+//! checkpoints — and the in-memory mirror is COMPACTED (its log prefix at or below the snapshot
+//! index is dropped) and the underlying log's now-superseded prefix segments are physically
+//! reclaimed. The crash-safe ORDER is non-negotiable: the snapshot is fsynced to its checkpoint
+//! BEFORE the log prefix is dropped, so a crash mid-compaction leaves either {prior snapshot + full
+//! log} or {new snapshot + (truncated) log} — never a gap where neither holds the committed state.
+//!
+//! On RECOVERY the snapshot checkpoint is read FIRST (installing its state-machine bytes, index,
+//! term, and `ConfState`), then the log records are replayed: any `KIND_ENTRY` record at or below
+//! the snapshot index is ignored (the existing `mirror_entry` compacted-prefix guard), so only the
+//! TAIL above the snapshot folds on top. A node restored from {snapshot + tail} therefore holds the
+//! EXACT committed metadata state it would by replaying the full log (#660 non-negotiable 1).
+//! A torn or missing snapshot checkpoint recovers as "no snapshot" and the node simply replays the
+//! full retained log (the pre-#660 path), so the snapshot is never load-bearing for correctness on
+//! its own — it is an optimization layered over the already-correct durable log.
 //!
 //! ## Scope (C1-I2 only)
 //!
@@ -69,7 +81,8 @@
 use std::sync::{Arc, RwLock};
 
 use ironbus_core::clock::Clock;
-use ironbus_core::types::RecordFlags;
+use ironbus_core::types::{Offset, RecordFlags};
+use ironbus_storage::checkpoint::MetadataSnapshotCheckpoint;
 use ironbus_storage::fs::Filesystem;
 use ironbus_storage::log::{Append, Log, LogConfig};
 use ironbus_storage::loss::LossReport;
@@ -92,6 +105,12 @@ pub const METADATA_SUBDIR: &str = "metaraft";
 /// surfaced as a recovery error rather than silently ignored.
 const KIND_ENTRY: u8 = 1;
 const KIND_STATE: u8 = 2;
+
+/// The filename of the dual-slot CRC metadata-snapshot checkpoint (#660), inside the `metaraft/`
+/// subdirectory alongside the log segments. Holds the most recent durable raft `Snapshot` (its
+/// index/term/`ConfState` + the metadata state-machine bytes); recovery reads it before replaying
+/// the log so the retained tail folds onto the snapshot.
+const SNAPSHOT_CHECKPOINT: &str = "snapshot.ckpt";
 
 /// Errors opening, persisting to, or recovering the durable metadata storage.
 #[derive(Debug)]
@@ -152,12 +171,21 @@ struct Core {
     /// (contiguous), mirroring `MemStorageCore`. A leader-change suffix rewrite drops the tail
     /// and re-pushes, so this is always the CURRENT logical log, never the physical history.
     entries: Vec<Entry>,
-    /// The index a hypothetical snapshot would be taken at: the metadata of the last
-    /// snapshot/compaction. For C1-I2 (no compaction yet) this is the dummy index 0 with
-    /// term 0, matching a fresh `MemStorageCore`.
+    /// The index the last snapshot/compaction was taken at: the metadata of the last snapshot. A
+    /// fresh group (no compaction yet) is the dummy index 0 with term 0, matching a fresh
+    /// `MemStorageCore`. After a compaction at index N this is N and `entries.first().index` is
+    /// `N + 1` (or the log is empty and `first_index() == N + 1`).
     snapshot_index: u64,
     /// The term of the entry at `snapshot_index` (0 for the dummy snapshot).
     snapshot_term: u64,
+    /// The serialized metadata STATE-MACHINE bytes of the last installed/created snapshot (#660):
+    /// the `Snapshot.data` payload [`MetadataStateMachine::snapshot`](crate::cluster::state_machine::MetadataStateMachine::snapshot)
+    /// produced at `snapshot_index`. Empty for the dummy (pre-compaction) snapshot. Served back in
+    /// [`Storage::snapshot`] so a far-behind learner receives the committed state, not just the
+    /// metadata. The group fills this in via [`MetadataLogStorage::install_snapshot_state`] when it
+    /// creates a snapshot from its applied state machine, and `apply_snapshot` sets it from a
+    /// received snapshot.
+    snapshot_data: Vec<u8>,
 }
 
 impl Core {
@@ -196,6 +224,55 @@ impl Core {
         self.entries.truncate(drop_from);
         self.entries.push(entry);
     }
+
+    /// Install a received snapshot into the mirror — the raft-rs `MemStorageCore::apply_snapshot`
+    /// contract (#660): adopt the snapshot's `(index, term)` as the new snapshot metadata, set the
+    /// hard-state commit to the snapshot index and raise the term, REPLACE the `ConfState` with the
+    /// snapshot's, store the snapshot DATA, and CLEAR the log (every entry the snapshot subsumes is
+    /// gone; the tail above it arrives by replication). Returns the snapshot index so the caller
+    /// can compute the log offset to physically reclaim.
+    ///
+    /// Refuses (returns `false`) a STALE snapshot whose index is below our current first index — we
+    /// already hold that state and a newer tail, so installing it would REGRESS committed state
+    /// (the `SnapshotOutOfDate` guard). The caller surfaces this fail-closed.
+    fn apply_snapshot(&mut self, index: u64, term: u64, conf_state: ConfState, data: Vec<u8>) -> bool {
+        if self.first_index() > index {
+            return false; // stale snapshot: we already have this and more.
+        }
+        self.snapshot_index = index;
+        self.snapshot_term = term;
+        self.snapshot_data = data;
+        self.hard_state.term = self.hard_state.term.max(term);
+        self.hard_state.commit = index;
+        self.conf_state = conf_state;
+        self.entries.clear();
+        true
+    }
+
+    /// Compact the mirror's log PREFIX up to (but not including) `compact_index` — the raft-rs
+    /// `MemStorageCore::compact` contract (#660): drop every in-memory entry strictly below
+    /// `compact_index`, and record `(compact_index - 1, its term)` as the new snapshot metadata so
+    /// `first_index()`/`term()` stay correct against the compacted log. `compact_index` must be at
+    /// or below the COMMITTED + applied frontier (the caller enforces this); a no-op if it is at or
+    /// below the current first index.
+    ///
+    /// The new snapshot's term is the term of the entry at `compact_index - 1` (the last entry the
+    /// snapshot subsumes), read from the mirror BEFORE the prefix is dropped, so a later `term()`
+    /// query at the snapshot index returns the right term.
+    fn compact(&mut self, compact_index: u64) {
+        let first = self.first_index();
+        if compact_index <= first {
+            return; // nothing below the current first index to drop.
+        }
+        // The snapshot index is one below the new first index; its term is the term of that entry.
+        let new_snapshot_index = compact_index - 1;
+        // `new_snapshot_index` is in [first, last]; locate it in the mirror to read its term.
+        let pos = usize::try_from(new_snapshot_index - first).expect("compact index fits usize");
+        self.snapshot_term = self.entries[pos].term;
+        self.snapshot_index = new_snapshot_index;
+        // Drop entries [first ..= new_snapshot_index] — i.e. the first `pos + 1` entries.
+        self.entries.drain(..=pos);
+    }
 }
 
 /// A durable raft-rs [`Storage`] backed by an IronBus CRC-framed [`Log`]. Synchronous and
@@ -212,6 +289,10 @@ pub struct MetadataLogStorage<F: Filesystem, C: Clock> {
     log: Log<F, C>,
     /// The in-memory projection the synchronous `Storage` reads serve from.
     core: Arc<RwLock<Core>>,
+    /// The dual-slot CRC checkpoint that durably holds the most recent metadata snapshot (#660),
+    /// in the `metaraft/` subdirectory alongside the log. Written (fsync) BEFORE the log prefix is
+    /// compacted, so a crash mid-compaction is always recoverable.
+    snapshot_checkpoint: MetadataSnapshotCheckpoint<F::File>,
 }
 
 impl<F: Filesystem, C: Clock> MetadataLogStorage<F, C> {
@@ -250,16 +331,43 @@ impl<F: Filesystem, C: Clock> MetadataLogStorage<F, C> {
             entries: Vec::new(),
             snapshot_index: 0,
             snapshot_term: 0,
+            snapshot_data: Vec::new(),
         };
+
+        // RECOVER THE SNAPSHOT FIRST (#660), so the log replay below folds only the TAIL above the
+        // snapshot index onto it. The checkpoint is opened (creating it if absent) through the
+        // metadata log's OWN filesystem (the `metaraft/` subdir), the same create-then-dir-sync
+        // discipline the engine uses for its cursor/attempts/producer-seq checkpoints. A torn or
+        // missing snapshot recovers as None, so the node falls back to a full-log replay — the
+        // snapshot is never load-bearing for correctness on its own.
+        let snapshot_checkpoint = {
+            let fs = log.filesystem();
+            let file = if fs.exists(SNAPSHOT_CHECKPOINT).map_err(StorageError::Io)? {
+                fs.open(SNAPSHOT_CHECKPOINT).map_err(StorageError::Io)?
+            } else {
+                let file = fs.create_new(SNAPSHOT_CHECKPOINT).map_err(StorageError::Io)?;
+                fs.sync_dir().map_err(StorageError::Io)?; // the new file's dir entry must be durable
+                file
+            };
+            let (checkpoint, recovered) = MetadataSnapshotCheckpoint::open(file)?;
+            if let Some(bytes) = recovered {
+                let snapshot = Snapshot::parse_from_bytes(&bytes)?;
+                install_snapshot_into_core(&mut core, &snapshot);
+            }
+            checkpoint
+        };
+
         Self::replay_into(&log, &mut core)?;
-        // Seed the voter set for a brand-new group ONLY (no persisted ConfState recovered).
-        // A recovered group keeps its durable membership: the seed never overwrites it.
+        // Seed the voter set for a brand-new group ONLY (no persisted ConfState recovered AND no
+        // snapshot installed one). A recovered group — log OR snapshot — keeps its durable
+        // membership: the seed never overwrites it.
         if core.conf_state.voters.is_empty() && core.conf_state.learners.is_empty() {
             core.conf_state.voters = conf_state_voters.to_vec();
         }
         Ok(Self {
             log,
             core: Arc::new(RwLock::new(core)),
+            snapshot_checkpoint,
         })
     }
 
@@ -268,10 +376,11 @@ impl<F: Filesystem, C: Clock> MetadataLogStorage<F, C> {
     /// checkpoints. The `Log` has already recovered to its longest valid prefix, so this only
     /// ever sees CRC-valid frames.
     fn replay_into(log: &Log<F, C>, core: &mut Core) -> Result<(), MetadataStorageError> {
-        // `read_from(ZERO, MAX)` returns every durable (flushed) record in offset order; the
-        // metadata log is small (one group's control plane), so a single forward pass at open
-        // is cheap.
-        let records = log.read_from(ironbus_core::types::Offset::ZERO, usize::MAX)?;
+        // Read every durable (flushed) record in offset order, starting at the EARLIEST retained
+        // offset (which rises past 0 once compaction has reaped prefix segments — reading from a
+        // reaped offset is `OffsetOutOfRange`). The metadata log is small (one group's control
+        // plane), so a single forward pass at open is cheap.
+        let records = log.read_from(log.earliest_offset(), usize::MAX)?;
         for record in records {
             let headers = record.headers.as_ref();
             let kind = *headers
@@ -284,7 +393,16 @@ impl<F: Filesystem, C: Clock> MetadataLogStorage<F, C> {
                 }
                 KIND_STATE => {
                     let (hs, cs) = decode_state(record.payload.as_ref())?;
-                    core.hard_state = hs;
+                    // Latest STATE record wins — EXCEPT it can never REGRESS the commit/term below
+                    // an installed snapshot (#660). A snapshot is persisted before the log prefix is
+                    // compacted, so a crash can leave a snapshot whose committed frontier is AHEAD of
+                    // the newest surviving STATE record; the snapshot's frontier is the floor (the
+                    // committed bar only ever rises), so a recovered node never re-admits a
+                    // below-snapshot commit. ConfState always takes the latest STATE record's value
+                    // (a tail conf-change is newer than the snapshot's membership).
+                    core.hard_state.term = hs.term.max(core.hard_state.term);
+                    core.hard_state.commit = hs.commit.max(core.hard_state.commit);
+                    core.hard_state.vote = hs.vote;
                     core.conf_state = cs;
                 }
                 other => return Err(MetadataStorageError::UnknownRecordKind(other)),
@@ -429,6 +547,214 @@ impl<F: Filesystem, C: Clock> MetadataLogStorage<F, C> {
     pub fn log(&self) -> &Log<F, C> {
         &self.log
     }
+
+    /// The index of the last snapshot/compaction (the dummy index 0 before any compaction). Every
+    /// log entry at or below this is subsumed by the durable snapshot; the retained log is the tail
+    /// above it. The group reads this to know whether it has caught the snapshot up to its applied
+    /// state.
+    #[must_use]
+    pub fn snapshot_index(&self) -> u64 {
+        self.core
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .snapshot_index
+    }
+
+    /// CREATE + persist a metadata snapshot at `index` carrying the serialized state-machine
+    /// `data`, then COMPACT the log up to it (#660). This is the leader/driver-cadence path: the
+    /// caller passes the bytes of its applied [`MetadataStateMachine::snapshot`](crate::cluster::state_machine::MetadataStateMachine::snapshot)
+    /// at the committed+applied `index` (and that index's `term`).
+    ///
+    /// The crash-safe order is NON-NEGOTIABLE (#660 non-negotiable 3):
+    /// 1. Build the raft `Snapshot` (index/term/`ConfState`/data) and write it to the dual-slot CRC
+    ///    checkpoint, which fsyncs it — the snapshot is DURABLE before anything is dropped.
+    /// 2. COMPACT the in-memory mirror (drop the entry prefix at or below `index`, record the new
+    ///    snapshot metadata).
+    /// 3. Physically RECLAIM the now-superseded durable log segments below the snapshot boundary
+    ///    (best-effort space reclamation; recovery is correct even if this is skipped, since the
+    ///    snapshot checkpoint subsumes the prefix and the `mirror_entry` guard ignores pre-snapshot
+    ///    records on replay).
+    ///
+    /// A crash between (1) and (3) leaves the durable snapshot + a possibly-un-truncated log; on
+    /// recovery the snapshot installs and the log tail folds on top — no committed state is lost and
+    /// no torn state is observable. `index` MUST be at or below the committed + applied frontier
+    /// (the caller enforces this); a snapshot at or below the current snapshot index is a no-op.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MetadataStorageError`] if the snapshot fails to encode, the checkpoint write
+    /// (fsync) fails, or the physical reclamation read/reap fails.
+    pub fn create_snapshot_and_compact(
+        &mut self,
+        index: u64,
+        term: u64,
+        data: &[u8],
+    ) -> Result<(), MetadataStorageError> {
+        {
+            let core = self
+                .core
+                .read()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            // No-op if we already have a snapshot at or above this index (never regress).
+            if index <= core.snapshot_index {
+                return Ok(());
+            }
+        }
+        let conf_state = self
+            .core
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .conf_state
+            .clone();
+
+        // (1) Build + DURABLY persist the snapshot BEFORE dropping any log prefix.
+        let mut snapshot = Snapshot::default();
+        snapshot.data = bytes::Bytes::copy_from_slice(data);
+        {
+            let meta = snapshot.mut_metadata();
+            meta.index = index;
+            meta.term = term;
+            meta.set_conf_state(conf_state);
+        }
+        let snapshot_bytes = snapshot.write_to_bytes()?;
+        self.snapshot_checkpoint.write(&snapshot_bytes)?;
+
+        // (2) Compact the in-memory mirror up to (and including) `index`. Store the snapshot data
+        // so a later `snapshot()` serves it. The mirror's compact records the new snapshot metadata
+        // (index/term) read from the entry it subsumes.
+        {
+            let mut core = self
+                .core
+                .write()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            core.compact(index + 1);
+            core.snapshot_data = data.to_vec();
+        }
+
+        // (3) Physically reclaim the superseded durable log prefix (best-effort).
+        self.reclaim_log_prefix(index)?;
+        Ok(())
+    }
+
+    /// Durably INSTALL a snapshot RECEIVED from the leader over the wire (#660): persist it to the
+    /// crash-safe checkpoint (fsync) BEFORE installing it into the mirror, then install it (adopting
+    /// its index/term/`ConfState`/data and clearing the log) and reclaim the superseded log prefix.
+    /// Returns `true` if the snapshot was installed, `false` if it was STALE (its index is at or
+    /// below our current first index — we already hold that state + a newer tail), which the caller
+    /// surfaces fail-closed.
+    ///
+    /// This is the receiving half of snapshot-based catch-up: a far-behind learner/follower that
+    /// raft-rs hands a snapshot in its `Ready` installs it here, then applies the replicated tail on
+    /// top — no gap, no dup, no replay of pre-snapshot entries (#660 non-negotiable 4).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MetadataStorageError`] if the snapshot fails to encode, the checkpoint write
+    /// (fsync) fails, or the physical reclamation fails.
+    pub fn install_received_snapshot(
+        &mut self,
+        snapshot: &Snapshot,
+    ) -> Result<bool, MetadataStorageError> {
+        let index = snapshot.get_metadata().index;
+        {
+            let core = self
+                .core
+                .read()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if core.first_index() > index {
+                return Ok(false); // stale: we already have this and a newer tail.
+            }
+        }
+        // DURABLY persist the received snapshot BEFORE installing it (fsync via the checkpoint).
+        let snapshot_bytes = snapshot.write_to_bytes()?;
+        self.snapshot_checkpoint.write(&snapshot_bytes)?;
+        // Install into the mirror (clears the log, adopts the snapshot's state).
+        let installed = {
+            let mut core = self
+                .core
+                .write()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            install_snapshot_into_core(&mut core, snapshot);
+            true
+        };
+        // Reclaim the now-superseded durable log prefix (the whole log is below the snapshot here).
+        self.reclaim_log_prefix(index)?;
+        Ok(installed)
+    }
+
+    /// Physically reclaim whole durable log SEGMENTS whose records are entirely superseded by a
+    /// snapshot at raft `snapshot_index` — BOUNDED, best-effort space reclamation (#660
+    /// non-negotiable 6). It scans the durable log once to find the lowest IronBus log OFFSET of any
+    /// record that must be RETAINED (an `KIND_ENTRY` whose raft index is strictly above
+    /// `snapshot_index`, or — conservatively — the newest `KIND_STATE` record, whichever is lower),
+    /// then reaps every sealed segment that lies entirely below that floor. A segment containing any
+    /// retained tail record is NEVER reaped, so the retained tail always survives; the active
+    /// segment is never reaped. Recovery stays correct whether or not this runs (the snapshot
+    /// checkpoint subsumes the prefix), so any reap error is surfaced but the compaction itself has
+    /// already succeeded durably.
+    fn reclaim_log_prefix(&mut self, snapshot_index: u64) -> Result<(), MetadataStorageError> {
+        // Find the protect floor: the lowest IronBus offset of a record that must be RETAINED.
+        // Anything strictly below this floor is fully superseded and may be reaped.
+        let records = self
+            .log
+            .read_from(Offset::ZERO, usize::MAX)?;
+        let mut protect_floor: Option<u64> = None;
+        for record in &records {
+            let headers = record.headers.as_ref();
+            let Some(&kind) = headers.first() else {
+                continue;
+            };
+            let retain = match kind {
+                // An ENTRY record is retained iff its raft index is strictly above the snapshot.
+                // The (index, term) are in the header right after the kind byte (LE u64 each).
+                KIND_ENTRY => entry_index_from_header(headers).is_some_and(|idx| idx > snapshot_index),
+                // Conservatively retain ALL state records: the latest one is load-bearing and the
+                // checkpoint-record bytes are tiny, so never reap a segment holding one. (After the
+                // snapshot the group rewrites a fresh STATE record on its next ready cycle, so old
+                // ones drain out of the active segment naturally over time.)
+                KIND_STATE => true,
+                _ => true,
+            };
+            if retain {
+                let off = record.offset.get();
+                protect_floor = Some(protect_floor.map_or(off, |f| f.min(off)));
+            }
+        }
+        // If nothing must be retained (every record is below the snapshot), protect floor is the
+        // log's next offset — everything is reapable. Otherwise reap strictly below the floor.
+        let floor = protect_floor.unwrap_or_else(|| self.log.next_offset().get());
+        // Reap whole sealed segments fully below the floor. The byte bound is set to 1 so the
+        // size predicate is always satisfied; the protect floor is what actually bounds the reap to
+        // fully-superseded segments (a segment is only dropped when the NEXT segment's base is at or
+        // below the floor, i.e. every record in the dropped segment is below the floor — retained
+        // tail records are never reaped). The active segment is never reaped.
+        self.log.reap_to_size(1, floor)?;
+        Ok(())
+    }
+}
+
+/// Read an `KIND_ENTRY` record's raft index from its header without decoding the protobuf payload.
+/// The header is `[KIND_ENTRY][index:u64-le][term:u64-le]`; returns `None` if it is too short.
+fn entry_index_from_header(headers: &[u8]) -> Option<u64> {
+    // [0] is the kind byte; [1..9] is the LE index.
+    let idx_bytes = headers.get(1..9)?;
+    let mut a = [0u8; 8];
+    a.copy_from_slice(idx_bytes);
+    Some(u64::from_le_bytes(a))
+}
+
+/// Install a recovered/received raft `Snapshot` into a [`Core`] (#660): adopt its `(index, term)`,
+/// `ConfState`, and DATA, set the hard-state commit/term, and clear the log. Shared by recovery
+/// (reading the checkpoint at open) and the live received-snapshot path. The snapshot's `data` is
+/// the serialized metadata state-machine bytes the group restores from.
+fn install_snapshot_into_core(core: &mut Core, snapshot: &Snapshot) {
+    let meta = snapshot.get_metadata();
+    core.apply_snapshot(
+        meta.index,
+        meta.term,
+        meta.get_conf_state().clone(),
+        snapshot.data.to_vec(),
+    );
 }
 
 /// Encode a `(HardState, ConfState)` checkpoint: each protobuf message length-prefixed
@@ -573,38 +899,42 @@ impl<F: Filesystem, C: Clock> Storage for MetadataLogStorage<F, C> {
             .last_index())
     }
 
-    /// The most recent metadata snapshot per raft-rs's contract: a snapshot at the committed
-    /// index carrying the current `ConfState`. For C1-I2 the snapshot data is empty (the
-    /// metadata state-machine bytes + log compaction are a focused follow-up); the metadata
-    /// group's in-cluster leader-establishment path does not require snapshot DATA, only the
-    /// metadata (index / term / conf state), which is filled in here.
+    /// Serve a metadata snapshot per raft-rs's contract (#660): a snapshot at a committed index,
+    /// carrying the `ConfState` AND the serialized metadata state-machine bytes in `Snapshot.data`,
+    /// so a far-behind learner/follower that raft-rs decides to catch up via snapshot receives the
+    /// COMMITTED STATE (not just the metadata). raft-rs requires the returned snapshot index be
+    /// `>= request_index`.
+    ///
+    /// We serve the DURABLY-CREATED snapshot (at `snapshot_index`, with its `snapshot_data`) when it
+    /// covers `request_index` — that snapshot's data is the exact point-in-time state machine cut.
+    /// When we do NOT yet have a data-bearing snapshot fresh enough for `request_index` (e.g. the
+    /// group hasn't created one at or above it yet), we return
+    /// [`SnapshotTemporarilyUnavailable`](raft::StorageError::SnapshotTemporarilyUnavailable), which
+    /// raft-rs handles by retrying later — by then the driver's snapshot cadence has created one. So
+    /// we never serve a snapshot whose DATA does not match its metadata (no torn/empty-data snapshot
+    /// is ever sent to a follower).
     fn snapshot(&self, request_index: u64, _to: u64) -> RaftResult<Snapshot> {
         let core = self
             .core
             .read()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let mut snapshot = Snapshot::default();
-        let commit = core.hard_state.commit;
-        // The snapshot index is the committed index (all entries at or below it are applied),
-        // clamped up to `request_index` as raft-rs requires (`index >= request_index`).
-        let index = commit.max(request_index);
-        {
+        // If we have a durable data-bearing snapshot at or above the requested index, serve it
+        // verbatim (its data is the consistent cut at `snapshot_index`).
+        if core.snapshot_index >= request_index && core.snapshot_index > 0 {
+            let mut snapshot = Snapshot::default();
+            snapshot.data = bytes::Bytes::copy_from_slice(&core.snapshot_data);
             let meta = snapshot.mut_metadata();
-            meta.index = index;
-            // The snapshot term is the term of the entry at the committed index when it is a
-            // present log entry; at/below the snapshot dummy it is the snapshot term.
-            meta.term = if commit == core.snapshot_index {
-                core.snapshot_term
-            } else if commit >= core.first_index() && commit <= core.last_index() {
-                let pos =
-                    usize::try_from(commit - core.first_index()).expect("commit index fits usize");
-                core.entries[pos].term
-            } else {
-                core.hard_state.term
-            };
+            meta.index = core.snapshot_index;
+            meta.term = core.snapshot_term;
             meta.set_conf_state(core.conf_state.clone());
+            return Ok(snapshot);
         }
-        Ok(snapshot)
+        // Otherwise we have no fresh-enough DATA-bearing snapshot to serve; ask raft-rs to retry,
+        // by which point the driver's snapshot cadence will have created one covering this index.
+        // (raft-rs treats this as transient, not an error.)
+        Err(RaftError::Store(
+            RaftStorageError::SnapshotTemporarilyUnavailable,
+        ))
     }
 }
 
@@ -866,5 +1196,330 @@ mod tests {
         // No cap returns all three.
         let all = storage.entries(1, 4, None, ctx()).unwrap();
         assert_eq!(all.len(), 3);
+    }
+
+    // --- #660: snapshot create + compaction + crash-safety + snapshot install. ---
+
+    /// A small metadata-state-machine snapshot blob (its exact bytes are opaque to the storage —
+    /// the storage carries them as `Snapshot.data`).
+    fn sm_bytes(tag: &str) -> Vec<u8> {
+        format!("SM-STATE@{tag}").into_bytes()
+    }
+
+    /// Append many entries, snapshot + compact at an index, and confirm the durable log is
+    /// BOUNDED (its `first_index` rises past the snapshot, the on-disk record count drops) AND the
+    /// retained tail above the snapshot is intact — the committed-state-preserved + bounded
+    /// invariants at the storage layer (#660 non-negotiables 1 + 6).
+    #[test]
+    fn snapshot_then_compact_truncates_the_log_and_keeps_the_tail() {
+        // A small segment cap so many entries roll into several sealed segments (so reaping can
+        // actually reclaim whole segments below the snapshot boundary).
+        let fs = InMemoryFs::new();
+        let mut storage =
+            MetadataLogStorage::open(&fs, ManualClock::new(), LogConfig::new(512).unwrap(), &[1])
+                .expect("open");
+        // 20 entries at term 1.
+        let entries: Vec<Entry> = (1..=20).map(|i| entry(i, 1, b"payload-bytes")).collect();
+        storage.append(&entries).expect("append");
+        storage.set_hard_state(&hard_state(1, 1, 20)).expect("hs");
+        storage.sync().expect("sync");
+        assert_eq!(storage.first_index().unwrap(), 1);
+        assert_eq!(storage.last_index().unwrap(), 20);
+        let records_before = storage.log().durable_record_count();
+
+        // Snapshot + compact at index 15 (committed + applied).
+        storage
+            .create_snapshot_and_compact(15, 1, &sm_bytes("idx15"))
+            .expect("snapshot+compact");
+
+        // The log is now BOUNDED: first_index rose past the snapshot, last_index is unchanged, and
+        // the durable on-disk record count dropped (whole prefix segments were reaped).
+        assert_eq!(storage.snapshot_index(), 15);
+        assert_eq!(
+            storage.first_index().unwrap(),
+            16,
+            "first index rose to snapshot_index + 1"
+        );
+        assert_eq!(storage.last_index().unwrap(), 20, "the tail is retained");
+        assert!(
+            storage.log().durable_record_count() < records_before,
+            "compaction reclaimed durable records ({} < {})",
+            storage.log().durable_record_count(),
+            records_before
+        );
+        // The retained tail entries (16..=20) are intact and a below-first read is Compacted.
+        let tail = storage.entries(16, 21, None, ctx()).expect("tail");
+        assert_eq!(tail.len(), 5);
+        assert_eq!(tail[0].index, 16);
+        assert!(
+            storage.entries(10, 16, None, ctx()).is_err(),
+            "a read below the compacted first index is rejected"
+        );
+        // term() at the snapshot index returns the snapshot term, not a panic.
+        assert_eq!(storage.term(15).unwrap(), 1);
+    }
+
+    /// THE COMMITTED-STATE-PRESERVED RECOVERY TEST (#660 non-negotiable 1): after a snapshot +
+    /// compaction, REOPEN over the same durable image and confirm the recovered storage installs
+    /// the snapshot (its data + index/term/`ConfState`) and folds the retained tail on top — the
+    /// recovered state equals the full pre-compaction state (snapshot+tail == full-replay).
+    #[test]
+    fn recovery_from_snapshot_plus_tail_equals_the_full_state() {
+        let fs = InMemoryFs::new();
+        {
+            let mut storage = MetadataLogStorage::open(
+                &fs,
+                ManualClock::new(),
+                LogConfig::new(512).unwrap(),
+                &[1, 2, 3],
+            )
+            .expect("open");
+            let entries: Vec<Entry> = (1..=12).map(|i| entry(i, 2, b"e")).collect();
+            storage.append(&entries).expect("append");
+            storage.set_hard_state(&hard_state(2, 1, 12)).expect("hs");
+            storage.sync().expect("sync");
+            // Snapshot at 8, keeping the tail 9..=12.
+            storage
+                .create_snapshot_and_compact(8, 2, &sm_bytes("idx8"))
+                .expect("snapshot+compact");
+        }
+
+        // Reopen: recovery reads the snapshot checkpoint FIRST, then replays only the tail.
+        let recovered = open(&fs, &[1, 2, 3]);
+        assert_eq!(
+            recovered.snapshot_index(),
+            8,
+            "the durable snapshot is recovered"
+        );
+        assert_eq!(
+            recovered.first_index().unwrap(),
+            9,
+            "first index is snapshot_index + 1"
+        );
+        assert_eq!(recovered.last_index().unwrap(), 12, "the tail recovered");
+        // The hard state commit survived (the snapshot's index is the floor, the tail STATE record
+        // raised it to 12).
+        let state = recovered.initial_state().unwrap();
+        assert_eq!(state.hard_state.commit, 12);
+        // The snapshot served back carries the SM data + index/term, ready for a learner.
+        let snap = recovered.snapshot(8, 1).expect("snapshot");
+        assert_eq!(snap.get_metadata().index, 8);
+        assert_eq!(snap.get_metadata().term, 2);
+        assert_eq!(snap.data.as_ref(), sm_bytes("idx8").as_slice());
+        // The tail entries are intact.
+        assert_eq!(recovered.entries(9, 13, None, ctx()).unwrap().len(), 4);
+    }
+
+    /// THE CRASH-SAFETY TEST (#660 non-negotiable 3): simulate a crash AFTER the snapshot was
+    /// persisted to its checkpoint but BEFORE the log prefix was reaped (the un-truncated-log case)
+    /// — recovery must still recover the correct committed state with NO loss and NO torn state. We
+    /// reproduce it by persisting a snapshot checkpoint over a FULL (un-compacted) log and reopening.
+    #[test]
+    fn crash_after_snapshot_persist_before_log_truncation_recovers_correctly() {
+        let fs = InMemoryFs::new();
+        {
+            let mut storage = MetadataLogStorage::open(
+                &fs,
+                ManualClock::new(),
+                LogConfig::new(64 * 1024).unwrap(), // single segment: nothing to reap
+                &[1],
+            )
+            .expect("open");
+            let entries: Vec<Entry> = (1..=10).map(|i| entry(i, 3, b"e")).collect();
+            storage.append(&entries).expect("append");
+            storage.set_hard_state(&hard_state(3, 1, 10)).expect("hs");
+            storage.sync().expect("sync");
+            // Snapshot + compact at 6. With one segment the reap is a no-op, so the FULL log
+            // survives on disk alongside the durable snapshot — exactly the crash-mid-compaction
+            // window (snapshot persisted, log not yet physically truncated).
+            storage
+                .create_snapshot_and_compact(6, 3, &sm_bytes("idx6"))
+                .expect("snapshot+compact");
+            // The on-disk log still holds all 10 records (single segment, not reaped).
+            assert_eq!(storage.log().durable_record_count() >= 10, true);
+        }
+
+        // Reopen: the snapshot installs (index 6), and the log replay's pre-snapshot entries (1..=6)
+        // are IGNORED by the mirror_entry compacted-prefix guard, while the tail (7..=10) folds on
+        // top. No loss, no torn state, no duplicate replay of pre-snapshot entries.
+        let recovered = open(&fs, &[1]);
+        assert_eq!(recovered.snapshot_index(), 6);
+        assert_eq!(
+            recovered.first_index().unwrap(),
+            7,
+            "the compacted-prefix guard dropped the pre-snapshot entries on replay"
+        );
+        assert_eq!(recovered.last_index().unwrap(), 10, "the tail is intact");
+        assert_eq!(recovered.term(6).unwrap(), 3, "snapshot term recovered");
+        assert_eq!(recovered.entries(7, 11, None, ctx()).unwrap().len(), 4);
+        let snap = recovered.snapshot(6, 1).expect("snapshot");
+        assert_eq!(snap.data.as_ref(), sm_bytes("idx6").as_slice());
+    }
+
+    /// A crash BEFORE the snapshot was persisted (no snapshot checkpoint) recovers via a FULL log
+    /// replay — the pre-#660 path, proving the snapshot is never load-bearing on its own.
+    #[test]
+    fn crash_before_snapshot_persist_recovers_via_full_log_replay() {
+        let fs = InMemoryFs::new();
+        {
+            let mut storage = open(&fs, &[1]);
+            let entries: Vec<Entry> = (1..=5).map(|i| entry(i, 1, b"e")).collect();
+            storage.append(&entries).expect("append");
+            storage.set_hard_state(&hard_state(1, 1, 5)).expect("hs");
+            storage.sync().expect("sync");
+            // NO snapshot created (the crash is before any compaction).
+        }
+        let recovered = open(&fs, &[1]);
+        assert_eq!(recovered.snapshot_index(), 0, "no snapshot");
+        assert_eq!(recovered.first_index().unwrap(), 1, "full log replayed");
+        assert_eq!(recovered.last_index().unwrap(), 5);
+    }
+
+    /// A torn snapshot checkpoint (corrupted both slots) recovers as "no snapshot" and falls back
+    /// to the full log replay — never a torn install (#660 non-negotiable 3, the torn case).
+    #[test]
+    fn a_torn_snapshot_checkpoint_falls_back_to_the_full_log() {
+        let fs = InMemoryFs::new();
+        {
+            let mut storage = MetadataLogStorage::open(
+                &fs,
+                ManualClock::new(),
+                LogConfig::new(64 * 1024).unwrap(),
+                &[1],
+            )
+            .expect("open");
+            let entries: Vec<Entry> = (1..=8).map(|i| entry(i, 1, b"e")).collect();
+            storage.append(&entries).expect("append");
+            storage.set_hard_state(&hard_state(1, 1, 8)).expect("hs");
+            storage.sync().expect("sync");
+            storage
+                .create_snapshot_and_compact(5, 1, &sm_bytes("idx5"))
+                .expect("snapshot+compact");
+        }
+        // Corrupt the snapshot checkpoint file in the metaraft/ subdir (flip bytes across BOTH
+        // slots so neither validates) — a torn snapshot.
+        let meta_fs = fs.subdir(METADATA_SUBDIR).expect("metaraft subdir");
+        let file = meta_fs.open(SNAPSHOT_CHECKPOINT).expect("open snapshot ckpt");
+        let mut raw = file.snapshot();
+        for b in raw.iter_mut() {
+            *b ^= 0xff;
+        }
+        file.write_all_at(&raw, 0).expect("write corrupted");
+        file.sync_data().expect("sync corrupted");
+
+        // Recovery ignores the torn snapshot and replays the FULL log (single segment was never
+        // reaped), so all 8 entries come back — no loss, no torn install.
+        let recovered = open(&fs, &[1]);
+        assert_eq!(recovered.snapshot_index(), 0, "torn snapshot ignored");
+        assert_eq!(recovered.first_index().unwrap(), 1, "full log replayed");
+        assert_eq!(recovered.last_index().unwrap(), 8);
+    }
+
+    /// Installing a RECEIVED snapshot (the learner/follower catch-up half) adopts its
+    /// index/term/`ConfState`/data, clears the log, and persists it durably — then the retained tail
+    /// can be appended on top (#660 non-negotiable 4).
+    #[test]
+    fn install_received_snapshot_adopts_state_and_survives_reopen() {
+        let fs = InMemoryFs::new();
+        {
+            let mut storage = open(&fs, &[1]);
+            // A snapshot arriving from a leader at index 30, term 5.
+            let mut snapshot = Snapshot::default();
+            snapshot.data = bytes::Bytes::copy_from_slice(&sm_bytes("recv30"));
+            {
+                let meta = snapshot.mut_metadata();
+                meta.index = 30;
+                meta.term = 5;
+                meta.set_conf_state(conf_state(vec![1, 2, 3], vec![4]));
+            }
+            let installed = storage.install_received_snapshot(&snapshot).expect("install");
+            assert!(installed);
+            assert_eq!(storage.snapshot_index(), 30);
+            assert_eq!(
+                storage.first_index().unwrap(),
+                31,
+                "first index is snapshot index + 1 after install"
+            );
+            // The tail above the snapshot replicates next: append 31, 32.
+            storage
+                .append(&[entry(31, 5, b"t1"), entry(32, 5, b"t2")])
+                .expect("append tail");
+            storage.set_hard_state(&hard_state(5, 0, 32)).expect("hs");
+            storage.sync().expect("sync");
+            assert_eq!(storage.last_index().unwrap(), 32);
+        }
+        // Reopen: the installed snapshot + the tail survive.
+        let recovered = open(&fs, &[1]);
+        assert_eq!(recovered.snapshot_index(), 30);
+        assert_eq!(recovered.first_index().unwrap(), 31);
+        assert_eq!(recovered.last_index().unwrap(), 32);
+        let state = recovered.initial_state().unwrap();
+        assert_eq!(state.conf_state.voters, vec![1, 2, 3]);
+        assert_eq!(state.conf_state.learners, vec![4]);
+        let snap = recovered.snapshot(30, 1).expect("snapshot");
+        assert_eq!(snap.data.as_ref(), sm_bytes("recv30").as_slice());
+    }
+
+    /// A STALE received snapshot (index below our current first index — we already hold that and a
+    /// newer tail) is REFUSED, never regressing committed state (#660 non-negotiable 1,
+    /// fail-closed): the `first_index() > index` `SnapshotOutOfDate` guard, matching MemStorage.
+    #[test]
+    fn a_stale_received_snapshot_is_refused() {
+        let fs = InMemoryFs::new();
+        let mut storage = open(&fs, &[1]);
+        // First install a snapshot at index 10, so our first index is 11.
+        let mut newer = Snapshot::default();
+        newer.data = bytes::Bytes::copy_from_slice(&sm_bytes("idx10"));
+        {
+            let meta = newer.mut_metadata();
+            meta.index = 10;
+            meta.term = 2;
+            meta.set_conf_state(conf_state(vec![1], vec![]));
+        }
+        assert!(storage.install_received_snapshot(&newer).expect("install newer"));
+        assert_eq!(storage.first_index().unwrap(), 11);
+
+        // A LATER-arriving snapshot at index 5 is stale: it is below our first index (11).
+        let mut stale = Snapshot::default();
+        {
+            let meta = stale.mut_metadata();
+            meta.index = 5;
+            meta.term = 1;
+            meta.set_conf_state(conf_state(vec![1], vec![]));
+        }
+        let installed = storage
+            .install_received_snapshot(&stale)
+            .expect("install call");
+        assert!(!installed, "a stale snapshot is refused");
+        // The newer snapshot is untouched (no regression).
+        assert_eq!(storage.snapshot_index(), 10);
+        assert_eq!(storage.first_index().unwrap(), 11);
+    }
+
+    /// `snapshot()` returns `SnapshotTemporarilyUnavailable` when no data-bearing snapshot fresh
+    /// enough for the request exists, so a torn/empty-data snapshot is never sent to a follower.
+    #[test]
+    fn snapshot_is_unavailable_until_one_is_created() {
+        let fs = InMemoryFs::new();
+        let mut storage = open(&fs, &[1]);
+        storage
+            .append(&[entry(1, 1, b"a"), entry(2, 1, b"b")])
+            .expect("append");
+        storage.set_hard_state(&hard_state(1, 1, 2)).expect("hs");
+        storage.sync().expect("sync");
+        // No snapshot created yet: a request is transiently unavailable.
+        assert!(matches!(
+            storage.snapshot(1, 0),
+            Err(RaftError::Store(
+                RaftStorageError::SnapshotTemporarilyUnavailable
+            ))
+        ));
+        // After creating one at index 2, the request is served with data.
+        storage
+            .create_snapshot_and_compact(2, 1, &sm_bytes("idx2"))
+            .expect("snapshot+compact");
+        let snap = storage.snapshot(1, 0).expect("snapshot now available");
+        assert_eq!(snap.get_metadata().index, 2);
+        assert_eq!(snap.data.as_ref(), sm_bytes("idx2").as_slice());
     }
 }

--- a/crates/ironbus-server/src/cluster/runtime.rs
+++ b/crates/ironbus-server/src/cluster/runtime.rs
@@ -48,9 +48,12 @@
 //! * **DATA-log replication (C2)** — this runtime replicates only the cluster METADATA (membership /
 //!   placement / config) over the one metadata Raft group; the broker's produce/consume data logs
 //!   are untouched.
-//! * **Snapshot transfer / log compaction (#660)**, **mTLS peer auth**, and **dynamic peer
-//!   discovery** are out of scope: peers are a static configured set, plaintext TCP, bound by the
-//!   [`transport`] codec's size + recursion limits and the [`PeerRegistry`] peer-id check.
+//! * **Metadata-log snapshot + compaction (#660)** IS wired here: the driver snapshots the applied
+//!   metadata state machine and truncates the metadata log on a bounded cadence / log-size threshold
+//!   (so the metadata log stays bounded), and a far-behind learner is caught up via snapshot transfer.
+//! * **mTLS peer auth** and **dynamic peer discovery** are out of scope: peers are a static configured
+//!   set, plaintext TCP, bound by the [`transport`] codec's size + recursion limits and the
+//!   [`PeerRegistry`] peer-id check.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::io;
@@ -143,6 +146,24 @@ const COMMITTED_HW_CHECKPOINT_INTERVAL: Duration = Duration::from_millis(500);
 /// is promoted exactly once — the committed conf change drops it from the learner set — so this is a
 /// low-rate background reconcile, the join-side analogue of the F2 failover cadence.
 const LEARNER_PROMOTION_INTERVAL: Duration = Duration::from_millis(500);
+
+/// How often a node SNAPSHOTS the metadata state machine + COMPACTS the metadata Raft log (#660), so
+/// the log does not grow without bound. It is deliberately PERIODIC + LOW-RATE — the metadata-log-over-
+/// IronBus-log (#659) appends one record per membership/placement/config/committed-HW change, which is a
+/// background control-plane rate, NOT a hot path, so a coarse cadence keeps the log bounded with
+/// negligible cost. EVERY node snapshots its OWN applied state (not just the leader): a snapshot is a
+/// purely-local compaction of already-committed state — it needs no consensus round and never changes
+/// client-visible behavior — so each node bounds its own log independently. It is the metadata-log
+/// analogue of [`COMMITTED_HW_CHECKPOINT_INTERVAL`]: bounded, self-healing (a skipped cycle simply
+/// snapshots more next time), and crash-safe (the snapshot is durable before the log prefix is dropped).
+const METADATA_SNAPSHOT_INTERVAL: Duration = Duration::from_secs(10);
+
+/// The retained-metadata-log length (entries above the last snapshot) past which a node snapshots +
+/// compacts EARLY, ahead of the [`METADATA_SNAPSHOT_INTERVAL`] cadence (#660). This bounds the log by
+/// SIZE as well as by time: a burst of membership/placement churn that appends faster than the cadence
+/// still triggers a compaction once the tail crosses this threshold, so the log can never grow without
+/// bound between periodic snapshots. It is generous (the metadata log is small) but finite.
+const METADATA_SNAPSHOT_LOG_THRESHOLD: u64 = 1024;
 
 /// The fixed TCP-port offset the DATA-plane peer listener binds at, RELATIVE to a node's configured
 /// metadata address (#717). One `--cluster-peer <id>=<addr>` entry thus serves BOTH transports: the
@@ -304,6 +325,11 @@ pub struct ClusterStatus {
     /// appears as a voter and leaves `learners`). Empty when no caught-up promotion is in flight; this is
     /// the witness that a learner was promoted ONLY after catching up (it never appears here while behind).
     pub learners_promoted: BTreeSet<u64>,
+    /// The index of the last metadata-log SNAPSHOT/compaction (#660), `0` before any. Every metadata log
+    /// entry at or below it is subsumed by the durable snapshot; the retained log is the bounded tail
+    /// above it. Observability: it RISES as the driver snapshots + compacts on its cadence, which is the
+    /// witness that the metadata log is being bounded (not growing forever).
+    pub snapshot_index: u64,
 }
 
 /// A command for the driver to propose to the metadata group on behalf of the broker (or a test):
@@ -1159,6 +1185,17 @@ fn run_driver<F, C>(
         .now_monotonic_nanos()
         .saturating_sub(checkpoint_interval_nanos);
 
+    // SNAPSHOT STATE (#660): the cadence + the last monotonic time we snapshotted + compacted the
+    // metadata log, so EVERY node bounds its OWN log PERIODICALLY (not per cycle). Unlike the checkpoint
+    // / promotion cadences this is NOT leader-only — a snapshot is a purely-local compaction of
+    // already-applied committed state, so each node compacts independently. Seeded back a full interval
+    // so the first compaction can fire once enough has been applied.
+    let snapshot_interval_nanos = duration_to_nanos(METADATA_SNAPSHOT_INTERVAL);
+    let mut last_snapshot_nanos = failover
+        .clock
+        .now_monotonic_nanos()
+        .saturating_sub(snapshot_interval_nanos);
+
     // TICK CADENCE (#632): raft's `tick()` advances a LOGICAL election/heartbeat counter and MUST be
     // driven on a fixed WALL-CLOCK cadence (`heartbeat_tick=3` × `TICK_INTERVAL` = ~300 ms heartbeats,
     // `election_tick=10` = ~1 s election). The loop below wakes on EVERY inbound peer message (so a
@@ -1382,6 +1419,36 @@ fn run_driver<F, C>(
             }
         }
 
+        // ----- SNAPSHOT + COMPACT the metadata log (#660). On a cadence OR once the retained log tail
+        // crosses the size threshold, snapshot the applied metadata state machine and TRUNCATE the log
+        // up to it, so the metadata log stays BOUNDED instead of growing forever (one record per
+        // membership/placement/config/committed-HW change, #659). This runs on EVERY node (not just the
+        // leader): a snapshot is a purely-local compaction of already-committed+applied state — no
+        // consensus round, no client-visible change — so each node bounds its own log independently. It
+        // is crash-safe (the snapshot is fsynced to its dual-slot checkpoint BEFORE the log prefix is
+        // dropped) and self-healing (a deferred/failed snapshot is simply retried next cycle). The
+        // snapshot ALSO enables snapshot-based catch-up: a far-behind learner gets the snapshot + the
+        // tail rather than the whole (now-compacted) log. -----
+        let snapshot_due = now.saturating_sub(last_snapshot_nanos) >= snapshot_interval_nanos;
+        let snapshot_over_threshold = group.retained_log_len() >= METADATA_SNAPSHOT_LOG_THRESHOLD;
+        if snapshot_due || snapshot_over_threshold {
+            match group.create_snapshot() {
+                Ok(true) => {
+                    tracing::debug!(
+                        snapshot_index = group.snapshot_index(),
+                        "cluster: snapshotted + compacted the metadata log (#660)"
+                    );
+                }
+                Ok(false) => {} // nothing new applied since the last snapshot — a no-op.
+                Err(e) => {
+                    // A snapshot/compaction failure is surfaced but NOT fatal: the log is still
+                    // correct (just un-compacted), and the next cycle retries.
+                    tracing::warn!(error = %e, "cluster: metadata snapshot/compaction deferred");
+                }
+            }
+            last_snapshot_nanos = now;
+        }
+
         // ----- F2: AUTO-FIRE the failover — PROVABLY committed-safe, fail-closed (#618b). On a committed
         // membership shrink (`departed_members` non-empty), the metadata leader auto-promotes a partition
         // a departed node LED, but ONLY a successor it can PROVE holds every committed record — i.e.
@@ -1589,6 +1656,9 @@ fn run_driver<F, C>(
                 s.last_committed_hw = group.state().committed_hws();
             }
             s.applied_index = applied;
+            // Publish the metadata-log snapshot index (#660): it rises as the driver snapshots +
+            // compacts, the witness that the metadata log is being bounded.
+            s.snapshot_index = group.snapshot_index();
             // Publish the leaderless-failover detection signal (the departed-members set), so the
             // data-plane failover driver can re-place every partition a departed node led (#618). Only
             // re-cloned when it actually changed (a committed membership shrink), not every tick.
@@ -2403,6 +2473,71 @@ mod tests {
         assert!(
             dir.path().join(super::super::METADATA_SUBDIR).exists(),
             "a configured 1-member cluster does create its metaraft/ log"
+        );
+        node.stop();
+    }
+
+    /// THE RUNTIME-LEVEL SNAPSHOT-CADENCE TEST (#660): a live single-node runtime, on its bounded
+    /// snapshot cadence, SNAPSHOTS the metadata state machine + COMPACTS the metadata log — the
+    /// driver's published `snapshot_index` RISES, the witness the metadata log is being bounded
+    /// (not growing forever). It also proves the snapshot trigger is wired into the live driver loop
+    /// without disrupting consensus (the node stays leader and keeps applying).
+    #[test]
+    fn the_runtime_snapshots_and_compacts_the_metadata_log_on_its_cadence() {
+        let ports = free_ports(1);
+        let peers = peer_map(&[1], &ports);
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut node = start_node(
+            &ClusterConfig {
+                node_id: 1,
+                peers,
+                role: StartRole::Voter,
+                pending_learners: BTreeSet::new(),
+            },
+            dir.path(),
+        );
+        assert!(
+            wait_until(host_scaled(Duration::from_secs(10)), || node
+                .status()
+                .is_leader),
+            "the lone voter self-elects"
+        );
+
+        // Commit a handful of metadata writes so the state machine has real committed state to
+        // snapshot (and an applied index above the genesis no-op).
+        for i in 0..5u64 {
+            node.propose_metadata(MetadataCommand::SetConfig {
+                key: format!("k{i}"),
+                value: i.to_string(),
+            })
+            .expect("propose");
+        }
+        assert!(
+            wait_until(host_scaled(Duration::from_secs(10)), || node
+                .status()
+                .applied_index
+                >= 5),
+            "the metadata writes commit + apply"
+        );
+
+        // The driver snapshots + compacts on the METADATA_SNAPSHOT_INTERVAL cadence: within a couple
+        // of intervals the published snapshot_index rises to cover the applied state. The deadline is
+        // a generous host-scaled bound around that bounded cadence (no wall-clock flake).
+        let snapshotted = wait_until(host_scaled(Duration::from_secs(40)), || {
+            let s = node.status();
+            s.snapshot_index > 0 && s.snapshot_index <= s.applied_index
+        });
+        let final_status = node.status();
+        assert!(
+            snapshotted,
+            "the runtime snapshotted + compacted the metadata log on its cadence \
+             (snapshot_index={}, applied_index={})",
+            final_status.snapshot_index, final_status.applied_index
+        );
+        // The node is still the healthy leader after compaction (consensus undisturbed).
+        assert!(
+            node.status().is_leader,
+            "the node remains leader after snapshot + compaction"
         );
         node.stop();
     }

--- a/crates/ironbus-server/src/cluster/state_machine.rs
+++ b/crates/ironbus-server/src/cluster/state_machine.rs
@@ -1082,7 +1082,10 @@ mod tests {
         let sm = populated_sm();
         let bytes = sm.snapshot();
         let restored = MetadataStateMachine::restore_from_snapshot(&bytes).expect("restore");
-        assert_eq!(restored, sm, "the restored state machine equals the original");
+        assert_eq!(
+            restored, sm,
+            "the restored state machine equals the original"
+        );
         assert_eq!(restored.applied_index(), sm.applied_index());
         // Spot-check a representative value from each map survived.
         assert_eq!(restored.role(1), Some(NodeRole::Voter));
@@ -1182,8 +1185,13 @@ mod tests {
 
         // Snapshot-at-6 + tail 7,8: restore the snapshot, then apply only the tail.
         let snapshot = populated_sm().snapshot();
-        let mut from_snap = MetadataStateMachine::restore_from_snapshot(&snapshot).expect("restore");
-        assert_eq!(from_snap.applied_index(), 6, "restored at the snapshot index");
+        let mut from_snap =
+            MetadataStateMachine::restore_from_snapshot(&snapshot).expect("restore");
+        assert_eq!(
+            from_snap.applied_index(),
+            6,
+            "restored at the snapshot index"
+        );
         from_snap.apply(
             7,
             &MetadataCommand::AddNode {

--- a/crates/ironbus-server/src/cluster/state_machine.rs
+++ b/crates/ironbus-server/src/cluster/state_machine.rs
@@ -162,6 +162,9 @@ pub enum DecodeError {
     /// A `PlacePartition` command had an empty replica set (a placement must hold at least one
     /// replica).
     EmptyReplicaSet,
+    /// A serialized state-machine SNAPSHOT (#660) carried an unknown format version, so it was not
+    /// written by a compatible encoder — fail closed rather than mis-decode a torn/foreign blob.
+    UnknownSnapshotVersion(u8),
 }
 
 impl core::fmt::Display for DecodeError {
@@ -179,6 +182,9 @@ impl core::fmt::Display for DecodeError {
                 write!(f, "placement leader is not in its own replica set")
             }
             DecodeError::EmptyReplicaSet => write!(f, "placement has an empty replica set"),
+            DecodeError::UnknownSnapshotVersion(v) => {
+                write!(f, "unknown metadata snapshot format version {v}")
+            }
         }
     }
 }
@@ -564,6 +570,174 @@ impl MetadataStateMachine {
     pub fn applied_index(&self) -> u64 {
         self.applied_index
     }
+
+    /// Serialize a CONSISTENT, point-in-time SNAPSHOT of the committed state machine (#660).
+    ///
+    /// A snapshot is a complete, canonical serialization of EVERY piece of committed metadata —
+    /// membership, placements, committed-HW, config — plus the `applied_index` the snapshot is
+    /// taken at. It is what the metadata Raft log snapshot/compaction (#660) captures BEFORE the
+    /// log prefix is truncated, and what a far-behind learner installs to catch up without
+    /// replaying the whole log (the snapshot-based catch-up that pairs with #617/#724).
+    ///
+    /// The encoding is the SAME explicit, length-prefixed, little-endian, zero-dependency style as
+    /// [`MetadataCommand::encode`] (so the snapshot adds NO new dependency and has one canonical
+    /// meaning across nodes), prefixed by a one-byte format `version` so a future field can be
+    /// added without mis-decoding an older blob. Maps are written in their `BTreeMap` order, which
+    /// is deterministic (sorted by key), so two state machines with identical committed state
+    /// serialize to BYTE-IDENTICAL snapshots — the property the round-trip and catch-up tests
+    /// rely on.
+    ///
+    /// The snapshot is BOUNDED: the metadata state is small by construction (a cluster's
+    /// members / placements / config, not per-record data), so the serialization is O(members +
+    /// placements + config) bytes — kilobytes, not the unbounded log.
+    #[must_use]
+    pub fn snapshot(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.push(SNAPSHOT_VERSION);
+        out.extend_from_slice(&self.applied_index.to_le_bytes());
+
+        // members: [count:u32][ (node:u64, role:u8) ... ] in BTreeMap (sorted) order.
+        push_u32_len(&mut out, self.members.len());
+        for (node, role) in &self.members {
+            out.extend_from_slice(&node.to_le_bytes());
+            out.push(role.tag());
+        }
+
+        // placements: [count:u32][ (partition:u64, replica_count:u32, replicas:u64..., leader:u64,
+        // epoch:u64) ... ] in sorted order.
+        push_u32_len(&mut out, self.placements.len());
+        for (partition, placement) in &self.placements {
+            out.extend_from_slice(&partition.to_le_bytes());
+            push_u32_len(&mut out, placement.replicas.len());
+            for r in &placement.replicas {
+                out.extend_from_slice(&r.to_le_bytes());
+            }
+            out.extend_from_slice(&placement.leader.to_le_bytes());
+            out.extend_from_slice(&placement.epoch.to_le_bytes());
+        }
+
+        // committed_hw: [count:u32][ (partition:u64, offset:u64) ... ] in sorted order.
+        push_u32_len(&mut out, self.committed_hw.len());
+        for (partition, offset) in &self.committed_hw {
+            out.extend_from_slice(&partition.to_le_bytes());
+            out.extend_from_slice(&offset.to_le_bytes());
+        }
+
+        // config: [count:u32][ (key:str, value:str) ... ] in sorted order.
+        push_u32_len(&mut out, self.config.len());
+        for (key, value) in &self.config {
+            push_str(&mut out, key);
+            push_str(&mut out, value);
+        }
+
+        out
+    }
+
+    /// Decode a serialized snapshot (the inverse of [`Self::snapshot`]) into a fresh state machine.
+    ///
+    /// Installing a snapshot REPLACES the whole committed state (it is a point-in-time cut, not a
+    /// delta), so this returns a brand-new [`MetadataStateMachine`] whose maps + `applied_index`
+    /// are exactly the snapshot's. A node restoring from a snapshot then applies the retained log
+    /// TAIL (entries strictly above `applied_index`) on top, reaching the identical committed state
+    /// it would have by replaying the full log.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`DecodeError`] if the buffer carries an unknown version, is truncated, has an
+    /// overrunning length, holds invalid UTF-8, names a malformed placement (leader absent from
+    /// its replica set / empty replica set), or has trailing bytes — so a torn or foreign blob is
+    /// a typed, fail-closed error, never a silently-mis-installed state.
+    pub fn restore_from_snapshot(buf: &[u8]) -> Result<Self, DecodeError> {
+        let mut cur = Cursor::new(buf);
+        let version = cur.u8()?;
+        if version != SNAPSHOT_VERSION {
+            return Err(DecodeError::UnknownSnapshotVersion(version));
+        }
+        let applied_index = cur.u64()?;
+
+        let mut members = BTreeMap::new();
+        let member_count = cur.u32()? as usize;
+        // Reject a hostile/torn count before allocating per-element: each member is 9 bytes.
+        if cur.remaining() < member_count.saturating_mul(9) {
+            return Err(DecodeError::BadLength);
+        }
+        for _ in 0..member_count {
+            let node = cur.u64()?;
+            let role = NodeRole::from_tag(cur.u8()?).ok_or(DecodeError::UnknownRole(0))?;
+            members.insert(node, role);
+        }
+
+        let mut placements = BTreeMap::new();
+        let placement_count = cur.u32()? as usize;
+        for _ in 0..placement_count {
+            let partition = cur.u64()?;
+            let replica_count = cur.u32()? as usize;
+            if cur.remaining() < replica_count.saturating_mul(8) {
+                return Err(DecodeError::BadLength);
+            }
+            let mut replicas = Vec::with_capacity(replica_count);
+            for _ in 0..replica_count {
+                replicas.push(cur.u64()?);
+            }
+            let leader = cur.u64()?;
+            let epoch = cur.u64()?;
+            if replicas.is_empty() {
+                return Err(DecodeError::EmptyReplicaSet);
+            }
+            if !replicas.contains(&leader) {
+                return Err(DecodeError::LeaderNotAReplica);
+            }
+            placements.insert(
+                partition,
+                Placement {
+                    replicas,
+                    leader,
+                    epoch,
+                },
+            );
+        }
+
+        let mut committed_hw = BTreeMap::new();
+        let hw_count = cur.u32()? as usize;
+        if cur.remaining() < hw_count.saturating_mul(16) {
+            return Err(DecodeError::BadLength);
+        }
+        for _ in 0..hw_count {
+            let partition = cur.u64()?;
+            let offset = cur.u64()?;
+            committed_hw.insert(partition, offset);
+        }
+
+        let mut config = BTreeMap::new();
+        let config_count = cur.u32()? as usize;
+        for _ in 0..config_count {
+            let key = cur.string()?;
+            let value = cur.string()?;
+            config.insert(key, value);
+        }
+
+        if cur.remaining() != 0 {
+            return Err(DecodeError::TrailingBytes);
+        }
+        Ok(MetadataStateMachine {
+            members,
+            placements,
+            committed_hw,
+            config,
+            applied_index,
+        })
+    }
+}
+
+/// The serialized-snapshot format version (#660). Bumped only if the snapshot field layout changes
+/// incompatibly; an unknown version is rejected fail-closed at decode time.
+const SNAPSHOT_VERSION: u8 = 1;
+
+/// Push a `usize` count as a `u32-le` length prefix, saturating at `u32::MAX` (a count this large
+/// is unreachable for the small metadata state, but the saturation keeps the encode total).
+fn push_u32_len(out: &mut Vec<u8>, n: usize) {
+    let len = u32::try_from(n).unwrap_or(u32::MAX);
+    out.extend_from_slice(&len.to_le_bytes());
 }
 
 #[cfg(test)]
@@ -844,5 +1018,230 @@ mod tests {
         sm.apply_encoded(5, &data).expect("apply encoded");
         assert_eq!(sm.role(1), Some(NodeRole::Voter));
         assert_eq!(sm.applied_index(), 5);
+    }
+
+    // --- #660: state-machine snapshot serialization + restore. ---
+
+    /// Build a state machine with one of every kind of committed state, so the snapshot exercises
+    /// every map (members, placements, committed-HW, config) and the applied index.
+    fn populated_sm() -> MetadataStateMachine {
+        let mut sm = MetadataStateMachine::new();
+        sm.apply(
+            1,
+            &MetadataCommand::AddNode {
+                node: 1,
+                role: NodeRole::Voter,
+            },
+        );
+        sm.apply(
+            2,
+            &MetadataCommand::AddNode {
+                node: 2,
+                role: NodeRole::Learner,
+            },
+        );
+        sm.apply(
+            3,
+            &MetadataCommand::PlacePartition {
+                partition: 7,
+                replicas: vec![1, 2, 3],
+                leader: 1,
+                epoch: 4,
+            },
+        );
+        sm.apply(
+            4,
+            &MetadataCommand::AssignPartition {
+                partition: 9,
+                leader: 2,
+                epoch: 5,
+            },
+        );
+        sm.apply(
+            5,
+            &MetadataCommand::CheckpointCommittedHw {
+                partition: 7,
+                offset: 1234,
+            },
+        );
+        sm.apply(
+            6,
+            &MetadataCommand::SetConfig {
+                key: "replication".to_owned(),
+                value: "3".to_owned(),
+            },
+        );
+        sm
+    }
+
+    /// A snapshot round-trips: restoring a serialized snapshot yields a state machine BYTE-EQUAL to
+    /// the original (every map + the applied index), proving the snapshot captures ALL committed
+    /// state at its index (the #660 committed-state-preserved invariant, at the SM layer).
+    #[test]
+    fn snapshot_then_restore_yields_an_identical_state_machine() {
+        let sm = populated_sm();
+        let bytes = sm.snapshot();
+        let restored = MetadataStateMachine::restore_from_snapshot(&bytes).expect("restore");
+        assert_eq!(restored, sm, "the restored state machine equals the original");
+        assert_eq!(restored.applied_index(), sm.applied_index());
+        // Spot-check a representative value from each map survived.
+        assert_eq!(restored.role(1), Some(NodeRole::Voter));
+        assert_eq!(restored.role(2), Some(NodeRole::Learner));
+        assert_eq!(
+            restored.placement(7),
+            Some(Placement {
+                replicas: vec![1, 2, 3],
+                leader: 1,
+                epoch: 4
+            })
+        );
+        assert_eq!(restored.placement(9), Some(Placement::leader_only(2, 5)));
+        assert_eq!(restored.committed_hw(7), Some(1234));
+        assert_eq!(restored.config("replication"), Some("3"));
+    }
+
+    /// Two state machines with IDENTICAL committed state serialize to BYTE-IDENTICAL snapshots
+    /// (the `BTreeMap` order is deterministic), regardless of the ORDER the commands were applied —
+    /// the point-in-time-consistency property a snapshot relies on.
+    #[test]
+    fn snapshot_is_deterministic_regardless_of_apply_order() {
+        let a = populated_sm();
+        // Apply the same commands in a DIFFERENT order, but at the same final applied index.
+        let mut b = MetadataStateMachine::new();
+        b.apply(
+            6,
+            &MetadataCommand::SetConfig {
+                key: "replication".to_owned(),
+                value: "3".to_owned(),
+            },
+        );
+        b.apply(
+            5,
+            &MetadataCommand::CheckpointCommittedHw {
+                partition: 7,
+                offset: 1234,
+            },
+        );
+        b.apply(
+            4,
+            &MetadataCommand::AssignPartition {
+                partition: 9,
+                leader: 2,
+                epoch: 5,
+            },
+        );
+        b.apply(
+            3,
+            &MetadataCommand::PlacePartition {
+                partition: 7,
+                replicas: vec![1, 2, 3],
+                leader: 1,
+                epoch: 4,
+            },
+        );
+        b.apply(
+            2,
+            &MetadataCommand::AddNode {
+                node: 2,
+                role: NodeRole::Learner,
+            },
+        );
+        // Re-set the applied index to match `a` (the last apply above set it to 2).
+        b.apply(
+            6,
+            &MetadataCommand::AddNode {
+                node: 1,
+                role: NodeRole::Voter,
+            },
+        );
+        assert_eq!(a.snapshot(), b.snapshot(), "snapshots are byte-identical");
+    }
+
+    /// Restoring a snapshot then applying the log TAIL on top reaches the SAME state as a full
+    /// replay (the snapshot+tail == full-replay invariant, at the SM layer). This is the heart of
+    /// snapshot-based catch-up: a node that installs a snapshot at index N and applies N+1.. is
+    /// identical to a node that replayed 1...
+    #[test]
+    fn restore_then_apply_tail_equals_full_replay() {
+        // Full replay: apply commands 1..=8.
+        let mut full = populated_sm();
+        full.apply(
+            7,
+            &MetadataCommand::AddNode {
+                node: 3,
+                role: NodeRole::Voter,
+            },
+        );
+        full.apply(
+            8,
+            &MetadataCommand::SetConfig {
+                key: "k".to_owned(),
+                value: "v".to_owned(),
+            },
+        );
+
+        // Snapshot-at-6 + tail 7,8: restore the snapshot, then apply only the tail.
+        let snapshot = populated_sm().snapshot();
+        let mut from_snap = MetadataStateMachine::restore_from_snapshot(&snapshot).expect("restore");
+        assert_eq!(from_snap.applied_index(), 6, "restored at the snapshot index");
+        from_snap.apply(
+            7,
+            &MetadataCommand::AddNode {
+                node: 3,
+                role: NodeRole::Voter,
+            },
+        );
+        from_snap.apply(
+            8,
+            &MetadataCommand::SetConfig {
+                key: "k".to_owned(),
+                value: "v".to_owned(),
+            },
+        );
+
+        assert_eq!(
+            from_snap, full,
+            "restore(snapshot@6) + apply(7,8) == full replay(1..=8)"
+        );
+        assert_eq!(from_snap.applied_index(), 8);
+    }
+
+    /// An empty (fresh) state machine snapshots and restores cleanly (the genesis case).
+    #[test]
+    fn an_empty_state_machine_snapshots_and_restores() {
+        let sm = MetadataStateMachine::new();
+        let bytes = sm.snapshot();
+        let restored = MetadataStateMachine::restore_from_snapshot(&bytes).expect("restore empty");
+        assert_eq!(restored, sm);
+        assert_eq!(restored.applied_index(), 0);
+    }
+
+    /// Restore fails CLOSED on a foreign / torn blob: an unknown version, trailing bytes, and a
+    /// truncated buffer are typed errors, never a silently mis-installed state.
+    #[test]
+    fn restore_rejects_a_foreign_or_torn_snapshot() {
+        // Unknown version byte.
+        assert_eq!(
+            MetadataStateMachine::restore_from_snapshot(&[0xff, 0, 0, 0, 0, 0, 0, 0, 0]),
+            Err(DecodeError::UnknownSnapshotVersion(0xff))
+        );
+        // Trailing bytes after a valid snapshot.
+        let mut bytes = populated_sm().snapshot();
+        bytes.push(0x00);
+        assert_eq!(
+            MetadataStateMachine::restore_from_snapshot(&bytes),
+            Err(DecodeError::TrailingBytes)
+        );
+        // Truncated mid-snapshot.
+        let good = populated_sm().snapshot();
+        assert!(matches!(
+            MetadataStateMachine::restore_from_snapshot(&good[..good.len() / 2]),
+            Err(DecodeError::Truncated | DecodeError::BadLength)
+        ));
+        // Empty buffer.
+        assert_eq!(
+            MetadataStateMachine::restore_from_snapshot(&[]),
+            Err(DecodeError::Truncated)
+        );
     }
 }

--- a/crates/ironbus-storage/src/checkpoint.rs
+++ b/crates/ironbus-storage/src/checkpoint.rs
@@ -56,6 +56,18 @@ pub const ATTEMPTS_PAYLOAD: usize = 32 * 1024;
 /// length field (65535), so a snapshot at the cap still frames.
 pub const PRODUCER_SEQ_PAYLOAD: usize = 60 * 1024;
 
+/// The per-slot payload cap for the durable METADATA-RAFT SNAPSHOT checkpoint (V2-C1, #660): a
+/// serialized raft `Snapshot` (its index/term/`ConfState` metadata plus the metadata
+/// state-machine's snapshot bytes — members / placements / committed-HW / config). The metadata
+/// state is small BY CONSTRUCTION (a cluster's control plane, NOT per-record data), so even a
+/// large cluster's snapshot is a few KiB; this 60 KiB cap holds a control plane with thousands of
+/// placements/members/config entries with generous headroom, and stays under the slot's `u16`
+/// length field (65535) so a snapshot at the cap still frames. The snapshot is persisted to BOTH
+/// slots alternately with the SAME dual-slot CRC discipline as the other checkpoints, so a crash
+/// mid-write reverts to the prior durable snapshot — NEVER a torn one — which (paired with the
+/// retained log tail) is what makes metadata compaction crash-safe (#660 non-negotiable 3).
+pub const METADATA_SNAPSHOT_PAYLOAD: usize = 60 * 1024;
+
 const SEQ_LEN: usize = 8;
 const LEN_LEN: usize = 2;
 const CRC_LEN: usize = 4;
@@ -141,6 +153,17 @@ pub type AttemptsCheckpoint<F> = SlotCheckpoint<F, ATTEMPTS_PAYLOAD>;
 /// it is what makes a replayed retry across a broker restart STILL deduped, and because the bound is
 /// SEQUENCE state (not wall-clock), a long offline gap never drops it — the beat over NATS.
 pub type ProducerSeqCheckpoint<F> = SlotCheckpoint<F, PRODUCER_SEQ_PAYLOAD>;
+
+/// The crash-safe checkpoint for the durable METADATA-RAFT SNAPSHOT (V2-C1, #660): a
+/// [`METADATA_SNAPSHOT_PAYLOAD`]-per-slot [`SlotCheckpoint`]. It reuses the identical dual-slot CRC
+/// discipline as the cursor, counters, attempt-count, and producer-seq checkpoints — a torn write
+/// reverts to the prior durable snapshot and a torn or missing one recovers as "no snapshot" (the
+/// node then recovers purely from the full retained log, the pre-#660 behavior) without ever
+/// blocking startup. Persisting the snapshot here BEFORE the metadata log prefix is truncated is
+/// what makes compaction crash-safe: a crash mid-compaction leaves either the prior snapshot + the
+/// full log, or the new snapshot + the (un-truncated or truncated) log — never a gap where neither
+/// holds the committed state.
+pub type MetadataSnapshotCheckpoint<F> = SlotCheckpoint<F, METADATA_SNAPSHOT_PAYLOAD>;
 
 impl<F: RandomAccessFile, const PAYLOAD_CAP: usize> SlotCheckpoint<F, PAYLOAD_CAP> {
     /// Bytes per slot for this cap: sequence, payload length, payload, CRC.


### PR DESCRIPTION
## What & why

The metadata Raft log (the KRaft-style metadata-over-IronBus-log, #659) grew **unbounded** — every membership / placement / config / committed-HW change appended forever. This adds **snapshot + compaction**: periodically snapshot the metadata state machine's committed state and **truncate** the metadata log up to the snapshot, so the log stays bounded. It also enables **snapshot-based catch-up**: a far-behind learner gets the snapshot + the tail, not the whole (now-compacted) log (#617/#724).

## Design

**1. State-machine snapshot (`state_machine.rs`).** `MetadataStateMachine::snapshot()` serializes ALL committed state (members, placements, committed-HW, config) + the applied index, in the same zero-dependency length-prefixed LE codec as `MetadataCommand` (no new dep). `BTreeMap` order is deterministic, so identical committed state → byte-identical snapshots (point-in-time consistency). `restore_from_snapshot()` is the fail-closed inverse.

**2. Durable, crash-safe persist + compaction (`metadata_storage.rs`).** `create_snapshot_and_compact(index, term, data)`:
1. Builds a raft `Snapshot` (index/term/`ConfState`/data) and writes it to a **dual-slot CRC checkpoint** (`MetadataSnapshotCheckpoint`, the same discipline as the cursor/attempts/producer-seq checkpoints) — **fsynced durable BEFORE anything is dropped**.
2. Compacts the in-memory mirror (drops the entry prefix ≤ index, records the new snapshot metadata — the `MemStorage` `compact`/`apply_snapshot` contract).
3. Physically reclaims the now-superseded log **segments** below the snapshot boundary (`reclaim_log_prefix` scans for the lowest retained-tail offset and reaps fully-superseded sealed segments; the active segment and any segment holding a retained record are never reaped).

`install_received_snapshot(snapshot)` is the receiving half (durable persist → install → reclaim), fail-closed on a stale snapshot (`first_index() > index`). `Storage::snapshot()` serves the durable data-bearing snapshot, else `SnapshotTemporarilyUnavailable` (never a torn/empty-data snapshot to a follower). Recovery reads the snapshot checkpoint FIRST, then folds only the log **tail** above the snapshot index (the existing `mirror_entry` compacted-prefix guard); STATE-record commit is a **floor** that never regresses below the snapshot.

**3. raft-rs wiring (`metadata_group.rs`).** `create_snapshot()` snapshots at the applied index. `drive_ready` now **installs a received snapshot** (durable persist + restore the SM from `Snapshot.data`) instead of erroring. `open` restores the SM from the durable snapshot, then the tail folds on top.

**4. Bounded cadence (`runtime.rs`).** The driver snapshots + compacts on `METADATA_SNAPSHOT_INTERVAL` (10 s) OR when the retained tail crosses `METADATA_SNAPSHOT_LOG_THRESHOLD` (1024). Runs on **every node** (a snapshot is a purely-local compaction of already-committed state — no consensus round, no client-visible change). `ClusterStatus.snapshot_index` published for observability.

## How each non-negotiable is guaranteed

1. **Compaction never loses committed state** — the snapshot captures ALL committed state at its index before truncation; recovery installs the snapshot + folds the retained tail; the STATE-commit floor prevents regression. *Proven by* `recovery_from_snapshot_plus_tail_equals_the_full_state`, `snapshot_and_compaction_bounds_the_log_and_survives_reopen`, `restore_then_apply_tail_equals_full_replay`.
2. **Point-in-time consistent** — snapshot taken at a committed+applied index; deterministic serialization. *Proven by* `snapshot_is_deterministic_regardless_of_apply_order`.
3. **Crash-safe** — snapshot fsynced to its dual-slot checkpoint BEFORE the log prefix is dropped; a crash mid-compaction leaves {snapshot + (un-truncated) log} or {prior snapshot + full log}, never a gap; a torn checkpoint falls back to full-log replay. *Proven by* `crash_after_snapshot_persist_before_log_truncation_recovers_correctly`, `crash_before_snapshot_persist_recovers_via_full_log_replay`, `a_torn_snapshot_checkpoint_falls_back_to_the_full_log`.
4. **Snapshot catch-up, no gap/dup** — raft-rs snapshot transfer; the receiver installs + applies the tail from the snapshot index. *Proven by* `a_far_behind_learner_catches_up_via_snapshot_transfer_on_a_mesh` (real multi-node mesh: a learner joining after the leader compacted converges via actual `MsgSnapshot`; its applied frontier matches the leader's).
5. **Single-node byte-identical** — diff is confined to `cluster/` (constructed only with a `ClusterConfig`) + a purely-additive `checkpoint.rs` alias. **No changes to engine/session/actor/storage produce-consume hot paths, server.rs, or ironbus-core.** *By construction* (grep of the diff confirms zero hot-path edits).
6. **Bounded** — cadence + size threshold documented; compaction reaps superseded segments; the snapshot itself is bounded (small control-plane state, 60 KiB slot cap). *Proven by* `snapshot_then_compact_truncates_the_log_and_keeps_the_tail` + `the_runtime_snapshots_and_compacts_the_metadata_log_on_its_cadence`.
7. **No regression** — all 830 server-lib tests pass (consensus/failover/rebalance/metadata-log suites green).

## Vendored codec

**No codec extension needed.** The vendored build-script-free `eraftpb::Snapshot` already has a `data: Bytes` field and `SnapshotMetadata { index, term, conf_state }` — the snapshot rides those existing fields, so this stays no-protoc / MSRV-1.78-safe with no changes to the committed generated code.

## Tests (all rerun 5× stable; new tests = 23)

`state_machine`: snapshot↔restore round-trip, determinism, restore+tail==full-replay, empty, fail-closed decode.
`metadata_storage`: compact bounds the log + keeps the tail, snapshot+tail recovery == full state, crash-after-persist-before-truncate, crash-before-persist, torn checkpoint fallback, install received snapshot + reopen, stale refused, unavailable-until-created.
`metadata_group`: snapshot+compaction bounds the log + survives reopen, far-behind LEARNER catches up via real snapshot transfer on a multi-node mesh.
`runtime`: a live single-node runtime snapshots + compacts on its cadence (`snapshot_index` rises, node stays leader).

## Gates

`cargo fmt --all --check` ✅ · `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` ✅ (rc=0) · `cargo test --workspace --all-features --locked` ✅ (0 failed; APFS flake didn't trigger) · server-lib 830 passed/0 failed · io-free-check ✅ (core untouched) · SPDX miss=0 ✅ · public-repo hygiene ✅.

## Deferred

mTLS peer auth and dynamic peer discovery remain out of scope (unchanged). Snapshot SENDING currently relies on raft-rs's transfer over the existing bounded peer codec; no new wire message types added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVWp2H2txnKGru4q2twxM3
