### PR TITLE
feat(cli): report + server check (Nagios) + interactive fuzzy selection (#589, #592, #583)

### DIFF
--- a/crates/ironbus-cli/src/fuzzy.rs
+++ b/crates/ironbus-cli/src/fuzzy.rs
@@ -1,0 +1,307 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! Interactive fuzzy stream/group selection (V2-M6, #583): when a verb needs a stream or group and
+//! none is given ON AN INTERACTIVE TERMINAL, offer a minimal fuzzy picker over the live names. It is
+//! SCRIPTABLE-SAFE by construction: a non-TTY stdin/stdout, the global `--json` envelope, or an
+//! explicit name on the command line all SKIP the picker, so a pipeline behaves exactly as before.
+//!
+//! NO heavyweight TUI dependency: the matcher is a tiny pure function (case-insensitive substring
+//! AND subsequence filter), and the prompt is a plain `stdin().read_line` loop — so the picker pulls
+//! ZERO new crates (MSRV-1.78-safe) and the cargo-deny allow-list is untouched. The interactive loop
+//! is Unix-gated in tests (`#[cfg(all(test, unix))]`) because it reads a terminal; the matcher
+//! itself is pure and tested on every platform.
+
+use crate::CliError;
+use std::io::{BufRead, IsTerminal, Write};
+
+/// Returns whether the matcher considers `query` a fuzzy match for `candidate`. The rule (matching
+/// the common `fzf`-style intuition, but minimal): case-insensitive, and EITHER a contiguous
+/// substring OR an in-order subsequence of the candidate's characters. An EMPTY query matches every
+/// candidate (the picker shows the full list before the operator types). The comparison is over
+/// Unicode scalar values lower-cased with `to_lowercase`, so an ASCII group/stream name (the
+/// common case) and a non-ASCII one both filter predictably.
+#[must_use]
+pub(crate) fn is_match(query: &str, candidate: &str) -> bool {
+    if query.is_empty() {
+        return true;
+    }
+    let q: Vec<char> = query.chars().flat_map(char::to_lowercase).collect();
+    let c: Vec<char> = candidate.chars().flat_map(char::to_lowercase).collect();
+    is_subsequence(&q, &c)
+}
+
+/// Whether `needle` is an in-order subsequence of `haystack` (every char of `needle` appears in
+/// `haystack`, in order, not necessarily contiguous). A contiguous substring is a special case, so
+/// this single test covers both the substring and the subsequence intuition.
+fn is_subsequence(needle: &[char], haystack: &[char]) -> bool {
+    let mut ni = 0;
+    for &h in haystack {
+        if ni == needle.len() {
+            break;
+        }
+        if needle[ni] == h {
+            ni += 1;
+        }
+    }
+    ni == needle.len()
+}
+
+/// Filters `candidates` to those matching `query`, preserving the input order (the caller sorts the
+/// list once, so the filtered view stays deterministic).
+#[must_use]
+pub(crate) fn filter<'a>(query: &str, candidates: &'a [String]) -> Vec<&'a str> {
+    candidates
+        .iter()
+        .map(String::as_str)
+        .filter(|c| is_match(query, c))
+        .collect()
+}
+
+/// Whether the interactive picker is eligible: it requires BOTH stdin AND stdout to be a terminal
+/// (so a redirected/piped stream never triggers a prompt), and the caller must NOT have requested
+/// the `--json` envelope or passed an explicit name. The global `--json` is detected by the
+/// dispatch (the captured-output path is non-interactive), so this guard plus the dispatch's stdout
+/// capture means `--json` can never reach an interactive prompt.
+#[must_use]
+pub(crate) fn is_interactive() -> bool {
+    std::io::stdin().is_terminal() && std::io::stdout().is_terminal()
+}
+
+/// Runs the interactive picker over `candidates` (the `noun`, e.g. "group" or "stream", labels the
+/// prompt), reading the operator's filter/selection from `input` and writing the prompt UI to
+/// `prompt_out` (kept as parameters so the loop is unit-testable without a real terminal). Returns
+/// the chosen name, or [`CliError::Usage`] if the operator gives up (EOF / empty list / an invalid
+/// selection), so a verb that REQUIRES a name fails cleanly rather than proceeding with none.
+///
+/// The protocol per round: print the numbered filtered list, then read one line. A line that is a
+/// number in range selects that entry; any other non-empty line becomes the new filter query; an
+/// empty line with exactly one match selects it (a fast path). EOF aborts.
+///
+/// # Errors
+/// [`CliError::Usage`] when the list is empty, the input ends without a selection, or the operator
+/// cannot narrow to a choice.
+pub(crate) fn pick(
+    noun: &str,
+    candidates: &[String],
+    input: &mut impl BufRead,
+    prompt_out: &mut impl Write,
+) -> Result<String, CliError> {
+    if candidates.is_empty() {
+        return Err(CliError::Usage(format!(
+            "no {noun}s available to choose from; pass one explicitly"
+        )));
+    }
+    let mut query = String::new();
+    loop {
+        let matches = filter(&query, candidates);
+        render_choices(noun, &query, &matches, prompt_out)?;
+        let mut line = String::new();
+        let n = input.read_line(&mut line)?;
+        if n == 0 {
+            // EOF: the operator aborted without choosing.
+            return Err(CliError::Usage(format!("no {noun} selected (input ended)")));
+        }
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            // An empty line selects the sole match, else re-prompts (shows the list again).
+            if matches.len() == 1 {
+                return Ok(matches[0].to_string());
+            }
+            continue;
+        }
+        // A numeric line selects by index (1-based) when in range.
+        if let Ok(idx) = trimmed.parse::<usize>() {
+            if idx >= 1 && idx <= matches.len() {
+                return Ok(matches[idx - 1].to_string());
+            }
+            writeln!(prompt_out, "  (no such choice: {idx})")?;
+            continue;
+        }
+        // Otherwise the line is a new filter query.
+        query = trimmed.to_string();
+    }
+}
+
+/// Renders one round of the picker UI: the current filter and the numbered, fuzzy-filtered choices.
+/// The default group/stream (the empty name) renders as `(default)` so it is selectable and visible.
+fn render_choices(
+    noun: &str,
+    query: &str,
+    matches: &[&str],
+    out: &mut impl Write,
+) -> Result<(), CliError> {
+    if query.is_empty() {
+        writeln!(
+            out,
+            "select a {noun} (type to filter, or a number to choose):"
+        )?;
+    } else {
+        writeln!(
+            out,
+            "select a {noun} matching \"{query}\" (type to refine, or a number to choose):"
+        )?;
+    }
+    if matches.is_empty() {
+        writeln!(out, "  (no matches; type a different filter)")?;
+    } else {
+        for (i, name) in matches.iter().enumerate() {
+            let shown = if name.is_empty() { "(default)" } else { name };
+            writeln!(out, "  {}: {shown}", i + 1)?;
+        }
+    }
+    write!(out, "> ")?;
+    out.flush().map_err(CliError::from)?;
+    Ok(())
+}
+
+/// Resolves a name for `noun`: if `explicit` is given, returns it unchanged (the scriptable path);
+/// otherwise, if the session is interactive, runs the picker over `candidates` reading the real
+/// stdin and writing the prompt to stderr (so the picker UI never pollutes stdout, which a `--json`
+/// or piped consumer reads). When NOT interactive and no explicit name is given, returns a usage
+/// error naming the missing argument — exactly the pre-picker behavior for a scripted run.
+///
+/// # Errors
+/// [`CliError::Usage`] when no name is given and the session is non-interactive, or the picker is
+/// aborted.
+pub(crate) fn resolve_or_pick(
+    noun: &str,
+    explicit: Option<&str>,
+    candidates: &[String],
+) -> Result<String, CliError> {
+    if let Some(name) = explicit {
+        return Ok(name.to_string());
+    }
+    if !is_interactive() {
+        return Err(CliError::Usage(format!(
+            "no {noun} given; pass one explicitly (a {noun} is required for a non-interactive run)"
+        )));
+    }
+    let stdin = std::io::stdin();
+    let mut locked = stdin.lock();
+    let stderr = std::io::stderr();
+    let mut prompt = stderr.lock();
+    pick(noun, candidates, &mut locked, &mut prompt)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_query_matches_everything() {
+        assert!(is_match("", "anything"));
+        assert!(is_match("", ""));
+    }
+
+    #[test]
+    fn substring_matches_case_insensitively() {
+        assert!(is_match("ord", "orders"));
+        assert!(is_match("ORD", "orders"));
+        assert!(is_match("ders", "orders"));
+        assert!(!is_match("xyz", "orders"));
+    }
+
+    #[test]
+    fn subsequence_matches_non_contiguous_in_order() {
+        // o..d..s appear in order in "orders" though not contiguous.
+        assert!(is_match("ods", "orders"));
+        assert!(is_match("evt", "events"));
+        // Out of order does NOT match.
+        assert!(!is_match("sdo", "orders"));
+    }
+
+    #[test]
+    fn filter_preserves_input_order() {
+        let names = vec![
+            "orders".to_string(),
+            "audit".to_string(),
+            "order-dlq".to_string(),
+        ];
+        let got = filter("ord", &names);
+        assert_eq!(got, vec!["orders", "order-dlq"]);
+    }
+
+    #[test]
+    fn pick_selects_by_number() {
+        let names = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+        let mut input = std::io::Cursor::new(b"2\n".to_vec());
+        let mut ui = Vec::new();
+        let chosen = pick("group", &names, &mut input, &mut ui).unwrap();
+        assert_eq!(chosen, "b");
+    }
+
+    #[test]
+    fn pick_filters_then_selects() {
+        let names = vec![
+            "orders".to_string(),
+            "audit".to_string(),
+            "order-dlq".to_string(),
+        ];
+        // First line "ord" filters to [orders, order-dlq]; "1" then selects orders.
+        let mut input = std::io::Cursor::new(b"ord\n1\n".to_vec());
+        let mut ui = Vec::new();
+        let chosen = pick("stream", &names, &mut input, &mut ui).unwrap();
+        assert_eq!(chosen, "orders");
+        // The UI prompt mentions the noun and the refine instruction.
+        let ui = String::from_utf8(ui).unwrap();
+        assert!(ui.contains("select a stream"), "{ui}");
+    }
+
+    #[test]
+    fn pick_empty_line_selects_the_sole_match() {
+        let names = vec!["orders".to_string(), "audit".to_string()];
+        // "aud" filters to exactly [audit]; an empty line then selects the lone match.
+        let mut input = std::io::Cursor::new(b"aud\n\n".to_vec());
+        let mut ui = Vec::new();
+        let chosen = pick("group", &names, &mut input, &mut ui).unwrap();
+        assert_eq!(chosen, "audit");
+    }
+
+    #[test]
+    fn pick_aborts_cleanly_on_eof() {
+        let names = vec!["a".to_string()];
+        let mut input = std::io::Cursor::new(Vec::new()); // immediate EOF
+        let mut ui = Vec::new();
+        let e = pick("group", &names, &mut input, &mut ui).unwrap_err();
+        assert_eq!(e.exit_code(), crate::EXIT_USAGE);
+    }
+
+    #[test]
+    fn pick_on_an_empty_candidate_list_is_a_usage_error() {
+        let names: Vec<String> = Vec::new();
+        let mut input = std::io::Cursor::new(b"1\n".to_vec());
+        let mut ui = Vec::new();
+        let e = pick("stream", &names, &mut input, &mut ui).unwrap_err();
+        assert_eq!(e.exit_code(), crate::EXIT_USAGE);
+    }
+
+    #[test]
+    fn pick_rejects_out_of_range_then_accepts_a_valid_choice() {
+        let names = vec!["a".to_string(), "b".to_string()];
+        // "9" is out of range (re-prompts), then "1" selects "a".
+        let mut input = std::io::Cursor::new(b"9\n1\n".to_vec());
+        let mut ui = Vec::new();
+        let chosen = pick("group", &names, &mut input, &mut ui).unwrap();
+        assert_eq!(chosen, "a");
+        let ui = String::from_utf8(ui).unwrap();
+        assert!(ui.contains("no such choice: 9"), "{ui}");
+    }
+
+    #[test]
+    fn resolve_or_pick_returns_an_explicit_name_unchanged_without_prompting() {
+        // The scriptable path: an explicit name is returned verbatim, no TTY needed.
+        let names = vec!["a".to_string()];
+        let got = resolve_or_pick("group", Some("explicit"), &names).unwrap();
+        assert_eq!(got, "explicit");
+    }
+
+    #[test]
+    fn the_default_empty_name_renders_as_default_in_the_ui() {
+        let names = vec![String::new(), "orders".to_string()];
+        let mut input = std::io::Cursor::new(b"1\n".to_vec());
+        let mut ui = Vec::new();
+        let chosen = pick("group", &names, &mut input, &mut ui).unwrap();
+        assert_eq!(chosen, ""); // the default group is selectable
+        let ui = String::from_utf8(ui).unwrap();
+        assert!(ui.contains("(default)"), "{ui}");
+    }
+}

--- a/crates/ironbus-cli/src/main.rs
+++ b/crates/ironbus-cli/src/main.rs
@@ -85,8 +85,18 @@ mod dict_cmd;
 mod completion;
 /// Named connection profiles (server + auth + TLS + data-dir), `kubectl config`-style (#581).
 mod context;
+/// The interactive fuzzy stream/group picker (TTY-only, scriptable-safe) (#583).
+mod fuzzy;
 /// The uniform `--json` envelope + frozen exit-code contract (V2-M6, #579).
 mod json_envelope;
+/// A bounded, dependency-free HTTP GET for the health server's text endpoints (#589, #592).
+mod metrics_fetch;
+/// A tiny Prometheus text-exposition reader for the `report` views (#589).
+mod prom;
+/// The `report` operator views over `/metrics` (#589).
+mod report;
+/// The `server` health-probe verbs (Nagios-style `check`, plus info/healthz/ready) (#592).
+mod server_check;
 
 use ironbus_client::{Client, ClientError};
 use ironbus_core::clock::Clock;
@@ -796,6 +806,10 @@ USAGE:
     ironbus repair --data-dir <dir> [--apply --force] [--json]
     ironbus top   (--addr <host:port> | --health-addr <host:port> | --data-dir <dir>)
                   [--interval <secs>] [--once] [--json] [--no-color]
+    ironbus report (groups | streams | storage | recovery | connections)
+                  [--addr <host:port> | --health-addr <host:port>] [--filter <name>]
+    ironbus server (info | healthz | ready | check)
+                  [--addr <host:port> | --health-addr <host:port>]
     ironbus bench (--duration <secs> | --count <n>) [--mode <publish|subscribe|round-trip>]
                   [--rate <msg/s>] [--payload-bytes <n>] [--payload-shape <realistic|random>]
                   [--fetch-batch <n>] [--group <name>] [--no-fsync] [--pubwindow <n>] [--stream] [--json]
@@ -993,6 +1007,24 @@ Notes:
     `ironbus top | cat` and a CI run produce clean text. --json emits a single versioned
     ironbus.cli.top.v1 object (the mode is tagged, so a script tells live from offline). The refresh
     SLEEPS between polls and never busy-spins. Offline mode is Unix-only in v1 (the on-disk store).
+    report is a strictly READ-ONLY operator report built from ONE GET /metrics against the broker's
+    health server: groups (per-work-group committed/lag/in-flight/consumed), streams (per-stream
+    produced throughput), storage (segments, durable bytes, disk-free, RAM headroom, write-amp;
+    a -1 disk/RAM sentinel renders as `unavailable`, never a misleading zero), recovery (recovery
+    runs, truncated/skipped bytes and records, quarantine, and the per-reason loss breakdown), and
+    connections (the ironbus_connections_* lifecycle + the pre-auth rejection reasons). The address
+    resolves flag > current-context > default. With the global --json it is the ironbus.cli.v1
+    envelope; otherwise a clean table. --filter <name> narrows the groups/streams view to one name;
+    with NO --filter on an interactive TTY, those two subjects offer a fuzzy picker over the live
+    names (a non-TTY / --json / explicit --filter run skips the picker and stays scriptable). It
+    never mutates the broker and never reads a metric it did not request.
+    server probes the broker's existing health server (READ-ONLY): info (version + uptime from
+    /metrics), healthz (liveness, GET /healthz), ready (readiness, GET /readyz), and check, a
+    Nagios-style one-line probe with a FROZEN exit code — IRONBUS OK (live AND ready, exit 0),
+    IRONBUS CRITICAL (reachable but not ready/not live, exit 3 = the ran-to-completion degraded
+    finding), IRONBUS UNREACHABLE (health server down, exit 5), or IRONBUS UNKNOWN (a malformed
+    response, exit 70). healthz and ready map to the broker's DISTINCT liveness vs readiness
+    endpoints (the server already ships the split). The address resolves flag > context > default.
     bench is a load generator that reports throughput, p50/p99/p999 latency, fsync cost, and
     bytes/op over the real wire and produce path. By DEFAULT it is PRODUCTION-SAFE: it spawns its
     own ISOLATED broker over a fresh ironbus-bench-<random> data directory and reads through a fresh
@@ -1194,6 +1226,8 @@ fn run(args: &[String], out: &mut impl Write) -> Result<(), CliError> {
         "verify" => run_verify(rest, out),
         "repair" => run_repair(rest, out),
         "top" => top::run_top(rest, out),
+        "report" => report::run_report(rest, out),
+        "server" => server_check::run_server(rest, out),
         "bench" => run_bench(rest, out),
         "upgrade" => run_upgrade(rest, out),
         "rollback" => run_rollback(rest, out),

--- a/crates/ironbus-cli/src/metrics_fetch.rs
+++ b/crates/ironbus-cli/src/metrics_fetch.rs
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! A tiny, dependency-free HTTP GET for the broker's health-server text endpoints (V2-M6, #589,
+//! #592): `GET /metrics` (Prometheus text exposition) and the Nagios-style health probes
+//! (`/healthz`, `/readyz`). It mirrors the trust model and the bounded-read defenses of
+//! [`crate::admin::fetch_admin`] (a per-request timeout and a hard body cap so a hung or hostile
+//! server cannot wedge the CLI), but speaks the PLAIN-text endpoints rather than the `/admin` JSON.
+//!
+//! READ-ONLY: every call is a `GET` against the existing health server; this module NEVER mutates
+//! the broker and NEVER changes `crates/ironbus-server/`. A missing or disabled endpoint, an
+//! unreachable port, or a non-200 status is mapped to a typed error the caller projects onto the
+//! frozen CLI exit-code scheme.
+
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::time::Duration;
+
+/// A read failure from the health-server text endpoints. The caller maps each variant onto the
+/// frozen CLI exit codes: [`HttpError::Unreachable`] → broker-unreachable (5),
+/// [`HttpError::Status`] / [`HttpError::Protocol`] → internal (70). A 404/503 carries its status so
+/// the probe verbs can classify it (e.g. `/readyz` 503 = not ready, NOT unreachable).
+#[derive(Debug)]
+pub(crate) enum HttpError {
+    /// The health server could not be reached or dropped the connection mid-exchange.
+    Unreachable(String),
+    /// The server answered with a non-200 status. Carries the numeric `status` so a probe can
+    /// distinguish a healthy 200 from a 503 (degraded) or 404 (endpoint absent) without re-parsing.
+    Status { status: u16, body: String },
+    /// The server answered but the response was not a usable HTTP response (no header/body split,
+    /// an over-long body, or an unparseable status line).
+    Protocol(String),
+}
+
+impl std::fmt::Display for HttpError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            HttpError::Unreachable(m) | HttpError::Protocol(m) => f.write_str(m),
+            HttpError::Status { status, body } => {
+                write!(f, "the endpoint returned HTTP {status}: {}", body.trim())
+            }
+        }
+    }
+}
+
+/// Per-request read/write timeout for a health-endpoint fetch (slow-server defense). Matches the
+/// `/admin` client's bound.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+/// The hard bound on a response body. A `/metrics` body is a bounded set of counters and a few
+/// histograms; 1 MiB is far above any real body and well below a memory hazard.
+const MAX_BODY: usize = 1 << 20; // 1 MiB
+
+/// Fetches `path` from the health server at `addr` over plain HTTP. On a 200, returns the response
+/// body. On any non-200, returns [`HttpError::Status`] carrying the status so the caller decides
+/// whether it is degraded (503), absent (404), or a hard error. Bounded by [`REQUEST_TIMEOUT`] and
+/// [`MAX_BODY`] so a hung or hostile server cannot wedge the CLI.
+///
+/// # Errors
+/// [`HttpError::Unreachable`] on a connect/IO failure; [`HttpError::Status`] on a non-200;
+/// [`HttpError::Protocol`] on an unparseable or over-long response.
+pub(crate) fn fetch(addr: &str, path: &str) -> Result<String, HttpError> {
+    let (status, body) = fetch_status(addr, path)?;
+    if status == 200 {
+        Ok(body)
+    } else {
+        Err(HttpError::Status { status, body })
+    }
+}
+
+/// Like [`fetch`] but returns the `(status, body)` pair even for a non-200, so a probe verb that
+/// MUST inspect a 503 (degraded) or 404 (endpoint absent) gets the status without it being folded
+/// into an error. A transport failure is still [`HttpError::Unreachable`]; a malformed HTTP
+/// response is still [`HttpError::Protocol`].
+///
+/// # Errors
+/// [`HttpError::Unreachable`] on a connect/IO failure; [`HttpError::Protocol`] on a malformed or
+/// over-long response.
+pub(crate) fn fetch_status(addr: &str, path: &str) -> Result<(u16, String), HttpError> {
+    let mut stream = TcpStream::connect(addr).map_err(|e| {
+        HttpError::Unreachable(format!("cannot reach health server at {addr}: {e}"))
+    })?;
+    stream
+        .set_read_timeout(Some(REQUEST_TIMEOUT))
+        .and_then(|()| stream.set_write_timeout(Some(REQUEST_TIMEOUT)))
+        .map_err(|e| HttpError::Unreachable(format!("cannot set socket timeout: {e}")))?;
+    let request = format!(
+        "GET {path} HTTP/1.1\r\n\
+         Host: {addr}\r\n\
+         Accept: */*\r\n\
+         Connection: close\r\n\
+         \r\n"
+    );
+    stream
+        .write_all(request.as_bytes())
+        .map_err(|e| HttpError::Unreachable(format!("cannot send request: {e}")))?;
+    let mut raw = Vec::new();
+    let mut buf = [0u8; 4096];
+    loop {
+        let n = stream
+            .read(&mut buf)
+            .map_err(|e| HttpError::Unreachable(format!("cannot read response: {e}")))?;
+        if n == 0 {
+            break;
+        }
+        raw.extend_from_slice(&buf[..n]);
+        if raw.len() > MAX_BODY {
+            return Err(HttpError::Protocol(
+                "response exceeded the size bound".to_string(),
+            ));
+        }
+    }
+    let text = String::from_utf8_lossy(&raw).into_owned();
+    let (status_line, body) = split_http_response(&text)
+        .ok_or_else(|| HttpError::Protocol("malformed HTTP response".to_string()))?;
+    let status = parse_status_code(status_line)
+        .ok_or_else(|| HttpError::Protocol(format!("unparseable status line: {status_line}")))?;
+    Ok((status, body.to_string()))
+}
+
+/// Splits a raw HTTP response into its (status line, body), or `None` if the header/body boundary is
+/// absent. The status line is the first line; the body is everything after the blank line.
+fn split_http_response(text: &str) -> Option<(&str, &str)> {
+    let (head, body) = text
+        .split_once("\r\n\r\n")
+        .or_else(|| text.split_once("\n\n"))?;
+    let status_line = head.lines().next().unwrap_or("");
+    Some((status_line, body))
+}
+
+/// Parses the numeric status code out of an HTTP status line (`HTTP/1.1 200 OK` → `200`). Returns
+/// `None` if the second whitespace-delimited token is not a 3-digit code.
+fn parse_status_code(status_line: &str) -> Option<u16> {
+    let code = status_line.split_whitespace().nth(1)?;
+    code.parse::<u16>().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_http_response_separates_status_and_body() {
+        let resp = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\nbody-here";
+        let (status, body) = split_http_response(resp).unwrap();
+        assert_eq!(status, "HTTP/1.1 200 OK");
+        assert_eq!(body, "body-here");
+    }
+
+    #[test]
+    fn parse_status_code_reads_the_numeric_code() {
+        assert_eq!(parse_status_code("HTTP/1.1 200 OK"), Some(200));
+        assert_eq!(
+            parse_status_code("HTTP/1.1 503 Service Unavailable"),
+            Some(503)
+        );
+        assert_eq!(parse_status_code("HTTP/1.1 404 Not Found"), Some(404));
+        assert_eq!(parse_status_code("garbage"), None);
+        assert_eq!(parse_status_code("HTTP/1.1 notacode OK"), None);
+    }
+
+    #[test]
+    fn http_error_status_displays_status_and_trimmed_body() {
+        let e = HttpError::Status {
+            status: 503,
+            body: "  writer frozen\n".to_string(),
+        };
+        assert_eq!(
+            e.to_string(),
+            "the endpoint returned HTTP 503: writer frozen"
+        );
+    }
+}

--- a/crates/ironbus-cli/src/prom.rs
+++ b/crates/ironbus-cli/src/prom.rs
@@ -1,0 +1,292 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! A tiny, dependency-free reader for the Prometheus text exposition format (V2-M6, #589), confined
+//! to the shapes the broker's `/metrics` endpoint emits: bare `name value` samples, labeled
+//! `name{label="v",..} value` samples, and the `# HELP`/`# TYPE` comment lines (ignored). It is
+//! deliberately small and tolerant of sample order, matching the hand-rolled `/admin` JSON
+//! extractors in [`crate::admin`] — the workspace keeps no serde / no prometheus-parser on the
+//! shipped rendering path, so the `report` views are driven by parsing these samples ALONE.
+//!
+//! It does NOT validate the exposition format as a whole; it pulls exactly the series the `report`
+//! verb renders. An absent series reads as absent (the caller substitutes a clean default), so a
+//! broker that does not emit a given counter never makes the report panic.
+
+use std::collections::BTreeMap;
+
+/// One parsed sample: its `value` (kept as the raw token so an integer counter and a float gauge
+/// both round-trip without precision loss) and its label set (empty for a bare sample). Labels are
+/// a `BTreeMap` so a lookup is order-independent and a render is deterministic.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct Sample {
+    /// The metric value, as the raw text token (e.g. `42`, `-1`, `3.5`, `1.2e3`). The caller parses
+    /// it to the numeric type it needs.
+    pub value: String,
+    /// The label set: `{group="orders"}` → `{"group": "orders"}`. Empty for a bare `name value`.
+    pub labels: BTreeMap<String, String>,
+}
+
+impl Sample {
+    /// Parses the value as a `u64`, returning `None` if it is not a bare unsigned integer (a `-1`
+    /// sentinel or a float thus reads as absent for an unsigned consumer).
+    pub fn as_u64(&self) -> Option<u64> {
+        self.value.parse::<u64>().ok()
+    }
+
+    /// Parses the value as an `i64` (for the `-1` sentinels such as `last_dead_lettered_offset` and
+    /// `ironbus_disk_free_bytes` on an in-memory broker).
+    pub fn as_i64(&self) -> Option<i64> {
+        self.value.parse::<i64>().ok()
+    }
+
+    /// Returns the value of label `key`, if present.
+    pub fn label(&self, key: &str) -> Option<&str> {
+        self.labels.get(key).map(String::as_str)
+    }
+}
+
+/// A parsed `/metrics` document: every sample, keyed by metric name. A metric name maps to ALL of
+/// its samples (one for a bare gauge/counter; many for a labeled family, one per label set). The
+/// caller asks for a metric by name and reads the bare value or walks the labeled family.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct Metrics {
+    by_name: BTreeMap<String, Vec<Sample>>,
+}
+
+impl Metrics {
+    /// Parses a Prometheus text-exposition body. `# HELP`/`# TYPE`/blank lines are skipped; every
+    /// other line is parsed as `name[{labels}] value` and indexed by name. A line that does not
+    /// match the sample grammar is skipped (the parser is tolerant: it pulls the series the report
+    /// needs and ignores anything it does not understand), so a future series can never break it.
+    #[must_use]
+    pub fn parse(body: &str) -> Self {
+        let mut by_name: BTreeMap<String, Vec<Sample>> = BTreeMap::new();
+        for line in body.lines() {
+            let line = line.trim();
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+            if let Some((name, sample)) = parse_sample_line(line) {
+                by_name.entry(name).or_default().push(sample);
+            }
+        }
+        Self { by_name }
+    }
+
+    /// Returns the single BARE sample for `name` (no labels), or `None` if the metric is absent or
+    /// every sample of it is labeled. Used for the scalar gauges/counters
+    /// (`ironbus_disk_free_bytes`, `ironbus_segment_count`, ...).
+    pub fn scalar(&self, name: &str) -> Option<&Sample> {
+        self.by_name.get(name)?.iter().find(|s| s.labels.is_empty())
+    }
+
+    /// Reads the bare scalar value of `name` as a `u64`, or `0` if the metric is absent (a broker
+    /// that never produced a given counter reports a clean zero, not a parse failure).
+    pub fn u64_or_zero(&self, name: &str) -> u64 {
+        self.scalar(name).and_then(Sample::as_u64).unwrap_or(0)
+    }
+
+    /// Reads the bare scalar value of `name` as an `i64`, or `default` if absent (for the `-1`
+    /// sentinels: an in-memory broker reports `ironbus_disk_free_bytes -1`).
+    pub fn i64_or(&self, name: &str, default: i64) -> i64 {
+        self.scalar(name)
+            .and_then(Sample::as_i64)
+            .unwrap_or(default)
+    }
+
+    /// Returns every sample of the labeled family `name` (one per label set), or an empty slice if
+    /// the family is absent. Used for the per-group / per-stream / per-state series.
+    pub fn family(&self, name: &str) -> &[Sample] {
+        self.by_name.get(name).map_or(&[], Vec::as_slice)
+    }
+
+    /// Looks up one sample of family `name` whose label `key` equals `value` (e.g. the
+    /// `ironbus_connections_total{state="accepted"}` sample), returning its value as a `u64` or `0`
+    /// if that label combination is absent.
+    pub fn labeled_u64(&self, name: &str, key: &str, value: &str) -> u64 {
+        self.family(name)
+            .iter()
+            .find(|s| s.label(key) == Some(value))
+            .and_then(Sample::as_u64)
+            .unwrap_or(0)
+    }
+}
+
+/// Parses one sample line `name[{labels}] value` into `(name, Sample)`. Returns `None` if the line
+/// does not fit the grammar (so the tolerant parser skips it). The value is the LAST
+/// whitespace-delimited token (Prometheus permits an optional trailing timestamp, which the broker
+/// never emits, but taking the token immediately after the metric identifier keeps us correct for
+/// the shapes we do parse).
+fn parse_sample_line(line: &str) -> Option<(String, Sample)> {
+    let bytes = line.as_bytes();
+    // The metric name runs up to the first `{` (labeled) or whitespace (bare).
+    let mut i = 0;
+    while i < bytes.len() && bytes[i] != b'{' && !bytes[i].is_ascii_whitespace() {
+        i += 1;
+    }
+    if i == 0 {
+        return None;
+    }
+    let name = line[..i].to_string();
+    let labels = if i < bytes.len() && bytes[i] == b'{' {
+        // A labeled sample: parse to the matching `}`.
+        let close = line[i..].find('}')? + i;
+        let parsed = parse_labels(&line[i + 1..close]);
+        i = close + 1;
+        parsed
+    } else {
+        BTreeMap::new()
+    };
+    // The remainder is `<ws> value [<ws> timestamp]`; the value is the first token after the name /
+    // label block.
+    let rest = line[i..].trim_start();
+    let value = rest.split_whitespace().next()?.to_string();
+    if value.is_empty() {
+        return None;
+    }
+    Some((name, Sample { value, labels }))
+}
+
+/// Parses the inside of a `{...}` label block: `key="value",key2="value2"`. Tolerant of spaces
+/// around commas and `=`. Undoes the two structural escapes the exporter emits inside a label
+/// value (`\"` and `\\`), matching the server's `escape_label`.
+fn parse_labels(inner: &str) -> BTreeMap<String, String> {
+    let mut labels = BTreeMap::new();
+    let bytes = inner.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        // Skip separators / whitespace.
+        while i < bytes.len() && (bytes[i] == b',' || bytes[i].is_ascii_whitespace()) {
+            i += 1;
+        }
+        // Read the key up to `=`.
+        let key_start = i;
+        while i < bytes.len() && bytes[i] != b'=' {
+            i += 1;
+        }
+        if i >= bytes.len() {
+            break;
+        }
+        let key = inner[key_start..i].trim().to_string();
+        i += 1; // past '='
+                // The value must be a quoted string.
+        while i < bytes.len() && bytes[i].is_ascii_whitespace() {
+            i += 1;
+        }
+        if i >= bytes.len() || bytes[i] != b'"' {
+            break;
+        }
+        i += 1; // past opening quote
+        let mut value = String::new();
+        while i < bytes.len() {
+            let c = bytes[i];
+            if c == b'\\' {
+                i += 1;
+                match bytes.get(i) {
+                    Some(b'"') => value.push('"'),
+                    Some(b'\\') => value.push('\\'),
+                    Some(b'n') => value.push('\n'),
+                    Some(other) => value.push(*other as char),
+                    None => break,
+                }
+            } else if c == b'"' {
+                i += 1; // past closing quote
+                break;
+            } else {
+                value.push(c as char);
+            }
+            i += 1;
+        }
+        if !key.is_empty() {
+            labels.insert(key, value);
+        }
+    }
+    labels
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = "\
+# HELP ironbus_segment_count Open plus sealed segments.
+# TYPE ironbus_segment_count gauge
+ironbus_segment_count 4
+# HELP ironbus_disk_free_bytes Free bytes.
+# TYPE ironbus_disk_free_bytes gauge
+ironbus_disk_free_bytes -1
+# TYPE ironbus_connections_total counter
+ironbus_connections_total{state=\"accepted\"} 10
+ironbus_connections_total{state=\"closed\"} 3
+# TYPE ironbus_group_consumer_lag gauge
+ironbus_group_consumer_lag{group=\"\"} 7
+ironbus_group_consumer_lag{group=\"orders\"} 2
+";
+
+    #[test]
+    fn parses_bare_and_labeled_samples() {
+        let m = Metrics::parse(SAMPLE);
+        assert_eq!(m.u64_or_zero("ironbus_segment_count"), 4);
+        assert_eq!(m.i64_or("ironbus_disk_free_bytes", 0), -1);
+        assert_eq!(
+            m.labeled_u64("ironbus_connections_total", "state", "accepted"),
+            10
+        );
+        assert_eq!(
+            m.labeled_u64("ironbus_connections_total", "state", "closed"),
+            3
+        );
+        let groups = m.family("ironbus_group_consumer_lag");
+        assert_eq!(groups.len(), 2);
+        assert_eq!(groups[0].label("group"), Some(""));
+        assert_eq!(groups[0].as_u64(), Some(7));
+        assert_eq!(groups[1].label("group"), Some("orders"));
+        assert_eq!(groups[1].as_u64(), Some(2));
+    }
+
+    #[test]
+    fn an_absent_metric_reads_as_a_clean_zero_or_default() {
+        let m = Metrics::parse(SAMPLE);
+        assert_eq!(m.u64_or_zero("ironbus_not_present"), 0);
+        assert_eq!(m.i64_or("ironbus_not_present", -1), -1);
+        assert!(m.family("ironbus_not_present").is_empty());
+        assert_eq!(m.labeled_u64("ironbus_not_present", "x", "y"), 0);
+    }
+
+    #[test]
+    fn comments_and_blank_lines_are_skipped() {
+        let m = Metrics::parse("\n# HELP x y\n\n# TYPE x gauge\n");
+        assert!(m.scalar("x").is_none());
+    }
+
+    #[test]
+    fn a_label_value_with_escapes_round_trips() {
+        let m = Metrics::parse("ironbus_group_consumer_lag{group=\"a\\\"b\\\\c\"} 5\n");
+        let f = m.family("ironbus_group_consumer_lag");
+        assert_eq!(f.len(), 1);
+        assert_eq!(f[0].label("group"), Some("a\"b\\c"));
+        assert_eq!(f[0].as_u64(), Some(5));
+    }
+
+    #[test]
+    fn a_float_value_does_not_parse_as_u64_but_round_trips_as_text() {
+        let m = Metrics::parse("ironbus_retry_ratio 0.25\n");
+        let s = m.scalar("ironbus_retry_ratio").unwrap();
+        assert_eq!(s.as_u64(), None);
+        assert_eq!(s.value, "0.25");
+    }
+
+    #[test]
+    fn the_overflow_label_bucket_is_just_another_label_value() {
+        let m = Metrics::parse("ironbus_stream_produced_total{stream=\"__overflow__\"} 99\n");
+        let f = m.family("ironbus_stream_produced_total");
+        assert_eq!(f[0].label("stream"), Some("__overflow__"));
+        assert_eq!(f[0].as_u64(), Some(99));
+    }
+
+    #[test]
+    fn a_histogram_count_line_parses_as_a_bare_sample() {
+        // The report reads `ironbus_append_duration_seconds_count` as a throughput proxy; it must
+        // parse like any other bare counter even though it is part of a histogram family.
+        let m = Metrics::parse("ironbus_append_duration_seconds_count 1234\n");
+        assert_eq!(m.u64_or_zero("ironbus_append_duration_seconds_count"), 1234);
+    }
+}

--- a/crates/ironbus-cli/src/report.rs
+++ b/crates/ironbus-cli/src/report.rs
@@ -1,0 +1,643 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! `ironbus report {groups,streams,storage,recovery,connections}` (V2-M6, #589): a human +
+//! `--json` operator report built ENTIRELY from the broker's existing `/metrics` Prometheus
+//! endpoint. It is READ-ONLY — one `GET /metrics` per run — and NEVER mutates the broker or
+//! changes `crates/ironbus-server/`; a missing series reads as a clean zero rather than a failure.
+//!
+//! Subcommands (each a focused slice of the same `/metrics` snapshot):
+//! - `groups`      — per-work-group lag / in-flight / committed offset + consumed throughput.
+//! - `streams`     — per-stream produced throughput.
+//! - `storage`     — segments, on-disk footprint, disk-free, RAM headroom, write amplification.
+//! - `recovery`    — recovery-run / loss / truncation / quarantine counters.
+//! - `connections` — `ironbus_connections_*` lifecycle + pre-auth-rejection counters.
+//!
+//! Output: the human table by default; the WHOLE report as the uniform `ironbus.cli.v1` envelope
+//! under the global `--json` (the dispatch captures the human text and wraps it — this module emits
+//! the same clean table either way, so a script keys off the envelope). The address resolves with
+//! the frozen `flag > current-context > default` precedence, exactly like `top`/`admin`.
+
+use crate::metrics_fetch::{self, HttpError};
+use crate::prom::Metrics;
+use crate::{context, fuzzy, CliError, DEFAULT_ADDR};
+use std::fmt::Write as _;
+use std::io::Write;
+
+/// The `report` subcommands. `Subject` is the noun the user picks; each maps to one renderer.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Subject {
+    Groups,
+    Streams,
+    Storage,
+    Recovery,
+    Connections,
+}
+
+impl Subject {
+    /// Parses the subcommand noun.
+    fn parse(s: &str) -> Option<Self> {
+        match s {
+            "groups" => Some(Self::Groups),
+            "streams" => Some(Self::Streams),
+            "storage" => Some(Self::Storage),
+            "recovery" => Some(Self::Recovery),
+            "connections" => Some(Self::Connections),
+            _ => None,
+        }
+    }
+}
+
+/// The parsed `report` invocation: which subject, which health-server address, and an optional
+/// `--filter <name>` that narrows the `groups`/`streams` views to one name (an explicit selection;
+/// it also SKIPS the interactive picker, keeping the verb scriptable).
+struct ReportArgs {
+    subject: Subject,
+    addr: Option<String>,
+    filter: Option<String>,
+}
+
+/// Parses `report <subject> [--addr|--health-addr <host:port>] [--filter <name>]`. `--addr` and
+/// `--health-addr` are synonyms (the health-server address), matching `top`/`admin`. An unknown
+/// subject or flag is a usage error; the address is OPTIONAL and resolved (flag > context > default)
+/// at fetch time. `--filter` applies only to the `groups`/`streams` subjects (a no-op for the
+/// scalar subjects); when omitted on a TTY, those two subjects offer the interactive fuzzy picker.
+fn parse_args(args: &[String]) -> Result<ReportArgs, CliError> {
+    let (subject_raw, rest) = args.split_first().ok_or_else(|| {
+        CliError::Usage(
+            "report needs a subject: groups | streams | storage | recovery | connections"
+                .to_string(),
+        )
+    })?;
+    let subject = Subject::parse(subject_raw).ok_or_else(|| {
+        CliError::Usage(format!(
+            "unknown report subject `{subject_raw}` (expected groups | streams | storage | \
+             recovery | connections)"
+        ))
+    })?;
+    let mut addr: Option<String> = None;
+    let mut filter: Option<String> = None;
+    let mut i = 0;
+    while i < rest.len() {
+        match rest[i].as_str() {
+            "--addr" | "--health-addr" => {
+                addr = Some(crate::take_value("--health-addr", rest, &mut i)?);
+            }
+            "--filter" => filter = Some(crate::take_value("--filter", rest, &mut i)?),
+            flag if flag.starts_with("--") => {
+                return Err(CliError::Usage(format!("unknown flag `{flag}` for report")));
+            }
+            other => {
+                return Err(CliError::Usage(format!(
+                    "report takes no positional arguments after the subject, got `{other}`"
+                )));
+            }
+        }
+    }
+    Ok(ReportArgs {
+        subject,
+        addr,
+        filter,
+    })
+}
+
+/// Dispatches `ironbus report <subject>`: resolves the address, fetches `/metrics` once, and writes
+/// the chosen subject's human table to `out`. The global `--json` envelope is applied by the
+/// top-level dispatch (it captures this human output), so this renders the same table either way.
+///
+/// # Errors
+/// [`CliError::Usage`] for a bad subject/flag; [`CliError::Unreachable`] when the broker's health
+/// server cannot be reached; [`CliError::Internal`] for a non-200 or malformed `/metrics` response.
+pub(crate) fn run_report(args: &[String], out: &mut impl Write) -> Result<(), CliError> {
+    let parsed = parse_args(args)?;
+    let addr = context::resolve_addr(parsed.addr.as_deref(), DEFAULT_ADDR)?;
+    let metrics = fetch_metrics(&addr)?;
+    // For the per-name subjects (groups/streams), resolve an optional name filter: an explicit
+    // `--filter` is used as-is (scriptable); otherwise, ON A TTY, the interactive fuzzy picker (#583)
+    // offers a choice from the LIVE names; a non-interactive run with no `--filter` shows them all.
+    let filter = resolve_filter(parsed.subject, parsed.filter.as_deref(), &metrics)?;
+    let text = render(parsed.subject, &addr, &metrics, filter.as_deref());
+    out.write_all(text.as_bytes())?;
+    Ok(())
+}
+
+/// Resolves the name filter for the `groups`/`streams` subjects. With an explicit `--filter`, that
+/// value is returned (no prompt — scriptable). With no `--filter` on an INTERACTIVE terminal, the
+/// fuzzy picker (#583) runs over the live names and returns the chosen one. With no `--filter` and
+/// NO terminal (a pipe / `--json` capture), it returns `None` — the full unfiltered table, exactly
+/// the scriptable default. The scalar subjects (storage/recovery/connections) take no filter.
+fn resolve_filter(
+    subject: Subject,
+    explicit: Option<&str>,
+    m: &Metrics,
+) -> Result<Option<String>, CliError> {
+    let noun = match subject {
+        Subject::Groups => "group",
+        Subject::Streams => "stream",
+        _ => return Ok(None),
+    };
+    if let Some(name) = explicit {
+        return Ok(Some(name.to_string()));
+    }
+    if !fuzzy::is_interactive() {
+        return Ok(None);
+    }
+    let candidates = match subject {
+        Subject::Groups => group_names(m),
+        Subject::Streams => stream_names(m),
+        _ => Vec::new(),
+    };
+    if candidates.is_empty() {
+        // Nothing to pick from: fall through to the (empty) table rather than prompting.
+        return Ok(None);
+    }
+    fuzzy::resolve_or_pick(noun, None, &candidates).map(Some)
+}
+
+/// Fetches and parses the broker's `/metrics` snapshot, mapping the transport/HTTP error onto the
+/// frozen CLI exit-code scheme (unreachable → 5, any other failure → internal 70).
+fn fetch_metrics(addr: &str) -> Result<Metrics, CliError> {
+    let body = metrics_fetch::fetch(addr, "/metrics").map_err(|e| map_metrics_error(addr, &e))?;
+    Ok(Metrics::parse(&body))
+}
+
+/// Maps a `/metrics` fetch failure to a `CliError`: a transport failure is broker-unreachable (5);
+/// a non-200 (e.g. the health server returned 503 while shutting down) or a malformed body is an
+/// internal/protocol fault (70), the same split `top`/`admin` use.
+fn map_metrics_error(addr: &str, e: &HttpError) -> CliError {
+    match e {
+        HttpError::Unreachable(_) => {
+            CliError::Unreachable(format!("reading /metrics from broker at {addr}: {e}"))
+        }
+        HttpError::Status { .. } | HttpError::Protocol(_) => {
+            CliError::Internal(format!("reading /metrics from broker at {addr}: {e}"))
+        }
+    }
+}
+
+/// Renders the chosen subject's human table from the parsed metrics. `filter`, when set, narrows the
+/// `groups`/`streams` views to the single named row (a no-op for the scalar subjects).
+fn render(subject: Subject, addr: &str, m: &Metrics, filter: Option<&str>) -> String {
+    match subject {
+        Subject::Groups => render_groups(addr, m, filter),
+        Subject::Streams => render_streams(addr, m, filter),
+        Subject::Storage => render_storage(addr, m),
+        Subject::Recovery => render_recovery(addr, m),
+        Subject::Connections => render_connections(addr, m),
+    }
+}
+
+/// The per-work-group view: committed offset, lag, in-flight, and consumed throughput. The four
+/// series are correlated by the `group` label; the default group renders as `(default)`. `filter`,
+/// when set, restricts the table to that one group.
+fn render_groups(addr: &str, m: &Metrics, filter: Option<&str>) -> String {
+    let mut s = String::new();
+    let _ = writeln!(s, "report groups (broker /metrics at {addr})");
+    let names: Vec<String> = group_names(m)
+        .into_iter()
+        .filter(|n| name_matches_filter(n, filter))
+        .collect();
+    if names.is_empty() {
+        s.push_str("  (no work-groups)\n");
+        return s;
+    }
+    let _ = writeln!(
+        s,
+        "{:<24} {:>14} {:>10} {:>10} {:>12}",
+        "GROUP", "COMMITTED", "LAG", "IN-FLIGHT", "CONSUMED"
+    );
+    for name in &names {
+        let committed = labeled(m, "ironbus_group_committed_offset", "group", name);
+        let lag = labeled(m, "ironbus_group_consumer_lag", "group", name);
+        let in_flight = labeled(m, "ironbus_group_in_flight", "group", name);
+        let consumed = labeled(m, "ironbus_group_consumed_total", "group", name);
+        let _ = writeln!(
+            s,
+            "{:<24} {committed:>14} {lag:>10} {in_flight:>10} {consumed:>12}",
+            display_name(name)
+        );
+    }
+    s
+}
+
+/// The per-stream view: produced-record throughput per stream label. `filter`, when set, restricts
+/// the table to that one stream.
+fn render_streams(addr: &str, m: &Metrics, filter: Option<&str>) -> String {
+    let mut s = String::new();
+    let _ = writeln!(s, "report streams (broker /metrics at {addr})");
+    let mut rows: Vec<(String, u64)> = m
+        .family("ironbus_stream_produced_total")
+        .iter()
+        .map(|sample| {
+            (
+                sample.label("stream").unwrap_or("").to_string(),
+                sample.as_u64().unwrap_or(0),
+            )
+        })
+        .filter(|(stream, _)| name_matches_filter(stream, filter))
+        .collect();
+    if rows.is_empty() {
+        s.push_str("  (no per-stream throughput)\n");
+        return s;
+    }
+    let _ = writeln!(s, "{:<32} {:>14}", "STREAM", "PRODUCED");
+    rows.sort_by(|a, b| a.0.cmp(&b.0));
+    for (stream, produced) in rows {
+        let _ = writeln!(s, "{:<32} {produced:>14}", display_name(&stream));
+    }
+    s
+}
+
+/// The storage view: segments, durable footprint, disk-free, RAM headroom, write amplification. The
+/// `-1` sentinels (disk-free / RAM headroom on an in-memory broker or unsupported platform) render
+/// as `unavailable` so the report is honest, not a misleading zero.
+fn render_storage(addr: &str, m: &Metrics) -> String {
+    let mut s = String::new();
+    let _ = writeln!(s, "report storage (broker /metrics at {addr})");
+    let _ = writeln!(
+        s,
+        "  segments:            {}",
+        m.u64_or_zero("ironbus_segment_count")
+    );
+    let _ = writeln!(
+        s,
+        "  durable bytes:       {}",
+        m.u64_or_zero("ironbus_durable_record_bytes")
+    );
+    let _ = writeln!(
+        s,
+        "  disk free:           {}",
+        sentinel_bytes(m.i64_or("ironbus_disk_free_bytes", -1))
+    );
+    let _ = writeln!(
+        s,
+        "  RAM headroom:        {}",
+        sentinel_bytes(m.i64_or("ironbus_ram_headroom_bytes", -1))
+    );
+    let _ = writeln!(
+        s,
+        "  logical written:     {}",
+        m.u64_or_zero("ironbus_logical_bytes_written")
+    );
+    let _ = writeln!(
+        s,
+        "  physical written:    {}",
+        m.u64_or_zero("ironbus_physical_bytes_written")
+    );
+    let _ = writeln!(
+        s,
+        "  write amp ratio:     {}",
+        scalar_text(m, "ironbus_write_amp_ratio")
+    );
+    s
+}
+
+/// The recovery view: recovery-run / loss / truncation / quarantine counters, plus the resilience
+/// freeze flag (`ironbus_writer_healthy`).
+fn render_recovery(addr: &str, m: &Metrics) -> String {
+    let mut s = String::new();
+    let _ = writeln!(s, "report recovery (broker /metrics at {addr})");
+    let healthy = m.u64_or_zero("ironbus_writer_healthy") == 1;
+    let _ = writeln!(s, "  writer healthy:        {healthy}");
+    let _ = writeln!(
+        s,
+        "  recovery runs:         {}",
+        m.u64_or_zero("ironbus_recovery_runs_total")
+    );
+    let _ = writeln!(
+        s,
+        "  recovery truncated B:  {}",
+        m.u64_or_zero("ironbus_recovery_truncated_bytes")
+    );
+    let _ = writeln!(
+        s,
+        "  records skipped:       {}",
+        m.u64_or_zero("ironbus_records_skipped")
+    );
+    let _ = writeln!(
+        s,
+        "  bytes skipped:         {}",
+        m.u64_or_zero("ironbus_bytes_skipped")
+    );
+    let _ = writeln!(
+        s,
+        "  last skip offset:      {}",
+        m.u64_or_zero("ironbus_last_skip_offset")
+    );
+    let _ = writeln!(
+        s,
+        "  truncations:           {}",
+        m.u64_or_zero("ironbus_truncations_total")
+    );
+    let _ = writeln!(
+        s,
+        "  truncated records:     {}",
+        m.u64_or_zero("ironbus_truncated_records_total")
+    );
+    let _ = writeln!(
+        s,
+        "  quarantine bytes:      {}",
+        m.u64_or_zero("ironbus_quarantine_bytes")
+    );
+    // The per-reason recovery-loss breakdown, if the broker emits it. One line per reason that lost
+    // any bytes (a clean broker emits zeros for every reason; we skip the all-zero rows so the
+    // common case is a single summary block).
+    let by_reason: Vec<(String, u64)> = m
+        .family("ironbus_recovery_loss_bytes")
+        .iter()
+        .filter_map(|sample| {
+            let bytes = sample.as_u64().unwrap_or(0);
+            (bytes > 0).then(|| (sample.label("reason").unwrap_or("").to_string(), bytes))
+        })
+        .collect();
+    if !by_reason.is_empty() {
+        s.push_str("  loss by reason:\n");
+        for (reason, bytes) in by_reason {
+            let _ = writeln!(s, "    {reason:<22} {bytes}");
+        }
+    }
+    s
+}
+
+/// The connections view: the lifecycle counters (`ironbus_connections_total{state}`), the live
+/// gauge (`ironbus_connections_open`), and the pre-auth rejection breakdown
+/// (`ironbus_connections_rejected_total{reason}`).
+fn render_connections(addr: &str, m: &Metrics) -> String {
+    let mut s = String::new();
+    let _ = writeln!(s, "report connections (broker /metrics at {addr})");
+    let _ = writeln!(
+        s,
+        "  open:                  {}",
+        m.u64_or_zero("ironbus_connections_open")
+    );
+    for state in ["accepted", "closed", "refused", "authenticated"] {
+        let _ = writeln!(
+            s,
+            "  {:<20} {}",
+            format!("{state}:"),
+            m.labeled_u64("ironbus_connections_total", "state", state)
+        );
+    }
+    s.push_str("  rejected (pre-auth):\n");
+    for reason in ["rate_limited", "half_open_cap", "locked_out", "auth_failed"] {
+        let _ = writeln!(
+            s,
+            "    {:<20} {}",
+            format!("{reason}:"),
+            m.labeled_u64("ironbus_connections_rejected_total", "reason", reason)
+        );
+    }
+    s
+}
+
+// --- shared helpers ---
+
+/// Whether `name` passes the optional exact-name `filter`: `None` ⇒ every name passes (the full
+/// table); `Some(f)` ⇒ only the row whose name equals `f`. (The fuzzy MATCHING is done by the picker
+/// when it CHOOSES the name; once chosen, the table shows exactly that one row.)
+fn name_matches_filter(name: &str, filter: Option<&str>) -> bool {
+    match filter {
+        None => true,
+        Some(f) => f == name,
+    }
+}
+
+/// The distinct work-group names across the group families, sorted for deterministic output. A
+/// group appears if ANY of its series carries a `group` label, so a group present in only one
+/// family is still listed.
+pub(crate) fn group_names(m: &Metrics) -> Vec<String> {
+    let mut names = std::collections::BTreeSet::new();
+    for family in [
+        "ironbus_group_committed_offset",
+        "ironbus_group_consumer_lag",
+        "ironbus_group_in_flight",
+        "ironbus_group_consumed_total",
+    ] {
+        for sample in m.family(family) {
+            if let Some(g) = sample.label("group") {
+                names.insert(g.to_string());
+            }
+        }
+    }
+    names.into_iter().collect()
+}
+
+/// The distinct stream names from the per-stream throughput family, sorted.
+pub(crate) fn stream_names(m: &Metrics) -> Vec<String> {
+    let mut names: Vec<String> = m
+        .family("ironbus_stream_produced_total")
+        .iter()
+        .filter_map(|s| s.label("stream").map(str::to_string))
+        .collect();
+    names.sort();
+    names.dedup();
+    names
+}
+
+/// Looks up one labeled `u64` sample, as a left-padded display string.
+fn labeled(m: &Metrics, name: &str, key: &str, value: &str) -> u64 {
+    m.labeled_u64(name, key, value)
+}
+
+/// Renders a possibly-empty label value: the empty default group/stream as `(default)`.
+fn display_name(name: &str) -> &str {
+    if name.is_empty() {
+        "(default)"
+    } else {
+        name
+    }
+}
+
+/// Renders a `-1` sentinel byte count as `unavailable`, else the number.
+fn sentinel_bytes(v: i64) -> String {
+    if v < 0 {
+        "unavailable".to_string()
+    } else {
+        v.to_string()
+    }
+}
+
+/// The raw text of a scalar series (for the float ratios), or `0` if absent.
+fn scalar_text(m: &Metrics, name: &str) -> String {
+    m.scalar(name)
+        .map_or_else(|| "0".to_string(), |s| s.value.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A representative `/metrics` body covering every series the five subjects render, in the exact
+    /// shapes the broker's health server emits (bare scalars, labeled families, `-1` sentinels).
+    const FIXTURE: &str = "\
+# TYPE ironbus_committed_offset gauge
+ironbus_committed_offset 100
+ironbus_flushed_offset 130
+ironbus_in_flight 4
+ironbus_writer_healthy 1
+ironbus_segment_count 4
+ironbus_durable_record_bytes 4096
+ironbus_disk_free_bytes -1
+ironbus_ram_headroom_bytes 1048576
+ironbus_logical_bytes_written 5000
+ironbus_physical_bytes_written 6000
+ironbus_write_amp_ratio 1.2
+ironbus_recovery_runs_total 2
+ironbus_recovery_truncated_bytes 48
+ironbus_records_skipped 3
+ironbus_bytes_skipped 48
+ironbus_last_skip_offset 12
+ironbus_truncations_total 1
+ironbus_truncated_records_total 3
+ironbus_quarantine_bytes 16
+ironbus_recovery_loss_bytes{reason=\"torn_tail\"} 48
+ironbus_recovery_loss_bytes{reason=\"unsynced\"} 0
+ironbus_connections_open 5
+ironbus_connections_total{state=\"accepted\"} 20
+ironbus_connections_total{state=\"closed\"} 15
+ironbus_connections_total{state=\"refused\"} 1
+ironbus_connections_total{state=\"authenticated\"} 18
+ironbus_connections_rejected_total{reason=\"rate_limited\"} 2
+ironbus_connections_rejected_total{reason=\"half_open_cap\"} 0
+ironbus_connections_rejected_total{reason=\"locked_out\"} 0
+ironbus_connections_rejected_total{reason=\"auth_failed\"} 4
+ironbus_group_committed_offset{group=\"\"} 100
+ironbus_group_committed_offset{group=\"orders\"} 120
+ironbus_group_consumer_lag{group=\"\"} 30
+ironbus_group_consumer_lag{group=\"orders\"} 10
+ironbus_group_in_flight{group=\"\"} 0
+ironbus_group_in_flight{group=\"orders\"} 4
+ironbus_group_consumed_total{group=\"\"} 100
+ironbus_group_consumed_total{group=\"orders\"} 120
+ironbus_stream_produced_total{stream=\"events\"} 90
+ironbus_stream_produced_total{stream=\"audit\"} 40
+";
+
+    fn metrics() -> Metrics {
+        Metrics::parse(FIXTURE)
+    }
+
+    #[test]
+    fn parse_args_rejects_a_bad_subject() {
+        let args = vec!["bogus".to_string()];
+        let e = parse_args(&args).unwrap_err();
+        assert_eq!(e.exit_code(), crate::EXIT_USAGE);
+    }
+
+    #[test]
+    fn parse_args_takes_every_subject_and_the_addr_synonyms() {
+        for subject in ["groups", "streams", "storage", "recovery", "connections"] {
+            let args = vec![subject.to_string()];
+            assert!(parse_args(&args).is_ok(), "{subject}");
+        }
+        let a = parse_args(&[
+            "groups".to_string(),
+            "--addr".to_string(),
+            "h:1".to_string(),
+        ])
+        .unwrap();
+        assert_eq!(a.addr.as_deref(), Some("h:1"));
+        let b = parse_args(&[
+            "groups".to_string(),
+            "--health-addr".to_string(),
+            "h:2".to_string(),
+        ])
+        .unwrap();
+        assert_eq!(b.addr.as_deref(), Some("h:2"));
+    }
+
+    #[test]
+    fn groups_table_lists_every_group_with_correlated_series() {
+        let text = render_groups("localhost:7000", &metrics(), None);
+        assert!(text.contains("report groups (broker /metrics at localhost:7000)"));
+        // The default group renders as (default), with its lag/in-flight/consumed correlated.
+        assert!(text.contains("(default)"), "{text}");
+        assert!(text.contains("orders"), "{text}");
+        // orders: committed=120 lag=10 in_flight=4 consumed=120
+        let orders_line = text.lines().find(|l| l.contains("orders")).unwrap();
+        assert!(orders_line.contains("120"), "{orders_line}");
+        assert!(orders_line.contains("10"), "{orders_line}");
+        assert!(orders_line.contains('4'), "{orders_line}");
+    }
+
+    #[test]
+    fn a_group_filter_restricts_the_table_to_one_row() {
+        let text = render_groups("localhost:7000", &metrics(), Some("orders"));
+        assert!(text.contains("orders"), "{text}");
+        // The default group is excluded by the filter.
+        assert!(!text.contains("(default)"), "{text}");
+    }
+
+    #[test]
+    fn streams_table_lists_each_stream_sorted() {
+        let text = render_streams("localhost:7000", &metrics(), None);
+        let audit = text.find("audit").unwrap();
+        let events = text.find("events").unwrap();
+        assert!(audit < events, "streams are sorted: {text}");
+        assert!(text.contains("90"), "{text}");
+        assert!(text.contains("40"), "{text}");
+    }
+
+    #[test]
+    fn a_stream_filter_restricts_the_table_to_one_row() {
+        let text = render_streams("localhost:7000", &metrics(), Some("audit"));
+        assert!(text.contains("audit"), "{text}");
+        assert!(!text.contains("events"), "{text}");
+    }
+
+    #[test]
+    fn storage_shows_sentinel_as_unavailable_and_real_bytes() {
+        let text = render_storage("localhost:7000", &metrics());
+        assert!(text.contains("segments:            4"), "{text}");
+        // disk-free is the -1 sentinel here -> unavailable; RAM headroom is real.
+        assert!(text.contains("disk free:           unavailable"), "{text}");
+        assert!(text.contains("RAM headroom:        1048576"), "{text}");
+        assert!(text.contains("write amp ratio:     1.2"), "{text}");
+    }
+
+    #[test]
+    fn recovery_shows_counters_and_only_nonzero_reasons() {
+        let text = render_recovery("localhost:7000", &metrics());
+        assert!(text.contains("writer healthy:        true"), "{text}");
+        assert!(text.contains("recovery runs:         2"), "{text}");
+        assert!(text.contains("records skipped:       3"), "{text}");
+        // Only the nonzero reason (torn_tail=48) is listed; the zero (unsynced) is suppressed.
+        assert!(text.contains("torn_tail"), "{text}");
+        assert!(
+            !text.contains("unsynced"),
+            "zero reasons suppressed: {text}"
+        );
+    }
+
+    #[test]
+    fn connections_shows_lifecycle_and_rejection_breakdown() {
+        let text = render_connections("localhost:7000", &metrics());
+        assert!(text.contains("open:                  5"), "{text}");
+        assert!(text.contains("accepted:"), "{text}");
+        assert!(text.contains("authenticated:"), "{text}");
+        assert!(text.contains("rate_limited:"), "{text}");
+        assert!(text.contains("auth_failed:"), "{text}");
+        // auth_failed=4 present in the rejection block.
+        let line = text.lines().find(|l| l.contains("auth_failed")).unwrap();
+        assert!(line.contains('4'), "{line}");
+    }
+
+    #[test]
+    fn group_and_stream_names_are_sorted_and_deduped() {
+        let m = metrics();
+        assert_eq!(group_names(&m), vec!["".to_string(), "orders".to_string()]);
+        assert_eq!(
+            stream_names(&m),
+            vec!["audit".to_string(), "events".to_string()]
+        );
+    }
+
+    #[test]
+    fn an_empty_metrics_body_renders_a_clean_empty_table_not_a_panic() {
+        let m = Metrics::parse("");
+        assert!(render_groups("a", &m, None).contains("(no work-groups)"));
+        assert!(render_streams("a", &m, None).contains("(no per-stream throughput)"));
+        // The scalar views render zeros / unavailable, never panic.
+        assert!(render_storage("a", &m).contains("segments:            0"));
+        assert!(render_recovery("a", &m).contains("recovery runs:         0"));
+        assert!(render_connections("a", &m).contains("open:                  0"));
+    }
+}

--- a/crates/ironbus-cli/src/report.rs
+++ b/crates/ironbus-cli/src/report.rs
@@ -49,6 +49,7 @@ impl Subject {
 /// The parsed `report` invocation: which subject, which health-server address, and an optional
 /// `--filter <name>` that narrows the `groups`/`streams` views to one name (an explicit selection;
 /// it also SKIPS the interactive picker, keeping the verb scriptable).
+#[derive(Debug)]
 struct ReportArgs {
     subject: Subject,
     addr: Option<String>,
@@ -623,7 +624,7 @@ ironbus_stream_produced_total{stream=\"audit\"} 40
     #[test]
     fn group_and_stream_names_are_sorted_and_deduped() {
         let m = metrics();
-        assert_eq!(group_names(&m), vec!["".to_string(), "orders".to_string()]);
+        assert_eq!(group_names(&m), vec![String::new(), "orders".to_string()]);
         assert_eq!(
             stream_names(&m),
             vec!["audit".to_string(), "events".to_string()]

--- a/crates/ironbus-cli/src/server_check.rs
+++ b/crates/ironbus-cli/src/server_check.rs
@@ -1,0 +1,348 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! `ironbus server {info,healthz,ready,check}` (V2-M6, #592): operator-facing probes of the
+//! broker's EXISTING health server. READ-ONLY — each verb is a single `GET` against
+//! `/healthz`, `/readyz`, or `/metrics` (`crates/ironbus-server/src/health.rs`); this module NEVER
+//! mutates the broker and NEVER changes the server crate.
+//!
+//! Verbs:
+//! - `info`    — version + uptime (from `/metrics`: `ironbus_build_info` + `ironbus_uptime_seconds`).
+//! - `healthz` — liveness (`GET /healthz`): is the accept loop progressing.
+//! - `ready`   — readiness (`GET /readyz`): is the durable-log writer healthy (not frozen).
+//! - `check`   — a Nagios-style one-line probe with a FROZEN exit code:
+//!     - OK         (live AND ready)                         → exit 0, `IRONBUS OK - ...`
+//!     - DEGRADED   (reachable but not ready / not live)     → exit 3, `IRONBUS CRITICAL - ...`
+//!       (3 = the frozen "ran-to-completion, degraded finding" code: the probe SUCCEEDED, the
+//!       non-zero is the finding, not a tool failure — the same contract `scrub`/`verify` use)
+//!     - UNREACHABLE (health server down / connection failed) → exit 5
+//!     - UNKNOWN     (a malformed / unexpected response)       → exit 70
+//!
+//! The broker already ships a real ready-vs-live SPLIT (`/healthz` liveness with a hysteresis
+//! watchdog vs `/readyz` writer-health), so `ready` and `healthz` map to DISTINCT endpoints — no
+//! server-side #577 gap to flag. The address resolves with the frozen `flag > current-context >
+//! default` precedence, exactly like `top`/`admin`/`report`.
+
+use crate::metrics_fetch::{self, HttpError};
+use crate::prom::Metrics;
+use crate::{context, CliError, DEFAULT_ADDR};
+use std::fmt::Write as _;
+use std::io::Write;
+
+/// The `server` verbs.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Verb {
+    Info,
+    Healthz,
+    Ready,
+    Check,
+}
+
+impl Verb {
+    fn parse(s: &str) -> Option<Self> {
+        match s {
+            "info" => Some(Self::Info),
+            "healthz" => Some(Self::Healthz),
+            "ready" => Some(Self::Ready),
+            "check" => Some(Self::Check),
+            _ => None,
+        }
+    }
+}
+
+/// Dispatches `ironbus server <verb> [--addr|--health-addr <host:port>]`.
+///
+/// # Errors
+/// [`CliError::Usage`] for a bad verb/flag; [`CliError::Unreachable`] (5) when the health server
+/// cannot be reached; [`CliError::HandledCorruption`] (3) when `check` finds a reachable-but-
+/// degraded broker; [`CliError::Internal`] (70) for a malformed response.
+pub(crate) fn run_server(args: &[String], out: &mut impl Write) -> Result<(), CliError> {
+    let (verb_raw, rest) = args.split_first().ok_or_else(|| {
+        CliError::Usage("server needs a verb: info | healthz | ready | check".to_string())
+    })?;
+    let verb = Verb::parse(verb_raw).ok_or_else(|| {
+        CliError::Usage(format!(
+            "unknown server verb `{verb_raw}` (expected info | healthz | ready | check)"
+        ))
+    })?;
+    let addr = parse_addr(rest)?;
+    let addr = context::resolve_addr(addr.as_deref(), DEFAULT_ADDR)?;
+    match verb {
+        Verb::Info => run_info(&addr, out),
+        Verb::Healthz => run_probe(&addr, "/healthz", "healthz", out),
+        Verb::Ready => run_probe(&addr, "/readyz", "ready", out),
+        Verb::Check => run_check(&addr, out),
+    }
+}
+
+/// Parses the optional `--addr`/`--health-addr <host:port>` (synonyms), rejecting any other flag or
+/// positional.
+fn parse_addr(rest: &[String]) -> Result<Option<String>, CliError> {
+    let mut addr: Option<String> = None;
+    let mut i = 0;
+    while i < rest.len() {
+        match rest[i].as_str() {
+            "--addr" | "--health-addr" => {
+                addr = Some(crate::take_value("--health-addr", rest, &mut i)?);
+            }
+            flag if flag.starts_with("--") => {
+                return Err(CliError::Usage(format!("unknown flag `{flag}` for server")));
+            }
+            other => {
+                return Err(CliError::Usage(format!(
+                    "server takes no positional arguments after the verb, got `{other}`"
+                )));
+            }
+        }
+    }
+    Ok(addr)
+}
+
+/// `server info`: version + uptime, read from `/metrics` (`ironbus_build_info{version=...}` and
+/// `ironbus_uptime_seconds`). READ-ONLY; an unreachable broker is exit 5, a malformed body exit 70.
+fn run_info(addr: &str, out: &mut impl Write) -> Result<(), CliError> {
+    let body = metrics_fetch::fetch(addr, "/metrics").map_err(|e| map_error(addr, &e))?;
+    let m = Metrics::parse(&body);
+    let version = build_version(&m).unwrap_or_else(|| "unknown".to_string());
+    let uptime = m.u64_or_zero("ironbus_uptime_seconds");
+    let mut s = String::new();
+    let _ = writeln!(s, "server info (broker at {addr})");
+    let _ = writeln!(s, "  version:  {version}");
+    let _ = writeln!(s, "  uptime:   {}", format_uptime(uptime));
+    out.write_all(s.as_bytes())?;
+    Ok(())
+}
+
+/// A liveness/readiness probe against `path`: prints `<label>: <state>` from the endpoint's status,
+/// and SUCCEEDS (exit 0) whether the state is up OR down — these verbs REPORT the state; only
+/// `check` turns a degraded state into a nonzero exit. A 200 is the healthy state; a 503 is the
+/// degraded state the endpoint reports (and carries the broker's one-line reason). Unreachable is
+/// still exit 5; a malformed response is exit 70.
+fn run_probe(addr: &str, path: &str, label: &str, out: &mut impl Write) -> Result<(), CliError> {
+    match metrics_fetch::fetch_status(addr, path) {
+        Ok((200, body)) => {
+            writeln!(out, "{label}: up ({})", body.trim())?;
+            Ok(())
+        }
+        Ok((503, body)) => {
+            writeln!(out, "{label}: down ({})", body.trim())?;
+            Ok(())
+        }
+        Ok((status, body)) => writeln!(out, "{label}: unexpected HTTP {status} ({})", body.trim())
+            .map_err(CliError::from),
+        Err(HttpError::Unreachable(_)) => Err(CliError::Unreachable(format!(
+            "probing {path} on broker at {addr}: health server unreachable"
+        ))),
+        Err(e) => Err(CliError::Internal(format!(
+            "probing {path} on broker at {addr}: {e}"
+        ))),
+    }
+}
+
+/// The Nagios-style `check`: one line + a FROZEN exit code. It probes BOTH liveness (`/healthz`)
+/// and readiness (`/readyz`) and reports the worst state:
+/// - both up                 → `IRONBUS OK - live and ready`                    exit 0
+/// - reachable but degraded  → `IRONBUS CRITICAL - <reason>`                    exit 3
+/// - health server down      → `IRONBUS UNREACHABLE - <reason>`                 exit 5
+/// - malformed response      → `IRONBUS UNKNOWN - <reason>`                     exit 70
+///
+/// The one-line status is ALWAYS written to `out` first (so a monitoring system captures the human
+/// text even on the degraded path), THEN the frozen exit code is returned via the error type. The
+/// degraded finding uses [`EXIT_HANDLED_CORRUPTION`] (3): the probe ran to completion and the
+/// non-zero communicates the finding, NOT a tool failure (the same frozen contract `verify` uses).
+fn run_check(addr: &str, out: &mut impl Write) -> Result<(), CliError> {
+    // Liveness first: if the accept loop is wedged the broker is CRITICAL regardless of readiness.
+    let live = match probe_state(addr, "/healthz") {
+        ProbeState::Up => Probe::Up,
+        ProbeState::Down(reason) => Probe::Down(reason),
+        ProbeState::Unreachable => return unreachable(out, addr),
+        ProbeState::Unknown(why) => return unknown(out, addr, why),
+    };
+    let ready = match probe_state(addr, "/readyz") {
+        ProbeState::Up => Probe::Up,
+        ProbeState::Down(reason) => Probe::Down(reason),
+        ProbeState::Unreachable => return unreachable(out, addr),
+        ProbeState::Unknown(why) => return unknown(out, addr, why),
+    };
+    match (&live, &ready) {
+        (Probe::Up, Probe::Up) => {
+            writeln!(out, "IRONBUS OK - live and ready")?;
+            Ok(())
+        }
+        _ => {
+            let reason = degraded_reason(&live, &ready);
+            writeln!(out, "IRONBUS CRITICAL - {reason}")?;
+            Err(CliError::HandledCorruption(format!(
+                "broker at {addr} is reachable but degraded: {reason}"
+            )))
+        }
+    }
+}
+
+/// A single probe outcome usable in the `check` decision: up, down-with-reason, transport-
+/// unreachable, or an unexpected response (UNKNOWN).
+enum ProbeState {
+    Up,
+    Down(String),
+    Unreachable,
+    Unknown(String),
+}
+
+/// A liveness/readiness state for the `check` decision (the transport/unknown cases short-circuit
+/// before this is built).
+enum Probe {
+    Up,
+    Down(String),
+}
+
+/// Probes one liveness/readiness `path`, classifying the 200/503/other/transport outcomes.
+fn probe_state(addr: &str, path: &str) -> ProbeState {
+    match metrics_fetch::fetch_status(addr, path) {
+        Ok((200, _)) => ProbeState::Up,
+        Ok((503, body)) => ProbeState::Down(body.trim().to_string()),
+        Ok((status, body)) => ProbeState::Unknown(format!("{path} HTTP {status}: {}", body.trim())),
+        Err(HttpError::Unreachable(_)) => ProbeState::Unreachable,
+        Err(e) => ProbeState::Unknown(format!("{path}: {e}")),
+    }
+}
+
+/// Builds the CRITICAL one-line reason from the live/ready states, naming which dimension failed.
+fn degraded_reason(live: &Probe, ready: &Probe) -> String {
+    match (live, ready) {
+        (Probe::Down(reason), _) => format!("not live ({reason})"),
+        (_, Probe::Down(reason)) => format!("not ready ({reason})"),
+        // Both Up is handled by the caller; this arm is unreachable in practice.
+        _ => "degraded".to_string(),
+    }
+}
+
+/// Writes the UNREACHABLE one-line status and returns the frozen exit-5 error.
+fn unreachable(out: &mut impl Write, addr: &str) -> Result<(), CliError> {
+    writeln!(
+        out,
+        "IRONBUS UNREACHABLE - cannot reach health server at {addr}"
+    )?;
+    Err(CliError::Unreachable(format!(
+        "health server at {addr} is unreachable"
+    )))
+}
+
+/// Writes the UNKNOWN one-line status and returns the frozen exit-70 error.
+fn unknown(out: &mut impl Write, addr: &str, why: String) -> Result<(), CliError> {
+    writeln!(out, "IRONBUS UNKNOWN - {why}")?;
+    Err(CliError::Internal(format!(
+        "probing broker at {addr}: {why}"
+    )))
+}
+
+/// Maps a `/metrics` fetch failure (for `info`) onto the frozen exit codes.
+fn map_error(addr: &str, e: &HttpError) -> CliError {
+    match e {
+        HttpError::Unreachable(_) => {
+            CliError::Unreachable(format!("reading broker info from {addr}: {e}"))
+        }
+        HttpError::Status { .. } | HttpError::Protocol(_) => {
+            CliError::Internal(format!("reading broker info from {addr}: {e}"))
+        }
+    }
+}
+
+/// Extracts the build version from the `ironbus_build_info{version="..."}` sample.
+fn build_version(m: &Metrics) -> Option<String> {
+    m.family("ironbus_build_info")
+        .iter()
+        .find_map(|s| s.label("version").map(str::to_string))
+}
+
+/// Formats an uptime in seconds as a compact `Nd Nh Nm Ns` (omitting leading zero units), for the
+/// human `info` view.
+fn format_uptime(secs: u64) -> String {
+    let days = secs / 86_400;
+    let hours = (secs % 86_400) / 3_600;
+    let mins = (secs % 3_600) / 60;
+    let s = secs % 60;
+    let mut out = String::new();
+    if days > 0 {
+        let _ = write!(out, "{days}d ");
+    }
+    if days > 0 || hours > 0 {
+        let _ = write!(out, "{hours}h ");
+    }
+    if days > 0 || hours > 0 || mins > 0 {
+        let _ = write!(out, "{mins}m ");
+    }
+    let _ = write!(out, "{s}s");
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unknown_verb_is_a_usage_error() {
+        let e = run_server(&["bogus".to_string()], &mut Vec::new()).unwrap_err();
+        assert_eq!(e.exit_code(), crate::EXIT_USAGE);
+    }
+
+    #[test]
+    fn no_verb_is_a_usage_error() {
+        let e = run_server(&[], &mut Vec::new()).unwrap_err();
+        assert_eq!(e.exit_code(), crate::EXIT_USAGE);
+    }
+
+    #[test]
+    fn parse_addr_takes_both_synonyms_and_rejects_others() {
+        assert_eq!(
+            parse_addr(&["--addr".to_string(), "h:1".to_string()]).unwrap(),
+            Some("h:1".to_string())
+        );
+        assert_eq!(
+            parse_addr(&["--health-addr".to_string(), "h:2".to_string()]).unwrap(),
+            Some("h:2".to_string())
+        );
+        assert!(parse_addr(&["--bogus".to_string()]).is_err());
+        assert!(parse_addr(&["positional".to_string()]).is_err());
+    }
+
+    #[test]
+    fn build_version_reads_the_label() {
+        let m = Metrics::parse("ironbus_build_info{version=\"2026.0620.1\"} 1\n");
+        assert_eq!(build_version(&m).as_deref(), Some("2026.0620.1"));
+        let none = Metrics::parse("");
+        assert_eq!(build_version(&none), None);
+    }
+
+    #[test]
+    fn format_uptime_omits_leading_zero_units() {
+        assert_eq!(format_uptime(0), "0s");
+        assert_eq!(format_uptime(59), "59s");
+        assert_eq!(format_uptime(61), "1m 1s");
+        assert_eq!(format_uptime(3_661), "1h 1m 1s");
+        assert_eq!(format_uptime(90_061), "1d 1h 1m 1s");
+    }
+
+    #[test]
+    fn degraded_reason_names_the_failed_dimension() {
+        let live_down = Probe::Down("no event-loop progress".to_string());
+        assert!(degraded_reason(&live_down, &Probe::Up).starts_with("not live"));
+        let ready_down = Probe::Down("writer frozen".to_string());
+        assert!(degraded_reason(&Probe::Up, &ready_down).starts_with("not ready"));
+    }
+
+    #[test]
+    fn check_exit_codes_are_the_frozen_contract() {
+        // The degraded finding is the frozen "ran-to-completion" code 3, not a tool failure; an
+        // unreachable broker is 5; an unknown response is 70. (The OK path returns Ok(()) -> 0.)
+        assert_eq!(
+            CliError::HandledCorruption("x".to_string()).exit_code(),
+            crate::EXIT_HANDLED_CORRUPTION
+        );
+        assert_eq!(
+            CliError::Unreachable("x".to_string()).exit_code(),
+            crate::EXIT_UNREACHABLE
+        );
+        assert_eq!(
+            CliError::Internal("x".to_string()).exit_code(),
+            crate::EXIT_INTERNAL
+        );
+    }
+}

--- a/crates/ironbus-cli/src/server_check.rs
+++ b/crates/ironbus-cli/src/server_check.rs
@@ -154,26 +154,23 @@ fn run_check(addr: &str, out: &mut impl Write) -> Result<(), CliError> {
         ProbeState::Up => Probe::Up,
         ProbeState::Down(reason) => Probe::Down(reason),
         ProbeState::Unreachable => return unreachable(out, addr),
-        ProbeState::Unknown(why) => return unknown(out, addr, why),
+        ProbeState::Unknown(why) => return unknown(out, addr, &why),
     };
     let ready = match probe_state(addr, "/readyz") {
         ProbeState::Up => Probe::Up,
         ProbeState::Down(reason) => Probe::Down(reason),
         ProbeState::Unreachable => return unreachable(out, addr),
-        ProbeState::Unknown(why) => return unknown(out, addr, why),
+        ProbeState::Unknown(why) => return unknown(out, addr, &why),
     };
-    match (&live, &ready) {
-        (Probe::Up, Probe::Up) => {
-            writeln!(out, "IRONBUS OK - live and ready")?;
-            Ok(())
-        }
-        _ => {
-            let reason = degraded_reason(&live, &ready);
-            writeln!(out, "IRONBUS CRITICAL - {reason}")?;
-            Err(CliError::HandledCorruption(format!(
-                "broker at {addr} is reachable but degraded: {reason}"
-            )))
-        }
+    if let (Probe::Up, Probe::Up) = (&live, &ready) {
+        writeln!(out, "IRONBUS OK - live and ready")?;
+        Ok(())
+    } else {
+        let reason = degraded_reason(&live, &ready);
+        writeln!(out, "IRONBUS CRITICAL - {reason}")?;
+        Err(CliError::HandledCorruption(format!(
+            "broker at {addr} is reachable but degraded: {reason}"
+        )))
     }
 }
 
@@ -226,7 +223,7 @@ fn unreachable(out: &mut impl Write, addr: &str) -> Result<(), CliError> {
 }
 
 /// Writes the UNKNOWN one-line status and returns the frozen exit-70 error.
-fn unknown(out: &mut impl Write, addr: &str, why: String) -> Result<(), CliError> {
+fn unknown(out: &mut impl Write, addr: &str, why: &str) -> Result<(), CliError> {
     writeln!(out, "IRONBUS UNKNOWN - {why}")?;
     Err(CliError::Internal(format!(
         "probing broker at {addr}: {why}"

--- a/crates/ironbus-cli/tests/report_server.rs
+++ b/crates/ironbus-cli/tests/report_server.rs
@@ -1,0 +1,337 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! End-to-end tests for the V2-M6 reporting verbs (#589 `report`, #592 `server`): they drive the
+//! REAL compiled `ironbus` binary against a REAL broker's health server, proving the wire path
+//! (the actual `/metrics`, `/healthz`, `/readyz` round-trips), the human + global-`--json` output,
+//! the FROZEN exit codes (including the Nagios `check` mapping), the broker-unreachable code, and
+//! the read-only / scriptable guarantees the unit tests cannot cover.
+//!
+//! Unix-only: the broker `serve` itself is Unix-only in v1, so the whole file is gated like the
+//! `top` end-to-end tests. The verbs themselves are cross-platform; this exercises them against a
+//! live Unix broker.
+#![cfg(unix)]
+
+use std::collections::BTreeMap;
+use std::io::{BufRead, BufReader, Read};
+use std::process::{Child, Command, Stdio};
+use std::time::Duration;
+
+const BIN: &str = env!("CARGO_BIN_EXE_ironbus");
+
+/// Kills and reaps the broker on drop, so a panicking assertion never leaks a serve process.
+struct ChildGuard(Child);
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+/// Boots `ironbus serve` with the wire and health ports on ephemeral loopback addresses (the health
+/// server serves `/metrics`, `/healthz`, `/readyz` whenever `--health-addr` is set — no extra flag
+/// is needed for the reporting verbs, which never touch `/admin`). Returns a kill-guard plus the
+/// parsed wire and health addresses.
+fn start_broker(data_dir: &str) -> (ChildGuard, String, String) {
+    let child = Command::new(BIN)
+        .args([
+            "serve",
+            "--data-dir",
+            data_dir,
+            "--addr",
+            "127.0.0.1:0",
+            "--health-addr",
+            "127.0.0.1:0",
+            "--checkpoint-interval",
+            "1",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn ironbus serve");
+    let mut guard = ChildGuard(child);
+    let stdout = guard.0.stdout.take().expect("piped stdout");
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let mut reader = BufReader::new(stdout);
+        for _ in 0..8 {
+            let mut line = String::new();
+            if reader.read_line(&mut line).unwrap_or(0) == 0 {
+                break;
+            }
+            if tx.send(line).is_err() {
+                break;
+            }
+        }
+    });
+    let mut wire = None;
+    let mut health = None;
+    while wire.is_none() || health.is_none() {
+        let Ok(line) = rx.recv_timeout(Duration::from_secs(10)) else {
+            break;
+        };
+        if let Some(a) = line
+            .split("listening on ")
+            .nth(1)
+            .and_then(|rest| rest.split(',').next())
+            .map(str::trim)
+        {
+            wire = Some(a.to_string());
+        } else if let Some(a) = line
+            .split("health endpoints on ")
+            .nth(1)
+            .and_then(|rest| rest.split(' ').next())
+            .map(str::trim)
+        {
+            health = Some(a.to_string());
+        }
+    }
+    let (Some(wire), Some(health)) = (wire, health) else {
+        let mut err = String::new();
+        if let Some(mut se) = guard.0.stderr.take() {
+            let _ = se.read_to_string(&mut err);
+        }
+        panic!("could not parse wire+health addresses; stderr: {err}");
+    };
+    (guard, wire, health)
+}
+
+/// Runs one `ironbus` subcommand to completion, returning stdout, stderr, and the exit code. The
+/// child's stdin/stdout are NOT a TTY (they are pipes), so the fuzzy picker is auto-skipped — the
+/// reporting verbs stay scriptable here exactly as in a real pipeline.
+fn run(args: &[&str]) -> (String, String, i32) {
+    let out = Command::new(BIN)
+        .args(args)
+        .output()
+        .expect("run an ironbus subcommand");
+    (
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+        out.status.code().unwrap_or(-1),
+    )
+}
+
+/// A unique temp data dir for one test, removed first so a prior run never leaks state.
+fn fresh_dir(tag: &str) -> String {
+    let dir = std::env::temp_dir().join(format!("ironbus-report-{tag}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    dir.to_str().expect("utf8 temp path").to_string()
+}
+
+/// Produces `n` messages on the wire so the broker has non-trivial counters for the report.
+fn produce(addr: &str, n: usize) {
+    for i in 0..n {
+        let (_o, _e, code) = run(&["pub", "--addr", addr, &format!("m{i}")]);
+        assert_eq!(code, 0, "pub exit code");
+    }
+}
+
+/// Snapshots a directory tree as a path -> bytes map, so a test can prove a verb did NOT mutate the
+/// data dir. Recurses every subdirectory.
+fn snapshot_tree(root: &std::path::Path) -> BTreeMap<String, Vec<u8>> {
+    let mut out = BTreeMap::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if let Ok(bytes) = std::fs::read(&path) {
+                let rel = path
+                    .strip_prefix(root)
+                    .unwrap_or(&path)
+                    .to_string_lossy()
+                    .into_owned();
+                out.insert(rel, bytes);
+            }
+        }
+    }
+    out
+}
+
+/// A loopback port bound then dropped: connecting to it (almost certainly) fails fast, so a verb
+/// targeting it exercises the broker-unreachable path deterministically.
+fn dead_addr() -> String {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral");
+    let addr = listener.local_addr().expect("addr").to_string();
+    drop(listener);
+    addr
+}
+
+#[test]
+fn report_storage_renders_from_live_metrics_and_exits_zero() {
+    let data_dir = fresh_dir("storage");
+    let (_broker, wire, health) = start_broker(&data_dir);
+    produce(&wire, 3);
+
+    let (out, err, code) = run(&["report", "storage", "--health-addr", &health]);
+    assert_eq!(code, 0, "report storage exits 0; stderr: {err}");
+    assert!(out.contains("report storage"), "{out}");
+    assert!(out.contains("segments:"), "{out}");
+    assert!(out.contains("durable bytes:"), "{out}");
+    // disk-free is a real on-disk broker here, so it is a number, not the in-memory sentinel.
+    assert!(out.contains("disk free:"), "{out}");
+}
+
+#[test]
+fn report_connections_shows_the_lifecycle_counters() {
+    let data_dir = fresh_dir("connections");
+    let (_broker, wire, health) = start_broker(&data_dir);
+    produce(&wire, 2); // each pub is an accepted+closed connection
+
+    let (out, err, code) = run(&["report", "connections", "--addr", &health]);
+    assert_eq!(code, 0, "report connections exits 0; stderr: {err}");
+    assert!(out.contains("report connections"), "{out}");
+    assert!(out.contains("accepted:"), "{out}");
+    assert!(out.contains("rejected (pre-auth):"), "{out}");
+}
+
+#[test]
+fn report_groups_is_scriptable_off_a_tty_and_lists_the_default_group() {
+    let data_dir = fresh_dir("groups");
+    let (_broker, wire, health) = start_broker(&data_dir);
+    produce(&wire, 4);
+    // Consume one so a named group exists with a committed cursor.
+    let (_o, _e, code) = run(&[
+        "sub", "--addr", &wire, "--group", "orders", "--max", "1", "--ack",
+    ]);
+    assert_eq!(code, 0, "sub exit code");
+
+    // No --filter and NO TTY (the child's stdout is a pipe): the fuzzy picker is SKIPPED and the
+    // full table is printed — proving the scriptable path.
+    let (out, err, code) = run(&["report", "groups", "--health-addr", &health]);
+    assert_eq!(code, 0, "report groups exits 0; stderr: {err}");
+    assert!(out.contains("report groups"), "{out}");
+    assert!(out.contains("GROUP"), "the table header prints: {out}");
+}
+
+#[test]
+fn report_filter_narrows_to_one_group_and_skips_the_picker() {
+    let data_dir = fresh_dir("filter");
+    let (_broker, wire, health) = start_broker(&data_dir);
+    produce(&wire, 3);
+    let (_o, _e, code) = run(&[
+        "sub", "--addr", &wire, "--group", "orders", "--max", "1", "--ack",
+    ]);
+    assert_eq!(code, 0, "sub exit code");
+
+    let (out, err, code) = run(&[
+        "report",
+        "groups",
+        "--health-addr",
+        &health,
+        "--filter",
+        "orders",
+    ]);
+    assert_eq!(code, 0, "report groups --filter exits 0; stderr: {err}");
+    assert!(out.contains("orders"), "{out}");
+}
+
+#[test]
+fn report_global_json_wraps_the_table_in_the_frozen_envelope() {
+    let data_dir = fresh_dir("json");
+    let (_broker, _wire, health) = start_broker(&data_dir);
+
+    // The global --json is LEADING (before the subcommand): the whole report is the cli.v1 envelope.
+    let (out, err, code) = run(&["--json", "report", "storage", "--health-addr", &health]);
+    assert_eq!(code, 0, "report --json exits 0; stderr: {err}");
+    assert!(
+        out.contains("\"schema\":\"ironbus.cli.v1\""),
+        "the frozen envelope schema: {out}"
+    );
+    assert!(out.contains("\"ok\":true"), "{out}");
+    assert!(out.contains("\"exit_code\":0"), "{out}");
+    // The human table is carried verbatim inside data.stdout.
+    assert!(
+        out.contains("report storage"),
+        "the table is carried: {out}"
+    );
+}
+
+#[test]
+fn report_against_a_dead_broker_exits_five() {
+    let dead = dead_addr();
+    let (_out, _err, code) = run(&["report", "storage", "--health-addr", &dead]);
+    assert_eq!(code, 5, "report against a down broker is unreachable (5)");
+}
+
+#[test]
+fn report_is_strictly_read_only() {
+    let data_dir = fresh_dir("readonly");
+    let (_broker, wire, health) = start_broker(&data_dir);
+    produce(&wire, 5);
+
+    let root = std::path::Path::new(&data_dir);
+    let before = snapshot_tree(root);
+    assert!(!before.is_empty(), "the data dir has files before report");
+
+    for subject in ["groups", "streams", "storage", "recovery", "connections"] {
+        let (_o, err, code) = run(&["report", subject, "--health-addr", &health]);
+        assert_eq!(code, 0, "report {subject} exits 0; stderr: {err}");
+    }
+    let after = snapshot_tree(root);
+    assert_eq!(
+        before, after,
+        "report is strictly read-only: the data dir must be byte-identical before and after"
+    );
+}
+
+#[test]
+fn server_check_on_a_healthy_broker_is_ok_and_exits_zero() {
+    let data_dir = fresh_dir("check-ok");
+    let (_broker, _wire, health) = start_broker(&data_dir);
+
+    let (out, err, code) = run(&["server", "check", "--health-addr", &health]);
+    assert_eq!(code, 0, "a healthy broker is OK (0); stderr: {err}");
+    assert!(out.contains("IRONBUS OK"), "the Nagios OK line: {out}");
+    assert!(out.contains("live and ready"), "{out}");
+}
+
+#[test]
+fn server_check_on_a_dead_broker_is_unreachable_and_exits_five() {
+    let dead = dead_addr();
+    let (out, _err, code) = run(&["server", "check", "--health-addr", &dead]);
+    assert_eq!(code, 5, "a down broker is UNREACHABLE (5)");
+    assert!(
+        out.contains("IRONBUS UNREACHABLE"),
+        "the Nagios line: {out}"
+    );
+}
+
+#[test]
+fn server_info_reports_version_and_uptime() {
+    let data_dir = fresh_dir("info");
+    let (_broker, _wire, health) = start_broker(&data_dir);
+
+    let (out, err, code) = run(&["server", "info", "--health-addr", &health]);
+    assert_eq!(code, 0, "server info exits 0; stderr: {err}");
+    assert!(out.contains("version:"), "{out}");
+    assert!(out.contains("uptime:"), "{out}");
+}
+
+#[test]
+fn server_healthz_and_ready_probe_the_distinct_endpoints() {
+    let data_dir = fresh_dir("probes");
+    let (_broker, _wire, health) = start_broker(&data_dir);
+
+    let (out, err, code) = run(&["server", "healthz", "--health-addr", &health]);
+    assert_eq!(code, 0, "healthz exits 0; stderr: {err}");
+    assert!(out.contains("healthz: up"), "liveness up: {out}");
+
+    let (out, err, code) = run(&["server", "ready", "--health-addr", &health]);
+    assert_eq!(code, 0, "ready exits 0; stderr: {err}");
+    assert!(out.contains("ready: up"), "readiness up: {out}");
+}
+
+#[test]
+fn server_check_global_json_carries_the_status_in_the_envelope() {
+    let data_dir = fresh_dir("check-json");
+    let (_broker, _wire, health) = start_broker(&data_dir);
+
+    let (out, err, code) = run(&["--json", "server", "check", "--health-addr", &health]);
+    assert_eq!(code, 0, "server check --json on OK exits 0; stderr: {err}");
+    assert!(out.contains("\"schema\":\"ironbus.cli.v1\""), "{out}");
+    assert!(out.contains("IRONBUS OK"), "the status is carried: {out}");
+}


### PR DESCRIPTION
## Summary

V2-M6 rich-CLI reporting verbs in `crates/ironbus-cli/`, all **READ-ONLY** over the broker's existing health server. **No change to `crates/ironbus-server/`.** Builds on the merged CLI foundation (global `--json` `ironbus.cli.v1` envelope, frozen exit codes, `context` profiles).

## The verbs

### `ironbus report {groups,streams,storage,recovery,connections}` (#589)
A human + `--json` operator report built from **one `GET /metrics`** (the Prometheus endpoint already merged in #570–#576).
- **groups** — per-work-group committed offset / lag / in-flight / consumed (correlated by the `group` label; default group renders `(default)`)
- **streams** — per-stream produced throughput (`ironbus_stream_produced_total`)
- **storage** — segments, durable bytes, disk-free, RAM headroom, write-amp (a `-1` disk/RAM sentinel renders `unavailable`, never a misleading zero)
- **recovery** — recovery-run / truncated / skipped / quarantine counters + the per-reason loss breakdown
- **connections** — `ironbus_connections_*` lifecycle + the pre-auth rejection reasons
- Global `--json` → the whole report as the `ironbus.cli.v1` envelope; else a clean table. A new dependency-free Prometheus reader (`prom.rs`) parses the samples; an absent series reads as a clean zero (never a panic).

### `ironbus server {info,healthz,ready,check}` (#592)
Probes the broker's **existing** health endpoints (`health.rs`).
- **info** — version + uptime (from `/metrics`: `ironbus_build_info` + `ironbus_uptime_seconds`)
- **healthz** — liveness (`GET /healthz`); **ready** — readiness (`GET /readyz`)
- **check** — Nagios one-line probe with **FROZEN exit codes**:
  - `IRONBUS OK` (live **and** ready) → **0**
  - `IRONBUS CRITICAL` (reachable but not ready / not live) → **3** (the frozen "ran-to-completion, degraded finding" code `verify`/`scrub` use — the probe succeeded, the non-zero is the finding, not a tool failure)
  - `IRONBUS UNREACHABLE` (health server down) → **5**
  - `IRONBUS UNKNOWN` (malformed response) → **70**

**No #577 server gap to flag:** the broker already ships a real ready-vs-live split (`/healthz` liveness watchdog vs `/readyz` writer-health), so `ready` and `healthz` map to **distinct** endpoints with no server change.

### Interactive fuzzy stream/group selection (#583)
A minimal, dependency-free fuzzy matcher (case-insensitive substring **and** subsequence) + a plain-prompt picker (`fuzzy.rs`). **Scriptable-safe:** an explicit `--filter`, a non-TTY stdin/stdout, or the global `--json` all **skip** the picker; only an interactive TTY with no name offers it. Wired into `report groups`/`report streams`.

## Read-only guarantee
Every verb is a `GET` against the existing health server; nothing mutates the broker. An end-to-end test snapshots the data dir before/after and asserts it is byte-identical across all five report subjects. `metrics_fetch.rs` is a bounded HTTP GET (per-request timeout + 1 MiB body cap) mirroring the `/admin` client's defenses; unreachable/erroring servers map to the correct exit code with a clean message, never a panic.

## Back-compat / scriptable proof
Address resolves `flag > current-context > default` like `top`/`admin`. The global `--json` (leading-only) wraps the table in the frozen envelope; a non-TTY pipe auto-skips the picker (integration test runs the verbs with piped stdio and gets the full table). All existing integration tests — incl. the golden-path acceptance test — stay green.

## Tests (integration tests confirmed run locally)
- **Unit (412 total, ~41 new):** the Prometheus parser, each report subject (incl. the empty-body no-panic case), the `check` exit-code mapping, `format_uptime`, the fuzzy matcher + picker (number / filter-then-select / sole-match / EOF / out-of-range / default-name).
- **End-to-end (`tests/report_server.rs`, 12):** the REAL binary vs a REAL broker — `report storage/connections/groups` from live `/metrics`; `--filter` narrows + skips the picker; scriptable off-TTY; global `--json` envelope; dead broker → 5; byte-for-byte read-only; `server check` OK→0 / dead→5 / `--json`; `info`; distinct `healthz`/`ready` probes.
- **Back-compat:** `acceptance` (golden-path), `golden_path` (13), `top` (6) all green. Full `cargo test -p ironbus-cli` = all targets green, 0 failures.

## Local-vs-CI verification
Local (disk-safe): `cargo fmt --all --check` CLEAN · `cargo check -p ironbus-cli` OK · `cargo clippy -p ironbus-cli --all-targets --locked -- -D warnings` CLEAN · `cargo test -p ironbus-cli` (unit + integration) all green · SPDX miss=0 on new `.rs` · `git grep -i butlr` empty (the only hit is the gate's own blocklist, `:(exclude)`-d). The full `--workspace --all-features` gate is left to CI (local disk ENOSPCs on it).

## Dependencies / MSRV
**No new dependencies** — `std::io::IsTerminal` (already used by `top`) for TTY detection, `std` for the HTTP GET and the fuzzy matcher. MSRV 1.78 preserved; cargo-deny allow-list untouched. Windows: the broker-dependent end-to-end tests are `#[cfg(unix)]`-gated (the broker `serve` is Unix-only in v1); the verbs and their unit tests are cross-platform.

## Caveats (honest)
- `check` folds WARN/CRIT into the single frozen degraded code (3) — the CLI's frozen exit table has no separate WARN vs CRIT slot; the WARN-vs-CRIT nuance lives in the one-line status text (always `CRITICAL` for a reachable-but-degraded broker today, since the only degraded signals are not-live / not-ready).
- `report`/`server` require the broker to have been started with `--health-addr` (the health server is opt-in); there is no implicit health port, matching `top`/`admin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVWp2H2txnKGru4q2twxM3