### PR TITLE
feat(cluster): follower-read dirty-tier leader-confirm — read-your-writes from a follower, never unconfirmed (#739)

### DIFF
--- a/crates/ironbus-proto/src/frame.rs
+++ b/crates/ironbus-proto/src/frame.rs
@@ -399,6 +399,22 @@ pub enum FrameType {
     /// peers). The session layer (`crate::session` in `ironbus-server`) and the client are its only
     /// encoder/decoder.
     NotLeader,
+    /// The FOLLOWER-READ DIRTY-TIER committed-HW CONFIRM frame (#739, V2-C6, wire tag 43). The tiny
+    /// HW-VERSION query (NOT the data) a FOLLOWER sends to the partition LEADER when a "latest/dirty"
+    /// follower-read reaches ABOVE the follower's known safe watermark (#723's
+    /// `ConfirmWithLeader`): it asks the leader for the partition's CURRENT committed high-watermark so
+    /// the follower can serve the now-confirmed prefix LOCALLY — and NEVER serve an offset the leader
+    /// has not confirmed committed. It rides the intra-cluster DATA-plane peer link (the same bounded
+    /// `[len][type][body]` envelope as the replication verbs), NOT the client wire: a CLIENT never sends
+    /// or receives it. Request and response SHARE this one tag, distinguished by a leading `kind` byte
+    /// (like [`FrameType::OffsetForLeaderEpoch`] / [`FrameType::MirrorPull`]). Body (request):
+    /// `kind: u8 = 0` (the partition id is carried by the data-plane envelope's partition prefix). Body
+    /// (response): `kind: u8 = 1`, `committed_hw: u64` — the leader's current committed HW (its read
+    /// plane's flushed frontier). It is a NEW append-only tag; tags 1-42 are byte-for-byte unchanged.
+    /// A single-node broker NEVER constructs the data plane, so this tag never appears off-cluster. The
+    /// cluster data plane (`crate::cluster::dataplane` / `crate::cluster::serve` in `ironbus-server`) is
+    /// its only encoder/decoder.
+    CommittedHwQuery,
 }
 
 impl FrameType {
@@ -448,6 +464,7 @@ impl FrameType {
             FrameType::MirrorPull => 40,
             FrameType::LeafPush => 41,
             FrameType::NotLeader => 42,
+            FrameType::CommittedHwQuery => 43,
         }
     }
 
@@ -498,6 +515,7 @@ impl FrameType {
             40 => FrameType::MirrorPull,
             41 => FrameType::LeafPush,
             42 => FrameType::NotLeader,
+            43 => FrameType::CommittedHwQuery,
             _ => return None,
         })
     }
@@ -630,7 +648,7 @@ mod tests {
     use super::*;
     use proptest::prelude::*;
 
-    const ALL_TYPES: [FrameType; 42] = [
+    const ALL_TYPES: [FrameType; 43] = [
         FrameType::Connect,
         FrameType::Info,
         FrameType::Ping,
@@ -673,6 +691,7 @@ mod tests {
         FrameType::MirrorPull,
         FrameType::LeafPush,
         FrameType::NotLeader,
+        FrameType::CommittedHwQuery,
     ];
 
     #[test]
@@ -733,6 +752,7 @@ mod tests {
         assert_eq!(FrameType::MirrorPull.as_u8(), 40);
         assert_eq!(FrameType::LeafPush.as_u8(), 41);
         assert_eq!(FrameType::NotLeader.as_u8(), 42);
+        assert_eq!(FrameType::CommittedHwQuery.as_u8(), 43);
     }
 
     #[test]
@@ -750,8 +770,9 @@ mod tests {
         // verbs; 38 is the cluster OffsetForLeaderEpoch divergence-query (#599, V2-C2-I4); 39 is the
         // cluster SegmentFingerprints divergence-advertisement (#611, V2-C4-I1); 40 is the
         // cross-cluster MirrorPull (#623, V2-C7-I1); 41 is the edge leaf-spoke LeafPush write-through
-        // (#625, V2-C7-I3); 42 is the cluster NotLeader produce-redirect (#735); 43 is now the next-free
-        // (still unknown) tag, so it frames but is not known.
+        // (#625, V2-C7-I3); 42 is the cluster NotLeader produce-redirect (#735); 43 is the follower-read
+        // dirty-tier CommittedHwQuery confirm (#739); 44 is now the next-free (still unknown) tag, so it
+        // frames but is not known.
         assert_eq!(FrameType::from_u8(37), Some(FrameType::AckReplicated));
         assert_eq!(
             FrameType::from_u8(38),
@@ -761,7 +782,8 @@ mod tests {
         assert_eq!(FrameType::from_u8(40), Some(FrameType::MirrorPull));
         assert_eq!(FrameType::from_u8(41), Some(FrameType::LeafPush));
         assert_eq!(FrameType::from_u8(42), Some(FrameType::NotLeader));
-        assert_eq!(FrameType::from_u8(43), None);
+        assert_eq!(FrameType::from_u8(43), Some(FrameType::CommittedHwQuery));
+        assert_eq!(FrameType::from_u8(44), None);
         for ty in [
             FrameType::BindSubject,
             FrameType::PubSubject,
@@ -804,7 +826,8 @@ mod tests {
         // 37 is the cluster AckReplicated report (#593); 38 is the cluster OffsetForLeaderEpoch
         // divergence-query (#599); 39 is the cluster SegmentFingerprints divergence-advertisement
         // (#611); 40 is the cross-cluster MirrorPull (#623); 41 is the edge leaf-spoke LeafPush (#625);
-        // 42 is the cluster NotLeader produce-redirect (#735); 43 is the next-free (still unknown) tag.
+        // 42 is the cluster NotLeader produce-redirect (#735); 43 is the follower-read dirty-tier
+        // CommittedHwQuery confirm (#739); 44 is the next-free (still unknown) tag.
         assert_eq!(FrameType::from_u8(37), Some(FrameType::AckReplicated));
         assert_eq!(
             FrameType::from_u8(38),
@@ -814,7 +837,8 @@ mod tests {
         assert_eq!(FrameType::from_u8(40), Some(FrameType::MirrorPull));
         assert_eq!(FrameType::from_u8(41), Some(FrameType::LeafPush));
         assert_eq!(FrameType::from_u8(42), Some(FrameType::NotLeader));
-        assert_eq!(FrameType::from_u8(43), None);
+        assert_eq!(FrameType::from_u8(43), Some(FrameType::CommittedHwQuery));
+        assert_eq!(FrameType::from_u8(44), None);
         for ty in [
             FrameType::StreamDeclare,
             FrameType::StreamInfo,
@@ -892,7 +916,8 @@ mod tests {
         // OffsetForLeaderEpoch divergence-query (#599, V2-C2-I4); 39 is the cluster SegmentFingerprints
         // divergence-advertisement (#611, V2-C4-I1); 40 is the cross-cluster MirrorPull (#623,
         // V2-C7-I1); 41 is the edge leaf-spoke LeafPush write-through (#625, V2-C7-I3); 42 is the
-        // cluster NotLeader produce-redirect (#735); 43 is now the next-free (still unknown) tag, so it
+        // cluster NotLeader produce-redirect (#735); 43 is the follower-read dirty-tier CommittedHwQuery
+        // confirm (#739); 44 is now the next-free (still unknown) tag, so it
         // frames but is not a known type. (Tags 27 = cluster-peer
         // Raft #667; 28-31 = the stream-addressed verbs #588; 32-33 = the cluster replication-fetch
         // verbs #590; 34-36 = the subject-routing verbs #585.)
@@ -905,7 +930,8 @@ mod tests {
         assert_eq!(FrameType::from_u8(40), Some(FrameType::MirrorPull));
         assert_eq!(FrameType::from_u8(41), Some(FrameType::LeafPush));
         assert_eq!(FrameType::from_u8(42), Some(FrameType::NotLeader));
-        assert_eq!(FrameType::from_u8(43), None);
+        assert_eq!(FrameType::from_u8(43), Some(FrameType::CommittedHwQuery));
+        assert_eq!(FrameType::from_u8(44), None);
         for ty in [FrameType::StreamFetch, FrameType::StreamCommit] {
             let mut buf = Vec::new();
             encode_frame(ty, b"\x07\x08", &mut buf).unwrap();
@@ -933,7 +959,8 @@ mod tests {
         // OffsetForLeaderEpoch divergence-query (#599, V2-C2-I4); 39 is the cluster SegmentFingerprints
         // divergence-advertisement (#611, V2-C4-I1); 40 is the cross-cluster MirrorPull (#623,
         // V2-C7-I1); 41 is the edge leaf-spoke LeafPush write-through (#625, V2-C7-I3); 42 is the
-        // cluster NotLeader produce-redirect (#735); 43 is now the next-free (still unknown) tag, so it
+        // cluster NotLeader produce-redirect (#735); 43 is the follower-read dirty-tier CommittedHwQuery
+        // confirm (#739); 44 is now the next-free (still unknown) tag, so it
         // frames but is not a known type. (Tags 27 = cluster-peer
         // Raft #667; 28-31 = the stream-addressed verbs #588; 32-33 = the cluster replication-fetch
         // verbs #590; 34-36 = the subject-routing verbs #585.)
@@ -946,7 +973,8 @@ mod tests {
         assert_eq!(FrameType::from_u8(40), Some(FrameType::MirrorPull));
         assert_eq!(FrameType::from_u8(41), Some(FrameType::LeafPush));
         assert_eq!(FrameType::from_u8(42), Some(FrameType::NotLeader));
-        assert_eq!(FrameType::from_u8(43), None);
+        assert_eq!(FrameType::from_u8(43), Some(FrameType::CommittedHwQuery));
+        assert_eq!(FrameType::from_u8(44), None);
         let mut buf = Vec::new();
         encode_frame(FrameType::DeliverBatch, b"\x09\x0a", &mut buf).unwrap();
         match decode_frame(&buf).unwrap() {
@@ -1141,7 +1169,7 @@ mod tests {
         /// An unknown type tag still decodes at the envelope level (forward compatibility):
         /// the body and length are recovered; only `from_u8` reports it unknown.
         #[test]
-        fn an_unknown_type_tag_still_frames(tag in 43u8..=255, body in prop::collection::vec(any::<u8>(), 0..256)) {
+        fn an_unknown_type_tag_still_frames(tag in 44u8..=255, body in prop::collection::vec(any::<u8>(), 0..256)) {
             let frame_len = 1u32 + u32::try_from(body.len()).unwrap();
             let mut buf = frame_len.to_le_bytes().to_vec();
             buf.push(tag);

--- a/crates/ironbus-server/src/cluster/client_ack.rs
+++ b/crates/ironbus-server/src/cluster/client_ack.rs
@@ -1043,4 +1043,94 @@ mod tests {
             "the leader uses the normal consume path, not the follower-read"
         );
     }
+
+    // ---- #739: the dirty-tier confirm fail-closes when the leader is unreachable -----------------
+
+    /// THE #739 in-process FAIL-CLOSED unit test: a caught-up follower whose KNOWN committed-HW bar is
+    /// STALE, with NO leader data address to confirm against. A `FollowerLatest` (dirty) read above the
+    /// stale bar CANNOT confirm (no route), so it FALLS BACK to the clean tier — it serves ONLY up to the
+    /// stale safe watermark, NEVER an unconfirmed offset (a read STARTING at the bar serves nothing).
+    #[test]
+    fn serve_follower_consume_dirty_tier_fails_closed_with_no_leader_route() {
+        let (caught, served_end) = caught_up_follower_gate(30);
+        assert!(served_end >= 6, "a healthy replicated prefix");
+        // Rebuild a gate over the SAME caught-up server with a STALE committed-HW bar and a follower target
+        // (so the dirty path tries to resolve a leader) but NO leader_data_addrs (so the confirm can find
+        // no route -> fail-closed). The follower target is set on the shared server.
+        let server = Arc::clone(caught.server());
+        let stale = served_end / 3;
+        assert!(stale > 0 && stale < served_end);
+        {
+            let mut srv = server.lock().unwrap();
+            srv.set_follower_target(P, 1); // names a leader, but with no data address mapped
+        }
+        let mut status = super::super::runtime::ClusterStatus::default();
+        status.last_committed_hw.insert(P, stale);
+        let gate = ClientAckGate::new(server, ClusterAckLevel::C2Fsync)
+            .with_status_handle(Arc::new(Mutex::new(status)));
+        // leader_data_addrs is EMPTY (never wired), so the confirm finds no route -> fail-closed.
+
+        // A DIRTY read from 0: it serves the clean prefix [0, stale) and never above the unconfirmed bar.
+        let mut from = Offset::ZERO;
+        let mut max_seen: Option<u64> = None;
+        let mut guard = 0u32;
+        loop {
+            guard += 1;
+            assert!(guard < 10_000, "chain failed to terminate");
+            let outcome = gate
+                .serve_follower_consume(P, ReadTier::FollowerLatest, from, usize::MAX, None)
+                .expect("a follower returns Some(outcome)");
+            let run = match outcome {
+                FollowerReadOutcome::Served(r) => r.run,
+                FollowerReadOutcome::ConfirmWithLeader { .. } => {
+                    panic!(
+                        "a fail-closed dirty read resolves to a clean Served run, never a confirm"
+                    )
+                }
+            };
+            if run.record_count == 0 {
+                break;
+            }
+            let mut off = run.first_offset.get();
+            let mut cursor = 0usize;
+            while cursor < run.bytes.len() {
+                let (_v, consumed) = ironbus_core::codec::decode(&run.bytes[cursor..]).unwrap();
+                assert!(
+                    off < stale,
+                    "fail-closed: served offset {off} at/above the unconfirmed bar {stale}"
+                );
+                max_seen = Some(max_seen.map_or(off, |m| m.max(off)));
+                off += 1;
+                cursor += consumed;
+            }
+            let next = run.next_offset.get();
+            if next <= from.get() {
+                break;
+            }
+            from = Offset::new(next);
+        }
+        assert!(
+            max_seen.is_some(),
+            "the clean fallback still served the committed prefix below the stale bar"
+        );
+        // A dirty read STARTING at the stale bar serves NOTHING (the confirm cannot raise the bar).
+        let at_bar = gate
+            .serve_follower_consume(
+                P,
+                ReadTier::FollowerLatest,
+                Offset::new(stale),
+                usize::MAX,
+                None,
+            )
+            .expect("a follower returns Some(outcome)");
+        match at_bar {
+            FollowerReadOutcome::Served(r) => assert_eq!(
+                r.run.record_count, 0,
+                "fail-closed: a dirty read at the bar with no reachable leader serves nothing"
+            ),
+            FollowerReadOutcome::ConfirmWithLeader { .. } => {
+                panic!("a fail-closed dirty read never surfaces a confirm to the caller")
+            }
+        }
+    }
 }

--- a/crates/ironbus-server/src/cluster/client_ack.rs
+++ b/crates/ironbus-server/src/cluster/client_ack.rs
@@ -42,7 +42,9 @@
 
 use std::collections::{BTreeMap, HashMap};
 use std::net::SocketAddr;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use ironbus_core::clock::Clock;
 use ironbus_core::keyshared::MemberId;
@@ -60,6 +62,17 @@ use super::serve::DataPlaneServer;
 /// client produce-ack gate routes every produce to it. Multi-partition routing (a produce to the right
 /// partition leader's seam) is the #693 multi-partition engine — FLAGGED, out of scope here.
 pub const DEFAULT_PARTITION: u64 = 0;
+
+/// The PRODUCTION dirty-tier committed-HW CONFIRM timeout (#739) in MILLISECONDS — the default the gate's
+/// `confirm_timeout_millis` is seeded with: [`HW_CONFIRM_TIMEOUT`](super::serve::HW_CONFIRM_TIMEOUT)
+/// (500 ms). Kept as a `u64` (no lossy `u128`->`u64` cast) and pinned to the [`Duration`] source of truth
+/// by the `const` assertion below, so the two can never drift.
+const HW_CONFIRM_DEFAULT_MILLIS: u64 = 500;
+
+// Compile-time guard: the `u64`-millis default MUST equal the production `Duration` confirm timeout, so
+// the gate's seeded default is exactly the hardcoded production budget (#739, production unchanged).
+const _: () =
+    assert!(super::serve::HW_CONFIRM_TIMEOUT.as_millis() == HW_CONFIRM_DEFAULT_MILLIS as u128);
 
 /// How a clustered produce to `partition` should be ROUTED at the wire level (#735, the `NOT_LEADER`
 /// redirect, half A). The output of [`ClientAckGate::produce_routing`]: the produce path consults it
@@ -132,6 +145,17 @@ pub struct ClientAckGate<F: Filesystem, C: Clock> {
     /// to a `0` committed bar (serve nothing) rather than risk a stale read. Read under a brief lock, never
     /// across a socket write.
     status: Option<Arc<Mutex<super::runtime::ClusterStatus>>>,
+    /// The DIRTY-TIER committed-HW CONFIRM connect+read timeout (#739), in MILLISECONDS — the budget
+    /// [`resolve_dirty_tier`](Self::resolve_dirty_tier) gives
+    /// [`query_leader_committed_hw`](super::serve::query_leader_committed_hw) for one over-the-wire confirm.
+    /// PRODUCTION holds [`HW_CONFIRM_TIMEOUT`](super::serve::HW_CONFIRM_TIMEOUT) (500 ms): a slow / dead
+    /// leader cannot stall the consume path, and on a timeout the read FAILS CLOSED to the clean tier
+    /// (never an unconfirmed offset). An [`AtomicU64`] so a test holding the shared `Arc<ClientAckGate>`
+    /// can OVERRIDE it to a host-scaled value ([`Self::set_confirm_timeout`]) so the confirm completes
+    /// under a contended CI runner — the override only changes HOW LONG the confirm waits, never the
+    /// fail-closed / never-serve-unconfirmed semantics. Read with `Relaxed` (a single scalar; no other
+    /// state is ordered against it).
+    confirm_timeout_millis: AtomicU64,
 }
 
 impl<F: Filesystem, C: Clock> ClientAckGate<F, C> {
@@ -149,6 +173,8 @@ impl<F: Filesystem, C: Clock> ClientAckGate<F, C> {
             leader_client_addrs: BTreeMap::new(),
             leader_data_addrs: BTreeMap::new(),
             status: None,
+            // PRODUCTION default — the dirty-tier confirm bounds at 500 ms unless overridden (#739).
+            confirm_timeout_millis: AtomicU64::new(HW_CONFIRM_DEFAULT_MILLIS),
         }
     }
 
@@ -187,6 +213,39 @@ impl<F: Filesystem, C: Clock> ClientAckGate<F, C> {
     pub fn with_status_handle(mut self, status: Arc<Mutex<super::runtime::ClusterStatus>>) -> Self {
         self.status = Some(status);
         self
+    }
+
+    /// Override the DIRTY-TIER committed-HW CONFIRM timeout (#739), returning the gate. PRODUCTION leaves
+    /// it at [`HW_CONFIRM_TIMEOUT`](super::serve::HW_CONFIRM_TIMEOUT) (500 ms — the default this builder is
+    /// NOT called for): this exists so a test can give a contended runner a host-scaled budget so the
+    /// confirm completes in time, WITHOUT changing the fail-closed / never-serve-unconfirmed semantics (the
+    /// timeout only governs how long the confirm waits). Builder-style; a non-cluster broker never builds
+    /// the gate, so this never runs off-cluster.
+    #[must_use]
+    pub fn with_confirm_timeout(self, timeout: Duration) -> Self {
+        self.set_confirm_timeout(timeout);
+        self
+    }
+
+    /// Set the DIRTY-TIER committed-HW CONFIRM timeout (#739) through a SHARED reference — usable on the
+    /// `Arc<ClientAckGate>` a runtime hands back ([`DataPlaneRuntime::client_gate`](super::serve::DataPlaneRuntime::client_gate)).
+    /// Same contract as [`Self::with_confirm_timeout`]: PRODUCTION never calls it (stays at 500 ms); a test
+    /// uses it to scale the confirm budget for a contended runner without weakening fail-closed. A timeout
+    /// of zero is clamped to 1 ms (a zero connect-timeout is an immediate error on some platforms — never
+    /// what a caller asking to "wait this long" means). `Relaxed`: a single scalar with nothing ordered
+    /// against it.
+    pub fn set_confirm_timeout(&self, timeout: Duration) {
+        let millis = u64::try_from(timeout.as_millis())
+            .unwrap_or(u64::MAX)
+            .max(1);
+        self.confirm_timeout_millis.store(millis, Ordering::Relaxed);
+    }
+
+    /// The current DIRTY-TIER committed-HW CONFIRM timeout (#739): [`HW_CONFIRM_TIMEOUT`](super::serve::HW_CONFIRM_TIMEOUT)
+    /// (500 ms) in production, or whatever a test installed via [`Self::set_confirm_timeout`].
+    #[must_use]
+    pub fn confirm_timeout(&self) -> Duration {
+        Duration::from_millis(self.confirm_timeout_millis.load(Ordering::Relaxed))
     }
 
     /// The per-partition committed-HW bar this node has applied from the replicated metadata (#722) — the
@@ -500,9 +559,12 @@ impl<F: Filesystem + Clone, C: Clock> ClientAckGate<F, C> {
                 .and_then(|leader_id| self.leader_data_addrs.get(&leader_id).copied())
         };
         // The real, bounded, over-the-wire confirm (#723's `ConfirmWithLeader`): ask the leader for its
-        // CURRENT committed HW. `None` on no route / timeout / link error -> fail closed (the clean tier).
-        let confirmed_hw = leader_data_addr
-            .and_then(|addr| super::serve::query_leader_committed_hw(addr, partition));
+        // CURRENT committed HW, bounded by the gate's confirm timeout (PRODUCTION 500 ms; a test may scale
+        // it). `None` on no route / timeout / link error -> fail closed (the clean tier).
+        let confirm_timeout = self.confirm_timeout();
+        let confirmed_hw = leader_data_addr.and_then(|addr| {
+            super::serve::query_leader_committed_hw(addr, partition, confirm_timeout)
+        });
         // RAISE the bar to the confirmed HW (never lower it): the re-serve uses `max(known, confirmed)`,
         // so it serves up to `min(own_flushed, raised_bar)`. On a FAILED confirm `confirmed_hw` is `None`,
         // so the bar stays the original `known_committed_hw` and the re-serve is the plain clean tier —

--- a/crates/ironbus-server/src/cluster/client_ack.rs
+++ b/crates/ironbus-server/src/cluster/client_ack.rs
@@ -116,6 +116,15 @@ pub struct ClientAckGate<F: Filesystem, C: Clock> {
     /// fires, but with no hint — the client re-tries its own known peers). Immutable after construction
     /// (the committed placement is static this phase; #693 dynamic re-placement is the flagged follow-up).
     leader_client_addrs: BTreeMap<u64, SocketAddr>,
+    /// The node-id -> DATA-PLANE peer address map (#739): the destination of the dirty-tier committed-HW
+    /// CONFIRM. When a "latest/dirty" follower-read reaches ABOVE the follower's safe watermark, the gate
+    /// dials the partition leader's data-plane address (mapped here from the follower's committed
+    /// leader-target node id) and asks for the leader's current committed HW before serving (#723's
+    /// `ConfirmWithLeader` over the wire). EMPTY when no data addresses are wired (the in-process tests
+    /// drive the confirm directly, and a no-addr confirm FAILS CLOSED to the clean tier — serve only up to
+    /// the safe watermark, never unconfirmed). Immutable after construction (static placement this phase;
+    /// #693 dynamic re-placement is the flagged follow-up).
+    leader_data_addrs: BTreeMap<u64, SocketAddr>,
     /// The shared metadata-plane status snapshot (#722/#735, half B): the source of the per-partition
     /// committed-HW bar (`last_committed_hw`) the follower-read safe watermark `min(own_flushed,
     /// known_committed_hw)` clamps to. `None` when no status handle was installed (the in-process tests
@@ -138,6 +147,7 @@ impl<F: Filesystem, C: Clock> ClientAckGate<F, C> {
             configured_level,
             outbox: Mutex::new(HashMap::new()),
             leader_client_addrs: BTreeMap::new(),
+            leader_data_addrs: BTreeMap::new(),
             status: None,
         }
     }
@@ -151,6 +161,19 @@ impl<F: Filesystem, C: Clock> ClientAckGate<F, C> {
     #[must_use]
     pub fn with_leader_client_addrs(mut self, addrs: BTreeMap<u64, SocketAddr>) -> Self {
         self.leader_client_addrs = addrs;
+        self
+    }
+
+    /// Install the node-id -> DATA-PLANE peer address map (#739) used to DIAL the partition leader for the
+    /// dirty-tier committed-HW CONFIRM, returning the gate. Each entry maps a cluster node id to the
+    /// address of that node's data-plane peer listener (its [`dataplane_addr`](super::runtime::dataplane_addr)).
+    /// The dirty-tier confirm works only with a populated map; with an EMPTY map a "latest" follower-read
+    /// above the safe watermark FAILS CLOSED to the clean tier (serve only up to the safe watermark, never
+    /// unconfirmed) rather than risk a stale read. Builder-style so the runtime can supply it at
+    /// construction (a non-cluster broker never builds the gate, so this never runs off-cluster).
+    #[must_use]
+    pub fn with_leader_data_addrs(mut self, addrs: BTreeMap<u64, SocketAddr>) -> Self {
+        self.leader_data_addrs = addrs;
         self
     }
 
@@ -376,12 +399,34 @@ impl<F: Filesystem + Clone, C: Clock> ClientAckGate<F, C> {
     ///
     /// Returns `None` when this node holds NO follower role for the partition (it is the leader, or holds
     /// no role): the caller then serves the consume through the normal (leader/local-engine) path. Returns
-    /// `Some(outcome)` when this node follows the partition: either the served zero-copy bytes
-    /// ([`FollowerReadOutcome::Served`]) or a [`FollowerReadOutcome::ConfirmWithLeader`] signal for a
-    /// latest/dirty read above the safe watermark.
+    /// `Some(outcome)` when this node follows the partition: the served zero-copy bytes
+    /// ([`FollowerReadOutcome::Served`]). A [`FollowerReadOutcome::ConfirmWithLeader`] is surfaced ONLY
+    /// when the dirty-tier leader confirm could not be performed AND was not needed (see below); a
+    /// `FollowerLatest` read that reaches above the safe watermark is RESOLVED in-place by the #739
+    /// dirty-tier confirm.
     ///
-    /// Locks the shared server briefly, never across a socket write. A poisoned lock fails SAFE to `None`
-    /// (the caller serves through the normal path rather than risk a stale follower read).
+    /// ## The DIRTY tier (#739): read-your-writes from a follower, never unconfirmed
+    ///
+    /// For a [`ReadTier::FollowerLatest`] (or a [`ReadTier::LeaderLocal`] degraded onto a follower) read
+    /// that reaches ABOVE the follower's safe watermark `min(own_flushed, known_committed_hw)`, the #723
+    /// classifier returns `ConfirmWithLeader` — it WON'T serve the unconfirmed tail speculatively. This
+    /// method then performs the real, bounded, over-the-wire committed-HW CONFIRM
+    /// ([`query_leader_committed_hw`](super::serve::query_leader_committed_hw)): it dials the partition
+    /// leader's data-plane address and asks for the leader's CURRENT committed HW (a tiny HW-version
+    /// query, NOT the data). On a successful confirm it RE-SERVES at the CLEAN tier with the bar RAISED to
+    /// `max(known_committed_hw, confirmed_hw)`, so it serves up to `min(own_flushed, confirmed_hw)` —
+    /// every served offset is one the LEADER confirmed committed AND the follower durably holds, never an
+    /// unconfirmed/divergent offset. On ANY confirm failure (no data address for the leader, a
+    /// connect/read timeout, a link error) it FAILS CLOSED: it re-serves at the CLEAN tier with the
+    /// ORIGINAL (un-raised) bar — serving only up to the safe watermark, never unconfirmed.
+    ///
+    /// The CLEAN tier ([`ReadTier::FollowerCommitted`], the common case) is UNCHANGED: a committed read
+    /// `<=` the safe watermark serves locally with NO leader round-trip — the confirm only ever runs for a
+    /// dirty read above the safe watermark.
+    ///
+    /// Locks the shared server briefly, NEVER across a socket write or the confirm round-trip (the confirm
+    /// is performed entirely off-lock). A poisoned lock fails SAFE to `None` (the caller serves through the
+    /// normal path rather than risk a stale follower read).
     #[must_use]
     pub fn serve_follower_consume(
         &self,
@@ -395,22 +440,94 @@ impl<F: Filesystem + Clone, C: Clock> ClientAckGate<F, C> {
         // Read BEFORE the server lock (its own brief lock), and `None` when unknown -> the serve fails
         // closed to a `0` safe bar (serve nothing) rather than risk a stale read.
         let known_committed_hw = self.known_committed_hw(partition);
+        // FIRST serve attempt under a SHORT lock (released before any network round-trip). The CLEAN tier
+        // resolves here with no round-trip; a DIRTY read above the safe watermark comes back as
+        // `ConfirmWithLeader` and is resolved off-lock below.
+        let first = {
+            let Ok(srv) = self.server.lock() else {
+                return None;
+            };
+            // Only a FOLLOWER serves a follower read. A leader / no-role partition returns `None` so the
+            // caller uses the normal consume path (the single-writer / leader read plane), never this.
+            if !srv.seam().controller().is_follower(partition) {
+                return None;
+            }
+            // A serve fault (IO) or a role race maps to `None` (the caller serves the normal path) — never
+            // a panic on the serve path and never an unsafe stale serve.
+            srv.seam()
+                .controller()
+                .serve_follower_read(
+                    partition,
+                    tier,
+                    known_committed_hw,
+                    from,
+                    max_records,
+                    max_bytes,
+                )
+                .ok()?
+        };
+        match first {
+            // CLEAN serve (or an empty run): the common, zero-round-trip path. Return it verbatim.
+            served @ FollowerReadOutcome::Served(_) => Some(served),
+            // DIRTY tier above the safe watermark: perform the real, bounded, over-the-wire leader confirm
+            // OFF-LOCK, then re-serve. Never speculative — the re-serve is clamped to the CONFIRMED HW.
+            FollowerReadOutcome::ConfirmWithLeader { .. } => {
+                self.resolve_dirty_tier(partition, known_committed_hw, from, max_records, max_bytes)
+            }
+        }
+    }
+
+    /// Resolve a DIRTY-TIER follower-read (#739) that reached above the safe watermark: perform the
+    /// bounded, over-the-wire committed-HW CONFIRM with the partition leader OFF-LOCK, then re-serve at the
+    /// CLEAN tier with the bar raised to the leader-confirmed HW (fail-closed to the un-raised bar on a
+    /// failed confirm). Returns the re-served outcome (always a `Served` run — never another confirm, and
+    /// never an unconfirmed offset).
+    fn resolve_dirty_tier(
+        &self,
+        partition: u64,
+        known_committed_hw: Option<u64>,
+        from: Offset,
+        max_records: usize,
+        max_bytes: Option<usize>,
+    ) -> Option<FollowerReadOutcome> {
+        // Find the partition's current leader (the follower's committed fetch target) and its DATA-plane
+        // address, under a SHORT lock that is released BEFORE the network round-trip.
+        let leader_data_addr = {
+            let Ok(srv) = self.server.lock() else {
+                return None;
+            };
+            srv.follower_leader(partition)
+                .and_then(|leader_id| self.leader_data_addrs.get(&leader_id).copied())
+        };
+        // The real, bounded, over-the-wire confirm (#723's `ConfirmWithLeader`): ask the leader for its
+        // CURRENT committed HW. `None` on no route / timeout / link error -> fail closed (the clean tier).
+        let confirmed_hw = leader_data_addr
+            .and_then(|addr| super::serve::query_leader_committed_hw(addr, partition));
+        // RAISE the bar to the confirmed HW (never lower it): the re-serve uses `max(known, confirmed)`,
+        // so it serves up to `min(own_flushed, raised_bar)`. On a FAILED confirm `confirmed_hw` is `None`,
+        // so the bar stays the original `known_committed_hw` and the re-serve is the plain clean tier —
+        // never an offset above the safe watermark, never unconfirmed.
+        let raised_bar = match (known_committed_hw, confirmed_hw) {
+            (Some(k), Some(c)) => Some(k.max(c)),
+            (None, Some(c)) => Some(c),
+            (k, None) => k,
+        };
+        // RE-SERVE at the CLEAN tier (committed-only) with the raised bar, under a short lock. The clean
+        // tier serves only `<= min(own_flushed, raised_bar)` — every served offset is leader-confirmed
+        // committed AND durably held here. This NEVER returns `ConfirmWithLeader` (the clean tier never
+        // does), so the dirty read is fully resolved with no second round-trip.
         let Ok(srv) = self.server.lock() else {
             return None;
         };
-        // Only a FOLLOWER serves a follower read. A leader / no-role partition returns `None` so the
-        // caller uses the normal consume path (the single-writer / leader read plane), never this.
         if !srv.seam().controller().is_follower(partition) {
             return None;
         }
-        // A serve fault (IO) or a role race maps to `None` (the caller serves the normal path) — never a
-        // panic on the serve path and never an unsafe stale serve.
         srv.seam()
             .controller()
             .serve_follower_read(
                 partition,
-                tier,
-                known_committed_hw,
+                ReadTier::FollowerCommitted,
+                raised_bar,
                 from,
                 max_records,
                 max_bytes,

--- a/crates/ironbus-server/src/cluster/dataplane.rs
+++ b/crates/ironbus-server/src/cluster/dataplane.rs
@@ -238,6 +238,98 @@ pub enum DataPlaneFrame {
     EpochQuery(OffsetForLeaderEpochBody),
     /// A leader → follower leader-epoch offset response (received on the follower side, #599).
     EpochResponse(OffsetForLeaderEpochResponse),
+    /// A follower → leader DIRTY-TIER committed-HW QUERY (received on the leader side, #739): the tiny
+    /// HW-version confirm a follower sends when a "latest" follower-read reaches above its safe
+    /// watermark. The partition is carried by the data-plane envelope's partition prefix.
+    CommittedHwQuery(CommittedHwQueryBody),
+    /// A leader → follower committed-HW RESPONSE (received on the follower side, #739): the leader's
+    /// CURRENT committed HW, which the follower uses to raise its servable bound before re-serving the
+    /// confirmed prefix locally — never an offset above this.
+    CommittedHwResponse(CommittedHwResponseBody),
+}
+
+/// The `kind` discriminant byte leading a [`FrameType::CommittedHwQuery`] body (#739), so the request
+/// and the response (which SHARE the wire tag 43, like `OffsetForLeaderEpoch`) are never confused.
+const HW_KIND_REQUEST: u8 = 0;
+const HW_KIND_RESPONSE: u8 = 1;
+
+/// The fixed little-endian byte length of an encoded [`CommittedHwQueryBody`]: just the `kind: u8`
+/// (the partition rides the data-plane envelope's partition prefix).
+const HW_QUERY_REQUEST_LEN: usize = 1;
+
+/// The fixed little-endian byte length of an encoded [`CommittedHwResponseBody`]: `kind: u8` +
+/// `committed_hw: u64`.
+const HW_QUERY_RESPONSE_LEN: usize = 1 + 8;
+
+/// A follower → leader DIRTY-TIER committed-HW QUERY (#739, the #723 `ConfirmWithLeader` over the
+/// wire): "what is YOUR current committed high-watermark for this partition?" — a tiny HW-VERSION query,
+/// NOT a data fetch. The follower asks this when a "latest" follower-read reaches ABOVE its known safe
+/// watermark, so it can serve the now-confirmed prefix locally and NEVER an unconfirmed offset. Rides
+/// the [`FrameType::CommittedHwQuery`] envelope (tag 43) with a leading `kind = 0` byte; the partition
+/// is the data-plane envelope's partition prefix.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CommittedHwQueryBody;
+
+impl CommittedHwQueryBody {
+    /// Encode this query to its fixed-layout body bytes (just the request `kind` byte).
+    #[must_use]
+    pub fn encode(&self) -> Vec<u8> {
+        vec![HW_KIND_REQUEST]
+    }
+
+    /// Decode a query from its body bytes.
+    ///
+    /// # Errors
+    /// Returns [`ReplicationError::Frame`] if `body` is not exactly the request length or its `kind`
+    /// byte is not the request discriminant — fail-closed, never guessed at.
+    pub fn decode(body: &[u8]) -> Result<CommittedHwQueryBody, ReplicationError> {
+        if body.len() != HW_QUERY_REQUEST_LEN || body[0] != HW_KIND_REQUEST {
+            return Err(ReplicationError::Frame {
+                what: format!("malformed CommittedHwQuery request (len {})", body.len()),
+            });
+        }
+        Ok(CommittedHwQueryBody)
+    }
+}
+
+/// A leader → follower committed-HW RESPONSE (#739): the leader's CURRENT committed HW for the
+/// partition (its read plane's flushed frontier — the SAME committed offset
+/// [`DataPlaneController::leader_committed_hw`] answers). The follower raises its servable bound to (at
+/// most) this and re-serves the confirmed prefix locally. Rides the [`FrameType::CommittedHwQuery`]
+/// envelope (tag 43) with a leading `kind = 1` byte.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CommittedHwResponseBody {
+    /// The leader's current committed high-watermark for the partition.
+    pub committed_hw: u64,
+}
+
+impl CommittedHwResponseBody {
+    /// Encode this response to its fixed-layout little-endian body bytes.
+    #[must_use]
+    pub fn encode(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(HW_QUERY_RESPONSE_LEN);
+        out.push(HW_KIND_RESPONSE);
+        out.extend_from_slice(&self.committed_hw.to_le_bytes());
+        out
+    }
+
+    /// Decode a response from its body bytes.
+    ///
+    /// # Errors
+    /// Returns [`ReplicationError::Frame`] if `body` is not exactly the response length or its `kind`
+    /// byte is not the response discriminant.
+    pub fn decode(body: &[u8]) -> Result<CommittedHwResponseBody, ReplicationError> {
+        if body.len() != HW_QUERY_RESPONSE_LEN || body[0] != HW_KIND_RESPONSE {
+            return Err(ReplicationError::Frame {
+                what: format!("malformed CommittedHwQuery response (len {})", body.len()),
+            });
+        }
+        let mut hw = [0u8; 8];
+        hw.copy_from_slice(&body[1..9]);
+        Ok(CommittedHwResponseBody {
+            committed_hw: u64::from_le_bytes(hw),
+        })
+    }
 }
 
 /// The leading byte of an [`OffsetForLeaderEpochBody`] encoding — the kind discriminant that
@@ -276,6 +368,17 @@ pub fn decode_dataplane_frame(type_tag: u8, body: &[u8]) -> Result<DataPlaneFram
                 what: "malformed OffsetForLeaderEpoch kind byte on a data-plane frame".to_string(),
             })),
         },
+        Some(FrameType::CommittedHwQuery) => match body.first().copied() {
+            Some(HW_KIND_REQUEST) => Ok(DataPlaneFrame::CommittedHwQuery(
+                CommittedHwQueryBody::decode(body)?,
+            )),
+            Some(HW_KIND_RESPONSE) => Ok(DataPlaneFrame::CommittedHwResponse(
+                CommittedHwResponseBody::decode(body)?,
+            )),
+            _ => Err(DataPlaneError::Replication(ReplicationError::Frame {
+                what: "malformed CommittedHwQuery kind byte on a data-plane frame".to_string(),
+            })),
+        },
         _ => Err(DataPlaneError::Replication(ReplicationError::Frame {
             what: format!("unexpected frame type tag {type_tag} on a data-plane link"),
         })),
@@ -303,6 +406,15 @@ pub enum DataPlaneAction {
         partition: u64,
         /// The leader's epoch end-offset answer.
         response: OffsetForLeaderEpochResponse,
+    },
+    /// Reply to the querying follower with this committed-HW answer (#739): the leader served a
+    /// dirty-tier [`DataPlaneFrame::CommittedHwQuery`] from its current committed HW. The follower uses
+    /// it to raise its servable bound (never above it) before re-serving the confirmed prefix locally.
+    SendCommittedHwResponse {
+        /// The partition the response is for.
+        partition: u64,
+        /// The leader's current committed-HW answer.
+        response: CommittedHwResponseBody,
     },
     /// Acks released by a follower's report reaching quorum: the caller maps each opaque token back to
     /// its parked producer reply and writes the wire `PubAck`. Empty unless this report advanced the
@@ -894,6 +1006,31 @@ impl<F: Filesystem, C: Clock> DataPlaneController<F, C> {
                 // An epoch response is consumed by an in-flight reconcile (the `leader_end_offset`
                 // closure of `reconcile_follower`), not by the steady-state frame router. A stray one
                 // is absorbed.
+                Ok(DataPlaneAction::None)
+            }
+            DataPlaneFrame::CommittedHwQuery(_) => {
+                // The DIRTY-TIER committed-HW confirm (#739): a follower asks the leader for its current
+                // committed HW. Answer it from the leader's read plane (the SAME committed offset
+                // `leader_committed_hw` advertises). A query landing on a node that does NOT lead the
+                // partition is a wrong-role error the caller drops — only the LEADER is an authoritative
+                // committed-HW source, so the follower never trusts a non-leader's answer and falls back
+                // to the clean tier. NEVER an over-claimed HW: the leader's flushed frontier is its
+                // proven-committed prefix.
+                let committed_hw = self.leader_committed_hw(partition).ok_or(
+                    DataPlaneError::WrongRole {
+                        partition,
+                        needed: "leader",
+                    },
+                )?;
+                Ok(DataPlaneAction::SendCommittedHwResponse {
+                    partition,
+                    response: CommittedHwResponseBody { committed_hw },
+                })
+            }
+            DataPlaneFrame::CommittedHwResponse(_) => {
+                // A committed-HW response is consumed by the in-flight dirty-tier confirm on the
+                // requesting (follower) side (a short-lived query link reads it directly), not by the
+                // steady-state frame router. A stray one is absorbed.
                 Ok(DataPlaneAction::None)
             }
         }

--- a/crates/ironbus-server/src/cluster/dataplane.rs
+++ b/crates/ironbus-server/src/cluster/dataplane.rs
@@ -1016,12 +1016,12 @@ impl<F: Filesystem, C: Clock> DataPlaneController<F, C> {
                 // committed-HW source, so the follower never trusts a non-leader's answer and falls back
                 // to the clean tier. NEVER an over-claimed HW: the leader's flushed frontier is its
                 // proven-committed prefix.
-                let committed_hw = self.leader_committed_hw(partition).ok_or(
-                    DataPlaneError::WrongRole {
-                        partition,
-                        needed: "leader",
-                    },
-                )?;
+                let committed_hw =
+                    self.leader_committed_hw(partition)
+                        .ok_or(DataPlaneError::WrongRole {
+                            partition,
+                            needed: "leader",
+                        })?;
                 Ok(DataPlaneAction::SendCommittedHwResponse {
                     partition,
                     response: CommittedHwResponseBody { committed_hw },
@@ -2917,6 +2917,78 @@ mod tests {
         for (off, _) in decode_run(&run.run) {
             assert!(off >= stale_known && off < leader_hw);
         }
+    }
+
+    /// THE #739 wire-routing test: a [`DataPlaneFrame::CommittedHwQuery`] routed through the LEADER's
+    /// `handle_frame` is answered with a [`DataPlaneAction::SendCommittedHwResponse`] carrying the leader's
+    /// current committed HW; the SAME query routed through a FOLLOWER is a wrong-role error (a follower is
+    /// never an authoritative committed-HW source, so the follower never trusts a non-leader's answer).
+    #[test]
+    fn committed_hw_query_is_answered_by_the_leader_and_rejected_by_a_follower() {
+        use super::{CommittedHwQueryBody, DataPlaneAction, DataPlaneFrame};
+        const P: u64 = 0;
+        let mut leader_log = open_log(InMemoryFs::new(), small_config());
+        for i in 0..20u32 {
+            leader_log
+                .append(&rec(format!("hw-{i:02}").as_bytes()))
+                .unwrap();
+        }
+        leader_log.sync().unwrap();
+        let plane = leader_plane(&leader_log);
+        let mut leader = DataPlaneController::<InMemoryFs, ManualClock>::new(1);
+        leader.start_leader(P, Arc::clone(&plane), EpochCache::new(), &[1, 2], quorum3());
+        let mut follower = DataPlaneController::new(2);
+        follower.start_follower(P, open_log(InMemoryFs::new(), small_config()));
+
+        // The leader answers the HW query from its current committed HW (its read plane's flushed frontier).
+        let action = leader
+            .handle_frame(P, DataPlaneFrame::CommittedHwQuery(CommittedHwQueryBody))
+            .expect("the leader answers a committed-HW query");
+        match action {
+            DataPlaneAction::SendCommittedHwResponse {
+                partition,
+                response,
+            } => {
+                assert_eq!(partition, P);
+                assert_eq!(
+                    response.committed_hw,
+                    leader.leader_committed_hw(P).unwrap(),
+                    "the answer is the leader's current committed HW"
+                );
+            }
+            other => panic!("expected a committed-HW response, got {other:?}"),
+        }
+        // A query routed to a FOLLOWER is a wrong-role error (only the leader answers authoritatively).
+        assert!(matches!(
+            follower.handle_frame(P, DataPlaneFrame::CommittedHwQuery(CommittedHwQueryBody)),
+            Err(DataPlaneError::WrongRole {
+                needed: "leader",
+                ..
+            })
+        ));
+        // A query for a partition no role is held for is an unknown-partition error.
+        assert!(matches!(
+            leader.handle_frame(99, DataPlaneFrame::CommittedHwQuery(CommittedHwQueryBody)),
+            Err(DataPlaneError::WrongRole { .. } | DataPlaneError::UnknownPartition { .. })
+        ));
+    }
+
+    /// The #739 committed-HW body codec round-trips and is fail-closed on a bad kind byte / length.
+    #[test]
+    fn committed_hw_bodies_round_trip_and_reject_malformed() {
+        use super::{CommittedHwQueryBody, CommittedHwResponseBody};
+        let q = CommittedHwQueryBody;
+        assert_eq!(CommittedHwQueryBody::decode(&q.encode()).unwrap(), q);
+        let r = CommittedHwResponseBody {
+            committed_hw: 1_234_567,
+        };
+        assert_eq!(CommittedHwResponseBody::decode(&r.encode()).unwrap(), r);
+        // A response decoded as a query (wrong kind byte) is rejected, and vice-versa.
+        assert!(CommittedHwQueryBody::decode(&r.encode()).is_err());
+        assert!(CommittedHwResponseBody::decode(&q.encode()).is_err());
+        // A truncated / empty body is rejected.
+        assert!(CommittedHwQueryBody::decode(&[]).is_err());
+        assert!(CommittedHwResponseBody::decode(&[1, 2, 3]).is_err());
     }
 
     /// A follower is NOT an authoritative committed-HW source: `leader_committed_hw` returns `None` on a

--- a/crates/ironbus-server/src/cluster/serve.rs
+++ b/crates/ironbus-server/src/cluster/serve.rs
@@ -1576,6 +1576,11 @@ mod tests {
                     end_offset: Offset::new(14),
                 },
             }),
+            // The #739 dirty-tier committed-HW confirm (tag 43): request + response share the tag.
+            DataPlaneFrame::CommittedHwQuery(crate::cluster::dataplane::CommittedHwQueryBody),
+            DataPlaneFrame::CommittedHwResponse(
+                crate::cluster::dataplane::CommittedHwResponseBody { committed_hw: 4242 },
+            ),
         ];
         for (partition, frame) in frames.iter().enumerate() {
             let p = partition as u64 + 1;
@@ -3759,5 +3764,449 @@ mod live_runtime_tests {
         f_rt2.stop();
         f_rt.stop();
         leader_rt.stop();
+    }
+
+    // ============================================================================================
+    //  #739: the follower-read DIRTY-TIER leader-confirm over the REAL wire.
+    // ============================================================================================
+
+    /// The served end of a follower-read run (its exclusive next offset).
+    fn run_next(outcome: &crate::cluster::dataplane::FollowerReadOutcome) -> u64 {
+        match outcome {
+            crate::cluster::dataplane::FollowerReadOutcome::Served(r) => r.run.next_offset.get(),
+            crate::cluster::dataplane::FollowerReadOutcome::ConfirmWithLeader { .. } => {
+                panic!("a resolved follower-read is always a Served run, never a confirm")
+            }
+        }
+    }
+
+    /// Chain follower-read consumes from `from` and return all served `(offset, payload)` pairs (drains
+    /// the whole servable prefix at the given tier, the read plane serving one sealed segment per call).
+    fn drain_follower_consume(
+        gate: &crate::cluster::client_ack::ClientAckGate<StdFs, ManualClock>,
+        partition: u64,
+        tier: crate::cluster::read_consistency::ReadTier,
+        from: u64,
+    ) -> Vec<(u64, Vec<u8>)> {
+        use ironbus_core::types::Offset;
+        let mut from = from;
+        let mut out = Vec::new();
+        let mut guard = 0u32;
+        loop {
+            guard += 1;
+            assert!(guard < 10_000, "follower-read chain failed to terminate");
+            let outcome = gate
+                .serve_follower_consume(partition, tier, Offset::new(from), usize::MAX, None)
+                .expect("a follower returns Some(outcome)");
+            let run = match &outcome {
+                crate::cluster::dataplane::FollowerReadOutcome::Served(r) => &r.run,
+                crate::cluster::dataplane::FollowerReadOutcome::ConfirmWithLeader { .. } => {
+                    panic!("a resolved follower-read is always a Served run, never a confirm")
+                }
+            };
+            let recs = decode_run(run);
+            if recs.is_empty() {
+                break;
+            }
+            out.extend(recs);
+            let next = run_next(&outcome);
+            if next <= from {
+                break;
+            }
+            from = next;
+        }
+        out
+    }
+
+    /// THE #739 DIRTY-TIER test over the REAL wire: a follower whose KNOWN committed-HW bar is STALE (a
+    /// low checkpoint) serves only its CLEAN committed prefix at the clean tier — but a LATEST/dirty read
+    /// reaching ABOVE that stale bar performs a real over-the-wire committed-HW CONFIRM with the live
+    /// leader and then serves the now-confirmed prefix LOCALLY, byte-faithfully, and NEVER an offset above
+    /// the leader-confirmed HW.
+    #[test]
+    fn live_runtime_follower_dirty_tier_confirms_with_the_leader_then_serves() {
+        use crate::cluster::read_consistency::ReadTier;
+        const P: u64 = 0;
+        let _serial = crate::cluster::heavy_cluster_test_guard();
+        let placement = Placement {
+            replicas: vec![1, 2],
+            leader: 1,
+            epoch: 7,
+        };
+        let placements: BTreeMap<u64, Placement> = [(P, placement)].into_iter().collect();
+        let isr = IsrConfig {
+            min_isr: 1,
+            max_lag_records: 0,
+        };
+        let data_addrs: BTreeMap<u64, SocketAddr> = [1u64, 2]
+            .into_iter()
+            .map(|id| (id, SocketAddr::from((Ipv4Addr::LOCALHOST, free_port()))))
+            .collect();
+
+        // The LEADER (node 1): a real on-disk leader serving through its read plane. Its committed HW is
+        // its read plane's flushed frontier (>= served_end).
+        let leader_dir = tempfile::tempdir().expect("leader dir");
+        let leader_log = leaked_disk_leader(leader_dir.path(), 30);
+        let leader_pl = disk_leader_plane(leader_log);
+        let served_end = plane_served_end(&leader_pl);
+        assert!(served_end >= 10, "leader has a healthy committed prefix");
+        let leader_server = DataPlaneServer::from_placements(
+            1,
+            &placements,
+            isr,
+            |p| (p == P).then(|| Arc::clone(&leader_pl)),
+            &DiskReplicaLogs {
+                root: leader_dir.path().to_path_buf(),
+            },
+            |_| EpochCache::new(),
+        )
+        .unwrap();
+        let leader_status = Arc::new(Mutex::new(crate::cluster::runtime::ClusterStatus::default()));
+        let mut leader_rt = DataPlaneRuntime::start_with_client_gate_aware(
+            leader_server,
+            data_addrs[&1],
+            &data_addrs,
+            crate::cluster::ack_level::ClusterAckLevel::C1,
+            BTreeMap::new(),
+            Arc::clone(&leader_status),
+        )
+        .expect("leader runtime");
+
+        // The FOLLOWER (node 2): a STALE committed-HW bar (a low checkpoint). The follower-read safe
+        // watermark is min(own_flushed, stale_known); the clean tier serves only up to it.
+        let stale_known = served_end / 3;
+        assert!(stale_known > 0 && stale_known < served_end);
+        let f_dir = tempfile::tempdir().expect("f dir");
+        let mut status = crate::cluster::runtime::ClusterStatus::default();
+        status.last_committed_hw.insert(P, stale_known);
+        let f_status = Arc::new(Mutex::new(status));
+        let follower_server = DataPlaneServer::from_placements(
+            2,
+            &placements,
+            isr,
+            |_| None,
+            &DiskReplicaLogs {
+                root: f_dir.path().to_path_buf(),
+            },
+            |_| EpochCache::new(),
+        )
+        .unwrap();
+        assert!(follower_server.seam().controller().is_follower(P));
+        // Start the follower runtime WITH the client gate: `data_addrs` is threaded as both the fetch
+        // targets AND (via #739) the gate's leader_data_addrs, so the dirty-tier confirm dials node 1.
+        let mut f_rt = DataPlaneRuntime::start_with_client_gate_aware(
+            follower_server,
+            data_addrs[&2],
+            &data_addrs,
+            crate::cluster::ack_level::ClusterAckLevel::C1,
+            BTreeMap::new(),
+            Arc::clone(&f_status),
+        )
+        .expect("follower runtime with client gate");
+        let gate = f_rt
+            .client_gate()
+            .cloned()
+            .expect("the follower runtime built a client gate");
+
+        // Wait until the follower's runtime fetch loop has replicated the leader's whole served prefix.
+        let f_hw = || {
+            f_rt.server()
+                .lock()
+                .unwrap()
+                .seam()
+                .controller()
+                .follower_high_watermark(P)
+                .unwrap_or(0)
+        };
+        assert!(
+            wait_until(Duration::from_secs(30), || f_hw() >= served_end),
+            "the follower replicated the served prefix (hw={}, served_end={served_end})",
+            f_hw()
+        );
+
+        // CLEAN tier at the stale bar: serves ONLY the committed prefix [0, stale_known) — never above.
+        let clean = drain_follower_consume(&gate, P, ReadTier::FollowerCommitted, 0);
+        assert!(
+            !clean.is_empty(),
+            "the clean tier served the committed prefix"
+        );
+        for (off, _) in &clean {
+            assert!(
+                *off < stale_known,
+                "clean tier served offset {off} at/above the stale bar {stale_known}"
+            );
+        }
+
+        // DIRTY tier from the stale bar: the read reaches ABOVE the safe watermark, so the gate performs
+        // the real over-the-wire committed-HW confirm with the live leader and serves the now-confirmed
+        // prefix [stale_known, served_end) — byte-faithfully, and NEVER above the leader's confirmed HW.
+        let leader_confirmed_hw = leader_pl.flushed();
+        assert!(leader_confirmed_hw >= served_end);
+        let dirty = drain_follower_consume(&gate, P, ReadTier::FollowerLatest, stale_known);
+        assert!(
+            !dirty.is_empty(),
+            "the dirty tier served the confirmed read-your-writes prefix above the stale bar"
+        );
+        for (off, payload) in &dirty {
+            assert!(
+                *off >= stale_known,
+                "the dirty serve resumed at the stale bar"
+            );
+            assert!(
+                *off < leader_confirmed_hw,
+                "the dirty serve crossed the leader-confirmed HW (offset {off} >= {leader_confirmed_hw}) — an UNCONFIRMED offset!"
+            );
+            // Byte-faithful: the payload is the leader's record verbatim (rep-NN).
+            assert_eq!(payload, format!("rep-{off:02}").as_bytes());
+        }
+        // The dirty serve extended STRICTLY beyond the stale bar — read-your-writes that the CLEAN tier
+        // (clamped to the stale bar) could never have served — proving the over-the-wire confirm RAISED
+        // the servable bound to the leader-confirmed HW. It is clamped to min(own_flushed, confirmed_hw):
+        // the follower's read-plane SEALED frontier can lag served_end by the still-unsealed active tail
+        // (the FLAGGED active-tail lag), so the bound is `>= stale_known` and `<= served_end`, never above.
+        let dirty_max = dirty.iter().map(|(o, _)| *o).max().unwrap();
+        assert!(
+            dirty_max >= stale_known,
+            "the dirty tier served read-your-writes at/above the stale bar (max={dirty_max}, stale={stale_known})"
+        );
+        assert!(
+            dirty_max < leader_confirmed_hw,
+            "the dirty tier never served above the leader-confirmed HW (max={dirty_max}, hw={leader_confirmed_hw})"
+        );
+
+        f_rt.stop();
+        leader_rt.stop();
+    }
+
+    /// THE #739 FAIL-CLOSED test: when the dirty-tier committed-HW confirm CANNOT reach the leader (the
+    /// leader is down / unreachable), a LATEST read above the safe watermark FALLS BACK to the clean tier
+    /// — it serves only up to the follower's safe watermark, NEVER an unconfirmed offset.
+    #[test]
+    fn live_runtime_follower_dirty_tier_fails_closed_when_the_leader_is_unreachable() {
+        use crate::cluster::read_consistency::ReadTier;
+        const P: u64 = 0;
+        let _serial = crate::cluster::heavy_cluster_test_guard();
+        let placement = Placement {
+            replicas: vec![1, 2],
+            leader: 1,
+            epoch: 2,
+        };
+        let placements: BTreeMap<u64, Placement> = [(P, placement)].into_iter().collect();
+        let isr = IsrConfig {
+            min_isr: 1,
+            max_lag_records: 0,
+        };
+        let data_addrs: BTreeMap<u64, SocketAddr> = [1u64, 2]
+            .into_iter()
+            .map(|id| (id, SocketAddr::from((Ipv4Addr::LOCALHOST, free_port()))))
+            .collect();
+
+        // Bring a leader up briefly to let the follower replicate, then STOP it so the confirm can't reach
+        // it. The follower keeps the replicated prefix; only the live leader confirm is now unavailable.
+        let leader_dir = tempfile::tempdir().expect("leader dir");
+        let leader_log = leaked_disk_leader(leader_dir.path(), 30);
+        let leader_pl = disk_leader_plane(leader_log);
+        let served_end = plane_served_end(&leader_pl);
+        let leader_server = DataPlaneServer::from_placements(
+            1,
+            &placements,
+            isr,
+            |p| (p == P).then(|| Arc::clone(&leader_pl)),
+            &DiskReplicaLogs {
+                root: leader_dir.path().to_path_buf(),
+            },
+            |_| EpochCache::new(),
+        )
+        .unwrap();
+        let mut leader_rt = DataPlaneRuntime::start_with_client_gate_aware(
+            leader_server,
+            data_addrs[&1],
+            &data_addrs,
+            crate::cluster::ack_level::ClusterAckLevel::C1,
+            BTreeMap::new(),
+            Arc::new(Mutex::new(crate::cluster::runtime::ClusterStatus::default())),
+        )
+        .expect("leader runtime");
+
+        let stale_known = served_end / 3;
+        assert!(stale_known > 0 && stale_known < served_end);
+        let f_dir = tempfile::tempdir().expect("f dir");
+        let mut status = crate::cluster::runtime::ClusterStatus::default();
+        status.last_committed_hw.insert(P, stale_known);
+        let f_status = Arc::new(Mutex::new(status));
+        let follower_server = DataPlaneServer::from_placements(
+            2,
+            &placements,
+            isr,
+            |_| None,
+            &DiskReplicaLogs {
+                root: f_dir.path().to_path_buf(),
+            },
+            |_| EpochCache::new(),
+        )
+        .unwrap();
+        let mut f_rt = DataPlaneRuntime::start_with_client_gate_aware(
+            follower_server,
+            data_addrs[&2],
+            &data_addrs,
+            crate::cluster::ack_level::ClusterAckLevel::C1,
+            BTreeMap::new(),
+            Arc::clone(&f_status),
+        )
+        .expect("follower runtime");
+        let gate = f_rt.client_gate().cloned().expect("client gate");
+        let f_hw = || {
+            f_rt.server()
+                .lock()
+                .unwrap()
+                .seam()
+                .controller()
+                .follower_high_watermark(P)
+                .unwrap_or(0)
+        };
+        assert!(
+            wait_until(Duration::from_secs(30), || f_hw() >= served_end),
+            "the follower replicated before the leader is stopped (hw={})",
+            f_hw()
+        );
+
+        // STOP the leader: its data-plane listener is gone, so the dirty-tier confirm dial will fail/
+        // time out. (The follower's fetch loop will also fail, but it has the prefix already.)
+        leader_rt.stop();
+
+        // A LATEST read above the stale bar now CANNOT confirm -> it FAILS CLOSED to the clean tier: it
+        // serves only [_, stale_known) — never an offset at/above the unconfirmed safe watermark.
+        let dirty = drain_follower_consume(&gate, P, ReadTier::FollowerLatest, 0);
+        for (off, _) in &dirty {
+            assert!(
+                *off < stale_known,
+                "fail-closed: served offset {off} at/above the unconfirmed bar {stale_known}"
+            );
+        }
+        // A read STARTING at the stale bar serves NOTHING when the confirm cannot reach the leader.
+        let at_bar = drain_follower_consume(&gate, P, ReadTier::FollowerLatest, stale_known);
+        assert!(
+            at_bar.is_empty(),
+            "fail-closed: with no reachable leader the dirty read above the safe watermark serves nothing"
+        );
+
+        f_rt.stop();
+    }
+
+    /// THE #739 CLEAN-TIER-NO-ROUNDTRIP test: a committed read (`<=` the safe watermark) serves LOCALLY
+    /// with NO leader confirm — proven by serving it with the LEADER NEVER STARTED (no data-plane listener
+    /// to confirm against). The clean tier never dials the leader, so it serves the committed prefix even
+    /// when no leader is reachable.
+    #[test]
+    fn live_runtime_follower_clean_tier_serves_without_a_leader_roundtrip() {
+        use crate::cluster::read_consistency::ReadTier;
+        const P: u64 = 0;
+        let _serial = crate::cluster::heavy_cluster_test_guard();
+        let placement = Placement {
+            replicas: vec![1, 2],
+            leader: 1,
+            epoch: 4,
+        };
+        let placements: BTreeMap<u64, Placement> = [(P, placement)].into_iter().collect();
+        let isr = IsrConfig {
+            min_isr: 1,
+            max_lag_records: 0,
+        };
+        let data_addrs: BTreeMap<u64, SocketAddr> = [1u64, 2]
+            .into_iter()
+            .map(|id| (id, SocketAddr::from((Ipv4Addr::LOCALHOST, free_port()))))
+            .collect();
+
+        // A leader runtime to let the follower replicate the prefix, then stopped (the clean tier needs
+        // no live leader at all once replicated — it serves locally with no confirm).
+        let leader_dir = tempfile::tempdir().expect("leader dir");
+        let leader_log = leaked_disk_leader(leader_dir.path(), 24);
+        let leader_pl = disk_leader_plane(leader_log);
+        let served_end = plane_served_end(&leader_pl);
+        let leader_server = DataPlaneServer::from_placements(
+            1,
+            &placements,
+            isr,
+            |p| (p == P).then(|| Arc::clone(&leader_pl)),
+            &DiskReplicaLogs {
+                root: leader_dir.path().to_path_buf(),
+            },
+            |_| EpochCache::new(),
+        )
+        .unwrap();
+        let mut leader_rt = DataPlaneRuntime::start_with_client_gate_aware(
+            leader_server,
+            data_addrs[&1],
+            &data_addrs,
+            crate::cluster::ack_level::ClusterAckLevel::C1,
+            BTreeMap::new(),
+            Arc::new(Mutex::new(crate::cluster::runtime::ClusterStatus::default())),
+        )
+        .expect("leader runtime");
+
+        // The follower KNOWS the full committed HW (a caught-up checkpoint), so the whole replicated prefix
+        // is within its safe watermark — a clean read serves all of it with NO confirm.
+        let f_dir = tempfile::tempdir().expect("f dir");
+        let mut status = crate::cluster::runtime::ClusterStatus::default();
+        status.last_committed_hw.insert(P, served_end);
+        let f_status = Arc::new(Mutex::new(status));
+        let follower_server = DataPlaneServer::from_placements(
+            2,
+            &placements,
+            isr,
+            |_| None,
+            &DiskReplicaLogs {
+                root: f_dir.path().to_path_buf(),
+            },
+            |_| EpochCache::new(),
+        )
+        .unwrap();
+        let mut f_rt = DataPlaneRuntime::start_with_client_gate_aware(
+            follower_server,
+            data_addrs[&2],
+            &data_addrs,
+            crate::cluster::ack_level::ClusterAckLevel::C1,
+            BTreeMap::new(),
+            Arc::clone(&f_status),
+        )
+        .expect("follower runtime");
+        let gate = f_rt.client_gate().cloned().expect("client gate");
+        let f_hw = || {
+            f_rt.server()
+                .lock()
+                .unwrap()
+                .seam()
+                .controller()
+                .follower_high_watermark(P)
+                .unwrap_or(0)
+        };
+        assert!(
+            wait_until(Duration::from_secs(30), || f_hw() >= served_end),
+            "the follower replicated before the leader is stopped (hw={})",
+            f_hw()
+        );
+
+        // STOP the leader: there is now NO data-plane listener to confirm against. The CLEAN tier must
+        // still serve the whole committed prefix locally (no leader round-trip on the committed path).
+        leader_rt.stop();
+
+        let clean = drain_follower_consume(&gate, P, ReadTier::FollowerCommitted, 0);
+        assert!(
+            !clean.is_empty(),
+            "the clean tier served the committed prefix with NO live leader to confirm against"
+        );
+        // The clean tier serves the committed prefix LOCALLY with no leader round-trip; its bound is the
+        // follower's read-plane SEALED frontier (`<= served_end`, the FLAGGED active-tail lag), never past
+        // it. The load-bearing fact for THIS test is that it served WITHOUT a reachable leader.
+        let clean_max = clean.iter().map(|(o, _)| *o).max().unwrap();
+        assert!(
+            clean_max < served_end,
+            "the clean tier never serves past the committed prefix (max={clean_max}, served_end={served_end})"
+        );
+        for (off, payload) in &clean {
+            assert_eq!(payload, format!("rep-{off:02}").as_bytes());
+        }
+
+        f_rt.stop();
     }
 }

--- a/crates/ironbus-server/src/cluster/serve.rs
+++ b/crates/ironbus-server/src/cluster/serve.rs
@@ -362,7 +362,11 @@ impl<S: Read + Write> DataPlaneLink<S> {
 /// must NOT stall the consumer — on a timeout the follower FAILS CLOSED to the clean tier (serve only up
 /// to its safe watermark, never an unconfirmed offset). The same `connect_timeout` + `read_timeout`
 /// discipline the follower fetch loop uses, sized for a single round-trip rather than a steady poll.
-const HW_CONFIRM_TIMEOUT: Duration = Duration::from_millis(500);
+///
+/// This is the PRODUCTION default; it is what [`ClientAckGate`](super::client_ack::ClientAckGate) holds
+/// unless overridden ([`ClientAckGate::set_confirm_timeout`](super::client_ack::ClientAckGate::set_confirm_timeout),
+/// a test-robustness seam). Production behaviour is unchanged: the confirm still bounds at 500 ms.
+pub const HW_CONFIRM_TIMEOUT: Duration = Duration::from_millis(500);
 
 /// Perform ONE bounded, over-the-wire DIRTY-TIER committed-HW CONFIRM (#739): dial the partition
 /// LEADER's data-plane address `leader_data_addr`, send a [`DataPlaneFrame::CommittedHwQuery`] for
@@ -371,18 +375,27 @@ const HW_CONFIRM_TIMEOUT: Duration = Duration::from_millis(500);
 /// wire — a tiny HW-version query (NOT the data) so a follower can serve a read-your-writes prefix above
 /// its known safe watermark, and NEVER an offset the leader has not confirmed committed.
 ///
-/// It is a short-lived, single-shot link with the `HW_CONFIRM_TIMEOUT` bound on BOTH the connect and the
-/// read, so a slow / dead / wrong-role leader cannot stall the consume path. Returns `Some(committed_hw)`
-/// ONLY on a clean round-trip whose response is the leader's committed HW for THIS partition; on ANY
-/// failure (no route, connect/read timeout, link error, wrong partition / verb) it returns `None` so the
-/// caller FAILS CLOSED to the clean tier (serves only up to its safe watermark — never unconfirmed).
+/// It is a short-lived, single-shot link with `timeout` bound on BOTH the connect and the read, so a
+/// slow / dead / wrong-role leader cannot stall the consume path. `timeout` is the caller's confirm
+/// budget — [`HW_CONFIRM_TIMEOUT`] (500 ms) in production; a test may pass a host-scaled value so the
+/// confirm completes under a contended CI runner WITHOUT changing the fail-closed semantics. Returns
+/// `Some(committed_hw)` ONLY on a clean round-trip whose response is the leader's committed HW for THIS
+/// partition; on ANY failure (no route, connect/read timeout, link error, wrong partition / verb) it
+/// returns `None` so the caller FAILS CLOSED to the clean tier (serves only up to its safe watermark —
+/// never unconfirmed). The timeout only governs HOW LONG the confirm waits — never WHETHER an unconfirmed
+/// offset is served (on a timeout it still returns `None` → fail-closed), so never-serve-unconfirmed holds
+/// for any timeout.
 ///
 /// It never panics and never serves data: it is a read-only HW query (single-writer preserved).
 #[must_use]
-pub fn query_leader_committed_hw(leader_data_addr: SocketAddr, partition: u64) -> Option<u64> {
-    let stream = TcpStream::connect_timeout(&leader_data_addr, HW_CONFIRM_TIMEOUT).ok()?;
-    stream.set_read_timeout(Some(HW_CONFIRM_TIMEOUT)).ok()?;
-    stream.set_write_timeout(Some(HW_CONFIRM_TIMEOUT)).ok()?;
+pub fn query_leader_committed_hw(
+    leader_data_addr: SocketAddr,
+    partition: u64,
+    timeout: Duration,
+) -> Option<u64> {
+    let stream = TcpStream::connect_timeout(&leader_data_addr, timeout).ok()?;
+    stream.set_read_timeout(Some(timeout)).ok()?;
+    stream.set_write_timeout(Some(timeout)).ok()?;
     let mut link = DataPlaneLink::new(stream);
     link.send(
         partition,
@@ -727,6 +740,11 @@ struct ClientGateConfig {
     /// The shared metadata status snapshot the follower-read reads the committed-HW bar from (#735, half
     /// B); `None` fails the follower-read closed (serve nothing) until a checkpoint is known.
     status: Option<Arc<Mutex<super::runtime::ClusterStatus>>>,
+    /// The dirty-tier committed-HW CONFIRM timeout (#739) the built gate holds — the connect+read budget
+    /// for [`query_leader_committed_hw`]. PRODUCTION uses [`HW_CONFIRM_TIMEOUT`] (500 ms); a test may
+    /// override it (e.g. host-scaled) so the confirm completes under a contended runner without weakening
+    /// the fail-closed semantics. A `None` here defaults to [`HW_CONFIRM_TIMEOUT`].
+    confirm_timeout: Option<Duration>,
 }
 
 pub struct DataPlaneRuntime<F: Filesystem, C: Clock> {
@@ -833,6 +851,7 @@ where
                 // the dirty-tier confirm reachable for a runtime started this way.
                 leader_data_addrs: peer_data_addrs.clone(),
                 status: None,
+                confirm_timeout: None,
             }),
         )
     }
@@ -868,6 +887,7 @@ where
                 // the safe watermark can confirm with the leader before serving (never unconfirmed).
                 leader_data_addrs: peer_data_addrs.clone(),
                 status: Some(status),
+                confirm_timeout: None,
             }),
         )
     }
@@ -903,6 +923,9 @@ where
                     .with_leader_data_addrs(cfg.leader_data_addrs);
             if let Some(status) = cfg.status {
                 gate = gate.with_status_handle(status);
+            }
+            if let Some(confirm_timeout) = cfg.confirm_timeout {
+                gate = gate.with_confirm_timeout(confirm_timeout);
             }
             Arc::new(gate)
         });
@@ -2819,6 +2842,37 @@ mod live_runtime_tests {
         pred()
     }
 
+    /// Scale a GENEROUS base budget by the observed host slowdown (#618): a local copy of the runtime
+    /// test's `host_scaled` (max-of-3-probes + a 24x cap), so a timing-sensitive budget stays truthful and
+    /// flake-free on a contended CI runner WITHOUT weakening what the test proves. On an unloaded host the
+    /// factor is ~1 and the budget stays the base. Used by the #739 dirty-tier HAPPY-PATH test to size the
+    /// over-the-wire committed-HW CONFIRM timeout so the confirm completes even under heavy CI contention
+    /// (the production default stays the hardcoded 500 ms — this only governs how long the confirm waits,
+    /// never the fail-closed / never-serve-unconfirmed semantics).
+    fn host_scaled(base: Duration) -> Duration {
+        fn probe_busy_nanos() -> u128 {
+            const ITERS: u64 = 2_000_000;
+            let start = Instant::now();
+            let mut acc: u64 = 0x9E37_79B9_7F4A_7C15;
+            for i in 0..ITERS {
+                acc = acc
+                    .wrapping_mul(6_364_136_223_846_793_005)
+                    .wrapping_add(i | 1);
+                acc ^= acc >> 29;
+            }
+            std::hint::black_box(acc);
+            start.elapsed().as_nanos().max(1)
+        }
+        const REFERENCE_BUSY_NANOS: u128 = 4_000_000;
+        const MAX_SCALE: u32 = 24;
+        let mut samples = [probe_busy_nanos(), probe_busy_nanos(), probe_busy_nanos()];
+        samples.sort_unstable();
+        let observed = samples[2];
+        let factor = (observed / REFERENCE_BUSY_NANOS).clamp(1, u128::from(MAX_SCALE));
+        let factor = u32::try_from(factor).unwrap_or(MAX_SCALE);
+        base * factor
+    }
+
     fn dump_segments(log: &Log<StdFs, ManualClock>) -> Vec<(String, Vec<u8>)> {
         let fs = log.filesystem();
         let mut out = Vec::new();
@@ -3907,6 +3961,14 @@ mod live_runtime_tests {
             .client_gate()
             .cloned()
             .expect("the follower runtime built a client gate");
+        // HAPPY-PATH ROBUSTNESS (#739): the over-the-wire committed-HW CONFIRM is bounded by a SHORT
+        // production timeout (500 ms). On a heavily-contended CI runner a localhost round-trip can exceed
+        // that, so the confirm would TIME OUT and the dirty read would (correctly) FAIL CLOSED to the clean
+        // tier — failing THIS happy-path assertion. Give the confirm a HOST-SCALED budget so it completes
+        // even under load. This changes ONLY how long this test waits for the confirm; production keeps the
+        // hardcoded default, and the fail-closed / never-serve-unconfirmed semantics are untouched (the
+        // fail-closed test below proves an unreachable leader still fails fast on connect-refused).
+        gate.set_confirm_timeout(host_scaled(Duration::from_millis(500)));
 
         // Wait until the follower's runtime fetch loop has replicated the leader's whole served prefix.
         let f_hw = || {

--- a/crates/ironbus-server/src/cluster/serve.rs
+++ b/crates/ironbus-server/src/cluster/serve.rs
@@ -199,6 +199,9 @@ fn frame_type_for(frame: &DataPlaneFrame) -> FrameType {
         DataPlaneFrame::EpochQuery(_) | DataPlaneFrame::EpochResponse(_) => {
             FrameType::OffsetForLeaderEpoch
         }
+        DataPlaneFrame::CommittedHwQuery(_) | DataPlaneFrame::CommittedHwResponse(_) => {
+            FrameType::CommittedHwQuery
+        }
     }
 }
 
@@ -211,6 +214,8 @@ fn encode_dataplane_body(frame: &DataPlaneFrame) -> Vec<u8> {
         DataPlaneFrame::AckReplicated(b) => b.encode(),
         DataPlaneFrame::EpochQuery(b) => b.encode(),
         DataPlaneFrame::EpochResponse(b) => b.encode(),
+        DataPlaneFrame::CommittedHwQuery(b) => b.encode(),
+        DataPlaneFrame::CommittedHwResponse(b) => b.encode(),
     }
 }
 
@@ -348,6 +353,50 @@ impl<S: Read + Write> DataPlaneLink<S> {
             }
             self.inbuf.extend_from_slice(&chunk[..n]);
         }
+    }
+}
+
+/// The bounded timeout for the DIRTY-TIER committed-HW confirm (#739): how long the follower's query
+/// link waits to CONNECT to, and to READ a [`CommittedHwResponseBody`] from, the partition leader. It is
+/// deliberately SHORT (sub-second): the confirm sits on the consume serve path, so a slow / dead leader
+/// must NOT stall the consumer — on a timeout the follower FAILS CLOSED to the clean tier (serve only up
+/// to its safe watermark, never an unconfirmed offset). The same `connect_timeout` + `read_timeout`
+/// discipline the follower fetch loop uses, sized for a single round-trip rather than a steady poll.
+const HW_CONFIRM_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Perform ONE bounded, over-the-wire DIRTY-TIER committed-HW CONFIRM (#739): dial the partition
+/// LEADER's data-plane address `leader_data_addr`, send a [`DataPlaneFrame::CommittedHwQuery`] for
+/// `partition`, and read back the leader's current committed HW from its
+/// [`DataPlaneFrame::CommittedHwResponse`]. This is the #723 `ConfirmWithLeader` made REAL over the
+/// wire — a tiny HW-version query (NOT the data) so a follower can serve a read-your-writes prefix above
+/// its known safe watermark, and NEVER an offset the leader has not confirmed committed.
+///
+/// It is a short-lived, single-shot link with the `HW_CONFIRM_TIMEOUT` bound on BOTH the connect and the
+/// read, so a slow / dead / wrong-role leader cannot stall the consume path. Returns `Some(committed_hw)`
+/// ONLY on a clean round-trip whose response is the leader's committed HW for THIS partition; on ANY
+/// failure (no route, connect/read timeout, link error, wrong partition / verb) it returns `None` so the
+/// caller FAILS CLOSED to the clean tier (serves only up to its safe watermark — never unconfirmed).
+///
+/// It never panics and never serves data: it is a read-only HW query (single-writer preserved).
+#[must_use]
+pub fn query_leader_committed_hw(leader_data_addr: SocketAddr, partition: u64) -> Option<u64> {
+    let stream = TcpStream::connect_timeout(&leader_data_addr, HW_CONFIRM_TIMEOUT).ok()?;
+    stream.set_read_timeout(Some(HW_CONFIRM_TIMEOUT)).ok()?;
+    stream.set_write_timeout(Some(HW_CONFIRM_TIMEOUT)).ok()?;
+    let mut link = DataPlaneLink::new(stream);
+    link.send(
+        partition,
+        &DataPlaneFrame::CommittedHwQuery(super::dataplane::CommittedHwQueryBody),
+    )
+    .ok()?;
+    // Read exactly one response, bounded by the read timeout. Anything other than a committed-HW response
+    // for THIS partition is a failed confirm → `None` → the caller serves the clean tier (never
+    // unconfirmed). The leader-side reader answers a CommittedHwQuery with exactly this frame.
+    match link.recv() {
+        Ok(Some((p, DataPlaneFrame::CommittedHwResponse(resp)))) if p == partition => {
+            Some(resp.committed_hw)
+        }
+        _ => None,
     }
 }
 
@@ -671,6 +720,10 @@ struct ClientGateConfig {
     /// The node-id -> CLIENT-address advertise map for the `NOT_LEADER` leader hint (#735); empty means the
     /// redirect carries no hint (the client re-tries its known peers).
     leader_client_addrs: BTreeMap<u64, SocketAddr>,
+    /// The node-id -> DATA-PLANE peer address map for the dirty-tier committed-HW confirm (#739); empty
+    /// means a "latest" follower-read above the safe watermark fails closed to the clean tier (never
+    /// unconfirmed).
+    leader_data_addrs: BTreeMap<u64, SocketAddr>,
     /// The shared metadata status snapshot the follower-read reads the committed-HW bar from (#735, half
     /// B); `None` fails the follower-read closed (serve nothing) until a checkpoint is known.
     status: Option<Arc<Mutex<super::runtime::ClusterStatus>>>,
@@ -774,6 +827,11 @@ where
             Some(ClientGateConfig {
                 configured_level,
                 leader_client_addrs: BTreeMap::new(),
+                // The dirty-tier confirm (#739) targets the leader's data-plane address — the SAME
+                // `peer_data_addrs` the follower fetch loop dials. With no #735-aware wiring there is no
+                // status handle, so the follower-read fails closed anyway; the data addresses still make
+                // the dirty-tier confirm reachable for a runtime started this way.
+                leader_data_addrs: peer_data_addrs.clone(),
                 status: None,
             }),
         )
@@ -805,6 +863,10 @@ where
             Some(ClientGateConfig {
                 configured_level,
                 leader_client_addrs,
+                // The dirty-tier committed-HW confirm (#739) dials the leader's DATA-plane address — the
+                // SAME `peer_data_addrs` the follower fetch loop uses — so a "latest" follower-read above
+                // the safe watermark can confirm with the leader before serving (never unconfirmed).
+                leader_data_addrs: peer_data_addrs.clone(),
                 status: Some(status),
             }),
         )
@@ -837,7 +899,8 @@ where
         let client_gate = client_cfg.map(|cfg| {
             let mut gate =
                 super::client_ack::ClientAckGate::new(Arc::clone(&server), cfg.configured_level)
-                    .with_leader_client_addrs(cfg.leader_client_addrs);
+                    .with_leader_client_addrs(cfg.leader_client_addrs)
+                    .with_leader_data_addrs(cfg.leader_data_addrs);
             if let Some(status) = cfg.status {
                 gate = gate.with_status_handle(status);
             }
@@ -1044,6 +1107,19 @@ fn run_dataplane_reader<F, C>(
                     }) => {
                         if link
                             .send(partition, &DataPlaneFrame::EpochResponse(response))
+                            .is_err()
+                        {
+                            return;
+                        }
+                    }
+                    // The DIRTY-TIER committed-HW confirm (#739): the leader answers a follower's
+                    // HW-version query with its current committed HW on the SAME link.
+                    Some(DataPlaneAction::SendCommittedHwResponse {
+                        partition,
+                        response,
+                    }) => {
+                        if link
+                            .send(partition, &DataPlaneFrame::CommittedHwResponse(response))
                             .is_err()
                         {
                             return;


### PR DESCRIPTION
## What & why (#739, C6-I4)

The follower-read **clean** tier (committed reads `<=` the safe watermark
`min(own_flushed, known_committed_hw)`) was already wired + proven over the wire
(#735). The **dirty** tier — a read ABOVE the follower's safe watermark
(read-your-writes from a follower for an offset it holds locally but hasn't yet
confirmed committed) — previously REFUSED/blocked: #723's `classify_follower_read`
returned `ConfirmWithLeader`, and the wire path served 0 for it.

This PR wires the dirty-tier **leader HW-version confirm** end-to-end: when a wire
consume requests an offset above the follower's safe watermark, the follower asks
the **leader** for its current committed HW (a tiny HW-version query, NOT the data),
and — if the leader confirms the offset is committed — serves it locally; otherwise
it serves only up to the confirmed HW (the clean tier), **never** uncommitted /
divergent data.

## Design

- **New wire frame `CommittedHwQuery` (tag 43)** — next-free after `NotLeader=42`.
  Request (`kind=0`) and response (`kind=1, committed_hw: u64`) share the tag like
  `OffsetForLeaderEpoch`. It rides the intra-cluster **data plane**, never the client
  wire — a client never sends/receives it, so it never appears off-cluster.
- **dataplane**: `CommittedHwQueryBody`/`CommittedHwResponseBody` codecs (fail-closed
  on bad kind/len); `DataPlaneFrame` variants + decode router; `handle_frame` answers
  a query from `leader_committed_hw` (the read plane's flushed frontier) and is
  **wrong-role on a non-leader** (a follower is never an authoritative HW source);
  `SendCommittedHwResponse` action.
- **serve**: the leader-side reader replies on the same link;
  `query_leader_committed_hw(addr, partition)` is a short-lived, **timeout-bounded**
  (500 ms connect+read) single-shot confirm link that returns `None` (→ fail closed)
  on any failure.
- **client_ack**: `serve_follower_consume` resolves a dirty read in place — it does
  the confirm **off-lock**, then re-serves at the **clean** tier with the bar RAISED
  to `max(known_committed_hw, confirmed_hw)`, so it serves up to
  `min(own_flushed, confirmed_hw)`. On any confirm failure it re-serves with the
  **un-raised** bar (fail-closed). The clean tier stays zero-round-trip.
- **runtime/CLI**: peer data addresses are threaded into the gate
  (`leader_data_addrs`) via `start_with_client_gate[_aware]`; the CLI already passes
  `peer_data_addrs`, so this is wired in a real serve with no CLI change.

## How each non-negotiable is guaranteed

1. **Never serve uncommitted/divergent data.** A dirty serve re-serves at the CLEAN
   tier with the bar = `max(known, confirmed)`; the clean tier serves only
   `<= min(own_flushed, raised_bar)` — every offset is leader-confirmed committed AND
   durably held. The safe-watermark clamp (#723, fail-closed to 0) is the floor; the
   confirm only ever RAISES the bound to the leader's confirmed HW.
   `client_ack.rs::resolve_dirty_tier`, `read_consistency::follower_safe_watermark`.
2. **Confirm is real (over the wire), bounded, fail-closed.**
   `serve.rs::query_leader_committed_hw` is an actual TCP query to the leader's
   data-plane listener with a 500 ms connect+read timeout; any failure → `None` →
   re-serve at the clean tier (≤ safe watermark). Never serves unconfirmed.
3. **Clean tier unchanged (no round-trip).** A committed read `<=` the safe watermark
   returns `Served` from the first lock with NO confirm; the confirm only runs on a
   `ConfirmWithLeader` outcome (above the safe watermark). Proven by a test that
   serves the clean prefix with the leader STOPPED.
4. **Single-node byte-identical.** The diff touches only `ironbus-proto` (the additive
   frame enum) and the `cluster::{client_ack, dataplane, serve}` modules. `session.rs`,
   `actor.rs`, and the engine are UNTOUCHED. The `ClientAckGate` is built ONLY on a
   clustered serve, so off-cluster the consume/produce path is byte-for-byte today's.
5. **Single-writer preserved.** The confirm is a read-only HW query; the follower
   serves via the read plane and never writes.

## Tests (all 5x-stable on macOS)

Real-socket (in `live_runtime_tests`, real `DataPlaneRuntime`s over loopback):
- `live_runtime_follower_dirty_tier_confirms_with_the_leader_then_serves` — a follower
  with a STALE committed-HW bar serves only its clean prefix at the clean tier, but a
  `FollowerLatest` read above the bar confirms with the live leader over the wire and
  serves the now-confirmed read-your-writes prefix byte-faithfully, never above the
  leader-confirmed HW.
- `live_runtime_follower_dirty_tier_fails_closed_when_the_leader_is_unreachable` — with
  the leader stopped, a dirty read above the bar falls back to the clean tier (serves
  only `<` the safe watermark; a read starting at the bar serves nothing).
- `live_runtime_follower_clean_tier_serves_without_a_leader_roundtrip` — the clean tier
  serves the committed prefix locally with the leader STOPPED (no round-trip).

In-process / codec:
- `dataplane::committed_hw_query_is_answered_by_the_leader_and_rejected_by_a_follower`
- `dataplane::committed_hw_bodies_round_trip_and_reject_malformed`
- `serve::every_dataplane_frame_round_trips_over_the_peer_codec` (extended)
- `client_ack::serve_follower_consume_dirty_tier_fails_closed_with_no_leader_route`
- proto: tag-43 bijection / frozen-wire / ALL_TYPES.

## Gates
`cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features
--locked -- -D warnings`, full `cargo test --workspace --all-features --locked`
(all green, incl. the APFS preallocate test), io-free-check on ironbus-core, SPDX
`miss=0`. New tests run 5x stable.

## Deferred / honest caveats
- The session's normal streaming fetch still requests the CLEAN tier (byte-identical);
  the dirty tier is exercised via the gate API + tests and is reachable in a real
  serve. Wiring a per-consumer "latest" opt-in through `session.rs` is a small,
  separate session change.
- Active-tail lag (FLAGGED in-tree): the follower's read-plane SEALED frontier can lag
  the leader's served end until the active segment seals, so a dirty serve is bounded
  by `min(own_flushed, confirmed_hw)`; it never serves above the confirmed HW (the
  correctness property), it may just lag by the unsealed tail (a liveness window).
- Default/single-stream partition; multi-partition is #693.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVWp2H2txnKGru4q2twxM3
