### PR TITLE
governance: org-agnostic independence gate + GOVERNANCE update (#502)

### DIFF
--- a/.github/forbidden-org-terms.txt
+++ b/.github/forbidden-org-terms.txt
@@ -1,0 +1,11 @@
+# Org-specific / vendor-lock terms forbidden anywhere in IronBus.
+#
+# IronBus is an INDEPENDENT, ORG-AGNOSTIC open-source project (see GOVERNANCE.md). It must never
+# carry references that couple it to a specific company, employer, org, or private deployment.
+# This list is the enforced (CI-failing) subset; the general policy — no org-specific references
+# of ANY kind — is in GOVERNANCE.md and is upheld in review. Add terms here as needed.
+#
+# Format: one case-insensitive substring per line; lines starting with '#' are comments.
+# The org-agnostic CI gate (.github/workflows/org-agnostic.yml) greps every tracked file
+# (except this list) for each term and fails the build if any is found.
+butlr

--- a/.github/workflows/org-agnostic.yml
+++ b/.github/workflows/org-agnostic.yml
@@ -1,0 +1,44 @@
+name: org-agnostic hygiene
+
+# IronBus is an independent, org-agnostic open-source project (GOVERNANCE.md). This gate enforces
+# that no org-specific / vendor-lock reference is ever committed: it greps every tracked file for
+# each term in .github/forbidden-org-terms.txt and fails the build if any is found.
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  no-org-references:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: forbid org-specific / vendor-lock references in tracked files
+        run: |
+          set -euo pipefail
+          terms_file=.github/forbidden-org-terms.txt
+          if [ ! -f "$terms_file" ]; then
+            echo "::error::$terms_file is missing — the org-agnostic gate cannot run"
+            exit 1
+          fi
+          found=0
+          while IFS= read -r raw; do
+            term="${raw%%$'\r'}"
+            [ -z "$term" ] && continue
+            case "$term" in \#*) continue ;; esac
+            # Search every tracked file EXCEPT the terms list itself (which legitimately holds the terms).
+            if git grep -I -i -n -e "$term" -- . ":(exclude)$terms_file" > /tmp/org_hits 2>/dev/null; then
+              echo "::error::forbidden org-specific term '$term' found — IronBus must stay org-agnostic (see GOVERNANCE.md):"
+              cat /tmp/org_hits
+              found=1
+            fi
+          done < "$terms_file"
+          if [ "$found" = "1" ]; then
+            echo "::error::org-agnostic hygiene FAILED: remove the org-specific reference(s) above. IronBus is org-neutral and open-source."
+            exit 1
+          fi
+          echo "org-agnostic hygiene: no forbidden org-specific references in tracked files"

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -5,6 +5,30 @@ reviews and merges pull requests, and is responsible for keeping the design
 coherent. Every change still follows the contribution process: green CI plus an
 independent review before merge.
 
+## Independence (org-agnostic)
+
+IronBus is an **independent, org-agnostic open-source project**. It is owned by no
+single company, employer, or organization; copyright is held collectively by "The
+IronBus Authors" and the project is licensed under
+[MIT](LICENSE-MIT) **OR** [Apache-2.0](LICENSE-APACHE) at the user's option.
+
+Because of that, the source and all tracked files must stay **org-neutral**: no
+references that couple IronBus to a specific company, employer, internal
+deployment, or private infrastructure may ever be committed — no org names, hosts,
+account handles, ticket trackers, or vendor-internal jargon. This is not merely a
+style preference; it is a project invariant:
+
+- The general rule — *no org-specific reference of any kind* — is upheld in review.
+- The concrete, known-risk subset is **CI-enforced**: the
+  [`org-agnostic hygiene`](.github/workflows/org-agnostic.yml) gate greps every
+  tracked file for each term in
+  [`.github/forbidden-org-terms.txt`](.github/forbidden-org-terms.txt) and **fails
+  the build** if any is found, so an org-specific reference can never land on
+  `main`. Add terms to that list as the project's contributor base grows.
+
+A contribution that would tie IronBus to one organization is out of scope by
+construction, regardless of who contributes it.
+
 ## How decisions are made
 
 - **Decisions are recorded on their owning GitHub issues.** Each subsystem has a


### PR DESCRIPTION
Resolves the governance items of #502.

- **License** (already enacted): MIT OR Apache-2.0 — LICENSE-MIT + LICENSE-APACHE present, `license` set in Cargo.toml, copyright 'The IronBus Authors' (org-agnostic).
- **Org ownership**: IronBus stays an **independent, org-agnostic open-source project** (owned by no single org). New `org-agnostic hygiene` CI gate greps every tracked file for org-specific / vendor-lock terms (`.github/forbidden-org-terms.txt`) and **fails the build** if any is found — so an org reference can never be committed. GOVERNANCE.md documents the independence invariant.
- **Versioning/release**: already published (RELEASING.md — rolling calendar versions; 0.0.0 is the intentional source pin).

Closes #502.

🤖 Generated with [Claude Code](https://claude.com/claude-code)