### PR TITLE
feat(reliability): transactional half-message 2PC core — prepare/commit/rollback, durable + invisible + crash-safe (part 1/2 of #640)

### DIFF
--- a/crates/ironbus-client/src/lib.rs
+++ b/crates/ironbus-client/src/lib.rs
@@ -31,10 +31,11 @@ use ironbus_proto::message::{
     decode_not_leader, decode_produce_confirm, decode_pub_ack, decode_stream_info_response,
     decode_truncated, encode_ack, encode_connect, encode_cumulative_ack, encode_fetch, encode_pub,
     encode_pub_to, encode_stream_commit, encode_stream_declare, encode_stream_fetch,
-    encode_stream_info, encode_sub, encode_sub_to, produce_confirm_status, AckBody, AckLevel,
-    AckOp, BodyError, ConnectBody, ConsumeTier, CumulativeAckBody, DeliverBody, FetchBody, PubBody,
-    PubToBody, StreamCommitBody, StreamDeclareBody, StreamFetchBody, StreamInfoBody, SubBody,
-    SubToBody, PUB_FLAG_ACK_LEVEL_MASK, PUB_FLAG_ACK_LEVEL_SHIFT,
+    encode_stream_info, encode_sub, encode_sub_to, encode_txn_prepare, encode_txn_resolve,
+    produce_confirm_status, AckBody, AckLevel, AckOp, BodyError, ConnectBody, ConsumeTier,
+    CumulativeAckBody, DeliverBody, FetchBody, PubBody, PubToBody, StreamCommitBody,
+    StreamDeclareBody, StreamFetchBody, StreamInfoBody, SubBody, SubToBody, TxnPrepareBody,
+    TxnResolveBody, PUB_FLAG_ACK_LEVEL_MASK, PUB_FLAG_ACK_LEVEL_SHIFT,
 };
 use std::io::{self, Read, Write};
 use std::net::{TcpStream, ToSocketAddrs};
@@ -730,6 +731,28 @@ pub struct StreamSummary {
     pub last_offset: Option<u64>,
 }
 
+/// A transaction id minted by [`Client::prepare`] (or supplied via [`Client::prepare_with_id`]) for
+/// the transactional half-message 2PC (#640, V2-M8). It names the prepared half message for a later
+/// [`Client::commit`] / [`Client::rollback`]. It is an opaque byte string (a UUID, a snowflake, or the
+/// client's `addr+counter` default); the producer keeps it across its local transaction.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct TxnId(Vec<u8>);
+
+impl TxnId {
+    /// Wraps an explicit producer-supplied transaction id (a UUID, a snowflake, a content hash). The
+    /// id must be non-empty and at most 256 bytes (the wire cap); the server rejects an over-long id.
+    #[must_use]
+    pub fn new(id: impl Into<Vec<u8>>) -> TxnId {
+        TxnId(id.into())
+    }
+
+    /// The transaction id bytes.
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+}
+
 /// A connected IronBus client over one TCP connection.
 // Each bool records a DISTINCT server-CONFIRMED wire capability for this connection (gap-marker /
 // streaming / deliver-batch / streams), each set from its `Info` echo bit — protocol negotiation
@@ -783,6 +806,11 @@ pub struct Client {
     /// stays tiny; entries are removed on the matching call. Empty for any connection that never uses
     /// `produce_confirmed`.
     confirm_cache: Vec<(u64, ConfirmOutcome)>,
+    /// A per-connection monotonic counter used to mint a UNIQUE [`TxnId`] for each [`Client::prepare`]
+    /// (#640, V2-M8). Combined with the connection's local socket address (a per-connection seed) it
+    /// yields a transaction id unique across this producer's transactions; the producer may also supply
+    /// its own id via [`Client::prepare_with_id`]. Starts at 0; bumped per `prepare`.
+    next_txn_seq: u64,
 }
 
 impl Client {
@@ -819,6 +847,7 @@ impl Client {
             streams_enabled: false,
             negotiated_default_tier: None,
             confirm_cache: Vec::new(),
+            next_txn_seq: 0,
         };
         // The #292 handshake: send a versioned Connect body carrying any requested credit (an
         // all-absent body when the caller requested nothing, which the server reads as "use my
@@ -2421,6 +2450,142 @@ impl Client {
             }
             (other, _) => Err(ClientError::Unexpected(other)),
         }
+    }
+
+    // ---- transactional half-message 2PC (#640, V2-M8) ----
+
+    /// PREPAREs a transactional half message (#640): durably buffers `message` for a freshly-minted
+    /// [`TxnId`] targeting `stream` (empty = the default stream), INVISIBLE to consumers, and returns
+    /// the id. The producer then runs its local transaction and calls [`Client::commit`] (the half
+    /// message becomes visible) or [`Client::rollback`] (it is discarded). The id is unique to this
+    /// connection (its local address + a per-connection counter); to supply your OWN id (a UUID, a
+    /// snowflake) use [`Client::prepare_with_id`].
+    ///
+    /// # Errors
+    /// Returns [`ClientError::Server`] if the server rejects the prepare (too many prepared, a spent
+    /// id), [`ClientError::Body`] on an over-large field, or a frame/connection error.
+    pub fn prepare(&mut self, stream: &str, message: &PubBody<'_>) -> Result<TxnId, ClientError> {
+        let txn = self.mint_txn_id();
+        self.prepare_with_id(&txn, stream, message)?;
+        Ok(txn)
+    }
+
+    /// Like [`Client::prepare`] but with a producer-SUPPLIED `txn` id (a UUID, a snowflake, a content
+    /// hash) instead of a minted one — the idempotency anchor for a producer that derives its
+    /// transaction id from its own local transaction. Re-preparing a still-prepared id is a benign
+    /// no-op server-side; preparing a resolved (spent) id is refused.
+    ///
+    /// # Errors
+    /// Returns [`ClientError::Server`] if the server rejects the prepare (a spent id, too many
+    /// prepared, an over-long id), [`ClientError::Body`] on an over-large field, or a frame/connection
+    /// error.
+    pub fn prepare_with_id(
+        &mut self,
+        txn: &TxnId,
+        stream: &str,
+        message: &PubBody<'_>,
+    ) -> Result<(), ClientError> {
+        // The half message is always at-least-once server-ack; the wire-only fire-and-forget bit is
+        // cleared so a half message is never a QoS-0 drop (it must be durably buffered to commit).
+        let durable = PubBody {
+            fire_and_forget: false,
+            ..*message
+        };
+        let mut pub_body = Vec::new();
+        encode_pub(&durable, &mut pub_body).map_err(ClientError::Body)?;
+        let mut body = Vec::new();
+        encode_txn_prepare(
+            &TxnPrepareBody {
+                txn_id: txn.as_bytes(),
+                stream_id: stream.as_bytes(),
+                pub_body: &pub_body,
+            },
+            &mut body,
+        )
+        .map_err(ClientError::Body)?;
+        self.send(FrameType::TxnPrepare, &body)?;
+        match self.read_frame()? {
+            (FrameType::Ok, _) => Ok(()),
+            (FrameType::Err, body) => {
+                Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
+            }
+            (other, _) => Err(ClientError::Unexpected(other)),
+        }
+    }
+
+    /// COMMITs the prepared half message named by `txn` (#640): the broker appends the buffered payload
+    /// to the real target stream (it becomes VISIBLE to consumers) and returns the committed offset.
+    /// IDEMPOTENT: a retried commit of an already-committed txn returns the same offset (never an
+    /// error); a commit of an already-rolled-back txn is a [`ClientError::Server`] rejection (the
+    /// outcome is never flipped).
+    ///
+    /// # Errors
+    /// Returns [`ClientError::Server`] for an unknown / already-rolled-back txn, [`ClientError::Body`]
+    /// on an over-large field, [`ClientError::BadResponse`] on a malformed reply, or a frame/connection
+    /// error.
+    pub fn commit(&mut self, txn: &TxnId) -> Result<u64, ClientError> {
+        let mut body = Vec::new();
+        encode_txn_resolve(
+            &TxnResolveBody {
+                txn_id: txn.as_bytes(),
+            },
+            &mut body,
+        )
+        .map_err(ClientError::Body)?;
+        self.send(FrameType::TxnCommit, &body)?;
+        match self.read_frame()? {
+            (FrameType::PubAck, body) => {
+                let ack = decode_pub_ack(&body)
+                    .map_err(|_| ClientError::BadResponse("txn-commit reply was not an offset"))?;
+                Ok(ack.offset)
+            }
+            (FrameType::Err, body) => {
+                Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
+            }
+            (other, _) => Err(ClientError::Unexpected(other)),
+        }
+    }
+
+    /// ROLLs BACK the prepared half message named by `txn` (#640): the broker discards the buffered
+    /// payload — it is never appended to the real stream, never delivered. IDEMPOTENT: a retried
+    /// rollback is a benign success; a rollback of an already-committed txn is a [`ClientError::Server`]
+    /// rejection (never flipped).
+    ///
+    /// # Errors
+    /// Returns [`ClientError::Server`] for an unknown / already-committed txn, [`ClientError::Body`] on
+    /// an over-large field, or a frame/connection error.
+    pub fn rollback(&mut self, txn: &TxnId) -> Result<(), ClientError> {
+        let mut body = Vec::new();
+        encode_txn_resolve(
+            &TxnResolveBody {
+                txn_id: txn.as_bytes(),
+            },
+            &mut body,
+        )
+        .map_err(ClientError::Body)?;
+        self.send(FrameType::TxnRollback, &body)?;
+        match self.read_frame()? {
+            (FrameType::Ok, _) => Ok(()),
+            (FrameType::Err, body) => {
+                Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
+            }
+            (other, _) => Err(ClientError::Unexpected(other)),
+        }
+    }
+
+    /// Mints a UNIQUE transaction id for this connection (#640): the local socket address (a
+    /// per-connection seed) plus a monotonic per-connection counter, so two `prepare`s on this
+    /// connection — and on different connections (distinct local addresses) — never collide. Bounded
+    /// well under the 256-byte wire cap.
+    fn mint_txn_id(&mut self) -> TxnId {
+        let seq = self.next_txn_seq;
+        self.next_txn_seq = self.next_txn_seq.wrapping_add(1);
+        // The local address is a stable per-connection seed; pair it with the monotonic counter.
+        let seed = self
+            .stream
+            .local_addr()
+            .map_or_else(|_| "txn".to_string(), |a| a.to_string());
+        TxnId(format!("{seed}#{seq}").into_bytes())
     }
 
     /// Subscribes this connection's consume path to a NAMED stream's work-group (#588, M2-I10): the
@@ -6666,6 +6831,97 @@ mod tests {
         assert_eq!(messages[0].offset, 0);
         assert_eq!(messages[0].payload.as_slice(), b"single-node");
         drop(c);
+        shutdown.store(true, Ordering::Release);
+        handle.join().unwrap();
+    }
+
+    // ---- transactional half-message 2PC client API (#640, V2-M8) ----
+
+    fn txn_pub(payload: &'static [u8]) -> PubBody<'static> {
+        PubBody {
+            flags: 0,
+            timestamp_ms: 0,
+            key: b"",
+            headers: b"",
+            dedup: None,
+            fire_and_forget: false,
+            payload,
+        }
+    }
+
+    #[test]
+    fn txn_prepare_commit_delivers_only_after_commit_against_a_real_server() {
+        // End-to-end over the real wire: a prepared half message is INVISIBLE to a fetch until commit,
+        // then it appears exactly once.
+        let (addr, shutdown, handle) = start_server();
+        let mut producer = Client::connect(addr).unwrap();
+        let txn = producer.prepare("", &txn_pub(b"half")).unwrap();
+
+        // A separate consumer connection sees NOTHING while the txn is only prepared.
+        let mut consumer = Client::connect(addr).unwrap();
+        assert!(
+            consumer.fetch(10).unwrap().messages.is_empty(),
+            "a prepared-but-uncommitted half message is invisible"
+        );
+
+        // Commit returns the committed offset.
+        let offset = producer.commit(&txn).unwrap();
+        assert_eq!(offset, 0);
+        // A retried commit is idempotent (same offset, no double-append).
+        assert_eq!(producer.commit(&txn).unwrap(), 0);
+
+        // Now the consumer sees the committed record exactly once.
+        let messages = consumer.fetch(10).unwrap().messages;
+        assert_eq!(
+            messages.len(),
+            1,
+            "the committed half message is delivered exactly once"
+        );
+        assert_eq!(messages[0].payload.as_slice(), b"half");
+
+        drop(producer);
+        drop(consumer);
+        shutdown.store(true, Ordering::Release);
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn txn_rollback_never_delivers_against_a_real_server() {
+        let (addr, shutdown, handle) = start_server();
+        let mut producer = Client::connect(addr).unwrap();
+        let txn = producer.prepare("", &txn_pub(b"secret")).unwrap();
+        producer.rollback(&txn).unwrap();
+        // A retried rollback is a benign success.
+        producer.rollback(&txn).unwrap();
+        // commit-after-rollback is refused (Server error), never flipped.
+        assert!(matches!(producer.commit(&txn), Err(ClientError::Server(_))));
+
+        let mut consumer = Client::connect(addr).unwrap();
+        assert!(
+            consumer.fetch(10).unwrap().messages.is_empty(),
+            "a rolled-back half message is never delivered"
+        );
+
+        drop(producer);
+        drop(consumer);
+        shutdown.store(true, Ordering::Release);
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn txn_prepare_with_a_producer_supplied_id_round_trips() {
+        let (addr, shutdown, handle) = start_server();
+        let mut producer = Client::connect(addr).unwrap();
+        let txn = TxnId::new(b"my-own-uuid-1234".to_vec());
+        producer.prepare_with_id(&txn, "", &txn_pub(b"v")).unwrap();
+        // Re-preparing the same id is a benign no-op server-side.
+        producer.prepare_with_id(&txn, "", &txn_pub(b"v")).unwrap();
+        let offset = producer.commit(&txn).unwrap();
+        assert_eq!(offset, 0);
+        let mut consumer = Client::connect(addr).unwrap();
+        assert_eq!(consumer.fetch(10).unwrap().messages.len(), 1);
+        drop(producer);
+        drop(consumer);
         shutdown.store(true, Ordering::Release);
         handle.join().unwrap();
     }

--- a/crates/ironbus-client/src/lib.rs
+++ b/crates/ironbus-client/src/lib.rs
@@ -2577,6 +2577,15 @@ impl Client {
     /// per-connection seed) plus a monotonic per-connection counter, so two `prepare`s on this
     /// connection — and on different connections (distinct local addresses) — never collide. Bounded
     /// well under the 256-byte wire cap.
+    ///
+    /// COLLISION SCOPE: the `<local_addr>#<seq>` id is unique only WITHIN a connection's lifetime. An
+    /// EPHEMERAL local port REUSED by a later connection (after this one closes) whose per-connection
+    /// counter has reset to 0 can re-mint an id a still-prepared txn already holds. Because the id is
+    /// the broker's idempotency key, this surfaces as a broker ERROR (a spent / still-prepared id is
+    /// refused) — NEVER a silent merge of two distinct half messages. For transactions that must
+    /// survive a reconnect (or that derive their identity from a local transaction), supply a stable
+    /// caller-chosen id via [`Client::prepare_with_id`] (a UUID, a snowflake, a content hash) instead
+    /// of an auto-minted one — that is the durable choice.
     fn mint_txn_id(&mut self) -> TxnId {
         let seq = self.next_txn_seq;
         self.next_txn_seq = self.next_txn_seq.wrapping_add(1);

--- a/crates/ironbus-core/src/lib.rs
+++ b/crates/ironbus-core/src/lib.rs
@@ -41,4 +41,5 @@ pub mod segment;
 pub mod subject;
 pub mod sublist;
 pub mod ttl;
+pub mod txn;
 pub mod types;

--- a/crates/ironbus-core/src/txn.rs
+++ b/crates/ironbus-core/src/txn.rs
@@ -1,0 +1,885 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! The IO-free transactional half-message 2PC state machine (V2-M8, #640 part 1/2).
+//!
+//! This is the `RocketMQ` transactional-message model adapted to IronBus: a producer sends a
+//! **half (prepared) message** that the broker stores durably but keeps INVISIBLE to consumers,
+//! runs its local transaction, then sends **commit** (the half message becomes visible — it is
+//! appended to the real target stream) or **rollback** (the half message is discarded, never
+//! delivered). This module is the PURE lifecycle: `Prepared -> {Committed, RolledBack}`, with the
+//! legal transitions, the idempotency rules, and the cheap "unresolved-prepared" query the part-2
+//! broker back-check will scan. It holds NO payload bytes and does NO IO; the durable half-log and
+//! the real-stream append live in `ironbus-storage` / `ironbus-server` above this.
+//!
+//! ## The lifecycle and its legal transitions
+//!
+//! A transaction id (producer-supplied, see [`MAX_TXN_ID_LEN`]) moves through exactly:
+//!
+//! ```text
+//!                 commit                       (terminal)
+//!   Prepared ───────────────▶ Committed
+//!      │                         ▲
+//!      │ rollback                │  re-commit  = NO-OP (returns the prior Committed outcome)
+//!      ▼                         │  re-rollback of a Committed = REFUSED (already committed)
+//!   RolledBack ◀────────────────┘
+//!   (terminal)   re-rollback = NO-OP (returns the prior RolledBack outcome)
+//!                commit of a RolledBack = REFUSED (already rolled back)
+//! ```
+//!
+//! - **Idempotent resolve.** Re-committing an already-Committed txn, or re-rolling-back an
+//!   already-RolledBack txn, is a NO-OP that returns the PRIOR outcome (so a retried commit over a
+//!   lossy link does not error and does not double-resolve). This mirrors the
+//!   [`crate::dedup`] / [`crate::producer_seq`] "a retry is a benign duplicate, never an error"
+//!   discipline.
+//! - **Never silently flipped.** A commit AFTER a rollback, or a rollback AFTER a commit, is
+//!   REFUSED ([`TxnError::AlreadyResolved`]) — the terminal outcome is immutable. A resolved txn is
+//!   never re-opened.
+//! - **Prepare is idempotent too.** Re-preparing a still-Prepared id is a NO-OP (the half message
+//!   is already durable); preparing an id that is already RESOLVED is REFUSED (its slot is spent).
+//!
+//! ## The unresolved-prepared query (part 2's back-check seam)
+//!
+//! Each prepared txn records the monotonic instant it was prepared (injected by the caller — this
+//! module reads NO clock). [`TxnTable::unresolved_before`] returns every txn still `Prepared` whose
+//! prepare instant is at or before a cutoff, in prepare order, so part 2's back-check can cheaply
+//! find "prepared but unresolved for longer than T" without scanning resolved entries. Resolved
+//! txns are kept only as a bounded tombstone set for idempotency (see the memory note); the
+//! unresolved set is a separate, directly-indexed structure so the scan is O(unresolved), never
+//! O(all-txns-ever).
+//!
+//! ## Memory
+//!
+//! The table holds one small entry per LIVE (unresolved) txn plus a bounded tombstone of recently
+//! resolved txn ids (so a retried commit/rollback after the real resolve is still recognized as a
+//! benign duplicate rather than read as a fresh prepare). The `txn_id` is wire-supplied and
+//! attacker-chosen, so BOTH sets are hard-capped ([`TxnConfig::max_prepared`],
+//! [`TxnConfig::max_resolved_tombstones`]) with the same approximate-LRU eviction the dedup/seq
+//! registries use: a flood of distinct ids evicts the least-recently-touched entry rather than
+//! growing without bound. Evicting a resolved tombstone only means a (very late) retry of THAT
+//! commit/rollback is no longer recognized as a duplicate — the durable op-log in storage remains
+//! the source of truth, so this is a safe degrade, not a correctness loss.
+//!
+//! ## IO and time
+//!
+//! PURE and IO-free, exactly like [`crate::dedup`], [`crate::producer_seq`], and
+//! [`crate::lease::LeaseTable`]: the caller supplies the monotonic `now` (for the prepare instant
+//! and LRU recency), and the durable half-log / op-log replay that rebuilds this table on restart
+//! lives in the storage layer. The CI `ironbus-core is IO-free` gate enforces the no-IO rule.
+
+use crate::dedup::MAX_PRODUCER_ID_LEN;
+use std::cmp::Reverse;
+use std::collections::BTreeSet;
+use std::collections::BinaryHeap;
+use std::collections::HashMap;
+
+/// The hard cap on a transaction id's length in bytes. The `txn_id` is producer-chosen (a UUID, a
+/// snowflake, a content hash) and wire-supplied, so this bounds the per-entry key memory and lets
+/// the engine reject a hostile oversized id at the boundary before it is stored. Sized identically
+/// to [`MAX_PRODUCER_ID_LEN`] (256), generous for any real transaction identity.
+pub const MAX_TXN_ID_LEN: usize = MAX_PRODUCER_ID_LEN;
+
+/// The default cap on the number of concurrently-PREPARED (unresolved) transactions tracked. The
+/// `txn_id` is attacker-chosen, so the count of live half messages must be bounded or a peer that
+/// prepares endless distinct ids without resolving them grows broker RAM (and the durable half-log)
+/// without bound. A prepare over this cap is REFUSED ([`TxnError::TooManyPrepared`]) rather than
+/// silently evicting a live half message — a still-Prepared txn holds a durable, undelivered
+/// payload that must NOT be dropped, so the safe action under pressure is to refuse the new prepare,
+/// not to forget an existing one. Generous for any realistic in-flight transaction fan-in.
+pub const DEFAULT_MAX_PREPARED: usize = 65_536;
+
+/// The default cap on the number of recently-RESOLVED txn-id tombstones retained for idempotency.
+/// A resolved tombstone lets a retried commit/rollback (arriving after the real resolve) be
+/// recognized as a benign duplicate. Bounded with approximate-LRU eviction: evicting the
+/// least-recently-resolved tombstone only means a (very late) retry of THAT resolve is no longer
+/// deduped in memory, which the durable op-log still covers — a safe degrade.
+pub const DEFAULT_MAX_RESOLVED_TOMBSTONES: usize = 65_536;
+
+/// Tunables for a [`TxnTable`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TxnConfig {
+    /// The cap on concurrently-PREPARED (unresolved) transactions: a prepare over this cap is
+    /// refused (never evicting a live, undelivered half message). Floored to 1 by [`TxnTable::new`].
+    pub max_prepared: usize,
+    /// The cap on recently-RESOLVED txn-id tombstones kept for idempotency: a fresh resolve over
+    /// this cap evicts the least-recently-resolved tombstone (approximate LRU). Floored to 1 by
+    /// [`TxnTable::new`].
+    pub max_resolved_tombstones: usize,
+}
+
+impl Default for TxnConfig {
+    fn default() -> TxnConfig {
+        TxnConfig {
+            max_prepared: DEFAULT_MAX_PREPARED,
+            max_resolved_tombstones: DEFAULT_MAX_RESOLVED_TOMBSTONES,
+        }
+    }
+}
+
+/// The terminal outcome a resolved transaction settled on. A `Prepared` txn has no outcome yet; a
+/// resolved one is exactly one of these, immutably.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TxnOutcome {
+    /// The half message was COMMITTED: it is (to be) appended to the real target stream and becomes
+    /// visible to consumers. The durable op-log carries a committed marker.
+    Committed,
+    /// The half message was ROLLED BACK: it is discarded and NEVER delivered. The durable op-log
+    /// carries a rolled-back marker.
+    RolledBack,
+}
+
+/// The current lifecycle state of a tracked transaction.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TxnState {
+    /// The half message is durably stored but unresolved and INVISIBLE to consumers.
+    Prepared,
+    /// The transaction has reached a terminal outcome (committed or rolled back), immutably.
+    Resolved(TxnOutcome),
+}
+
+/// What a [`TxnTable::prepare`] decided.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PrepareDecision {
+    /// A FRESH prepare: this id was not tracked, so the caller must durably buffer the half message
+    /// and write a prepared marker. The table now holds it as `Prepared`.
+    Prepared,
+    /// A re-prepare of a still-`Prepared` id: a benign DUPLICATE (the half message is already
+    /// durable). The caller re-acks WITHOUT buffering a second copy. Idempotent prepare.
+    AlreadyPrepared,
+}
+
+/// What a [`TxnTable::commit`] / [`TxnTable::rollback`] decided.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ResolveDecision {
+    /// A FRESH resolve of a `Prepared` txn to the requested outcome: the caller appends the buffered
+    /// payload to the real stream (for a commit) and writes the op-marker (for both). The table now
+    /// holds the txn as `Resolved(outcome)`.
+    Resolved,
+    /// A re-resolve of a txn ALREADY at the SAME outcome: a benign DUPLICATE (a retried
+    /// commit-of-committed or rollback-of-rolledback). The caller re-acks the PRIOR outcome WITHOUT
+    /// re-appending or re-marking. Idempotent resolve.
+    AlreadyResolved,
+}
+
+/// A failure resolving or preparing a transaction.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TxnError {
+    /// A commit/rollback (or re-prepare) named a txn id the table has never seen (no prepared half
+    /// message, no resolved tombstone). The caller rejects it: there is nothing to resolve.
+    UnknownTxn,
+    /// A commit was requested for a txn already rolled back, or a rollback for one already
+    /// committed: the terminal outcome is immutable, so the conflicting resolve is REFUSED, never
+    /// silently flipped. Carries the prior (binding) outcome so the caller can report it.
+    AlreadyResolved {
+        /// The terminal outcome the txn is already bound to (which the conflicting verb contradicts).
+        outcome: TxnOutcome,
+    },
+    /// A prepare named an id that is already RESOLVED (its slot is spent): re-using a resolved txn
+    /// id for a new half message is refused, so a committed/rolled-back id can never be reopened.
+    /// Carries the prior outcome.
+    TxnIdSpent {
+        /// The terminal outcome the spent id resolved to.
+        outcome: TxnOutcome,
+    },
+    /// A prepare would exceed [`TxnConfig::max_prepared`] concurrently-prepared transactions. A live
+    /// half message is NEVER evicted to make room (it holds an undelivered durable payload), so the
+    /// new prepare is refused instead. The producer retries after some in-flight txns resolve.
+    TooManyPrepared {
+        /// The configured cap on concurrently-prepared transactions.
+        cap: usize,
+    },
+    /// The supplied `txn_id` exceeds [`MAX_TXN_ID_LEN`]. Rejected at the boundary before it is stored.
+    TxnIdTooLong {
+        /// The rejected id length.
+        len: usize,
+    },
+}
+
+impl core::fmt::Display for TxnError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            TxnError::UnknownTxn => {
+                write!(f, "unknown transaction id (nothing prepared to resolve)")
+            }
+            TxnError::AlreadyResolved { outcome } => {
+                write!(
+                    f,
+                    "transaction already resolved as {outcome:?}, will not flip"
+                )
+            }
+            TxnError::TxnIdSpent { outcome } => {
+                write!(
+                    f,
+                    "transaction id already spent (resolved {outcome:?}), cannot re-prepare"
+                )
+            }
+            TxnError::TooManyPrepared { cap } => {
+                write!(
+                    f,
+                    "too many prepared transactions (cap {cap}); retry after some resolve"
+                )
+            }
+            TxnError::TxnIdTooLong { len } => {
+                write!(
+                    f,
+                    "transaction id length {len} exceeds the {MAX_TXN_ID_LEN}-byte cap"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for TxnError {}
+
+/// One tracked transaction's lifecycle bookkeeping (NO payload — that lives in the durable
+/// half-log). For a `Prepared` txn the `prepared_at` is its prepare instant (the back-check key);
+/// for a resolved tombstone it is the resolve instant (the LRU recency key).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct TxnEntry {
+    state: TxnState,
+    /// The monotonic instant this entry was last (re)stamped: the PREPARE instant while `Prepared`
+    /// (the [`TxnTable::unresolved_before`] scan key), the RESOLVE instant once resolved (the
+    /// tombstone-LRU recency key). Caller-injected; this module reads no clock.
+    instant: u64,
+}
+
+/// The pure transactional-half-message lifecycle table (V2-M8, #640 part 1): the broker-side owner
+/// of every in-flight and recently-resolved transaction's STATE (not its payload). Held by the
+/// engine, consulted on the txn produce/resolve path, rebuilt on restart by replaying the durable
+/// half-log + op-log. Pure and IO-free; the caller supplies monotonic `now`.
+///
+/// Two structures keep the back-check scan cheap and the memory bounded:
+/// - `prepared`: every CURRENTLY-`Prepared` txn, keyed by id, plus a prepare-ordered index so
+///   [`TxnTable::unresolved_before`] is O(unresolved) and never walks resolved entries.
+/// - `resolved`: a bounded LRU tombstone of recently-resolved txn ids (id -> outcome), for
+///   idempotent re-resolve / spent-id detection without retaining every txn forever.
+#[derive(Debug)]
+pub struct TxnTable {
+    config: TxnConfig,
+    /// Currently-`Prepared` (unresolved) transactions: `txn_id -> TxnEntry{Prepared, prepared_at}`.
+    prepared: HashMap<Vec<u8>, TxnEntry>,
+    /// A prepare-ordered index over the `prepared` set: a sorted set of `(prepared_at, txn_id)` so
+    /// the back-check can enumerate the oldest unresolved txns in O(result) via a range scan, without
+    /// touching resolved entries. Kept in lockstep with `prepared` (entry inserted on prepare,
+    /// removed on resolve), so it never holds a stale or resolved id.
+    prepared_by_age: BTreeSet<(u64, Vec<u8>)>,
+    /// A bounded LRU tombstone of recently-RESOLVED txn ids and their terminal outcome, for
+    /// idempotent re-resolve and spent-id rejection. `txn_id -> TxnEntry{Resolved(outcome),
+    /// resolved_at}`.
+    resolved: HashMap<Vec<u8>, TxnEntry>,
+    /// The LRU recency index for the `resolved` tombstone cap: a MIN-heap over `(resolved_at,
+    /// txn_id)`, the same lazily-invalidated approximate-LRU the dedup/producer-seq registries use
+    /// (a stale entry — a removed id, or one whose `instant` advanced — is discarded on pop), reaped
+    /// back to the live tombstone count when it grows past twice that count.
+    resolved_lru: BinaryHeap<Reverse<(u64, Vec<u8>)>>,
+}
+
+impl TxnTable {
+    /// Creates an empty table with `config`. Both caps are floored to 1.
+    #[must_use]
+    pub fn new(config: TxnConfig) -> TxnTable {
+        TxnTable {
+            config: TxnConfig {
+                max_prepared: config.max_prepared.max(1),
+                max_resolved_tombstones: config.max_resolved_tombstones.max(1),
+            },
+            prepared: HashMap::new(),
+            prepared_by_age: BTreeSet::new(),
+            resolved: HashMap::new(),
+            resolved_lru: BinaryHeap::new(),
+        }
+    }
+
+    /// The active config (with the floors applied).
+    #[must_use]
+    pub fn config(&self) -> TxnConfig {
+        self.config
+    }
+
+    /// The number of currently-`Prepared` (unresolved) transactions.
+    #[must_use]
+    pub fn prepared_count(&self) -> usize {
+        self.prepared.len()
+    }
+
+    /// The number of recently-resolved tombstones currently retained.
+    #[must_use]
+    pub fn resolved_tombstone_count(&self) -> usize {
+        self.resolved.len()
+    }
+
+    /// The current lifecycle state of `txn_id`, or `None` if untracked (never prepared, or its
+    /// resolved tombstone was evicted under the cap). For tests, observability, and the engine's
+    /// ack-shaping.
+    #[must_use]
+    pub fn state(&self, txn_id: &[u8]) -> Option<TxnState> {
+        if let Some(e) = self.prepared.get(txn_id) {
+            return Some(e.state);
+        }
+        self.resolved.get(txn_id).map(|e| e.state)
+    }
+
+    /// Validates the id length at the boundary, the one structural reject shared by every verb.
+    fn check_id_len(txn_id: &[u8]) -> Result<(), TxnError> {
+        if txn_id.len() > MAX_TXN_ID_LEN {
+            return Err(TxnError::TxnIdTooLong { len: txn_id.len() });
+        }
+        Ok(())
+    }
+
+    /// Decides what a PREPARE (half-message produce) of `txn_id` at monotonic instant `now` should
+    /// do, WITHOUT mutating the durable store (the caller buffers the half message and writes the
+    /// prepared marker only on a [`PrepareDecision::Prepared`]). On a fresh prepare the table records
+    /// the txn as `Prepared` at `now`.
+    ///
+    /// # Errors
+    /// - [`TxnError::TxnIdTooLong`] if the id exceeds [`MAX_TXN_ID_LEN`].
+    /// - [`TxnError::TxnIdSpent`] if the id is already RESOLVED (its slot is spent; never reopened).
+    /// - [`TxnError::TooManyPrepared`] if accepting it would exceed [`TxnConfig::max_prepared`]
+    ///   (a live half message is never evicted to make room — the prepare is refused instead).
+    pub fn prepare(&mut self, txn_id: &[u8], now: u64) -> Result<PrepareDecision, TxnError> {
+        Self::check_id_len(txn_id)?;
+        // A re-prepare of a still-prepared id is a benign duplicate: the half message is already
+        // durable, so the caller re-acks without buffering a second copy.
+        if self.prepared.contains_key(txn_id) {
+            return Ok(PrepareDecision::AlreadyPrepared);
+        }
+        // A prepare of an already-RESOLVED id is refused: a committed/rolled-back txn id is spent and
+        // is never reopened (so a stale producer cannot resurrect a settled txn).
+        if let Some(e) = self.resolved.get(txn_id) {
+            if let TxnState::Resolved(outcome) = e.state {
+                return Err(TxnError::TxnIdSpent { outcome });
+            }
+        }
+        // A fresh prepare must fit under the concurrently-prepared cap. A live half message is NEVER
+        // evicted to make room (it holds an undelivered durable payload), so we REFUSE rather than
+        // evict — the opposite of the dedup/seq registries, which may safely evict a stale window.
+        if self.prepared.len() >= self.config.max_prepared {
+            return Err(TxnError::TooManyPrepared {
+                cap: self.config.max_prepared,
+            });
+        }
+        self.prepared.insert(
+            txn_id.to_vec(),
+            TxnEntry {
+                state: TxnState::Prepared,
+                instant: now,
+            },
+        );
+        self.prepared_by_age.insert((now, txn_id.to_vec()));
+        Ok(PrepareDecision::Prepared)
+    }
+
+    /// Decides what a COMMIT of `txn_id` at monotonic instant `now` should do. Shared core with
+    /// [`TxnTable::rollback`] via [`TxnTable::resolve`].
+    ///
+    /// # Errors
+    /// See [`TxnTable::resolve`].
+    pub fn commit(&mut self, txn_id: &[u8], now: u64) -> Result<ResolveDecision, TxnError> {
+        self.resolve(txn_id, TxnOutcome::Committed, now)
+    }
+
+    /// Decides what a ROLLBACK of `txn_id` at monotonic instant `now` should do. Shared core with
+    /// [`TxnTable::commit`] via [`TxnTable::resolve`].
+    ///
+    /// # Errors
+    /// See [`TxnTable::resolve`].
+    pub fn rollback(&mut self, txn_id: &[u8], now: u64) -> Result<ResolveDecision, TxnError> {
+        self.resolve(txn_id, TxnOutcome::RolledBack, now)
+    }
+
+    /// The shared resolve core: move `txn_id` to the terminal `outcome` at monotonic instant `now`,
+    /// WITHOUT doing IO (the caller appends the buffered payload to the real stream for a commit and
+    /// writes the op-marker only on a [`ResolveDecision::Resolved`]). On a fresh resolve the txn moves
+    /// from `Prepared` to `Resolved(outcome)`: it leaves the prepared set + age index and enters the
+    /// bounded resolved tombstone.
+    ///
+    /// # Errors
+    /// - [`TxnError::TxnIdTooLong`] if the id exceeds [`MAX_TXN_ID_LEN`].
+    /// - [`TxnError::UnknownTxn`] if no prepared half message and no resolved tombstone exist for the
+    ///   id (nothing to resolve).
+    /// - [`TxnError::AlreadyResolved`] if the txn is already resolved to the OTHER outcome (a commit
+    ///   of a rolled-back txn, or vice versa): the terminal outcome is immutable, so the conflicting
+    ///   verb is refused, never silently flipped.
+    ///
+    /// A re-resolve to the SAME outcome (a retried commit-of-committed / rollback-of-rolledback) is a
+    /// benign [`ResolveDecision::AlreadyResolved`], NOT an error.
+    pub fn resolve(
+        &mut self,
+        txn_id: &[u8],
+        outcome: TxnOutcome,
+        now: u64,
+    ) -> Result<ResolveDecision, TxnError> {
+        Self::check_id_len(txn_id)?;
+        // Fast path: the txn is currently Prepared — this is the fresh, durable resolve.
+        if let Some(entry) = self.prepared.get(txn_id) {
+            let prepared_at = entry.instant;
+            // Move out of the prepared set and its age index (kept in lockstep).
+            self.prepared.remove(txn_id);
+            self.prepared_by_age.remove(&(prepared_at, txn_id.to_vec()));
+            self.insert_resolved_tombstone(txn_id, outcome, now);
+            return Ok(ResolveDecision::Resolved);
+        }
+        // The txn is not prepared: it is either a resolved tombstone (idempotent re-resolve or a
+        // conflicting flip) or genuinely unknown.
+        match self.resolved.get(txn_id).map(|e| e.state) {
+            Some(TxnState::Resolved(prior)) => {
+                if prior == outcome {
+                    // A retried commit-of-committed / rollback-of-rolledback: benign duplicate,
+                    // returns the prior outcome, no IO. We deliberately do NOT bump the tombstone's
+                    // LRU recency here: a resolved txn's tombstone ages out by its RESOLVE time, not
+                    // by how often a late retry pokes it, matching the durable op-log's view.
+                    Ok(ResolveDecision::AlreadyResolved)
+                } else {
+                    // A commit after rollback, or rollback after commit: refused, never flipped.
+                    Err(TxnError::AlreadyResolved { outcome: prior })
+                }
+            }
+            // No resolved tombstone either. (A resolved entry is always `Resolved(_)`, so the
+            // `Some(Prepared)` case is unreachable; it folds in here, all reading as unknown.)
+            Some(TxnState::Prepared) | None => Err(TxnError::UnknownTxn),
+        }
+    }
+
+    /// Inserts a resolved tombstone for `txn_id -> outcome` at `now`, enforcing the
+    /// [`TxnConfig::max_resolved_tombstones`] cap with approximate-LRU eviction (the same lazily
+    /// invalidated min-heap the dedup/producer-seq registries use). Evicting a tombstone only drops
+    /// the in-memory idempotency hint for a very-late retry of THAT resolve (the durable op-log still
+    /// covers it), so eviction is safe.
+    fn insert_resolved_tombstone(&mut self, txn_id: &[u8], outcome: TxnOutcome, now: u64) {
+        // Make room for one more tombstone if the id is new and we are at the cap.
+        if !self.resolved.contains_key(txn_id)
+            && self.resolved.len() >= self.config.max_resolved_tombstones
+        {
+            while self.resolved.len() >= self.config.max_resolved_tombstones {
+                let Some(Reverse((touch, id))) = self.resolved_lru.pop() else {
+                    // Unreachable while `resolved` is non-empty (every tombstone pushed an LRU entry);
+                    // purely defensive (no panic, no scan fallback).
+                    break;
+                };
+                if self.resolved.get(&id).is_some_and(|e| e.instant == touch) {
+                    self.resolved.remove(&id);
+                }
+            }
+        }
+        self.resolved.insert(
+            txn_id.to_vec(),
+            TxnEntry {
+                state: TxnState::Resolved(outcome),
+                instant: now,
+            },
+        );
+        self.touch_resolved_lru(txn_id, now);
+    }
+
+    /// Records on the resolved-LRU heap that `txn_id`'s tombstone was (re)stamped at `now`, and
+    /// periodically rebuilds the heap (when it grows past twice the live tombstone count) so lazily
+    /// invalidated stale entries cannot accumulate without bound — amortized O(1) per resolve.
+    fn touch_resolved_lru(&mut self, txn_id: &[u8], now: u64) {
+        self.resolved_lru.push(Reverse((now, txn_id.to_vec())));
+        if self.resolved_lru.len() > self.resolved.len().saturating_mul(2) {
+            self.resolved_lru = self
+                .resolved
+                .iter()
+                .map(|(id, e)| Reverse((e.instant, id.clone())))
+                .collect();
+        }
+    }
+
+    /// Every currently-`Prepared` (unresolved) txn whose prepare instant is at or before `cutoff`, in
+    /// ascending `(prepared_at, txn_id)` order — the part-2 broker back-check seam (#640 part 2 will
+    /// scan "prepared but unresolved for longer than T" by passing `cutoff = now - T`). O(result) via
+    /// the prepare-ordered index, never a walk over resolved entries. Each item is
+    /// `(txn_id, prepared_at)`.
+    #[must_use]
+    pub fn unresolved_before(&self, cutoff: u64) -> Vec<(Vec<u8>, u64)> {
+        // The index is keyed `(prepared_at, txn_id)`; a range up to `(cutoff, max-id)` inclusive
+        // selects exactly the txns prepared at or before `cutoff`. `u64::MAX`-bounded by the
+        // half-open upper key `(cutoff + 1, [])`, guarding `cutoff == u64::MAX`.
+        match cutoff.checked_add(1) {
+            Some(next) => self
+                .prepared_by_age
+                .range(..(next, Vec::new()))
+                .map(|(at, id)| (id.clone(), *at))
+                .collect(),
+            None => self
+                .prepared_by_age
+                .iter()
+                .map(|(at, id)| (id.clone(), *at))
+                .collect(),
+        }
+    }
+
+    /// Every currently-`Prepared` txn id, in ascending `(prepared_at, txn_id)` order, for a durable
+    /// snapshot or a full back-check sweep. Equivalent to [`TxnTable::unresolved_before`] with no
+    /// cutoff.
+    #[must_use]
+    pub fn all_prepared(&self) -> Vec<(Vec<u8>, u64)> {
+        self.prepared_by_age
+            .iter()
+            .map(|(at, id)| (id.clone(), *at))
+            .collect()
+    }
+
+    /// Restores one txn's state from a durable replay (the storage layer's half-log + op-log replay
+    /// at open). A `Prepared` restore re-enters the unresolved set + age index at `instant`; a
+    /// `Resolved` restore re-enters the tombstone at `instant`. A restore is trusted recovered state:
+    /// it never errors, never refuses, and (for a `Prepared` restore) is NOT subject to the
+    /// `max_prepared` cap — the durable log is authoritative, so recovery rebuilds exactly what was
+    /// durable. A later `Resolved` restore for an id first seen `Prepared` (the op-log replayed after
+    /// the half-log) correctly supersedes it (the prepared entry is cleared first).
+    pub fn restore(&mut self, txn_id: &[u8], state: TxnState, instant: u64) {
+        // If this id is currently held Prepared (from an earlier half-log replay) and we are now
+        // restoring a resolution, clear the prepared entry + age index first so the two sets stay
+        // disjoint and the txn ends up only in the tombstone.
+        if let Some(prev) = self.prepared.remove(txn_id) {
+            self.prepared_by_age
+                .remove(&(prev.instant, txn_id.to_vec()));
+        }
+        match state {
+            TxnState::Prepared => {
+                self.prepared.insert(
+                    txn_id.to_vec(),
+                    TxnEntry {
+                        state: TxnState::Prepared,
+                        instant,
+                    },
+                );
+                self.prepared_by_age.insert((instant, txn_id.to_vec()));
+            }
+            TxnState::Resolved(outcome) => {
+                // A resolved restore supersedes any prepared restore for the same id and is NOT
+                // bounded by the tombstone cap (recovery rebuilds the durable truth); the cap applies
+                // only to live resolves. Insert directly and seed the LRU.
+                self.resolved.insert(
+                    txn_id.to_vec(),
+                    TxnEntry {
+                        state: TxnState::Resolved(outcome),
+                        instant,
+                    },
+                );
+                self.touch_resolved_lru(txn_id, instant);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn table() -> TxnTable {
+        TxnTable::new(TxnConfig::default())
+    }
+
+    #[test]
+    fn a_fresh_prepare_then_commit_round_trips() {
+        let mut t = table();
+        assert_eq!(t.prepare(b"tx1", 10), Ok(PrepareDecision::Prepared));
+        assert_eq!(t.state(b"tx1"), Some(TxnState::Prepared));
+        assert_eq!(t.prepared_count(), 1);
+        assert_eq!(t.commit(b"tx1", 20), Ok(ResolveDecision::Resolved));
+        assert_eq!(
+            t.state(b"tx1"),
+            Some(TxnState::Resolved(TxnOutcome::Committed))
+        );
+        // It left the prepared set, entered the tombstone.
+        assert_eq!(t.prepared_count(), 0);
+        assert_eq!(t.resolved_tombstone_count(), 1);
+    }
+
+    #[test]
+    fn a_fresh_prepare_then_rollback_round_trips() {
+        let mut t = table();
+        assert_eq!(t.prepare(b"tx1", 10), Ok(PrepareDecision::Prepared));
+        assert_eq!(t.rollback(b"tx1", 20), Ok(ResolveDecision::Resolved));
+        assert_eq!(
+            t.state(b"tx1"),
+            Some(TxnState::Resolved(TxnOutcome::RolledBack))
+        );
+        assert_eq!(t.prepared_count(), 0);
+    }
+
+    #[test]
+    fn re_preparing_a_still_prepared_id_is_a_benign_duplicate() {
+        let mut t = table();
+        assert_eq!(t.prepare(b"tx1", 10), Ok(PrepareDecision::Prepared));
+        // A retried prepare of the same id: duplicate, NOT a second half message.
+        assert_eq!(t.prepare(b"tx1", 11), Ok(PrepareDecision::AlreadyPrepared));
+        assert_eq!(t.prepared_count(), 1, "no second prepared entry");
+    }
+
+    #[test]
+    fn re_committing_a_committed_txn_is_a_benign_duplicate_not_an_error() {
+        let mut t = table();
+        t.prepare(b"tx1", 10).unwrap();
+        assert_eq!(t.commit(b"tx1", 20), Ok(ResolveDecision::Resolved));
+        // The headline idempotency rule: a retried commit returns AlreadyResolved, never an error,
+        // and never re-appends.
+        assert_eq!(t.commit(b"tx1", 21), Ok(ResolveDecision::AlreadyResolved));
+        assert_eq!(t.commit(b"tx1", 22), Ok(ResolveDecision::AlreadyResolved));
+    }
+
+    #[test]
+    fn re_rolling_back_a_rolledback_txn_is_a_benign_duplicate() {
+        let mut t = table();
+        t.prepare(b"tx1", 10).unwrap();
+        assert_eq!(t.rollback(b"tx1", 20), Ok(ResolveDecision::Resolved));
+        assert_eq!(t.rollback(b"tx1", 21), Ok(ResolveDecision::AlreadyResolved));
+    }
+
+    #[test]
+    fn commit_after_rollback_is_refused_not_flipped() {
+        let mut t = table();
+        t.prepare(b"tx1", 10).unwrap();
+        t.rollback(b"tx1", 20).unwrap();
+        // The load-bearing safety rule: a commit of a rolled-back txn is REFUSED, the outcome is not
+        // silently flipped.
+        assert_eq!(
+            t.commit(b"tx1", 30),
+            Err(TxnError::AlreadyResolved {
+                outcome: TxnOutcome::RolledBack
+            })
+        );
+        // And the txn stays rolled back.
+        assert_eq!(
+            t.state(b"tx1"),
+            Some(TxnState::Resolved(TxnOutcome::RolledBack))
+        );
+    }
+
+    #[test]
+    fn rollback_after_commit_is_refused_not_flipped() {
+        let mut t = table();
+        t.prepare(b"tx1", 10).unwrap();
+        t.commit(b"tx1", 20).unwrap();
+        assert_eq!(
+            t.rollback(b"tx1", 30),
+            Err(TxnError::AlreadyResolved {
+                outcome: TxnOutcome::Committed
+            })
+        );
+        assert_eq!(
+            t.state(b"tx1"),
+            Some(TxnState::Resolved(TxnOutcome::Committed))
+        );
+    }
+
+    #[test]
+    fn committing_or_rolling_back_an_unknown_txn_is_rejected() {
+        let mut t = table();
+        assert_eq!(t.commit(b"ghost", 10), Err(TxnError::UnknownTxn));
+        assert_eq!(t.rollback(b"ghost", 10), Err(TxnError::UnknownTxn));
+    }
+
+    #[test]
+    fn re_preparing_a_resolved_id_is_refused_as_spent() {
+        let mut t = table();
+        t.prepare(b"tx1", 10).unwrap();
+        t.commit(b"tx1", 20).unwrap();
+        // The id's slot is spent: re-using it for a new half message is refused (no resurrection).
+        assert_eq!(
+            t.prepare(b"tx1", 30),
+            Err(TxnError::TxnIdSpent {
+                outcome: TxnOutcome::Committed
+            })
+        );
+    }
+
+    #[test]
+    fn an_oversized_txn_id_is_rejected_at_the_boundary() {
+        let mut t = table();
+        let too_long = vec![b'x'; MAX_TXN_ID_LEN + 1];
+        assert_eq!(
+            t.prepare(&too_long, 10),
+            Err(TxnError::TxnIdTooLong {
+                len: MAX_TXN_ID_LEN + 1
+            })
+        );
+        assert_eq!(
+            t.commit(&too_long, 10),
+            Err(TxnError::TxnIdTooLong {
+                len: MAX_TXN_ID_LEN + 1
+            })
+        );
+        // Exactly at the cap is accepted.
+        let at_cap = vec![b'x'; MAX_TXN_ID_LEN];
+        assert_eq!(t.prepare(&at_cap, 10), Ok(PrepareDecision::Prepared));
+    }
+
+    #[test]
+    fn distinct_txns_are_independent() {
+        let mut t = table();
+        t.prepare(b"a", 10).unwrap();
+        t.prepare(b"b", 11).unwrap();
+        t.commit(b"a", 20).unwrap();
+        // Resolving a never touches b.
+        assert_eq!(
+            t.state(b"a"),
+            Some(TxnState::Resolved(TxnOutcome::Committed))
+        );
+        assert_eq!(t.state(b"b"), Some(TxnState::Prepared));
+        assert_eq!(t.prepared_count(), 1);
+    }
+
+    #[test]
+    fn unresolved_before_returns_only_old_prepared_txns_in_age_order() {
+        let mut t = table();
+        t.prepare(b"old1", 10).unwrap();
+        t.prepare(b"old2", 20).unwrap();
+        t.prepare(b"new1", 100).unwrap();
+        // Resolve one so it must NOT appear in the unresolved scan.
+        t.commit(b"old2", 25).unwrap();
+        // Everything prepared at or before 50: old1 (10) only (old2 resolved, new1 too new).
+        let stale = t.unresolved_before(50);
+        assert_eq!(stale, vec![(b"old1".to_vec(), 10)]);
+        // At or before 100 picks up new1 too, in age order.
+        let all = t.unresolved_before(100);
+        assert_eq!(all, vec![(b"old1".to_vec(), 10), (b"new1".to_vec(), 100)]);
+        // all_prepared agrees with no cutoff.
+        assert_eq!(t.all_prepared(), all);
+    }
+
+    #[test]
+    fn unresolved_before_handles_the_u64_max_cutoff() {
+        let mut t = table();
+        t.prepare(b"a", u64::MAX).unwrap();
+        // A cutoff of u64::MAX must include a txn prepared at u64::MAX (no overflow).
+        assert_eq!(
+            t.unresolved_before(u64::MAX),
+            vec![(b"a".to_vec(), u64::MAX)]
+        );
+    }
+
+    #[test]
+    fn the_prepared_set_is_hard_capped_and_refuses_rather_than_evicts() {
+        // A live half message is never evicted: a prepare over the cap is refused, so an
+        // undelivered durable payload is never silently dropped.
+        let cap = 4;
+        let mut t = TxnTable::new(TxnConfig {
+            max_prepared: cap,
+            ..TxnConfig::default()
+        });
+        for i in 0..cap as u64 {
+            let id = format!("tx-{i}");
+            assert_eq!(t.prepare(id.as_bytes(), i), Ok(PrepareDecision::Prepared));
+        }
+        assert_eq!(t.prepared_count(), cap);
+        // The next prepare is refused (NOT an eviction of an existing half message).
+        assert_eq!(
+            t.prepare(b"overflow", 100),
+            Err(TxnError::TooManyPrepared { cap })
+        );
+        // Every original half message survives.
+        assert_eq!(t.prepared_count(), cap);
+        // Resolving one frees a slot, so a subsequent prepare fits.
+        t.commit(b"tx-0", 200).unwrap();
+        assert_eq!(t.prepare(b"overflow", 201), Ok(PrepareDecision::Prepared));
+    }
+
+    #[test]
+    fn the_resolved_tombstone_set_is_lru_bounded_under_a_flood() {
+        // The resolved tombstones are bounded: a flood of resolved txns evicts the oldest tombstone,
+        // never growing without bound. (Eviction only loses the in-memory idempotency hint for a
+        // very-late retry; the durable op-log still covers it.)
+        let max = 8;
+        let mut t = TxnTable::new(TxnConfig {
+            max_prepared: 1_000,
+            max_resolved_tombstones: max,
+        });
+        for i in 0..(max as u64 * 10) {
+            let id = format!("tx-{i}");
+            t.prepare(id.as_bytes(), i).unwrap();
+            t.commit(id.as_bytes(), i + 1).unwrap();
+            assert!(
+                t.resolved_tombstone_count() <= max,
+                "tombstone count exceeded the cap"
+            );
+        }
+        assert_eq!(t.resolved_tombstone_count(), max);
+        // The prepared set is empty (all resolved).
+        assert_eq!(t.prepared_count(), 0);
+    }
+
+    #[test]
+    fn an_evicted_tombstone_makes_a_late_retry_read_as_unknown_not_a_false_resolve() {
+        let max = 2;
+        let mut t = TxnTable::new(TxnConfig {
+            max_prepared: 1_000,
+            max_resolved_tombstones: max,
+        });
+        // Resolve the victim first (oldest tombstone).
+        t.prepare(b"victim", 0).unwrap();
+        t.commit(b"victim", 1).unwrap();
+        // Flood newer resolved txns, each more recent, forcing the victim's tombstone out.
+        for i in 0..max as u64 {
+            let id = format!("new-{i}");
+            t.prepare(id.as_bytes(), 10 + i).unwrap();
+            t.commit(id.as_bytes(), 11 + i).unwrap();
+        }
+        assert_eq!(t.resolved_tombstone_count(), max);
+        // The victim's tombstone is gone, so its state is now unknown (a late commit retry reads as
+        // UnknownTxn — a safe at-least-once degrade the durable op-log covers, never a false flip).
+        assert_eq!(t.state(b"victim"), None);
+        assert_eq!(t.commit(b"victim", 100), Err(TxnError::UnknownTxn));
+    }
+
+    #[test]
+    fn restore_rebuilds_prepared_and_resolved_state() {
+        let mut t = table();
+        // Replay a half-log: two prepared txns.
+        t.restore(b"p1", TxnState::Prepared, 10);
+        t.restore(b"p2", TxnState::Prepared, 20);
+        // Replay the op-log: p1 committed (supersedes its prepared restore).
+        t.restore(b"p1", TxnState::Resolved(TxnOutcome::Committed), 30);
+        // p1 is now resolved (left the prepared set), p2 stays prepared.
+        assert_eq!(
+            t.state(b"p1"),
+            Some(TxnState::Resolved(TxnOutcome::Committed))
+        );
+        assert_eq!(t.state(b"p2"), Some(TxnState::Prepared));
+        assert_eq!(t.prepared_count(), 1);
+        // The back-check sees only the still-prepared p2.
+        assert_eq!(t.unresolved_before(u64::MAX), vec![(b"p2".to_vec(), 20)]);
+        // A retried commit of the restored-committed p1 is a benign duplicate (cross-restart idem).
+        assert_eq!(t.commit(b"p1", 40), Ok(ResolveDecision::AlreadyResolved));
+        // p2 can still be freshly resolved.
+        assert_eq!(t.rollback(b"p2", 50), Ok(ResolveDecision::Resolved));
+    }
+
+    #[test]
+    fn restore_then_resolve_a_prepared_txn_is_a_fresh_resolve() {
+        // The crash-after-prepare case: only the half-log replayed (no op-marker), so the txn comes
+        // back Prepared and a later commit is a FRESH resolve (not a duplicate).
+        let mut t = table();
+        t.restore(b"tx1", TxnState::Prepared, 10);
+        assert_eq!(t.state(b"tx1"), Some(TxnState::Prepared));
+        assert_eq!(t.commit(b"tx1", 20), Ok(ResolveDecision::Resolved));
+    }
+
+    #[test]
+    fn the_caps_are_floored_to_one() {
+        let t = TxnTable::new(TxnConfig {
+            max_prepared: 0,
+            max_resolved_tombstones: 0,
+        });
+        assert_eq!(t.config().max_prepared, 1);
+        assert_eq!(t.config().max_resolved_tombstones, 1);
+    }
+
+    #[test]
+    fn heavy_resolve_keeps_the_lru_heap_bounded() {
+        // Many resolves pile up LRU entries; the periodic rebuild keeps the heap from growing without
+        // bound and keeps eviction correct (the count stays capped throughout).
+        let max = 8;
+        let mut t = TxnTable::new(TxnConfig {
+            max_prepared: 1_000,
+            max_resolved_tombstones: max,
+        });
+        for i in 0..2_000u64 {
+            let id = format!("tx-{i}");
+            t.prepare(id.as_bytes(), i * 2).unwrap();
+            t.commit(id.as_bytes(), i * 2 + 1).unwrap();
+            assert!(t.resolved_tombstone_count() <= max);
+        }
+        assert_eq!(t.resolved_tombstone_count(), max);
+    }
+}

--- a/crates/ironbus-proto/src/frame.rs
+++ b/crates/ironbus-proto/src/frame.rs
@@ -415,6 +415,42 @@ pub enum FrameType {
     /// cluster data plane (`crate::cluster::dataplane` / `crate::cluster::serve` in `ironbus-server`) is
     /// its only encoder/decoder.
     CommittedHwQuery,
+    /// Producer → broker TRANSACTIONAL HALF-MESSAGE PREPARE (#640, V2-M8, wire tag 44). The producer
+    /// sends a half (prepared) message: a target stream + the verbatim [`crate::message::PubBody`]
+    /// payload + a producer-supplied transaction id. The broker durably stores the half message in its
+    /// `<data_dir>/txn/` half-log and acks, but the message is INVISIBLE to consumers — it is NOT in
+    /// the real target stream. The producer then runs its local transaction and sends
+    /// [`FrameType::TxnCommit`] (the half message becomes visible) or [`FrameType::TxnRollback`] (it is
+    /// discarded, never delivered). This is the `RocketMQ` transactional-message model adapted to
+    /// IronBus. The SUCCESS reply is a body-less [`FrameType::Ok`] (the half message is durable); a
+    /// malformed body / over-long id / too-many-prepared is an [`FrameType::Err`]. It is a NEW
+    /// append-only tag a non-transactional client never sends; tags 1-43 are byte-for-byte unchanged,
+    /// and a deployment that never sends it has no `txn/` subtree (the hot path is unchanged). Body: a
+    /// [`crate::message::TxnPrepareBody`] (`body_version: u8`, `field_len: u16` over `txn_id` then
+    /// `stream_id` each u16-length-prefixed, then the verbatim `PubBody` bytes as the remainder).
+    TxnPrepare,
+    /// Producer → broker TRANSACTIONAL COMMIT (#640, V2-M8, wire tag 45). Commits the prepared half
+    /// message named by `txn_id`: the broker appends the buffered payload to the REAL target stream
+    /// (the half message becomes visible to consumers) and writes a committed op-marker, then returns
+    /// the committed offset. IDEMPOTENT: a retried commit of an already-committed txn returns the
+    /// original offset and appends nothing (never an error); a commit of an already-ROLLED-BACK txn is
+    /// REFUSED (the outcome is never silently flipped). The SUCCESS reply is a [`FrameType::PubAck`]
+    /// (tag 14) carrying the committed offset (reusing the frozen 8-byte-offset body); an unknown /
+    /// already-rolled-back / malformed txn id is an [`FrameType::Err`]. A NEW append-only tag a
+    /// non-transactional client never sends; tags 1-44 are byte-for-byte unchanged. Body: a
+    /// [`crate::message::TxnResolveBody`] (`body_version: u8`, `field_len: u16` over the `txn_id`
+    /// u16-length name).
+    TxnCommit,
+    /// Producer → broker TRANSACTIONAL ROLLBACK (#640, V2-M8, wire tag 46). Rolls back the prepared
+    /// half message named by `txn_id`: the broker writes a rolled-back op-marker and the buffered
+    /// payload is DISCARDED — it is never appended to the real stream, never delivered to a consumer.
+    /// IDEMPOTENT: a retried rollback of an already-rolled-back txn is a benign success; a rollback of
+    /// an already-COMMITTED txn is REFUSED (never flipped). The SUCCESS reply is a body-less
+    /// [`FrameType::Ok`]; an unknown / already-committed / malformed txn id is an [`FrameType::Err`]. A
+    /// NEW append-only tag a non-transactional client never sends; tags 1-45 are byte-for-byte
+    /// unchanged. Body: a [`crate::message::TxnResolveBody`] (the same shape as `TxnCommit`: a
+    /// `txn_id` u16-length name in a version/length-framed block).
+    TxnRollback,
 }
 
 impl FrameType {
@@ -465,6 +501,9 @@ impl FrameType {
             FrameType::LeafPush => 41,
             FrameType::NotLeader => 42,
             FrameType::CommittedHwQuery => 43,
+            FrameType::TxnPrepare => 44,
+            FrameType::TxnCommit => 45,
+            FrameType::TxnRollback => 46,
         }
     }
 
@@ -516,6 +555,9 @@ impl FrameType {
             41 => FrameType::LeafPush,
             42 => FrameType::NotLeader,
             43 => FrameType::CommittedHwQuery,
+            44 => FrameType::TxnPrepare,
+            45 => FrameType::TxnCommit,
+            46 => FrameType::TxnRollback,
             _ => return None,
         })
     }
@@ -648,7 +690,7 @@ mod tests {
     use super::*;
     use proptest::prelude::*;
 
-    const ALL_TYPES: [FrameType; 43] = [
+    const ALL_TYPES: [FrameType; 46] = [
         FrameType::Connect,
         FrameType::Info,
         FrameType::Ping,
@@ -692,6 +734,9 @@ mod tests {
         FrameType::LeafPush,
         FrameType::NotLeader,
         FrameType::CommittedHwQuery,
+        FrameType::TxnPrepare,
+        FrameType::TxnCommit,
+        FrameType::TxnRollback,
     ];
 
     #[test]
@@ -753,6 +798,9 @@ mod tests {
         assert_eq!(FrameType::LeafPush.as_u8(), 41);
         assert_eq!(FrameType::NotLeader.as_u8(), 42);
         assert_eq!(FrameType::CommittedHwQuery.as_u8(), 43);
+        assert_eq!(FrameType::TxnPrepare.as_u8(), 44);
+        assert_eq!(FrameType::TxnCommit.as_u8(), 45);
+        assert_eq!(FrameType::TxnRollback.as_u8(), 46);
     }
 
     #[test]
@@ -771,8 +819,9 @@ mod tests {
         // cluster SegmentFingerprints divergence-advertisement (#611, V2-C4-I1); 40 is the
         // cross-cluster MirrorPull (#623, V2-C7-I1); 41 is the edge leaf-spoke LeafPush write-through
         // (#625, V2-C7-I3); 42 is the cluster NotLeader produce-redirect (#735); 43 is the follower-read
-        // dirty-tier CommittedHwQuery confirm (#739); 44 is now the next-free (still unknown) tag, so it
-        // frames but is not known.
+        // dirty-tier CommittedHwQuery confirm (#739); 44-46 are the transactional half-message verbs
+        // TxnPrepare/TxnCommit/TxnRollback (#640, V2-M8); 47 is now the next-free (still unknown) tag,
+        // so it frames but is not known.
         assert_eq!(FrameType::from_u8(37), Some(FrameType::AckReplicated));
         assert_eq!(
             FrameType::from_u8(38),
@@ -783,7 +832,10 @@ mod tests {
         assert_eq!(FrameType::from_u8(41), Some(FrameType::LeafPush));
         assert_eq!(FrameType::from_u8(42), Some(FrameType::NotLeader));
         assert_eq!(FrameType::from_u8(43), Some(FrameType::CommittedHwQuery));
-        assert_eq!(FrameType::from_u8(44), None);
+        assert_eq!(FrameType::from_u8(44), Some(FrameType::TxnPrepare));
+        assert_eq!(FrameType::from_u8(45), Some(FrameType::TxnCommit));
+        assert_eq!(FrameType::from_u8(46), Some(FrameType::TxnRollback));
+        assert_eq!(FrameType::from_u8(47), None);
         for ty in [
             FrameType::BindSubject,
             FrameType::PubSubject,
@@ -827,7 +879,8 @@ mod tests {
         // divergence-query (#599); 39 is the cluster SegmentFingerprints divergence-advertisement
         // (#611); 40 is the cross-cluster MirrorPull (#623); 41 is the edge leaf-spoke LeafPush (#625);
         // 42 is the cluster NotLeader produce-redirect (#735); 43 is the follower-read dirty-tier
-        // CommittedHwQuery confirm (#739); 44 is the next-free (still unknown) tag.
+        // CommittedHwQuery confirm (#739); 44-46 are the transactional half-message verbs (#640); 47 is
+        // the next-free (still unknown) tag.
         assert_eq!(FrameType::from_u8(37), Some(FrameType::AckReplicated));
         assert_eq!(
             FrameType::from_u8(38),
@@ -838,7 +891,10 @@ mod tests {
         assert_eq!(FrameType::from_u8(41), Some(FrameType::LeafPush));
         assert_eq!(FrameType::from_u8(42), Some(FrameType::NotLeader));
         assert_eq!(FrameType::from_u8(43), Some(FrameType::CommittedHwQuery));
-        assert_eq!(FrameType::from_u8(44), None);
+        assert_eq!(FrameType::from_u8(44), Some(FrameType::TxnPrepare));
+        assert_eq!(FrameType::from_u8(45), Some(FrameType::TxnCommit));
+        assert_eq!(FrameType::from_u8(46), Some(FrameType::TxnRollback));
+        assert_eq!(FrameType::from_u8(47), None);
         for ty in [
             FrameType::StreamDeclare,
             FrameType::StreamInfo,
@@ -876,6 +932,37 @@ mod tests {
                 assert_eq!(body, b"\x01\x02");
             }
             FrameDecode::Incomplete { .. } => panic!("complete"),
+        }
+    }
+
+    #[test]
+    fn txn_half_message_tags_are_the_next_free_tags_after_committed_hw_query() {
+        // #640 (V2-M8): the transactional half-message verbs TxnPrepare (44), TxnCommit (45), and
+        // TxnRollback (46) take the next FREE tags after the follower-read CommittedHwQuery confirm
+        // (43). Pinned here so a future reorder breaks a test, not a deployed protocol. They are
+        // ADDITIVE: tags 1-43 are byte-for-byte unchanged, and a non-transactional client never sends
+        // them; 47 is the next-free (still unknown) tag.
+        assert_eq!(FrameType::TxnPrepare.as_u8(), 44);
+        assert_eq!(FrameType::TxnCommit.as_u8(), 45);
+        assert_eq!(FrameType::TxnRollback.as_u8(), 46);
+        assert_eq!(FrameType::from_u8(44), Some(FrameType::TxnPrepare));
+        assert_eq!(FrameType::from_u8(45), Some(FrameType::TxnCommit));
+        assert_eq!(FrameType::from_u8(46), Some(FrameType::TxnRollback));
+        assert_eq!(FrameType::from_u8(47), None);
+        for ty in [
+            FrameType::TxnPrepare,
+            FrameType::TxnCommit,
+            FrameType::TxnRollback,
+        ] {
+            let mut buf = Vec::new();
+            encode_frame(ty, b"\x01\x02", &mut buf).unwrap();
+            match decode_frame(&buf).unwrap() {
+                FrameDecode::Frame { type_tag, body, .. } => {
+                    assert_eq!(FrameType::from_u8(type_tag), Some(ty));
+                    assert_eq!(body, b"\x01\x02");
+                }
+                FrameDecode::Incomplete { .. } => panic!("complete"),
+            }
         }
     }
 
@@ -931,7 +1018,10 @@ mod tests {
         assert_eq!(FrameType::from_u8(41), Some(FrameType::LeafPush));
         assert_eq!(FrameType::from_u8(42), Some(FrameType::NotLeader));
         assert_eq!(FrameType::from_u8(43), Some(FrameType::CommittedHwQuery));
-        assert_eq!(FrameType::from_u8(44), None);
+        assert_eq!(FrameType::from_u8(44), Some(FrameType::TxnPrepare));
+        assert_eq!(FrameType::from_u8(45), Some(FrameType::TxnCommit));
+        assert_eq!(FrameType::from_u8(46), Some(FrameType::TxnRollback));
+        assert_eq!(FrameType::from_u8(47), None);
         for ty in [FrameType::StreamFetch, FrameType::StreamCommit] {
             let mut buf = Vec::new();
             encode_frame(ty, b"\x07\x08", &mut buf).unwrap();
@@ -974,7 +1064,10 @@ mod tests {
         assert_eq!(FrameType::from_u8(41), Some(FrameType::LeafPush));
         assert_eq!(FrameType::from_u8(42), Some(FrameType::NotLeader));
         assert_eq!(FrameType::from_u8(43), Some(FrameType::CommittedHwQuery));
-        assert_eq!(FrameType::from_u8(44), None);
+        assert_eq!(FrameType::from_u8(44), Some(FrameType::TxnPrepare));
+        assert_eq!(FrameType::from_u8(45), Some(FrameType::TxnCommit));
+        assert_eq!(FrameType::from_u8(46), Some(FrameType::TxnRollback));
+        assert_eq!(FrameType::from_u8(47), None);
         let mut buf = Vec::new();
         encode_frame(FrameType::DeliverBatch, b"\x09\x0a", &mut buf).unwrap();
         match decode_frame(&buf).unwrap() {
@@ -1169,7 +1262,7 @@ mod tests {
         /// An unknown type tag still decodes at the envelope level (forward compatibility):
         /// the body and length are recovered; only `from_u8` reports it unknown.
         #[test]
-        fn an_unknown_type_tag_still_frames(tag in 44u8..=255, body in prop::collection::vec(any::<u8>(), 0..256)) {
+        fn an_unknown_type_tag_still_frames(tag in 47u8..=255, body in prop::collection::vec(any::<u8>(), 0..256)) {
             let frame_len = 1u32 + u32::try_from(body.len()).unwrap();
             let mut buf = frame_len.to_le_bytes().to_vec();
             buf.push(tag);

--- a/crates/ironbus-proto/src/message.rs
+++ b/crates/ironbus-proto/src/message.rs
@@ -2422,6 +2422,159 @@ pub fn decode_sub_to(body: &[u8]) -> Result<SubToBody<'_>, BodyError> {
 }
 
 // ===================================================================================
+// TRANSACTIONAL HALF-MESSAGE WIRE BODIES (#640, V2-M8): the prepare/commit/rollback verbs for the
+// RocketMQ-style transactional half-message 2PC. Each rides the SAME `body_version: u8` + `field_len:
+// u16` frame as the explicit-stream-id verbs (#588), so a future version appends fields without a wire
+// break. TxnPrepare carries the txn id + target stream + the verbatim `PubBody` tail; TxnCommit and
+// TxnRollback share one `TxnResolveBody` shape (just the txn id). The txn-id field is `u16`-length-
+// prefixed and capped at `MAX_TXN_ID_LEN` BEFORE any read (fail-closed): a malformed/oversized id is a
+// typed `BodyError`, never a panic or over-read.
+// ===================================================================================
+
+/// The hard cap on a transaction-id byte length the proto codecs enforce at the wire boundary (#640):
+/// the engine's `ironbus_core::txn` further bounds it (the same 256), but this cap fails a
+/// hostile/oversized id closed at decode time BEFORE it crosses into the server, so a malformed-id
+/// frame is a typed [`BodyError::BadLength`] rather than a large reservation. Kept in lockstep with
+/// `ironbus_core::txn::MAX_TXN_ID_LEN` (proto is dependency-light and does not import core).
+pub const MAX_TXN_ID_LEN: usize = 256;
+
+/// Reads a `u16`-length-prefixed transaction-id field, enforcing [`MAX_TXN_ID_LEN`] (#640). A declared
+/// length over the cap is a typed [`BodyError::BadLength`] (fail-closed) BEFORE the bytes are taken, so
+/// a hostile id cannot force an over-read; a short body is [`BodyError::Truncated`] via [`Reader::take`].
+/// The returned slice borrows the body (zero-copy).
+fn read_txn_id<'a>(r: &mut Reader<'a>) -> Result<&'a [u8], BodyError> {
+    let len = r.u16()? as usize;
+    if len > MAX_TXN_ID_LEN {
+        return Err(BodyError::BadLength);
+    }
+    r.take(len)
+}
+
+/// A producer's TRANSACTIONAL HALF-MESSAGE PREPARE (the `TxnPrepare` frame body, tag 44, #640): a
+/// producer-supplied `txn_id`, the REAL target `stream_id`, and the verbatim [`PubBody`] bytes (the
+/// half message's payload). The broker durably stores the half message INVISIBLE to consumers and acks;
+/// a later [`TxnResolveBody`] commit/rollback resolves it. The `pub_body` is carried as an opaque
+/// borrowed slice (decoded by the caller with [`decode_pub`]), so the publish body codec is shared
+/// UNCHANGED with `Pub`/`PubTo`.
+///
+/// Layout (version+length framed): `body_version: u8`, `field_len: u16` (over the `txn_id` + `stream_id`
+/// fields), then the v1 block: `txn_id: u16-len + bytes`, `stream_id: u16-len + bytes`; then the verbatim
+/// `PubBody` bytes as the REMAINDER after the block (so a future version may grow the block while the
+/// `PubBody` stays the tail).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TxnPrepareBody<'a> {
+    /// The producer-supplied transaction id (the lifecycle key, capped at [`MAX_TXN_ID_LEN`]).
+    pub txn_id: &'a [u8],
+    /// The REAL target stream the committed payload is appended to (empty = the default stream).
+    pub stream_id: &'a [u8],
+    /// The verbatim [`PubBody`] bytes, decoded by the caller with [`decode_pub`].
+    pub pub_body: &'a [u8],
+}
+
+/// Encodes a `TxnPrepare` body onto the end of `out` (#640): the version byte, the field-block length
+/// over the `txn_id` + `stream_id` fields, those two fields, then the verbatim `pub_body` bytes. The
+/// caller produces `pub_body` with [`encode_pub`].
+///
+/// # Errors
+/// Returns [`BodyError::FieldTooLarge`] if the txn id, stream id, or their framed block exceeds the
+/// `u16` wire limit.
+pub fn encode_txn_prepare(req: &TxnPrepareBody<'_>, out: &mut Vec<u8>) -> Result<(), BodyError> {
+    // The block is the two u16-len-prefixed fields: (2 + txn_id) + (2 + stream_id).
+    let block_len = 2usize
+        .checked_add(req.txn_id.len())
+        .and_then(|n| n.checked_add(2))
+        .and_then(|n| n.checked_add(req.stream_id.len()))
+        .ok_or(BodyError::FieldTooLarge)?;
+    let field_len = u16::try_from(block_len).map_err(|_| BodyError::FieldTooLarge)?;
+    out.push(STREAM_WIRE_BODY_VERSION);
+    out.extend_from_slice(&field_len.to_le_bytes());
+    push_var(out, req.txn_id)?;
+    push_var(out, req.stream_id)?;
+    out.extend_from_slice(req.pub_body);
+    Ok(())
+}
+
+/// Decodes a `TxnPrepare` body (#640) into its `txn_id`, `stream_id`, and the verbatim `pub_body` tail,
+/// cap-before-alloc and panic-free. The caller decodes `pub_body` with [`decode_pub`]. A body too short
+/// for its declared block, a txn id over [`MAX_TXN_ID_LEN`], or a stream id over [`MAX_STREAM_ID_LEN`]
+/// is a typed [`BodyError`] (fail-closed). An EMPTY body is NOT valid ([`BodyError::Truncated`]).
+///
+/// # Errors
+/// [`BodyError::Truncated`] for a short body, [`BodyError::BadLength`] for an over-cap id/stream, or
+/// [`BodyError::BadHandshakeVersion`] for an unknown body version.
+pub fn decode_txn_prepare(body: &[u8]) -> Result<TxnPrepareBody<'_>, BodyError> {
+    let mut r = Reader::new(body);
+    let version = r.u8()?;
+    if version != STREAM_WIRE_BODY_VERSION {
+        return Err(BodyError::BadHandshakeVersion { version });
+    }
+    let field_len = r.u16()? as usize;
+    let block = r.take(field_len)?;
+    // The PubBody is everything AFTER the declared block (a future version may grow the block without
+    // disturbing the PubBody tail).
+    let pub_body = r.rest();
+    let mut fr = Reader::new(block);
+    let txn_id = read_txn_id(&mut fr)?;
+    let stream_id = read_stream_id(&mut fr)?;
+    Ok(TxnPrepareBody {
+        txn_id,
+        stream_id,
+        pub_body,
+    })
+}
+
+/// A producer's TRANSACTIONAL COMMIT or ROLLBACK (the `TxnCommit` tag 45 / `TxnRollback` tag 46 frame
+/// body, #640): it names the `txn_id` to resolve. The two verbs share this one body shape (the
+/// [`FrameType`](crate::frame::FrameType)
+/// disambiguates commit vs rollback), exactly as a request/response pair shares a tag elsewhere. A commit
+/// replies a [`PubAck`](crate::frame::FrameType::PubAck) carrying the committed offset; a rollback replies
+/// a body-less `Ok`.
+///
+/// Layout (version+length framed, forward-compatible): `body_version: u8` ([`STREAM_WIRE_BODY_VERSION`]),
+/// `field_len: u16` (the length of the v1 block), then the v1 block: `txn_id: u16-len + bytes`. Bytes past
+/// `field_len` (a future version's appended fields) are TOLERATED and ignored.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TxnResolveBody<'a> {
+    /// The transaction id to commit or roll back (capped at [`MAX_TXN_ID_LEN`]).
+    pub txn_id: &'a [u8],
+}
+
+/// Encodes a `TxnCommit` / `TxnRollback` body onto the end of `out` (#640): the version byte, the
+/// field-block length over the `txn_id`, then the `txn_id`.
+///
+/// # Errors
+/// Returns [`BodyError::FieldTooLarge`] if the txn id exceeds the `u16` wire limit.
+pub fn encode_txn_resolve(req: &TxnResolveBody<'_>, out: &mut Vec<u8>) -> Result<(), BodyError> {
+    let id_len = u16::try_from(req.txn_id.len()).map_err(|_| BodyError::FieldTooLarge)?;
+    let field_len = u16::try_from(2 + req.txn_id.len()).map_err(|_| BodyError::FieldTooLarge)?;
+    out.push(STREAM_WIRE_BODY_VERSION);
+    out.extend_from_slice(&field_len.to_le_bytes());
+    out.extend_from_slice(&id_len.to_le_bytes());
+    out.extend_from_slice(req.txn_id);
+    Ok(())
+}
+
+/// Decodes a `TxnCommit` / `TxnRollback` body (#640) into its `txn_id`, cap-before-alloc and panic-free.
+/// A body too short for its declared block, or a txn id over [`MAX_TXN_ID_LEN`], is a typed
+/// [`BodyError`] (fail-closed). An EMPTY body is NOT valid ([`BodyError::Truncated`]).
+///
+/// # Errors
+/// [`BodyError::Truncated`] for a short body, [`BodyError::BadLength`] for an over-cap id, or
+/// [`BodyError::BadHandshakeVersion`] for an unknown body version.
+pub fn decode_txn_resolve(body: &[u8]) -> Result<TxnResolveBody<'_>, BodyError> {
+    let mut r = Reader::new(body);
+    let version = r.u8()?;
+    if version != STREAM_WIRE_BODY_VERSION {
+        return Err(BodyError::BadHandshakeVersion { version });
+    }
+    let field_len = r.u16()? as usize;
+    let block = r.take(field_len)?;
+    let mut fr = Reader::new(block);
+    let txn_id = read_txn_id(&mut fr)?;
+    Ok(TxnResolveBody { txn_id })
+}
+
+// ===================================================================================
 // SUBJECT-ADDRESSED WIRE BODIES (#585, V2-M2-I9): the subject->stream binding + subject-addressed
 // pub/sub verbs that complete the SUBJECTS story — BindSubject (tag 34), PubSubject (tag 35), SubSubject
 // (tag 36). Each rides the SAME `body_version: u8` + `field_len: u16` frame as the explicit-stream-id
@@ -4672,6 +4825,110 @@ mod tests {
         let pb = decode_pub(decoded.pub_body).unwrap();
         assert_eq!(pb.payload, b"hello-named-stream");
         assert_eq!(pb.key, b"k");
+    }
+
+    #[test]
+    fn txn_prepare_carries_txn_id_stream_and_the_verbatim_pub_body() {
+        // #640: TxnPrepare prefixes the txn id + target stream, then carries the EXISTING PubBody bytes
+        // verbatim, so the session reuses decode_pub UNCHANGED. Every field round-trips and the pub_body
+        // decodes back through the existing codec.
+        let mut pub_body = Vec::new();
+        encode_pub(
+            &PubBody {
+                flags: 0,
+                timestamp_ms: 9,
+                key: b"k",
+                headers: b"h",
+                dedup: None,
+                fire_and_forget: false,
+                payload: b"half-message",
+            },
+            &mut pub_body,
+        )
+        .unwrap();
+        for (txn, stream) in [
+            (b"tx-1".as_slice(), b"orders".as_slice()),
+            (b"tx-1", b""), // default stream
+        ] {
+            let mut buf = Vec::new();
+            encode_txn_prepare(
+                &TxnPrepareBody {
+                    txn_id: txn,
+                    stream_id: stream,
+                    pub_body: &pub_body,
+                },
+                &mut buf,
+            )
+            .unwrap();
+            assert_eq!(
+                buf[0], STREAM_WIRE_BODY_VERSION,
+                "leads with the body version"
+            );
+            let decoded = decode_txn_prepare(&buf).unwrap();
+            assert_eq!(decoded.txn_id, txn);
+            assert_eq!(decoded.stream_id, stream);
+            assert_eq!(decoded.pub_body, pub_body.as_slice());
+            // The carried pub_body decodes through the UNCHANGED PubBody codec.
+            let pb = decode_pub(decoded.pub_body).unwrap();
+            assert_eq!(pb.payload, b"half-message");
+        }
+    }
+
+    #[test]
+    fn txn_resolve_round_trips_the_txn_id() {
+        // #640: TxnCommit / TxnRollback share the TxnResolveBody shape, carrying just the txn id.
+        for txn in [b"tx-1".as_slice(), b"a-very-distinct-uuid-1234"] {
+            let mut buf = Vec::new();
+            encode_txn_resolve(&TxnResolveBody { txn_id: txn }, &mut buf).unwrap();
+            assert_eq!(buf[0], STREAM_WIRE_BODY_VERSION);
+            assert_eq!(decode_txn_resolve(&buf).unwrap().txn_id, txn);
+        }
+    }
+
+    #[test]
+    fn txn_bodies_reject_malformed_and_oversized_input() {
+        // An empty body is truncated (no version byte).
+        assert_eq!(decode_txn_prepare(&[]), Err(BodyError::Truncated));
+        assert_eq!(decode_txn_resolve(&[]), Err(BodyError::Truncated));
+        // A wrong body version fails closed.
+        let mut buf = Vec::new();
+        encode_txn_resolve(&TxnResolveBody { txn_id: b"t" }, &mut buf).unwrap();
+        buf[0] = STREAM_WIRE_BODY_VERSION + 1;
+        assert!(matches!(
+            decode_txn_resolve(&buf),
+            Err(BodyError::BadHandshakeVersion { .. })
+        ));
+        // An over-cap txn id is rejected by the inner cap check (cap-before-alloc): the declared
+        // inner length is over MAX_TXN_ID_LEN, so read_txn_id fails BadLength before taking the id
+        // bytes. The outer block is fully supplied so the outer take succeeds first.
+        let over = u16::try_from(MAX_TXN_ID_LEN + 1).unwrap();
+        let mut bad = Vec::new();
+        bad.push(STREAM_WIRE_BODY_VERSION);
+        let field_len = 2u16 + over; // inner len field (2) + the declared id bytes
+        bad.extend_from_slice(&field_len.to_le_bytes());
+        bad.extend_from_slice(&over.to_le_bytes()); // declared txn_id len, over the cap
+        bad.extend_from_slice(&vec![0u8; over as usize]); // fill the block so the outer take succeeds
+        assert_eq!(decode_txn_resolve(&bad), Err(BodyError::BadLength));
+    }
+
+    #[test]
+    fn txn_prepare_tolerates_a_future_appended_block_field() {
+        // #640 forward-compat: a future version may append fields INSIDE the declared block; a v1 reader
+        // takes the WHOLE declared block and reads only the v1 fields, leaving the PubBody tail intact.
+        let mut buf = Vec::new();
+        buf.push(STREAM_WIRE_BODY_VERSION);
+        // block = txn_id("t") + stream_id("s") + a future trailing field, all inside field_len.
+        let mut block = Vec::new();
+        push_var(&mut block, b"t").unwrap();
+        push_var(&mut block, b"s").unwrap();
+        block.extend_from_slice(b"\xAA\xBB"); // a future field a v1 reader ignores
+        buf.extend_from_slice(&u16::try_from(block.len()).unwrap().to_le_bytes());
+        buf.extend_from_slice(&block);
+        buf.extend_from_slice(b"PUBBODYTAIL"); // the verbatim pub_body after the block
+        let decoded = decode_txn_prepare(&buf).unwrap();
+        assert_eq!(decoded.txn_id, b"t");
+        assert_eq!(decoded.stream_id, b"s");
+        assert_eq!(decoded.pub_body, b"PUBBODYTAIL");
     }
 
     #[test]

--- a/crates/ironbus-proto/src/message.rs
+++ b/crates/ironbus-proto/src/message.rs
@@ -4932,6 +4932,49 @@ mod tests {
     }
 
     #[test]
+    fn the_txn_prepare_body_is_byte_frozen() {
+        // #640: pin the EXACT bytes a v1 TxnPrepare body produces, so an accidental wire-format drift
+        // breaks a test here, not a deployed producer — the frame-body twin of the TXNH/TXNO on-disk
+        // byte-freeze. The pub_body is carried VERBATIM (an opaque tail), so a fixed literal pins the
+        // framing independently of the PubBody codec. Layout: version, field_len(u16 LE over the
+        // block), txn_id(u16-len + bytes), stream_id(u16-len + bytes), then the verbatim pub_body.
+        let mut buf = Vec::new();
+        encode_txn_prepare(
+            &TxnPrepareBody {
+                txn_id: b"tx",
+                stream_id: b"orders",
+                pub_body: b"OPAQUE-PUB-BODY",
+            },
+            &mut buf,
+        )
+        .unwrap();
+        let mut expected = Vec::new();
+        expected.push(1); // STREAM_WIRE_BODY_VERSION
+        // field_len = (2 + txn_id"tx") + (2 + stream_id"orders") = 4 + 8 = 12.
+        expected.extend_from_slice(&12u16.to_le_bytes());
+        expected.extend_from_slice(&2u16.to_le_bytes()); // txn_id len
+        expected.extend_from_slice(b"tx");
+        expected.extend_from_slice(&6u16.to_le_bytes()); // stream_id len
+        expected.extend_from_slice(b"orders");
+        expected.extend_from_slice(b"OPAQUE-PUB-BODY"); // the verbatim pub_body tail
+        assert_eq!(buf, expected, "the v1 TxnPrepare body wire format is frozen");
+    }
+
+    #[test]
+    fn the_txn_resolve_body_is_byte_frozen() {
+        // #640: pin the EXACT bytes a v1 TxnCommit / TxnRollback body produces (both share the
+        // TxnResolveBody shape). Layout: version, field_len(u16 LE), txn_id(u16-len + bytes).
+        let mut buf = Vec::new();
+        encode_txn_resolve(&TxnResolveBody { txn_id: b"tx" }, &mut buf).unwrap();
+        let mut expected = Vec::new();
+        expected.push(1); // STREAM_WIRE_BODY_VERSION
+        expected.extend_from_slice(&4u16.to_le_bytes()); // field_len = 2 (id-len field) + 2 (id bytes)
+        expected.extend_from_slice(&2u16.to_le_bytes()); // txn_id len
+        expected.extend_from_slice(b"tx");
+        assert_eq!(buf, expected, "the v1 TxnResolve body wire format is frozen");
+    }
+
+    #[test]
     fn sub_to_round_trips_stream_id_and_group() {
         // #588: SubTo carries both a stream id and a work-group name, each round-tripping; empty
         // stream id (default stream) and empty group (default group) both round-trip.

--- a/crates/ironbus-proto/src/message.rs
+++ b/crates/ironbus-proto/src/message.rs
@@ -4950,14 +4950,17 @@ mod tests {
         .unwrap();
         let mut expected = Vec::new();
         expected.push(1); // STREAM_WIRE_BODY_VERSION
-        // field_len = (2 + txn_id"tx") + (2 + stream_id"orders") = 4 + 8 = 12.
+                          // field_len = (2 + txn_id"tx") + (2 + stream_id"orders") = 4 + 8 = 12.
         expected.extend_from_slice(&12u16.to_le_bytes());
         expected.extend_from_slice(&2u16.to_le_bytes()); // txn_id len
         expected.extend_from_slice(b"tx");
         expected.extend_from_slice(&6u16.to_le_bytes()); // stream_id len
         expected.extend_from_slice(b"orders");
         expected.extend_from_slice(b"OPAQUE-PUB-BODY"); // the verbatim pub_body tail
-        assert_eq!(buf, expected, "the v1 TxnPrepare body wire format is frozen");
+        assert_eq!(
+            buf, expected,
+            "the v1 TxnPrepare body wire format is frozen"
+        );
     }
 
     #[test]
@@ -4971,7 +4974,10 @@ mod tests {
         expected.extend_from_slice(&4u16.to_le_bytes()); // field_len = 2 (id-len field) + 2 (id bytes)
         expected.extend_from_slice(&2u16.to_le_bytes()); // txn_id len
         expected.extend_from_slice(b"tx");
-        assert_eq!(buf, expected, "the v1 TxnResolve body wire format is frozen");
+        assert_eq!(
+            buf, expected,
+            "the v1 TxnResolve body wire format is frozen"
+        );
     }
 
     #[test]

--- a/crates/ironbus-server/src/codes.rs
+++ b/crates/ironbus-server/src/codes.rs
@@ -169,6 +169,11 @@ impl ErrorCode {
     /// [`EngineError::Storage`].
     pub const ERR_STORAGE: ErrorCode = ErrorCode("ERR_STORAGE");
 
+    /// A transactional half-message verb was rejected by the lifecycle (#640): an unknown/spent txn
+    /// id, a conflicting resolve (commit-after-rollback / rollback-after-commit, refused not flipped),
+    /// too many prepared, or an over-long id. Maps [`EngineError::Txn`].
+    pub const ERR_TXN: ErrorCode = ErrorCode("ERR_TXN");
+
     /// Maps an [`EngineError`] to its stable code. The single source of truth the conformance
     /// vectors and any wire error-code scheme share. A storage error is split into the two named
     /// outcomes ([`Self::ERR_AT_CAPACITY`] for the byte-cap shed) plus the residual
@@ -193,6 +198,7 @@ impl ErrorCode {
             EngineError::GenerationExhausted => Self::ERR_GENERATION_EXHAUSTED,
             EngineError::MissingRecord { .. } => Self::ERR_MISSING_RECORD,
             EngineError::ZeroMaxInFlight => Self::ERR_ZERO_MAX_IN_FLIGHT,
+            EngineError::Txn(_) => Self::ERR_TXN,
             EngineError::Storage(_) if error.is_at_capacity() => Self::ERR_AT_CAPACITY,
             EngineError::Storage(_) => Self::ERR_STORAGE,
         }

--- a/crates/ironbus-server/src/engine.rs
+++ b/crates/ironbus-server/src/engine.rs
@@ -3880,6 +3880,22 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
     // carry the durable txn dedup — a flagged follow-up — so its commit redrive is at-least-once; the
     // default stream, the common case, is exactly-once.)
     //
+    // DURABILITY-SCOPE CAVEATS (be honest about what the guarantee rests on — see docs/RECOVERY.md
+    // "Transactional messages (2PC)"):
+    //   (a) The default-stream exactly-once / no-committed-empty guarantee is SCOPED to
+    //       `DurabilityLevel::Sync` (the default). It rests on A3 (the real record's covering fsync)
+    //       running BEFORE B (the op-marker, which ALWAYS force-fsyncs). Under a RELAXED level
+    //       (`interval`/`async`/`none`) A3 is a no-fsync `flush_no_sync`, so a power cut can leave the
+    //       lifecycle state Committed (B fsync'd) while the unsynced real record is lost — a
+    //       committed-but-empty txn. This is consistent with the relaxed-level acked-loss waiver (I2 is
+    //       already waived there), but it is a NEW asymmetry: the lifecycle marker is durable while its
+    //       record is not. Use `sync` (the default) for the no-committed-empty guarantee.
+    //   (b) A NAMED (non-default) target stream's commit redrive is at-least-once on a crash (only the
+    //       default stream carries the durable txn-id seq dedup), as noted above.
+    //   (c) The txn-id dedup high-water shares the bounded LRU `producer-seq.ckpt` slot, so a VERY late
+    //       default-stream redrive whose high-water was evicted degrades to at-least-once (safe — never
+    //       loss, never a flip); immediate redrives are unaffected (see `commit_real_append`).
+    //
     // The INVISIBILITY invariant holds throughout: the payload lives in `txn/` (never the real stream)
     // until step A, and a consumer never reads `txn/`; a rolled-back txn's payload is never written to
     // the real stream at all.
@@ -3956,6 +3972,13 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
     /// already-committed txn returns the original offset and appends nothing; a commit of an
     /// already-rolled-back txn is REFUSED. See the module-level crash-safety argument above.
     ///
+    /// DURABILITY SCOPE: the no-committed-empty guarantee (a durable Committed marker always has its
+    /// real record durable too) holds under [`DurabilityLevel::Sync`] (the default), where A3 force-
+    /// fsyncs the record before the op-marker B. Under a RELAXED level A3 is a no-fsync flush while B
+    /// always fsyncs, so a power cut can leave a Committed lifecycle over a lost (unsynced) record — a
+    /// committed-but-empty txn, consistent with that level's acked-loss waiver. See caveat (a) in the
+    /// module-level argument and docs/RECOVERY.md.
+    ///
     /// # Errors
     /// [`EngineError::Txn`] for an unknown id or a commit-after-rollback (refused, never flipped); a
     /// storage error from the real-stream append, the op-marker append, or a durability barrier.
@@ -4022,6 +4045,13 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
     /// out-of-order guard. After the append the durable seq high-water is FLUSHED (the caller's
     /// responsibility, via [`Engine::flush_txn_commit_dedup`]) before the op-marker, so the dedup
     /// identity is durable before the commit point.
+    ///
+    /// DEDUP HIGH-WATER AGING (caveat (c)): the txn-id high-water shares the bounded (LRU, ~4096-entry)
+    /// `producer-seq.ckpt` slot. A VERY late default-stream redrive whose high-water was EVICTED by
+    /// newer producers before the redrive runs degrades to at-least-once (it re-appends a fresh copy) —
+    /// which is SAFE (never loss, never a flipped outcome). An immediate crash-recovery redrive is
+    /// unaffected: the txn pseudo-ids were just written and sort to the front of the LRU, so they are
+    /// still present when recovery replays the Prepared txn.
     fn commit_real_append(
         &mut self,
         txn_id: &[u8],

--- a/crates/ironbus-server/src/engine.rs
+++ b/crates/ironbus-server/src/engine.rs
@@ -16183,6 +16183,92 @@ mod tests {
     }
 
     #[test]
+    fn crash_between_a2_and_a3_clamps_the_phantom_high_water_and_redrives_fresh() {
+        use ironbus_storage::fault::FaultFs;
+        // THE CLAMP BRANCH (the A2<->A3 torn-tail window), the one the durable-seq ordering exists
+        // for: the producer-seq high-water (A2) was fsync'd, but the real-stream record's covering
+        // fsync (A3) was LOST in the torn tail. On recovery `seed_producer_seq_from_recovered` must
+        // CLAMP the over-the-head high-water and DROP it, so the redrive re-appends the record FRESH
+        // exactly once at the real head — no double-append (the first write was lost), no loss.
+        //
+        // We construct the EXACT torn state faithfully (the in-memory FS would otherwise sync both):
+        // run the real commit steps A (write, no fsync) and A2 (fsync the seq checkpoint) so the
+        // high-water is durable, then ARM an fsync fault and run A3 (commit_batch's covering fsync),
+        // which fails and freezes the writer with the record still UNSYNCED — exactly the mid-A2/A3
+        // crash. A power loss then reverts the unsynced record while the fsync'd seq checkpoint
+        // survives, and a clean reopen drives recovery's clamp.
+        let (faultfs, control) = FaultFs::new(InMemoryFs::new());
+        let probe = faultfs.inner().clone();
+        {
+            let mut e = Engine::open(faultfs, ManualClock::new(), config(10, 5)).unwrap();
+            e.txn_prepare(b"tx1", "", &txn_half(b"once")).unwrap();
+            // The buffered half (durably fsync'd at prepare) is what a redrive re-appends. Pull it
+            // exactly as `txn_commit` does, then run the commit ordering by hand so we can inject the
+            // fault precisely BETWEEN A2 and A3.
+            let half = e
+                .txn
+                .as_ref()
+                .and_then(|s| s.prepared_payload(b"tx1").cloned())
+                .expect("the prepared half is buffered");
+            // STEP A: write the real record (no fsync) — assigns offset 0 and records the txn-id seq
+            // high-water in memory.
+            let off = e.commit_real_append(b"tx1", &half).unwrap();
+            assert_eq!(off, Offset::new(0), "the first real append takes offset 0");
+            // STEP A2: fsync the producer-seq checkpoint, making the dedup high-water DURABLE before
+            // the record. This sync must SUCCEED (the fault is not yet armed).
+            e.flush_txn_commit_dedup().unwrap();
+            // STEP A3: the record's covering fsync — ARM the fault so it FAILS, leaving the record
+            // written-but-unsynced and freezing the writer. This is the torn A2<->A3 crash point.
+            control.set_fail_sync(true);
+            assert!(
+                e.commit_batch().is_err(),
+                "A3's covering fsync fails (the torn-tail crash point), freezing the writer"
+            );
+            // The op-marker B was never reached, so the txn is still Prepared on disk.
+            // CRASH (drop the frozen engine).
+        }
+        // POWER LOSS: the unsynced real record reverts (lost), the fsync'd producer-seq.ckpt survives
+        // (so its high-water now points PAST the durable head — the phantom the clamp must drop).
+        probe.simulate_power_loss();
+
+        // RECOVER over the surviving disk with a CLEAN fs (no fault layer), exactly as a real reopen.
+        let mut reopened = Engine::open(probe.clone(), ManualClock::new(), config(10, 5)).unwrap();
+        // The record was lost: the real stream is empty, and the txn replays as Prepared (no op-marker
+        // was ever written), so it is recoverable and still invisible.
+        assert_eq!(
+            reopened.flushed_offset(),
+            Offset::new(0),
+            "the unsynced real record was lost in the torn tail"
+        );
+        assert_eq!(
+            reopened.txn_prepared_count(),
+            1,
+            "the txn replays as Prepared (the op-marker never landed)"
+        );
+        assert!(
+            matches!(reopened.poll(0).unwrap(), Poll::Idle),
+            "still invisible after the crash"
+        );
+        // THE CLAMP'S TEETH: the recovered high-water pointed at offset 0 with a durable head of 0
+        // (0 >= flushed), so `seed_producer_seq_from_recovered` DROPPED it. The redrive (a fresh
+        // commit of the still-Prepared txn) therefore re-appends FRESH at offset 0 — it is NOT deduped
+        // away to a phantom offset (which would have been a silent loss).
+        let redriven = reopened.txn_commit(b"tx1").unwrap();
+        assert_eq!(
+            redriven,
+            Offset::new(0),
+            "the dropped phantom high-water lets the redrive re-append FRESH at the real head"
+        );
+        // EXACTLY ONCE: the record is now durable and visible, exactly one copy — no double, no loss.
+        assert_eq!(
+            reopened.flushed_offset(),
+            Offset::new(1),
+            "exactly one record after the redrive (no double-append, no loss)"
+        );
+        assert_eq!(drain_visible(&mut reopened), vec![b"once".to_vec()]);
+    }
+
+    #[test]
     fn re_prepare_of_a_prepared_id_is_a_benign_duplicate() {
         let mut e = open(config(10, 5));
         e.txn_prepare(b"tx1", "", &txn_half(b"v")).unwrap();

--- a/crates/ironbus-server/src/engine.rs
+++ b/crates/ironbus-server/src/engine.rs
@@ -52,6 +52,7 @@ use ironbus_storage::loss::LossReport;
 use ironbus_storage::naming::MAX_STREAM_NAME_LEN;
 use ironbus_storage::segment::{OwnedRecord, RawByteRun, StorageError};
 use ironbus_storage::streamset::{CommitOutcome, StreamError, StreamId, StreamSet};
+use ironbus_storage::txn::{TxnStore, TxnStoreError};
 use std::collections::BTreeMap;
 
 /// What the engine does with a produce that would exceed the durable-log byte cap
@@ -673,6 +674,12 @@ pub enum EngineError {
         /// How many bound streams matched (always `>= 2`).
         matched: usize,
     },
+    /// A transactional half-message verb (#640, V2-M8) was rejected by the pure lifecycle: an
+    /// unknown / spent txn id, a conflicting resolve (commit-after-rollback or rollback-after-commit,
+    /// which is REFUSED, never flipped), too many concurrently-prepared transactions, or an over-long
+    /// txn id. Carries the typed [`ironbus_core::txn::TxnError`] reason. Fail-closed at the boundary;
+    /// the half message's durable state is never corrupted by a rejected verb.
+    Txn(ironbus_core::txn::TxnError),
 }
 
 impl core::fmt::Display for EngineError {
@@ -741,6 +748,7 @@ impl core::fmt::Display for EngineError {
                 "subject {subject:?} resolves to {matched} bound streams (single-home: a subject must \
                  resolve to exactly one stream; overlap fan-out is opt-in)"
             ),
+            EngineError::Txn(e) => write!(f, "transaction error: {e}"),
         }
     }
 }
@@ -749,6 +757,7 @@ impl std::error::Error for EngineError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             EngineError::Storage(e) => Some(e),
+            EngineError::Txn(e) => Some(e),
             _ => None,
         }
     }
@@ -1597,6 +1606,40 @@ pub struct EngineConfigSnapshot {
 /// persisted in `cursor.ckpt`. Named groups (#9) are independent in-memory cursors.
 const DEFAULT_GROUP: &str = "";
 
+/// The RESERVED internal dedup `producer_id` PREFIX for transactional-commit real-stream appends
+/// (#640, V2-M8). A txn commit appends the buffered payload to the real stream through the DURABLE
+/// effectively-once producer-SEQUENCE dedup keyed on `prefix + txn_id` (seq 0), so a crash-recovery
+/// re-commit re-append is recognized as a benign duplicate at the original offset and the dedup
+/// SURVIVES a restart (the crash-window-(b) guarantee). The leading NUL byte cannot appear in a wire
+/// producer id (graphic bytes only), so a txn's dedup high-water is ISOLATED in its own per-producer
+/// entry and never collides with, evicts, or is evicted by a real producer's window. Each distinct txn
+/// id is its OWN single-sequence producer (seq 0), so txns resolving out of order never trip the
+/// producer-seq out-of-order guard.
+const TXN_DEDUP_PRODUCER_PREFIX: &[u8] = b"\x00ironbus-txn:";
+
+/// Builds the reserved-namespace producer id for a txn-commit real-stream append (#640):
+/// [`TXN_DEDUP_PRODUCER_PREFIX`] followed by the txn id. The txn id is bounded by the wire/lifecycle
+/// `MAX_TXN_ID_LEN` (256), and the prefix is short, so the result stays well within
+/// `ironbus_core::dedup::MAX_PRODUCER_ID_LEN`.
+fn txn_dedup_producer_id(txn_id: &[u8]) -> Vec<u8> {
+    let mut pid = Vec::with_capacity(TXN_DEDUP_PRODUCER_PREFIX.len() + txn_id.len());
+    pid.extend_from_slice(TXN_DEDUP_PRODUCER_PREFIX);
+    pid.extend_from_slice(txn_id);
+    pid
+}
+
+/// Maps a [`TxnStoreError`] (a durable txn-store IO/framing failure) to an [`EngineError`]: a storage
+/// error propagates as [`EngineError::Storage`]; an unframable record (unreachable from the bounded
+/// wire path) surfaces as the structural [`StorageError::SegmentFull`] rather than a panic.
+fn txn_store_error_to_engine(e: TxnStoreError) -> EngineError {
+    match e {
+        TxnStoreError::Storage(s) => EngineError::Storage(s),
+        TxnStoreError::Unframable => {
+            EngineError::Storage(ironbus_storage::segment::StorageError::SegmentFull)
+        }
+    }
+}
+
 /// The build version string for the metric registry's `ironbus_build_info` (#97), the crate
 /// version baked in at compile time.
 fn crate_version() -> &'static str {
@@ -2378,6 +2421,18 @@ pub struct Engine<F: Filesystem, C: Clock> {
     /// log, but with NO total-byte cap (a poison record must never be shed, it is the durable
     /// evidence of a dropped message).
     dlq_config: LogConfig,
+    /// The durable TRANSACTIONAL HALF-MESSAGE store (V2-M8, #640): the `txn/` sub-log that buffers
+    /// prepared (half) messages INVISIBLE to consumers and their commit/rollback op-markers, plus the
+    /// in-memory lifecycle table it rebuilds at open. Opened LAZILY on the first `TxnPrepare` (so a
+    /// broker that never produces a transactional message never creates the subdirectory), or eagerly
+    /// by [`Engine::open`] when the subdirectory already exists, so prepared half messages + their
+    /// resolutions are recovered before the first resolve after a crash. `None` keeps the non-txn hot
+    /// path byte-for-byte unchanged.
+    txn: Option<TxnStore<F, C>>,
+    /// The [`LogConfig`] the txn store's log is opened with: the same segment sizing as the main log,
+    /// with NO total-byte cap (a half message / op-marker must never be shed — a prepared half message
+    /// is an undelivered durable payload, and a resolution is the durable record of the commit/rollback).
+    txn_config: LogConfig,
     /// The per-STREAM default message TTL (V2-M4, #549): a record reached on the poll path whose
     /// EFFECTIVE TTL (the lower of this and the record's own per-message TTL) has passed against the
     /// WALL-clock seam (anchored to the record's durable producer `timestamp_ms`) is EXPIRED — skipped
@@ -2699,6 +2754,31 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
             None
         };
 
+        // The TRANSACTIONAL HALF-MESSAGE store's log (V2-M8, #640) shares the main log's segment
+        // sizing but is NEVER byte-capped: a prepared half message is an undelivered durable payload
+        // and a resolution op-marker is the durable record of the commit/rollback, so neither may be
+        // shed. Eagerly open it (recovering the lifecycle table + buffered payloads) IF its `txn/`
+        // subdirectory already exists from a prior run, so a crash-orphaned prepared half message is
+        // recoverable before the first resolve after a crash. A fresh data directory has no `txn/`
+        // subdir yet, so the store stays unopened (lazy) and the non-transactional path never creates
+        // it — keeping the hot path byte-for-byte unchanged.
+        let txn_config = LogConfig {
+            max_segment_bytes: config.log.max_segment_bytes,
+            max_total_bytes: 0,
+            max_quarantine_bytes: 0,
+            daily_physical_write_budget_bytes: 0,
+        };
+        let txn = if Self::txn_dir_exists(&log) {
+            Some(TxnStore::open(
+                log.filesystem(),
+                log.clock_clone(),
+                txn_config,
+                ironbus_core::txn::TxnConfig::default(),
+            )?)
+        } else {
+            None
+        };
+
         // Build the backpressure controllers (#68, #69) from the config knobs BEFORE the struct
         // literal, since the literal moves the non-Copy `config.delivery` and field expressions are
         // evaluated in source order (a later read of `config` would then be a
@@ -2764,6 +2844,11 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
             last_dead_lettered: None,
             dlq,
             dlq_config,
+            // The transactional half-message store (V2-M8, #640): opened above iff the `txn/` subdir
+            // already exists, else `None` until the first `TxnPrepare` lazily creates it. A
+            // non-transactional broker keeps this `None`, so the produce/consume hot path is unchanged.
+            txn,
+            txn_config,
             // Empty by default: no group is key_shared until an operator configures one (#64), so an
             // unconfigured engine is plain competing everywhere and unchanged.
             key_shared_groups: std::collections::BTreeSet::new(),
@@ -2950,6 +3035,16 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
     /// data directory never materializes the sink subdirectory.
     fn dlq_dir_exists(log: &Log<F, C>, subdir: &str) -> bool {
         log.filesystem().subdir_exists(subdir).unwrap_or(false)
+    }
+
+    /// Whether the transactional half-message store's `txn/` subdirectory already exists, so a prior
+    /// run prepared at least one half message (V2-M8, #640). Used by [`Engine::open`] to decide whether
+    /// to eagerly open the store (recovering the lifecycle table + buffered prepared payloads) versus
+    /// deferring to the lazy open on the first `TxnPrepare`. A non-creating probe
+    /// ([`ironbus_storage::txn::TxnStore::dir_exists`]), so `Engine::open` on a fresh data directory
+    /// never materializes the `txn/` subtree.
+    fn txn_dir_exists(log: &Log<F, C>) -> bool {
+        TxnStore::<F, C>::dir_exists(log.filesystem()).unwrap_or(false)
     }
 
     /// Opens (creating if absent) the default group's durable per-message ATTEMPT-COUNT checkpoint
@@ -3735,6 +3830,317 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         // dirtied here, so this never syncs the root a second time.
         let _outcome: CommitOutcome = self.streams.commit_tick();
         Ok(offset)
+    }
+
+    // ===================================================================================
+    // TRANSACTIONAL HALF-MESSAGE 2PC (#640, V2-M8 part 1/2): prepare / commit / rollback.
+    //
+    // A producer PREPAREs a half message — durably buffered in `txn/`, INVISIBLE to consumers — then
+    // runs its local transaction and COMMITs (the half message is appended to the real target stream
+    // and becomes visible) or ROLLs it BACK (the half message is discarded, never delivered). All
+    // three go through the single-writer engine (the actor's `Command::Run`), so they are serialized
+    // with every produce and never race.
+    //
+    // ## The crash-safety argument (the load-bearing property)
+    //
+    // The commit must move the buffered payload to the real stream AND record the resolution across TWO
+    // separate logs (the real stream + the `txn/` op-log), and a crash anywhere must NEVER
+    // double-append on replay. The ORDERING (in `txn_commit`'s fresh-resolve path) is:
+    //
+    //   commit(txn):
+    //     A.  WRITE the buffered payload to the REAL target stream (NO fsync), DEDUPED by the DURABLE
+    //         producer-SEQUENCE high-water keyed on the txn id (`txn_dedup_producer_id(txn)`, seq 0).
+    //         This assigns `real_offset` and records the txn-id high-water IN MEMORY.
+    //     A2. FLUSH the producer-seq checkpoint (fsync the high-water) — BEFORE the record's own fsync.
+    //     A3. COMMIT-BATCH (fsync the record), making the real append durable.
+    //     B.  append + fsync the COMMITTED op-marker (carrying `real_offset`) to the `txn/` op-log.
+    //
+    // The op-marker (B) is the COMMIT POINT: a txn is committed iff its op-marker is durable. The crash
+    // windows, each proven by a test:
+    //   (a) crash AFTER prepare, BEFORE A: only the half record is durable, so on reopen the txn
+    //       replays as Prepared (unresolved, recoverable). A later commit is a FRESH resolve.
+    //       (storage test `crash_after_prepare_before_op_replays_as_prepared`; engine tests below.)
+    //   (b) crash AFTER A3 (real record durable), BEFORE B: the txn replays as Prepared (no op-marker),
+    //       payload buffered, so recovery re-commits. Its step A re-WRITEs the SAME payload under the
+    //       SAME txn-id seq, which the DURABLE producer-seq high-water (made durable in A2, restored
+    //       from `producer-seq.ckpt` on open) recognizes as a DUPLICATE — original offset, appends
+    //       NOTHING. EXACTLY ONCE (no dup, no loss).
+    //   (c) crash AFTER B: the txn replays as Committed; no replay work, and a retried commit is a
+    //       benign idempotent no-op returning the recorded offset.
+    //
+    // The two-fsync sub-window A2<->A3 is why A2 (the high-water fsync) is ordered BEFORE A3 (the
+    // record fsync), NOT after:
+    //   - crash between A2 and A3 (high-water durable, record NOT): the record is lost in the torn
+    //     tail; on recovery `seed_producer_seq_from_recovered` CLAMPS a high-water whose offset is at
+    //     or past the durable head and DROPS it, so the redrive re-writes FRESH at the real head — no
+    //     double (the first write was lost), no loss (the redrive lands it).
+    //   - crash after A3 (record durable): the high-water was fsync'd first, so it is durable too, and
+    //     the redrive dedups to the original offset.
+    // Either way the real append is exactly-once across a crash. (A NAMED target stream does not yet
+    // carry the durable txn dedup — a flagged follow-up — so its commit redrive is at-least-once; the
+    // default stream, the common case, is exactly-once.)
+    //
+    // The INVISIBILITY invariant holds throughout: the payload lives in `txn/` (never the real stream)
+    // until step A, and a consumer never reads `txn/`; a rolled-back txn's payload is never written to
+    // the real stream at all.
+    // ===================================================================================
+
+    /// Lazily opens the transactional half-message store, creating the `txn/` subtree on the FIRST
+    /// transactional verb (so a non-transactional broker never materializes it). A no-op if already
+    /// open. Returns a mutable borrow of the store for the caller's verb.
+    ///
+    /// # Errors
+    /// Propagates a storage error from creating the subdirectory or opening the txn log.
+    fn ensure_txn_store(&mut self) -> Result<&mut TxnStore<F, C>, EngineError> {
+        if self.txn.is_none() {
+            let store = TxnStore::open(
+                self.log.filesystem(),
+                self.log.clock_clone(),
+                self.txn_config,
+                ironbus_core::txn::TxnConfig::default(),
+            )
+            .map_err(EngineError::Storage)?;
+            self.txn = Some(store);
+        }
+        // Just-ensured to be `Some`.
+        Ok(self.txn.as_mut().expect("txn store ensured"))
+    }
+
+    /// PREPAREs a transactional half message (#640): durably buffers `message` for `txn_id` targeting
+    /// the real `stream`, INVISIBLE to consumers, and acks. The half message survives a restart as
+    /// `Prepared` until a [`Engine::txn_commit`] or [`Engine::txn_rollback`] resolves it. Idempotent: a
+    /// re-prepare of a still-prepared id is a benign no-op (the half message is already durable).
+    ///
+    /// # Errors
+    /// [`EngineError::Txn`] for an unknown/spent id, too-many-prepared, or an over-long txn id; a
+    /// storage error from creating/opening the `txn/` store or the durable half-record append.
+    pub fn txn_prepare(
+        &mut self,
+        txn_id: &[u8],
+        stream: &str,
+        message: &Append<'_>,
+    ) -> Result<(), EngineError> {
+        let now = self.log.now_monotonic();
+        let store = self.ensure_txn_store()?;
+        // Decide FIRST on the pure lifecycle (no IO): a fresh prepare durably buffers; a benign
+        // duplicate re-acks without a second half record; a spent/over-cap id is refused.
+        match store
+            .table_mut()
+            .prepare(txn_id, now)
+            .map_err(EngineError::Txn)?
+        {
+            ironbus_core::txn::PrepareDecision::AlreadyPrepared => Ok(()),
+            ironbus_core::txn::PrepareDecision::Prepared => {
+                // Durably append + fsync the half record. If the durable write fails, ROLL BACK the
+                // in-memory prepared state so the table and the durable log stay consistent (the
+                // prepare did not happen), and surface the error.
+                match store.append_half(txn_id, stream, message) {
+                    Ok(()) => Ok(()),
+                    Err(e) => {
+                        // The half record is NOT durable: undo the in-memory prepare (mark it rolled
+                        // back in memory only — no op record is written, and on reopen there is no half
+                        // record either, so the txn is simply absent). We use the table's rollback to
+                        // clear the prepared entry; the durable log never saw this txn.
+                        let _ = store.table_mut().rollback(txn_id, now);
+                        Err(txn_store_error_to_engine(e))
+                    }
+                }
+            }
+        }
+    }
+
+    /// COMMITs the prepared half message named by `txn_id` (#640): appends the buffered payload to the
+    /// real target stream (DEDUPED by the txn id) and fsyncs it, writes + fsyncs the committed
+    /// op-marker, then advances the lifecycle to Committed. Returns the committed real offset. The half
+    /// message becomes VISIBLE to consumers only here. Idempotent: a retried commit of an
+    /// already-committed txn returns the original offset and appends nothing; a commit of an
+    /// already-rolled-back txn is REFUSED. See the module-level crash-safety argument above.
+    ///
+    /// # Errors
+    /// [`EngineError::Txn`] for an unknown id or a commit-after-rollback (refused, never flipped); a
+    /// storage error from the real-stream append, the op-marker append, or a durability barrier.
+    pub fn txn_commit(&mut self, txn_id: &[u8]) -> Result<Offset, EngineError>
+    where
+        F: Clone,
+    {
+        let now = self.log.now_monotonic();
+        // Decide on the pure lifecycle FIRST (no IO). A fresh resolve must do the real append + marker;
+        // a benign duplicate returns the prior committed offset (recorded in the op-marker, recovered
+        // on replay) WITHOUT re-appending; a conflicting flip is refused.
+        let decision = {
+            let store = self.ensure_txn_store()?;
+            store
+                .table_mut()
+                .commit(txn_id, now)
+                .map_err(EngineError::Txn)?
+        };
+        match decision {
+            ironbus_core::txn::ResolveDecision::AlreadyResolved => {
+                // A retried commit of an already-committed txn (the in-memory table or the replayed
+                // op-marker already says Committed). The payload is already on the real stream and was
+                // dropped from the buffer on the first commit, so we return the recorded real offset
+                // from the DURABLE producer-seq high-water WITHOUT re-appending — exactly idempotent.
+                Ok(self.dedup_offset_for(txn_id))
+            }
+            ironbus_core::txn::ResolveDecision::Resolved => {
+                // The FRESH commit (or the crash-recovery redrive of a Prepared txn). Pull the buffered
+                // half message and run the crash-safe ordering (see the module-level argument):
+                //   STEP A:  WRITE the payload to the real stream (no fsync), DEDUPED by the durable
+                //            txn-id seq — this assigns the offset and records the seq high-water in
+                //            memory. A redrive re-write reads seq 0 as a duplicate at the original offset.
+                //   STEP A2: FLUSH the producer-seq checkpoint (fsync the high-water) BEFORE the record's
+                //            fsync, so the dedup identity is durable no later than the record (and a crash
+                //            that loses the record clamps the over-the-head high-water away on recovery).
+                //   STEP A3: COMMIT-BATCH (fsync the record), making the real append durable.
+                //   STEP B:  append + fsync the COMMITTED op-marker (the commit point), carrying the offset.
+                let half = self
+                    .txn
+                    .as_ref()
+                    .and_then(|s| s.prepared_payload(txn_id).cloned())
+                    .ok_or(EngineError::Txn(ironbus_core::txn::TxnError::UnknownTxn))?;
+                let real_offset = self.commit_real_append(txn_id, &half)?; // STEP A (write, no fsync)
+                self.flush_txn_commit_dedup()?; // STEP A2: dedup identity durable before the record
+                self.commit_batch()?; // STEP A3: the real record is now durable
+                                      // STEP B: the commit point. On its failure the in-memory table already says Committed
+                                      // but no marker is durable; a reopen replays as Prepared and re-commits, deduped by the
+                                      // (now-durable, from A2) txn-id seq — safe. We surface the error.
+                let store = self.ensure_txn_store()?;
+                store
+                    .mark_committed(txn_id, real_offset.get())
+                    .map_err(txn_store_error_to_engine)?;
+                Ok(real_offset)
+            }
+        }
+    }
+
+    /// Appends a committed half message's payload to its real target stream, DEDUPED by the txn id via
+    /// the DURABLE producer-SEQUENCE high-water (#639), so a crash-recovery re-commit re-appending the
+    /// same payload is recognized as a duplicate at the original offset, never a second copy — and the
+    /// dedup SURVIVES a restart (unlike the in-memory `msg_id` window). The txn id is used as the
+    /// `producer_id` (in the reserved [`TXN_DEDUP_PRODUCER_ID`]-prefixed namespace), epoch 0, seq 0:
+    /// every txn is its own single-sequence producer, so resolving txns out of order never trips the
+    /// out-of-order guard. After the append the durable seq high-water is FLUSHED (the caller's
+    /// responsibility, via [`Engine::flush_txn_commit_dedup`]) before the op-marker, so the dedup
+    /// identity is durable before the commit point.
+    fn commit_real_append(
+        &mut self,
+        txn_id: &[u8],
+        half: &ironbus_storage::txn::HalfMessage,
+    ) -> Result<Offset, EngineError>
+    where
+        F: Clone,
+    {
+        // Build the real-stream append from the preserved half message, with HAS_KEY cleared (the
+        // segment codec re-derives it from the key length).
+        let flags = RecordFlags::from_bits(half.flags.bits() & !RecordFlags::HAS_KEY.bits());
+        let append = Append {
+            timestamp_ms: half.timestamp_ms,
+            flags,
+            key: &half.key,
+            headers: &half.headers,
+            payload: &half.payload,
+        };
+        let pid = txn_dedup_producer_id(txn_id);
+        // The default stream routes through the DURABLE producer-sequence dedup (seq 0). A NAMED target
+        // stream does not yet carry per-stream dedup (a flagged follow-up), so its commit append is
+        // at-least-once on a crash-recovery redrive; for the default (and most common) target the
+        // durable seq high-water makes the commit replay exactly-once across a restart.
+        //
+        // The ORDERING here is the crash-safety crux (see the module-level argument). The append is a
+        // WRITE-only (no fsync): it assigns the offset and records the txn-id seq high-water IN MEMORY.
+        // The caller (`txn_commit`) then flushes the seq checkpoint (fsync the high-water) BEFORE
+        // `commit_batch` fsyncs the record, so:
+        //   - crash after the high-water fsync but before the record fsync: the record is lost in the
+        //     torn tail; recovery CLAMPS the recovered high-water (its offset >= the durable head) and
+        //     DROPS it, so the redrive re-appends FRESH (no double, no loss).
+        //   - crash after the record fsync: the high-water is already durable (flushed first), so the
+        //     redrive reads seq 0 as a DUPLICATE at the original offset (no double).
+        // Either way the real append is exactly-once across a crash.
+        if half.stream.is_empty() {
+            let dedup = DedupRequest {
+                producer_id: &pid,
+                epoch: 0,
+                msg_id: txn_id,
+                seq: Some(0),
+            };
+            let outcome = self.append_no_sync_dedup(&append, Some(dedup))?;
+            match outcome {
+                AppendOutcome::Appended(offset) | AppendOutcome::Duplicate(offset) => Ok(offset),
+                // The txn seq dedup never fences or rejects out-of-order (epoch 0, single seq 0), so
+                // these are unreachable; surface a typed error rather than panic if a future change
+                // reaches them.
+                AppendOutcome::Fenced { .. } | AppendOutcome::OutOfOrder { .. } => {
+                    Err(EngineError::Txn(ironbus_core::txn::TxnError::UnknownTxn))
+                }
+            }
+        } else {
+            // A named target stream: produce-in-stream is its own append+commit (no durable txn dedup
+            // yet); at-least-once on a crash-recovery redrive (flagged follow-up).
+            self.produce_in_stream(&half.stream, &append)
+        }
+    }
+
+    /// Durably flushes the producer-sequence high-water so the txn-commit real-append dedup SURVIVES a
+    /// restart (#640). Called by [`Engine::txn_commit`] AFTER the (write-only) real append records the
+    /// txn-id high-water in memory and BEFORE the record's covering fsync, so the dedup identity is
+    /// durable no later than the record itself (and a crash that loses the record also has its
+    /// over-the-head high-water clamped away on recovery). A no-op if no txn (or sequenced producer)
+    /// has ever committed.
+    ///
+    /// # Errors
+    /// Propagates a storage error from creating or writing the producer-seq checkpoint.
+    fn flush_txn_commit_dedup(&mut self) -> Result<(), EngineError> {
+        self.ensure_producer_seq_checkpoint()?;
+        self.checkpoint_producer_seq()
+    }
+
+    /// Looks up the durable offset the producer-sequence high-water holds for a txn id's committed real
+    /// append (the effectively-once identity used by [`Engine::commit_real_append`]). Used to return a
+    /// stable offset on an idempotent re-commit whose buffered payload is already gone. Falls back to
+    /// the log's flushed head if the high-water aged out (a bounded staleness — the txn is committed
+    /// regardless).
+    fn dedup_offset_for(&self, txn_id: &[u8]) -> Offset {
+        let pid = txn_dedup_producer_id(txn_id);
+        match self.producer_seq.high_water(&pid) {
+            // The recorded last-accepted offset for this txn's single seq 0 IS its committed offset.
+            Some((_epoch, Some(_seq), last_offset)) => last_offset,
+            _ => self.log.flushed_offset(),
+        }
+    }
+
+    /// ROLLs BACK the prepared half message named by `txn_id` (#640): writes + fsyncs a rolled-back
+    /// op-marker; the buffered payload is DISCARDED and never appended to the real stream — never
+    /// delivered. Idempotent: a retried rollback of an already-rolled-back txn is a benign success; a
+    /// rollback of an already-committed txn is REFUSED (never flipped).
+    ///
+    /// # Errors
+    /// [`EngineError::Txn`] for an unknown id or a rollback-after-commit (refused, never flipped); a
+    /// storage error from the op-marker append or its durability barrier.
+    pub fn txn_rollback(&mut self, txn_id: &[u8]) -> Result<(), EngineError> {
+        let now = self.log.now_monotonic();
+        let store = self.ensure_txn_store()?;
+        match store
+            .table_mut()
+            .rollback(txn_id, now)
+            .map_err(EngineError::Txn)?
+        {
+            // A retried rollback of an already-rolled-back txn: benign no-op (the op-marker is durable).
+            ironbus_core::txn::ResolveDecision::AlreadyResolved => Ok(()),
+            ironbus_core::txn::ResolveDecision::Resolved => {
+                // The FRESH rollback: durably record the rolled-back op-marker. The buffered payload is
+                // dropped by the store; it never reaches the real stream.
+                store
+                    .mark_rolled_back(txn_id)
+                    .map_err(txn_store_error_to_engine)
+            }
+        }
+    }
+
+    /// The count of currently-`Prepared` (unresolved) half messages (#640), for observability and the
+    /// part-2 back-check. `0` when no txn store is open.
+    #[must_use]
+    pub fn txn_prepared_count(&self) -> usize {
+        self.txn.as_ref().map_or(0, TxnStore::prepared_count)
     }
 
     /// CREATE-OR-ENSURE the named stream `stream` WITHOUT producing to it (#588, M2-I10): the

--- a/crates/ironbus-server/src/engine.rs
+++ b/crates/ironbus-server/src/engine.rs
@@ -15910,4 +15910,282 @@ mod tests {
         let d = message(e2.poll_in_stream("", DEFAULT_GROUP, 0).unwrap());
         assert_eq!(d.record.payload.as_ref(), b"d0");
     }
+
+    // ===================================================================================
+    // TRANSACTIONAL HALF-MESSAGE 2PC (#640, V2-M8 part 1/2): engine-level prepare/commit/rollback,
+    // the INVISIBILITY invariant, the crash windows, and byte-identical-when-unused.
+    // ===================================================================================
+
+    fn txn_half(payload: &[u8]) -> Append<'static> {
+        Append {
+            timestamp_ms: 0,
+            flags: RecordFlags::EMPTY,
+            key: b"",
+            headers: b"",
+            payload: Box::leak(payload.to_vec().into_boxed_slice()),
+        }
+    }
+
+    /// Drains the default group, returning every delivered payload (acking each), so a test can assert
+    /// EXACTLY what a consumer sees.
+    fn drain_visible(e: &mut Engine<InMemoryFs, ManualClock>) -> Vec<Vec<u8>> {
+        let mut seen = Vec::new();
+        loop {
+            match e.poll(0).unwrap() {
+                Poll::Message(d) => {
+                    seen.push(d.record.payload.to_vec());
+                    e.ack(&d.token);
+                }
+                Poll::Idle => break,
+                other => panic!("unexpected poll outcome: {other:?}"),
+            }
+        }
+        seen
+    }
+
+    #[test]
+    fn a_prepared_half_message_is_invisible_until_commit() {
+        // THE INVISIBILITY INVARIANT: a Prepared-but-uncommitted half message is NEVER returned by the
+        // consume path; it appears in the target stream ONLY after commit.
+        let mut e = open(config(10, 5));
+        e.txn_prepare(b"tx1", "", &txn_half(b"half")).unwrap();
+        assert_eq!(e.txn_prepared_count(), 1);
+        // The consumer sees NOTHING (the half message lives in txn/, not the real stream).
+        assert!(
+            matches!(e.poll(0).unwrap(), Poll::Idle),
+            "prepared half is invisible"
+        );
+        assert_eq!(
+            e.flushed_offset(),
+            Offset::new(0),
+            "nothing in the real stream yet"
+        );
+        // Commit: now it appears in the real stream, exactly once.
+        let off = e.txn_commit(b"tx1").unwrap();
+        assert_eq!(off, Offset::new(0));
+        assert_eq!(e.txn_prepared_count(), 0);
+        assert_eq!(drain_visible(&mut e), vec![b"half".to_vec()]);
+    }
+
+    #[test]
+    fn a_rolled_back_half_message_is_never_delivered() {
+        // After rollback the half message NEVER appears in the real stream.
+        let mut e = open(config(10, 5));
+        e.txn_prepare(b"tx1", "", &txn_half(b"secret")).unwrap();
+        e.txn_rollback(b"tx1").unwrap();
+        assert_eq!(e.txn_prepared_count(), 0);
+        assert!(
+            matches!(e.poll(0).unwrap(), Poll::Idle),
+            "rolled-back half is never delivered"
+        );
+        assert_eq!(
+            e.flushed_offset(),
+            Offset::new(0),
+            "nothing was ever appended to the real stream"
+        );
+        assert!(drain_visible(&mut e).is_empty());
+    }
+
+    #[test]
+    fn commit_interleaves_with_normal_produces_visibly_only_after_commit() {
+        // A normal produce is immediately visible; a prepared half is not, until committed — and the
+        // committed record lands at its own offset after the earlier normal produces.
+        let mut e = open(config(10, 5));
+        assert_eq!(produce(&mut e, b"n0"), Offset::new(0));
+        e.txn_prepare(b"tx1", "", &txn_half(b"txn")).unwrap();
+        assert_eq!(produce(&mut e, b"n1"), Offset::new(1));
+        // So far only the two normal produces are visible.
+        // (Peek without acking is awkward; instead assert the txn commit lands at offset 2.)
+        let off = e.txn_commit(b"tx1").unwrap();
+        assert_eq!(
+            off,
+            Offset::new(2),
+            "the committed record lands after the normal produces"
+        );
+        assert_eq!(
+            drain_visible(&mut e),
+            vec![b"n0".to_vec(), b"n1".to_vec(), b"txn".to_vec()]
+        );
+    }
+
+    #[test]
+    fn recommit_is_idempotent_returning_the_same_offset() {
+        // A retried commit of an already-committed txn returns the SAME offset and appends nothing.
+        let mut e = open(config(10, 5));
+        e.txn_prepare(b"tx1", "", &txn_half(b"v")).unwrap();
+        let off1 = e.txn_commit(b"tx1").unwrap();
+        let off2 = e.txn_commit(b"tx1").unwrap();
+        let off3 = e.txn_commit(b"tx1").unwrap();
+        assert_eq!(off1, off2);
+        assert_eq!(off2, off3);
+        // Exactly one record is visible (no double-append from the re-commits).
+        assert_eq!(drain_visible(&mut e), vec![b"v".to_vec()]);
+    }
+
+    #[test]
+    fn commit_after_rollback_and_rollback_after_commit_are_refused() {
+        let mut e = open(config(10, 5));
+        // commit-after-rollback is refused, never flipped.
+        e.txn_prepare(b"a", "", &txn_half(b"a")).unwrap();
+        e.txn_rollback(b"a").unwrap();
+        assert!(matches!(e.txn_commit(b"a"), Err(EngineError::Txn(_))));
+        // rollback-after-commit is refused too.
+        e.txn_prepare(b"b", "", &txn_half(b"b")).unwrap();
+        e.txn_commit(b"b").unwrap();
+        assert!(matches!(e.txn_rollback(b"b"), Err(EngineError::Txn(_))));
+        // Only b's committed record is visible (a was rolled back).
+        assert_eq!(drain_visible(&mut e), vec![b"b".to_vec()]);
+    }
+
+    #[test]
+    fn an_unknown_commit_or_rollback_is_rejected() {
+        let mut e = open(config(10, 5));
+        // Open the txn store first (so a real store exists), then resolve a ghost.
+        e.txn_prepare(b"real", "", &txn_half(b"r")).unwrap();
+        assert!(matches!(e.txn_commit(b"ghost"), Err(EngineError::Txn(_))));
+        assert!(matches!(e.txn_rollback(b"ghost"), Err(EngineError::Txn(_))));
+    }
+
+    #[test]
+    fn crash_after_prepare_reopens_as_prepared_and_recoverable() {
+        // CRASH WINDOW (a): only the half record is durable. On reopen the txn is Prepared
+        // (recoverable, unresolved) and STILL invisible to consumers; a later commit is a fresh resolve.
+        let fs = InMemoryFs::new();
+        {
+            let mut e = Engine::open(fs.clone(), ManualClock::new(), config(10, 5)).unwrap();
+            e.txn_prepare(b"tx1", "", &txn_half(b"half")).unwrap();
+            // CRASH: no commit/rollback.
+        }
+        let mut reopened = Engine::open(fs.clone(), ManualClock::new(), config(10, 5)).unwrap();
+        assert_eq!(
+            reopened.txn_prepared_count(),
+            1,
+            "the prepared half survived the restart"
+        );
+        assert!(
+            matches!(reopened.poll(0).unwrap(), Poll::Idle),
+            "still invisible after restart"
+        );
+        assert_eq!(
+            reopened.flushed_offset(),
+            Offset::new(0),
+            "not in the real stream"
+        );
+        // A fresh commit after restart delivers it exactly once.
+        let off = reopened.txn_commit(b"tx1").unwrap();
+        assert_eq!(off, Offset::new(0));
+        assert_eq!(drain_visible(&mut reopened), vec![b"half".to_vec()]);
+    }
+
+    #[test]
+    fn a_committed_txn_reopens_as_resolved_and_recommit_is_idempotent() {
+        // CRASH WINDOW (c): the op-marker is durable, so on reopen the txn is Committed; the real
+        // record is present exactly once, and a retried commit after restart is a benign idempotent
+        // no-op (NO double-append).
+        let fs = InMemoryFs::new();
+        {
+            let mut e = Engine::open(fs.clone(), ManualClock::new(), config(10, 5)).unwrap();
+            e.txn_prepare(b"tx1", "", &txn_half(b"committed")).unwrap();
+            e.txn_commit(b"tx1").unwrap();
+            // CLEAN shutdown after the durable commit.
+        }
+        let mut reopened = Engine::open(fs.clone(), ManualClock::new(), config(10, 5)).unwrap();
+        assert_eq!(reopened.txn_prepared_count(), 0, "resolved, not prepared");
+        // The committed record is present exactly once.
+        assert_eq!(reopened.flushed_offset(), Offset::new(1));
+        // A retried commit after restart is idempotent (no second append).
+        let off = reopened.txn_commit(b"tx1").unwrap();
+        assert_eq!(
+            off,
+            Offset::new(0),
+            "the recorded committed offset, not a new append"
+        );
+        assert_eq!(
+            reopened.flushed_offset(),
+            Offset::new(1),
+            "still exactly one record"
+        );
+        assert_eq!(drain_visible(&mut reopened), vec![b"committed".to_vec()]);
+    }
+
+    #[test]
+    fn recommit_after_a_crash_before_the_op_marker_is_deduped_no_double_append() {
+        // CRASH WINDOW (b), THE HARD ONE: a crash AFTER the real record is durable but BEFORE the
+        // op-marker. We SIMULATE it by reopening after a commit that durably appended + flushed the
+        // seq high-water but whose op-marker we delete from the txn store — the txn replays as
+        // Prepared, and the redrive re-commit must dedup the real append to the ORIGINAL offset (no
+        // double). We approximate the window by: commit normally (real record + seq high-water + marker
+        // all durable), reopen, then re-commit — the durable producer-seq high-water dedups the
+        // re-append to the original offset. This proves the dedup identity SURVIVES a restart, which is
+        // exactly what makes window (b)'s redrive idempotent.
+        let fs = InMemoryFs::new();
+        let committed_off;
+        {
+            let mut e = Engine::open(fs.clone(), ManualClock::new(), config(10, 5)).unwrap();
+            e.txn_prepare(b"tx1", "", &txn_half(b"once")).unwrap();
+            committed_off = e.txn_commit(b"tx1").unwrap();
+        }
+        // Reopen: the producer-seq high-water for the txn id is restored from producer-seq.ckpt.
+        let mut reopened = Engine::open(fs.clone(), ManualClock::new(), config(10, 5)).unwrap();
+        // Re-driving the SAME real append (the window-(b) recovery action) under the same txn-id seq is
+        // a DUPLICATE at the original offset — never a second record.
+        let half = ironbus_storage::txn::HalfMessage {
+            txn_id: b"tx1".to_vec(),
+            stream: String::new(),
+            timestamp_ms: 0,
+            key: Vec::new(),
+            headers: Vec::new(),
+            payload: b"once".to_vec(),
+            flags: RecordFlags::EMPTY,
+        };
+        let redriven = reopened.commit_real_append(b"tx1", &half).unwrap();
+        assert_eq!(
+            redriven, committed_off,
+            "the durable txn-id seq dedups the crash-recovery re-append to the original offset"
+        );
+        // Still exactly one record in the real stream (the re-append was a no-op duplicate).
+        reopened.commit_batch().unwrap();
+        assert_eq!(
+            reopened.flushed_offset(),
+            Offset::new(1),
+            "no double-append across the restart"
+        );
+    }
+
+    #[test]
+    fn re_prepare_of_a_prepared_id_is_a_benign_duplicate() {
+        let mut e = open(config(10, 5));
+        e.txn_prepare(b"tx1", "", &txn_half(b"v")).unwrap();
+        // A retried prepare is a benign no-op: no second half record buffered.
+        e.txn_prepare(b"tx1", "", &txn_half(b"v")).unwrap();
+        assert_eq!(e.txn_prepared_count(), 1);
+        // Commit still delivers exactly one record.
+        e.txn_commit(b"tx1").unwrap();
+        assert_eq!(drain_visible(&mut e), vec![b"v".to_vec()]);
+    }
+
+    #[test]
+    fn the_txn_subdir_is_absent_until_the_first_prepare() {
+        // BYTE-IDENTICAL-WHEN-UNUSED: a broker that never produces a transactional message never
+        // materializes the txn/ subtree, so the data dir is byte-for-byte the non-txn broker.
+        let fs = InMemoryFs::new();
+        let mut e = Engine::open(fs.clone(), ManualClock::new(), config(10, 5)).unwrap();
+        assert!(
+            !ironbus_storage::txn::TxnStore::<InMemoryFs, ManualClock>::dir_exists(&fs).unwrap(),
+            "no txn/ subdir before any prepare"
+        );
+        // Normal produce/consume is entirely unaffected and never creates txn/.
+        produce(&mut e, b"normal");
+        assert_eq!(drain_visible(&mut e), vec![b"normal".to_vec()]);
+        assert!(
+            !ironbus_storage::txn::TxnStore::<InMemoryFs, ManualClock>::dir_exists(&fs).unwrap(),
+            "normal produce/consume never materializes txn/"
+        );
+        // Only the first prepare creates it.
+        e.txn_prepare(b"tx1", "", &txn_half(b"v")).unwrap();
+        assert!(
+            ironbus_storage::txn::TxnStore::<InMemoryFs, ManualClock>::dir_exists(&fs).unwrap(),
+            "the first prepare materializes txn/"
+        );
+    }
 }

--- a/crates/ironbus-server/src/session.rs
+++ b/crates/ironbus-server/src/session.rs
@@ -40,12 +40,13 @@ use ironbus_proto::message::{
     decode_ack, decode_bind_subject, decode_connect, decode_cumulative_ack, decode_fetch,
     decode_pub, decode_pub_subject, decode_pub_to, decode_stream_commit, decode_stream_declare,
     decode_stream_fetch, decode_stream_info, decode_sub, decode_sub_subject, decode_sub_to,
-    encode_dead_letter, encode_deliver, encode_deliver_batch, encode_gap_marker, encode_info,
-    encode_not_leader, encode_produce_confirm, encode_pub_ack, encode_stream_info_response,
-    encode_truncated, gap_reason, parse_connect_auth, produce_confirm_status, pub_ack_level,
-    AckLevel, AckOp, ConsumeTier, CreditAdvert, DeadLetterBody, DeliverBatchHeader, DeliverBody,
-    GapMarkerBody, InfoBody, NotLeaderBody, ProduceConfirmBody, PubAckBody, StreamInfoResponseBody,
-    TruncatedBody, DEAD_LETTER_MAX_DELIVER, PUB_WIRE_ONLY_FLAGS,
+    decode_txn_prepare, decode_txn_resolve, encode_dead_letter, encode_deliver,
+    encode_deliver_batch, encode_gap_marker, encode_info, encode_not_leader,
+    encode_produce_confirm, encode_pub_ack, encode_stream_info_response, encode_truncated,
+    gap_reason, parse_connect_auth, produce_confirm_status, pub_ack_level, AckLevel, AckOp,
+    ConsumeTier, CreditAdvert, DeadLetterBody, DeliverBatchHeader, DeliverBody, GapMarkerBody,
+    InfoBody, NotLeaderBody, ProduceConfirmBody, PubAckBody, StreamInfoResponseBody, TruncatedBody,
+    DEAD_LETTER_MAX_DELIVER, PUB_WIRE_ONLY_FLAGS,
 };
 use ironbus_storage::fs::Filesystem;
 use ironbus_storage::log::Append;
@@ -809,6 +810,23 @@ impl Session {
             Some(FrameType::SubSubject) => {
                 self.require_scope(crate::auth::Scope::Subscribe, "SubSubject", out)?;
                 self.handle_sub_subject(engine, body, out).map(|()| false)
+            }
+            // The TRANSACTIONAL half-message verbs (#640, V2-M8): a producer-side 2PC. Prepare/commit/
+            // rollback all PRODUCE (or resolve a produce), so they require the `publish` scope, exactly
+            // like Pub/PubTo. None advances a COMMITTED CONSUMER cursor (a commit appends to the real
+            // stream, which is a produce, not a consumer-cursor commit), so each returns `false` (no
+            // interval checkpoint). They route through the single-writer engine via `engine.with`.
+            Some(FrameType::TxnPrepare) => {
+                self.require_scope(crate::auth::Scope::Publish, "TxnPrepare", out)?;
+                self.handle_txn_prepare(engine, body, out).map(|()| false)
+            }
+            Some(FrameType::TxnCommit) => {
+                self.require_scope(crate::auth::Scope::Publish, "TxnCommit", out)?;
+                self.handle_txn_commit(engine, body, out).map(|()| false)
+            }
+            Some(FrameType::TxnRollback) => {
+                self.require_scope(crate::auth::Scope::Publish, "TxnRollback", out)?;
+                self.handle_txn_rollback(engine, body, out).map(|()| false)
             }
             Some(FrameType::Unsub) => {
                 self.require_scope(crate::auth::Scope::Subscribe, "Unsub", out)?;
@@ -3013,6 +3031,177 @@ impl Session {
         }
     }
 
+    /// Handles a `TxnPrepare` (#640, V2-M8): durably buffer a transactional HALF (prepared) message
+    /// targeting a real stream, INVISIBLE to consumers, and ack. The half message survives a restart
+    /// as `Prepared` until a `TxnCommit`/`TxnRollback` resolves it. The body carries the txn id + the
+    /// target stream + the verbatim `PubBody` payload. Replies a body-less `Ok` on a durable prepare,
+    /// or `Err` on a malformed body / over-long id / too-many-prepared. Routes through the single-writer
+    /// engine via `engine.with`; never panics, fail-closed at the boundary.
+    fn handle_txn_prepare<
+        F: Filesystem + Clone + 'static,
+        C: Clock + Clone + 'static,
+        E: EngineAccess<F, C>,
+    >(
+        &mut self,
+        engine: &E,
+        body: &[u8],
+        out: &mut Vec<u8>,
+    ) -> Result<(), SessionError> {
+        if !self.connected {
+            reply_err(out, "not connected");
+            return Ok(());
+        }
+        let Ok(decoded) = decode_txn_prepare(body) else {
+            reply_err(out, "malformed txn-prepare body");
+            return Ok(());
+        };
+        // The txn-id wire cap is enforced by the decoder (cap-before-alloc); an empty id is refused
+        // here (a half message needs a stable identity to commit/rollback against).
+        if decoded.txn_id.is_empty() {
+            reply_err(out, "txn_id must not be empty");
+            return Ok(());
+        }
+        let Ok(stream) = core::str::from_utf8(decoded.stream_id) else {
+            reply_err(out, "stream id must be valid UTF-8");
+            return Ok(());
+        };
+        let Ok(msg) = decode_pub(decoded.pub_body) else {
+            reply_err(out, "malformed pub body");
+            return Ok(());
+        };
+        // Build the OWNED half message (the wire body borrows the connection buffer, which the closure
+        // cannot hold). The wire-only PUB flags (dedup/fire-and-forget bits) are masked off so only the
+        // real stored content flags reach the durable half record.
+        let txn_id = Bytes::copy_from_slice(decoded.txn_id);
+        let stream = stream.to_string();
+        let timestamp_ms = msg.timestamp_ms;
+        let flags = msg.flags & !PUB_WIRE_ONLY_FLAGS;
+        let key = Bytes::copy_from_slice(msg.key);
+        let headers = Bytes::copy_from_slice(msg.headers);
+        let payload = Bytes::copy_from_slice(msg.payload);
+        let outcome = engine.with(move |e| {
+            let view = Append {
+                timestamp_ms,
+                flags: RecordFlags::from_bits(flags),
+                key: &key,
+                headers: &headers,
+                payload: &payload,
+            };
+            e.txn_prepare(&txn_id, &stream, &view)
+        })?;
+        match outcome {
+            Ok(()) => {
+                reply(out, FrameType::Ok, &[]);
+                Ok(())
+            }
+            Err(e) if e.is_fatal() => {
+                reply_err(out, "fatal storage error");
+                Err(SessionError::EngineFatal(e))
+            }
+            Err(e) => {
+                reply_err(out, &e.to_string());
+                Ok(())
+            }
+        }
+    }
+
+    /// Handles a `TxnCommit` (#640, V2-M8): commit the prepared half message named by `txn_id`. The
+    /// broker appends the buffered payload to the real target stream (it becomes VISIBLE) and writes
+    /// the committed op-marker, then replies a `PubAck` carrying the committed offset. Idempotent: a
+    /// retried commit returns the original offset; a commit of an already-rolled-back txn is an `Err`.
+    /// Routes through the single-writer engine; fail-closed at the boundary, never panics.
+    fn handle_txn_commit<
+        F: Filesystem + Clone + 'static,
+        C: Clock + Clone + 'static,
+        E: EngineAccess<F, C>,
+    >(
+        &mut self,
+        engine: &E,
+        body: &[u8],
+        out: &mut Vec<u8>,
+    ) -> Result<(), SessionError> {
+        if !self.connected {
+            reply_err(out, "not connected");
+            return Ok(());
+        }
+        let Ok(decoded) = decode_txn_resolve(body) else {
+            reply_err(out, "malformed txn-commit body");
+            return Ok(());
+        };
+        if decoded.txn_id.is_empty() {
+            reply_err(out, "txn_id must not be empty");
+            return Ok(());
+        }
+        let txn_id = Bytes::copy_from_slice(decoded.txn_id);
+        let outcome = engine.with(move |e| e.txn_commit(&txn_id))?;
+        match outcome {
+            Ok(offset) => {
+                let mut ack_body = Vec::new();
+                encode_pub_ack(
+                    &PubAckBody {
+                        offset: offset.get(),
+                    },
+                    &mut ack_body,
+                );
+                reply(out, FrameType::PubAck, &ack_body);
+                Ok(())
+            }
+            Err(e) if e.is_fatal() => {
+                reply_err(out, "fatal storage error");
+                Err(SessionError::EngineFatal(e))
+            }
+            Err(e) => {
+                reply_err(out, &e.to_string());
+                Ok(())
+            }
+        }
+    }
+
+    /// Handles a `TxnRollback` (#640, V2-M8): roll back the prepared half message named by `txn_id`.
+    /// The broker writes a rolled-back op-marker; the buffered payload is DISCARDED and never appended
+    /// to the real stream (never delivered). Replies a body-less `Ok`. Idempotent: a retried rollback
+    /// is a benign success; a rollback of an already-committed txn is an `Err`. Routes through the
+    /// single-writer engine; fail-closed at the boundary, never panics.
+    fn handle_txn_rollback<
+        F: Filesystem + Clone + 'static,
+        C: Clock + Clone + 'static,
+        E: EngineAccess<F, C>,
+    >(
+        &mut self,
+        engine: &E,
+        body: &[u8],
+        out: &mut Vec<u8>,
+    ) -> Result<(), SessionError> {
+        if !self.connected {
+            reply_err(out, "not connected");
+            return Ok(());
+        }
+        let Ok(decoded) = decode_txn_resolve(body) else {
+            reply_err(out, "malformed txn-rollback body");
+            return Ok(());
+        };
+        if decoded.txn_id.is_empty() {
+            reply_err(out, "txn_id must not be empty");
+            return Ok(());
+        }
+        let txn_id = Bytes::copy_from_slice(decoded.txn_id);
+        let outcome = engine.with(move |e| e.txn_rollback(&txn_id))?;
+        match outcome {
+            Ok(()) => {
+                reply(out, FrameType::Ok, &[]);
+                Ok(())
+            }
+            Err(e) if e.is_fatal() => {
+                reply_err(out, "fatal storage error");
+                Err(SessionError::EngineFatal(e))
+            }
+            Err(e) => {
+                reply_err(out, &e.to_string());
+                Ok(())
+            }
+        }
+    }
+
     /// Handles a `SubTo` (#588, M2-I10): subscribe to a NAMED stream's per-stream work-group. Binds
     /// BOTH `self.stream` (the named stream) and `self.subscription` (the work-group within it), so
     /// this connection's subsequent `Flow`/`Ack` route to that stream's OWN competing work-group via
@@ -3941,7 +4130,8 @@ mod tests {
     use ironbus_core::lease::LeaseConfig;
     use ironbus_core::types::RecordFlags;
     use ironbus_proto::message::{
-        decode_deliver, decode_pub_ack, encode_ack, encode_pub, AckBody, PubBody, PubDedup,
+        decode_deliver, decode_pub_ack, encode_ack, encode_pub, encode_txn_prepare,
+        encode_txn_resolve, AckBody, PubBody, PubDedup, TxnPrepareBody, TxnResolveBody,
         PUB_FLAG_ACK_LEVEL_SHIFT, PUB_FLAG_FIRE_AND_FORGET,
     };
     use ironbus_storage::fs::InMemoryFs;
@@ -10660,5 +10850,172 @@ mod tests {
             .unwrap();
         assert_eq!(one_response(&out).0, FrameType::Info);
         assert!(s.authenticated && s.audit.is_none());
+    }
+
+    // ---- transactional half-message 2PC over the wire (#640, V2-M8) ----
+
+    /// Builds a `TxnPrepare` frame for `txn_id` targeting the default stream with `payload`.
+    fn txn_prepare_frame(txn_id: &[u8], payload: &[u8]) -> Vec<u8> {
+        let mut pub_body = Vec::new();
+        encode_pub(
+            &PubBody {
+                flags: 0,
+                timestamp_ms: 0,
+                key: b"",
+                headers: b"",
+                dedup: None,
+                fire_and_forget: false,
+                payload,
+            },
+            &mut pub_body,
+        )
+        .unwrap();
+        let mut body = Vec::new();
+        encode_txn_prepare(
+            &TxnPrepareBody {
+                txn_id,
+                stream_id: b"",
+                pub_body: &pub_body,
+            },
+            &mut body,
+        )
+        .unwrap();
+        frame(FrameType::TxnPrepare, &body)
+    }
+
+    fn txn_resolve_frame(ty: FrameType, txn_id: &[u8]) -> Vec<u8> {
+        let mut body = Vec::new();
+        encode_txn_resolve(&TxnResolveBody { txn_id }, &mut body).unwrap();
+        frame(ty, &body)
+    }
+
+    #[test]
+    fn txn_prepare_is_invisible_then_commit_delivers_over_the_wire() {
+        // The end-to-end INVISIBILITY invariant over the real consume path: a prepared half message is
+        // NEVER delivered by Flow/Deliver; it appears ONLY after commit.
+        let e = DirectEngine::new(engine());
+        // Producer connection prepares + commits.
+        let mut prod = Session::with_member_id(MemberId::new(1));
+        let mut out = Vec::new();
+        prod.process(&e, &frame(FrameType::Connect, b""), &mut out)
+            .unwrap();
+        out.clear();
+        prod.process(&e, &txn_prepare_frame(b"tx1", b"half"), &mut out)
+            .unwrap();
+        assert_eq!(one_response(&out).0, FrameType::Ok, "prepare is acked Ok");
+
+        // A consumer Flow sees NOTHING (the half message is invisible).
+        let mut cons = connect_and_sub(&e, MemberId::new(2), b"");
+        out.clear();
+        cons.process(&e, &frame(FrameType::Flow, &10u32.to_le_bytes()), &mut out)
+            .unwrap();
+        assert!(
+            delivered_payloads(&out).is_empty(),
+            "a prepared-but-uncommitted half message is never delivered"
+        );
+
+        // Commit: the producer gets a PubAck with the committed offset.
+        out.clear();
+        prod.process(
+            &e,
+            &txn_resolve_frame(FrameType::TxnCommit, b"tx1"),
+            &mut out,
+        )
+        .unwrap();
+        let (ty, ack) = one_response(&out);
+        assert_eq!(ty, FrameType::PubAck, "commit replies a PubAck");
+        assert_eq!(decode_pub_ack(&ack).unwrap().offset, 0);
+
+        // Now the consumer Flow delivers the committed record exactly once.
+        out.clear();
+        cons.process(&e, &frame(FrameType::Flow, &10u32.to_le_bytes()), &mut out)
+            .unwrap();
+        assert_eq!(
+            delivered_payloads(&out),
+            vec![b"half".to_vec()],
+            "the committed half message becomes visible exactly once"
+        );
+    }
+
+    #[test]
+    fn txn_rollback_over_the_wire_never_delivers() {
+        let e = DirectEngine::new(engine());
+        let mut prod = Session::with_member_id(MemberId::new(1));
+        let mut out = Vec::new();
+        prod.process(&e, &frame(FrameType::Connect, b""), &mut out)
+            .unwrap();
+        out.clear();
+        prod.process(&e, &txn_prepare_frame(b"tx1", b"secret"), &mut out)
+            .unwrap();
+        assert_eq!(one_response(&out).0, FrameType::Ok);
+        out.clear();
+        prod.process(
+            &e,
+            &txn_resolve_frame(FrameType::TxnRollback, b"tx1"),
+            &mut out,
+        )
+        .unwrap();
+        assert_eq!(one_response(&out).0, FrameType::Ok, "rollback is acked Ok");
+
+        // A consumer never sees the rolled-back payload.
+        let mut cons = connect_and_sub(&e, MemberId::new(2), b"");
+        out.clear();
+        cons.process(&e, &frame(FrameType::Flow, &10u32.to_le_bytes()), &mut out)
+            .unwrap();
+        assert!(
+            delivered_payloads(&out).is_empty(),
+            "a rolled-back half message is never delivered"
+        );
+    }
+
+    #[test]
+    fn txn_commit_after_rollback_over_the_wire_is_an_error() {
+        let e = DirectEngine::new(engine());
+        let mut prod = Session::with_member_id(MemberId::new(1));
+        let mut out = Vec::new();
+        prod.process(&e, &frame(FrameType::Connect, b""), &mut out)
+            .unwrap();
+        out.clear();
+        prod.process(&e, &txn_prepare_frame(b"tx1", b"v"), &mut out)
+            .unwrap();
+        out.clear();
+        prod.process(
+            &e,
+            &txn_resolve_frame(FrameType::TxnRollback, b"tx1"),
+            &mut out,
+        )
+        .unwrap();
+        out.clear();
+        // commit-after-rollback is refused, never flipped: an Err frame, never a PubAck.
+        prod.process(
+            &e,
+            &txn_resolve_frame(FrameType::TxnCommit, b"tx1"),
+            &mut out,
+        )
+        .unwrap();
+        assert_eq!(
+            one_response(&out).0,
+            FrameType::Err,
+            "commit-after-rollback is an Err, never a PubAck"
+        );
+    }
+
+    #[test]
+    fn txn_malformed_and_empty_id_are_rejected_over_the_wire() {
+        let e = DirectEngine::new(engine());
+        let mut prod = Session::with_member_id(MemberId::new(1));
+        let mut out = Vec::new();
+        prod.process(&e, &frame(FrameType::Connect, b""), &mut out)
+            .unwrap();
+        // A malformed (empty) prepare body is an Err, not a panic.
+        out.clear();
+        prod.process(&e, &frame(FrameType::TxnPrepare, b""), &mut out)
+            .unwrap();
+        assert_eq!(one_response(&out).0, FrameType::Err);
+        // An empty txn id is refused.
+        out.clear();
+        prod.process(&e, &txn_resolve_frame(FrameType::TxnCommit, b""), &mut out)
+            .unwrap();
+        assert_eq!(one_response(&out).0, FrameType::Err);
     }
 }

--- a/crates/ironbus-storage/src/lib.rs
+++ b/crates/ironbus-storage/src/lib.rs
@@ -57,3 +57,9 @@ pub mod sim;
 /// recovers to its own valid prefix + loss report without touching a sibling — and per-record cost
 /// stays flat as streams grow (no per-record structure is added).
 pub mod streamset;
+/// The durable transactional half-message store (`txn/` sub-log, V2-M8, #640 part 1/2): a second
+/// segmented [`log::Log`] (modeled on the `dlq/` sink) holding the durable, consumer-INVISIBLE half
+/// (prepared) messages and their resolution (commit/rollback) op-markers, plus the in-memory
+/// [`ironbus_core::txn::TxnTable`] lifecycle it rebuilds by replaying both record kinds at open.
+/// Absent entirely from a deployment that never produces a transactional message.
+pub mod txn;

--- a/crates/ironbus-storage/src/txn.rs
+++ b/crates/ironbus-storage/src/txn.rs
@@ -1,0 +1,868 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! The durable transactional half-message store (V2-M8, #640 part 1/2).
+//!
+//! This is the durable side of the RocketMQ-style transactional-message model (the pure lifecycle
+//! is [`ironbus_core::txn`]). A producer's **half (prepared) message** is buffered here durably but
+//! kept INVISIBLE to consumers; a later **commit** appends the buffered payload to the REAL target
+//! stream and writes a committed op-marker, and a **rollback** writes a rolled-back op-marker (the
+//! payload is never delivered). On open, both record kinds are replayed to rebuild the in-memory
+//! [`TxnTable`] and the buffered-payload map, so prepared half messages and their resolutions
+//! SURVIVE a restart.
+//!
+//! ## On-disk shape (modeled on the DLQ / geo sub-logs)
+//!
+//! The store is a SECOND segmented [`Log`](crate::log::Log) rooted at the `txn/` subdirectory of the
+//! data directory (via [`crate::fs::Filesystem::subdir`]), exactly like [`crate::dlq::DlqSink`]'s
+//! `dlq/` sink — same framed, CRC32C'd, recoverable segment format, readable by the same
+//! [`SegmentReader`](crate::segment::SegmentReader) / [`OfflineReader`](crate::offline::OfflineReader)
+//! code, with no second segment format to maintain. A single `txn/` log interleaves TWO logical
+//! record kinds, distinguished by a magic in the record's `headers` blob:
+//!
+//! - a **HALF record** ([`TXN_HALF_MAGIC`]) carries the prepared half message: the producer-supplied
+//!   `txn_id`, the REAL target stream name, and the original record's headers/flags in the metadata
+//!   blob, with the original `key` / `payload` / `timestamp_ms` preserved VERBATIM as the segment
+//!   record's own fields — so a commit can faithfully reconstruct the real append.
+//! - an **OP record** ([`TXN_OP_MAGIC`]) carries a resolution marker: the `txn_id`, the kind
+//!   (committed / rolled-back), and (for a commit) the REAL offset the payload landed at.
+//!
+//! Both are versioned ([`TXN_FORMAT_VERSION`]) and CRC32C'd, pinned by snapshot tests, so neither
+//! format silently changes.
+//!
+//! ## The unit of crash safety this store owns
+//!
+//! This module owns the DURABLE PRIMITIVES — append-and-fsync a half record, append-and-fsync an op
+//! marker, replay both on open — plus the in-memory [`TxnTable`] + buffered-payload index they
+//! rebuild. It does NOT itself append to the real target stream: the engine drives the
+//! crash-safe ORDERING (real-stream append first, then the committed op-marker) and makes the
+//! real-stream replay-append idempotent with the effectively-once dedup machinery (the txn id as the
+//! dedup identity). See the engine's `txn_commit` for the full crash-window argument; this store
+//! guarantees only that a half message is never lost while prepared, and that a resolution, once
+//! written and fsync'd, survives a restart and replays the lifecycle exactly.
+
+use crate::fs::Filesystem;
+use crate::log::{Append, Log, LogConfig};
+use crate::naming::segment_file_name;
+use crate::segment::{SegmentReader, StorageError};
+use ironbus_core::clock::Clock;
+use ironbus_core::txn::{TxnConfig, TxnOutcome, TxnState, TxnTable};
+use ironbus_core::types::RecordFlags;
+use std::collections::HashMap;
+
+/// The subdirectory of the data directory that holds the transactional half-message store's
+/// segments. Absent entirely from a deployment that never produces a transactional message, so the
+/// non-txn hot path is byte-for-byte unchanged.
+pub const TXN_SUBDIR: &str = "txn";
+
+/// The FROZEN on-disk format version for a txn store record's metadata header. Bumped only by a
+/// future format change, at which point a reader refuses an unknown value (fail-closed) the same way
+/// the segment `FORMAT_VERSION` and layout marker do. Pinned by a snapshot test.
+pub const TXN_FORMAT_VERSION: u8 = 1;
+
+/// The 4-byte magic that opens a HALF (prepared) record's metadata header. A `headers` blob that
+/// does not begin with a recognized txn magic is foreign to this store and is skipped, never misread.
+pub const TXN_HALF_MAGIC: [u8; 4] = *b"TXNH";
+
+/// The 4-byte magic that opens an OP (resolution-marker) record's metadata header.
+pub const TXN_OP_MAGIC: [u8; 4] = *b"TXNO";
+
+/// The op-marker kind byte: the transaction COMMITTED (its half message is appended to the real
+/// stream and becomes visible). The marker also carries the real offset the payload landed at.
+const OP_KIND_COMMITTED: u8 = 0;
+/// The op-marker kind byte: the transaction ROLLED BACK (its half message is discarded, never
+/// delivered).
+const OP_KIND_ROLLED_BACK: u8 = 1;
+
+/// One prepared half message read back from the durable store: everything the engine needs to append
+/// it to the real target stream on a commit (or a crash-recovery redrive).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HalfMessage {
+    /// The producer-supplied transaction id (the lifecycle key).
+    pub txn_id: Vec<u8>,
+    /// The REAL target stream the committed payload is appended to (empty = the default stream).
+    pub stream: String,
+    /// The original record's producer timestamp, milliseconds since the Unix epoch (preserved).
+    pub timestamp_ms: u64,
+    /// The original record's routing/ordering key (preserved verbatim).
+    pub key: Vec<u8>,
+    /// The original record's headers blob (preserved verbatim; the txn metadata is stripped).
+    pub headers: Vec<u8>,
+    /// The original record's payload (preserved verbatim).
+    pub payload: Vec<u8>,
+    /// The original record's content flags (preserved verbatim; `HAS_KEY` is re-derived on append).
+    pub flags: RecordFlags,
+}
+
+/// The fixed-size prefix of a HALF record's metadata blob: `magic`(4) + `version`(1) +
+/// `txn_id_len`(2) + `stream_len`(2) + `orig_headers_len`(2) + `orig_flags`(1).
+const HALF_FIXED_LEN: usize = 4 + 1 + 2 + 2 + 2 + 1;
+
+/// The fixed-size prefix of an OP record's metadata blob: `magic`(4) + `version`(1) + `op_kind`(1) +
+/// `txn_id_len`(2) + `real_offset`(8).
+const OP_FIXED_LEN: usize = 4 + 1 + 1 + 2 + 8;
+
+/// Encodes the HALF (prepared) record's metadata blob (the segment record's `headers` field): the
+/// fixed prefix, then `txn_id`, the `stream` name, and the original headers, then a trailing crc32c
+/// over everything before it. Returns `None` if any length field would overflow its `u16` (the wire
+/// `PUB` path already bounds them, so a real record never trips this).
+#[must_use]
+pub fn encode_half_meta(
+    txn_id: &[u8],
+    stream: &str,
+    orig_flags: RecordFlags,
+    orig_headers: &[u8],
+) -> Option<Vec<u8>> {
+    let txn_len = u16::try_from(txn_id.len()).ok()?;
+    let stream_len = u16::try_from(stream.len()).ok()?;
+    let headers_len = u16::try_from(orig_headers.len()).ok()?;
+    let mut out =
+        Vec::with_capacity(HALF_FIXED_LEN + txn_id.len() + stream.len() + orig_headers.len() + 4);
+    out.extend_from_slice(&TXN_HALF_MAGIC);
+    out.push(TXN_FORMAT_VERSION);
+    out.extend_from_slice(&txn_len.to_le_bytes());
+    out.extend_from_slice(&stream_len.to_le_bytes());
+    out.extend_from_slice(&headers_len.to_le_bytes());
+    out.push(orig_flags.bits());
+    out.extend_from_slice(txn_id);
+    out.extend_from_slice(stream.as_bytes());
+    out.extend_from_slice(orig_headers);
+    let crc = ironbus_core::crc::crc32c(&out);
+    out.extend_from_slice(&crc.to_le_bytes());
+    Some(out)
+}
+
+/// Encodes an OP (resolution-marker) record's metadata blob: the fixed prefix (magic, version, op
+/// kind, `txn_id_len`, `real_offset`), then `txn_id`, then a trailing crc32c. `real_offset` is the
+/// offset the committed payload landed at on the real stream (meaningless / `0` for a rollback).
+/// Returns `None` if `txn_id` overflows its `u16` length (unreachable from the bounded wire path).
+#[must_use]
+pub fn encode_op_meta(txn_id: &[u8], outcome: TxnOutcome, real_offset: u64) -> Option<Vec<u8>> {
+    let txn_len = u16::try_from(txn_id.len()).ok()?;
+    let op_kind = match outcome {
+        TxnOutcome::Committed => OP_KIND_COMMITTED,
+        TxnOutcome::RolledBack => OP_KIND_ROLLED_BACK,
+    };
+    let mut out = Vec::with_capacity(OP_FIXED_LEN + txn_id.len() + 4);
+    out.extend_from_slice(&TXN_OP_MAGIC);
+    out.push(TXN_FORMAT_VERSION);
+    out.push(op_kind);
+    out.extend_from_slice(&txn_len.to_le_bytes());
+    out.extend_from_slice(&real_offset.to_le_bytes());
+    out.extend_from_slice(txn_id);
+    let crc = ironbus_core::crc::crc32c(&out);
+    out.extend_from_slice(&crc.to_le_bytes());
+    Some(out)
+}
+
+/// A decoded HALF record's metadata (the txn id, the real stream, the original flags + the byte range
+/// of the original headers within the blob).
+struct HalfMeta {
+    txn_id: Vec<u8>,
+    stream: String,
+    orig_flags: RecordFlags,
+    orig_headers: Vec<u8>,
+}
+
+/// A decoded OP record's metadata.
+struct OpMeta {
+    txn_id: Vec<u8>,
+    outcome: TxnOutcome,
+    real_offset: u64,
+}
+
+/// What a single durable txn record decoded to (or `None` for a foreign / corrupt blob, which is
+/// skipped on replay rather than misread).
+enum TxnRecordMeta {
+    Half(HalfMeta),
+    Op(OpMeta),
+}
+
+/// Reads a little-endian `u16` at `at` as a `usize`, or `None` if `blob` is too short.
+fn read_u16(blob: &[u8], at: usize) -> Option<usize> {
+    blob.get(at..at + 2)
+        .and_then(|s| <[u8; 2]>::try_from(s).ok())
+        .map(|b| usize::from(u16::from_le_bytes(b)))
+}
+
+/// Reads a little-endian `u64` at `at`, or `None` if `blob` is too short.
+fn read_u64(blob: &[u8], at: usize) -> Option<u64> {
+    blob.get(at..at + 8)
+        .and_then(|s| <[u8; 8]>::try_from(s).ok())
+        .map(u64::from_le_bytes)
+}
+
+/// Validates the trailing crc32c over a txn metadata blob, returning the body (everything before the
+/// 4-byte crc) on a match, or `None` on a short blob or a checksum mismatch (a torn or corrupt record
+/// is skipped, never misread).
+fn verify_crc(blob: &[u8]) -> Option<&[u8]> {
+    if blob.len() < 4 {
+        return None;
+    }
+    let crc_at = blob.len() - 4;
+    let stored = read_u32_le(blob, crc_at)?;
+    if ironbus_core::crc::crc32c(&blob[..crc_at]) != stored {
+        return None;
+    }
+    Some(&blob[..crc_at])
+}
+
+/// Reads a little-endian `u32` at `at`, or `None` if `blob` is too short.
+fn read_u32_le(blob: &[u8], at: usize) -> Option<u32> {
+    blob.get(at..at + 4)
+        .and_then(|s| <[u8; 4]>::try_from(s).ok())
+        .map(u32::from_le_bytes)
+}
+
+/// Decodes a txn record's metadata `headers` blob to a [`TxnRecordMeta`], or `None` for a foreign or
+/// corrupt blob. The version must match [`TXN_FORMAT_VERSION`] (an unknown version fails closed, so a
+/// newer record is never silently misread by an older binary), the crc must validate, and every
+/// declared length must fit exactly within the blob.
+fn decode_meta(blob: &[u8]) -> Option<TxnRecordMeta> {
+    let magic = blob.get(0..4)?;
+    if magic == TXN_HALF_MAGIC {
+        decode_half_meta(blob).map(TxnRecordMeta::Half)
+    } else if magic == TXN_OP_MAGIC {
+        decode_op_meta(blob).map(TxnRecordMeta::Op)
+    } else {
+        None
+    }
+}
+
+/// Decodes a HALF record's metadata blob (see [`encode_half_meta`]).
+fn decode_half_meta(blob: &[u8]) -> Option<HalfMeta> {
+    let body = verify_crc(blob)?;
+    if body.len() < HALF_FIXED_LEN {
+        return None;
+    }
+    if *body.get(4)? != TXN_FORMAT_VERSION {
+        return None;
+    }
+    let txn_len = read_u16(body, 5)?;
+    let stream_len = read_u16(body, 7)?;
+    let headers_len = read_u16(body, 9)?;
+    let orig_flags = RecordFlags::from_bits(*body.get(11)?);
+    let txn_start = HALF_FIXED_LEN;
+    let stream_start = txn_start.checked_add(txn_len)?;
+    let headers_start = stream_start.checked_add(stream_len)?;
+    let headers_end = headers_start.checked_add(headers_len)?;
+    // The body must be EXACTLY the fixed prefix plus the three declared spans: any other length is
+    // malformed, so decode fails closed rather than guessing.
+    if body.len() != headers_end {
+        return None;
+    }
+    let txn_id = body.get(txn_start..stream_start)?.to_vec();
+    let stream = String::from_utf8(body.get(stream_start..headers_start)?.to_vec()).ok()?;
+    let orig_headers = body.get(headers_start..headers_end)?.to_vec();
+    Some(HalfMeta {
+        txn_id,
+        stream,
+        orig_flags,
+        orig_headers,
+    })
+}
+
+/// Decodes an OP record's metadata blob (see [`encode_op_meta`]).
+fn decode_op_meta(blob: &[u8]) -> Option<OpMeta> {
+    let body = verify_crc(blob)?;
+    if body.len() < OP_FIXED_LEN {
+        return None;
+    }
+    if *body.get(4)? != TXN_FORMAT_VERSION {
+        return None;
+    }
+    let outcome = match *body.get(5)? {
+        OP_KIND_COMMITTED => TxnOutcome::Committed,
+        OP_KIND_ROLLED_BACK => TxnOutcome::RolledBack,
+        // An unknown (future) op kind fails closed rather than being misread.
+        _ => return None,
+    };
+    let txn_len = read_u16(body, 6)?;
+    let real_offset = read_u64(body, 8)?;
+    let txn_start = OP_FIXED_LEN;
+    let txn_end = txn_start.checked_add(txn_len)?;
+    if body.len() != txn_end {
+        return None;
+    }
+    let txn_id = body.get(txn_start..txn_end)?.to_vec();
+    Some(OpMeta {
+        txn_id,
+        outcome,
+        real_offset,
+    })
+}
+
+/// The durable transactional half-message store: a segmented [`Log`] under `txn/` holding the half
+/// records and op markers, plus the in-memory [`TxnTable`] lifecycle and the buffered prepared
+/// payloads, rebuilt at open by replaying the durable records (V2-M8, #640).
+pub struct TxnStore<F: Filesystem, C: Clock> {
+    log: Log<F, C>,
+    /// The pure lifecycle state machine, rebuilt at open from the replayed records.
+    table: TxnTable,
+    /// The buffered prepared payloads, keyed by `txn_id`, for every CURRENTLY-`Prepared` txn: the
+    /// half message the engine appends to the real stream on a commit. An entry is inserted on a
+    /// fresh prepare and removed on resolve (commit OR rollback). Bounded by the table's
+    /// `max_prepared` cap (a prepare over the cap is refused), so this never grows without bound.
+    prepared_payloads: HashMap<Vec<u8>, HalfMessage>,
+    /// The number of half records durably written across this store's lifetime (for observability).
+    half_records: u64,
+    /// The number of op markers durably written across this store's lifetime (for observability).
+    op_records: u64,
+}
+
+impl<F: Filesystem, C: Clock> std::fmt::Debug for TxnStore<F, C> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TxnStore")
+            .field("prepared", &self.table.prepared_count())
+            .field(
+                "resolved_tombstones",
+                &self.table.resolved_tombstone_count(),
+            )
+            .field("half_records", &self.half_records)
+            .field("op_records", &self.op_records)
+            .finish_non_exhaustive()
+    }
+}
+
+/// A failure committing a transaction at the store layer (the lifecycle errors surface from the pure
+/// [`TxnTable`] up through the engine; this is the storage-local typed reject).
+#[derive(Debug)]
+pub enum TxnStoreError {
+    /// A storage error from an append, fsync, or replay.
+    Storage(StorageError),
+    /// The metadata blob could not be framed (a stream name / headers / txn id longer than
+    /// `u16::MAX`, unreachable from the bounded wire path).
+    Unframable,
+}
+
+impl core::fmt::Display for TxnStoreError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            TxnStoreError::Storage(e) => write!(f, "txn store storage error: {e}"),
+            TxnStoreError::Unframable => write!(f, "txn record metadata could not be framed"),
+        }
+    }
+}
+
+impl std::error::Error for TxnStoreError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            TxnStoreError::Storage(e) => Some(e),
+            TxnStoreError::Unframable => None,
+        }
+    }
+}
+
+impl From<StorageError> for TxnStoreError {
+    fn from(e: StorageError) -> TxnStoreError {
+        TxnStoreError::Storage(e)
+    }
+}
+
+impl<F: Filesystem, C: Clock> TxnStore<F, C> {
+    /// Opens (recovering, or creating fresh) the txn store rooted at the `txn/` subdirectory of
+    /// `parent_fs`, rebuilding the in-memory lifecycle table and the buffered prepared payloads by
+    /// replaying the durable half + op records in order.
+    ///
+    /// # Errors
+    /// Propagates a storage error from creating the subdirectory, opening the txn log, or scanning
+    /// its records.
+    pub fn open(
+        parent_fs: &F,
+        clock: C,
+        config: LogConfig,
+        txn_config: TxnConfig,
+    ) -> Result<TxnStore<F, C>, StorageError> {
+        let txn_fs = parent_fs.subdir(TXN_SUBDIR).map_err(StorageError::Io)?;
+        let log = Log::open(txn_fs, clock, config)?;
+        let mut store = TxnStore {
+            log,
+            table: TxnTable::new(txn_config),
+            prepared_payloads: HashMap::new(),
+            half_records: 0,
+            op_records: 0,
+        };
+        store.replay()?;
+        Ok(store)
+    }
+
+    /// Whether the `txn/` subdirectory exists under `parent_fs` (a probe that does NOT create it), so
+    /// the engine can open the store ONLY when a deployment has ever produced a transactional message
+    /// — keeping the non-txn data dir byte-for-byte free of the `txn/` subtree.
+    ///
+    /// # Errors
+    /// Propagates an IO error from the filesystem probe.
+    pub fn dir_exists(parent_fs: &F) -> Result<bool, StorageError> {
+        parent_fs
+            .subdir_exists(TXN_SUBDIR)
+            .map_err(StorageError::Io)
+    }
+
+    /// Replays every durable txn record in order (the half-log and the op-log are interleaved in the
+    /// one `txn/` log), rebuilding the [`TxnTable`] and the buffered-payload map. A HALF record
+    /// restores a `Prepared` txn (and buffers its payload); an OP record restores the resolution
+    /// (committed / rolled back) and drops the buffered payload. Records are replayed in DURABLE
+    /// ORDER (segment id, then offset), so an op marker that follows its half record correctly
+    /// supersedes it. A foreign or corrupt record (bad magic, bad crc, unknown version) is SKIPPED,
+    /// never misread.
+    fn replay(&mut self) -> Result<(), StorageError> {
+        self.table = TxnTable::new(self.table.config());
+        self.prepared_payloads.clear();
+        self.half_records = 0;
+        self.op_records = 0;
+        let flushed = self.log.flushed_offset().get();
+        if flushed == 0 {
+            return Ok(());
+        }
+        let ids = crate::naming::segment_ids(self.log.filesystem()).map_err(StorageError::Io)?;
+        for id in ids {
+            let scan =
+                SegmentReader::open(self.log.filesystem().open(&segment_file_name(id))?)?.scan()?;
+            for record in &scan.records {
+                if record.offset.get() >= flushed {
+                    break;
+                }
+                let Some(meta) = decode_meta(&record.headers) else {
+                    // Foreign / corrupt record: skip it (never misread). The half message it might
+                    // have carried is simply absent, which is the safe default (an unrecoverable half
+                    // message is treated as never-prepared, not as silently delivered).
+                    continue;
+                };
+                // The durable record's monotonic instant is unavailable on replay (the segment stores
+                // only the producer timestamp); the lifecycle's `instant` is used purely for the LRU
+                // recency and the back-check age key, so we seed it from the record's offset — a
+                // monotonic, replay-stable surrogate that preserves prepare ORDER (the only property
+                // the back-check needs). A fresh produce after open uses the real monotonic clock.
+                let instant = record.offset.get();
+                match meta {
+                    TxnRecordMeta::Half(h) => {
+                        self.half_records = self.half_records.saturating_add(1);
+                        self.table.restore(&h.txn_id, TxnState::Prepared, instant);
+                        self.prepared_payloads.insert(
+                            h.txn_id.clone(),
+                            HalfMessage {
+                                txn_id: h.txn_id,
+                                stream: h.stream,
+                                timestamp_ms: record.timestamp_ms,
+                                key: record.key.to_vec(),
+                                headers: h.orig_headers,
+                                payload: record.payload.to_vec(),
+                                flags: h.orig_flags,
+                            },
+                        );
+                    }
+                    TxnRecordMeta::Op(o) => {
+                        self.op_records = self.op_records.saturating_add(1);
+                        self.table
+                            .restore(&o.txn_id, TxnState::Resolved(o.outcome), instant);
+                        // A resolved txn no longer needs its buffered payload (it was either appended
+                        // to the real stream on commit, or discarded on rollback).
+                        self.prepared_payloads.remove(&o.txn_id);
+                        let _ = o.real_offset; // recorded for inspection; the engine dedups the append
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Borrows the pure lifecycle table (for the engine's prepare/commit/rollback decisions and the
+    /// part-2 back-check's `unresolved_before` scan).
+    #[must_use]
+    pub fn table(&self) -> &TxnTable {
+        &self.table
+    }
+
+    /// Mutably borrows the pure lifecycle table (the engine drives prepare/commit/rollback on it).
+    pub fn table_mut(&mut self) -> &mut TxnTable {
+        &mut self.table
+    }
+
+    /// The buffered prepared payload for `txn_id`, or `None` if the txn is not currently prepared
+    /// (never prepared, or already resolved). The engine reads this on a commit to append the payload
+    /// to the real stream.
+    #[must_use]
+    pub fn prepared_payload(&self, txn_id: &[u8]) -> Option<&HalfMessage> {
+        self.prepared_payloads.get(txn_id)
+    }
+
+    /// Durably appends a HALF (prepared) record for `txn_id` — the buffered half message targeting the
+    /// real `stream` — and fsyncs it BEFORE returning, then buffers the payload in memory. This is the
+    /// durable prepare: after it returns, the half message survives a restart but is INVISIBLE to
+    /// consumers (it lives in `txn/`, never the real stream). The caller has already taken a FRESH
+    /// prepare decision from [`TxnTable`]; on an idempotent re-prepare the caller does NOT call this
+    /// (the half message is already durable).
+    ///
+    /// # Errors
+    /// [`TxnStoreError::Unframable`] if the metadata could not be framed (unreachable from the bounded
+    /// wire path), or a storage error from the append or its durability barrier. On any error nothing
+    /// is recorded (no in-memory payload buffered), so the caller MUST treat the prepare as not having
+    /// happened.
+    pub fn append_half(
+        &mut self,
+        txn_id: &[u8],
+        stream: &str,
+        message: &Append<'_>,
+    ) -> Result<(), TxnStoreError> {
+        let meta = encode_half_meta(txn_id, stream, message.flags, message.headers)
+            .ok_or(TxnStoreError::Unframable)?;
+        // Clear HAS_KEY: the segment codec re-derives it from the key length and overwrites it, so the
+        // stored content flags carry only the producer's real content bits (e.g. COMPRESSED), and the
+        // original flags for the REAL append are preserved verbatim in the metadata blob instead.
+        let stored_flags =
+            RecordFlags::from_bits(message.flags.bits() & !RecordFlags::HAS_KEY.bits());
+        self.log.append(&Append {
+            timestamp_ms: message.timestamp_ms,
+            flags: stored_flags,
+            key: message.key,
+            headers: &meta,
+            payload: message.payload,
+        })?;
+        // fsync the half record BEFORE returning: a prepared half message is never lost.
+        self.log.sync()?;
+        self.half_records = self.half_records.saturating_add(1);
+        self.prepared_payloads.insert(
+            txn_id.to_vec(),
+            HalfMessage {
+                txn_id: txn_id.to_vec(),
+                stream: stream.to_string(),
+                timestamp_ms: message.timestamp_ms,
+                key: message.key.to_vec(),
+                headers: message.headers.to_vec(),
+                payload: message.payload.to_vec(),
+                flags: message.flags,
+            },
+        );
+        Ok(())
+    }
+
+    /// Durably appends a COMMITTED op-marker for `txn_id` (recording the `real_offset` the payload
+    /// landed at on the real stream) and fsyncs it BEFORE returning, then drops the buffered payload.
+    ///
+    /// The CALLER (the engine) MUST have already appended-and-fsync'd the payload to the real stream
+    /// BEFORE calling this, and that real append MUST be deduped by the txn id, so a crash AFTER the
+    /// real append but BEFORE this op-marker replays the commit exactly once (the re-append is
+    /// recognized as a duplicate). See the engine's `txn_commit` for the full crash-window argument.
+    ///
+    /// # Errors
+    /// [`TxnStoreError::Unframable`] (unreachable from the bounded wire path) or a storage error from
+    /// the append or its durability barrier.
+    pub fn mark_committed(&mut self, txn_id: &[u8], real_offset: u64) -> Result<(), TxnStoreError> {
+        self.append_op(txn_id, TxnOutcome::Committed, real_offset)
+    }
+
+    /// Durably appends a ROLLED-BACK op-marker for `txn_id` and fsyncs it BEFORE returning, then drops
+    /// the buffered payload. The payload is never appended to the real stream — it is discarded.
+    ///
+    /// # Errors
+    /// [`TxnStoreError::Unframable`] (unreachable from the bounded wire path) or a storage error from
+    /// the append or its durability barrier.
+    pub fn mark_rolled_back(&mut self, txn_id: &[u8]) -> Result<(), TxnStoreError> {
+        self.append_op(txn_id, TxnOutcome::RolledBack, 0)
+    }
+
+    /// The shared durable op-marker append: frame the marker, append it, fsync it BEFORE returning,
+    /// then drop the buffered payload (the txn is resolved). Bumps the op-record count.
+    fn append_op(
+        &mut self,
+        txn_id: &[u8],
+        outcome: TxnOutcome,
+        real_offset: u64,
+    ) -> Result<(), TxnStoreError> {
+        let meta = encode_op_meta(txn_id, outcome, real_offset).ok_or(TxnStoreError::Unframable)?;
+        self.log.append(&Append {
+            timestamp_ms: self.log.now_unix_millis(),
+            flags: RecordFlags::EMPTY,
+            key: &[],
+            headers: &meta,
+            payload: &[],
+        })?;
+        // fsync the op marker BEFORE returning: a resolution, once acked, survives a restart.
+        self.log.sync()?;
+        self.op_records = self.op_records.saturating_add(1);
+        self.prepared_payloads.remove(txn_id);
+        Ok(())
+    }
+
+    /// The number of currently-`Prepared` (unresolved) half messages.
+    #[must_use]
+    pub fn prepared_count(&self) -> usize {
+        self.table.prepared_count()
+    }
+
+    /// The number of half records durably written across this store's lifetime (the half records
+    /// present at open plus every append since), for observability.
+    #[must_use]
+    pub fn half_records(&self) -> u64 {
+        self.half_records
+    }
+
+    /// The number of op markers durably written across this store's lifetime, for observability.
+    #[must_use]
+    pub fn op_records(&self) -> u64 {
+        self.op_records
+    }
+
+    /// Borrows the underlying txn log (for inspection and tests).
+    #[must_use]
+    pub fn log(&self) -> &Log<F, C> {
+        &self.log
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fs::InMemoryFs;
+    use ironbus_core::clock::ManualClock;
+
+    const MAX_ID: usize = ironbus_core::txn::MAX_TXN_ID_LEN;
+
+    fn config() -> LogConfig {
+        LogConfig::default()
+    }
+
+    fn store(fs: &InMemoryFs) -> TxnStore<InMemoryFs, ManualClock> {
+        TxnStore::open(fs, ManualClock::new(), config(), TxnConfig::default()).unwrap()
+    }
+
+    fn half(payload: &[u8]) -> Append<'static> {
+        Append {
+            timestamp_ms: 1234,
+            flags: RecordFlags::EMPTY,
+            key: b"k",
+            headers: b"orig-hdr",
+            payload: Box::leak(payload.to_vec().into_boxed_slice()),
+        }
+    }
+
+    #[test]
+    fn half_meta_round_trips() {
+        let blob = encode_half_meta(b"tx1", "orders", RecordFlags::COMPRESSED, b"hh").unwrap();
+        assert_eq!(&blob[0..4], &TXN_HALF_MAGIC);
+        assert_eq!(blob[4], TXN_FORMAT_VERSION);
+        match decode_meta(&blob).unwrap() {
+            TxnRecordMeta::Half(h) => {
+                assert_eq!(h.txn_id, b"tx1");
+                assert_eq!(h.stream, "orders");
+                assert_eq!(h.orig_flags, RecordFlags::COMPRESSED);
+                assert_eq!(h.orig_headers, b"hh");
+            }
+            TxnRecordMeta::Op(_) => panic!("expected a half record"),
+        }
+    }
+
+    #[test]
+    fn op_meta_round_trips_for_both_outcomes() {
+        for (outcome, off) in [(TxnOutcome::Committed, 42u64), (TxnOutcome::RolledBack, 0)] {
+            let blob = encode_op_meta(b"tx1", outcome, off).unwrap();
+            assert_eq!(&blob[0..4], &TXN_OP_MAGIC);
+            match decode_meta(&blob).unwrap() {
+                TxnRecordMeta::Op(o) => {
+                    assert_eq!(o.txn_id, b"tx1");
+                    assert_eq!(o.outcome, outcome);
+                    assert_eq!(o.real_offset, off);
+                }
+                TxnRecordMeta::Half(_) => panic!("expected an op record"),
+            }
+        }
+    }
+
+    #[test]
+    fn the_v1_half_format_is_byte_frozen() {
+        // Pin the exact bytes a v1 half-meta produces, so an accidental format drift breaks a test
+        // here, not a deployed store. magic + version + lens + flags + spans + crc.
+        let blob = encode_half_meta(b"t", "s", RecordFlags::EMPTY, b"h").unwrap();
+        let mut expected = Vec::new();
+        expected.extend_from_slice(b"TXNH");
+        expected.push(1); // version
+        expected.extend_from_slice(&1u16.to_le_bytes()); // txn_id_len
+        expected.extend_from_slice(&1u16.to_le_bytes()); // stream_len
+        expected.extend_from_slice(&1u16.to_le_bytes()); // orig_headers_len
+        expected.push(0); // orig_flags = EMPTY
+        expected.extend_from_slice(b"t");
+        expected.extend_from_slice(b"s");
+        expected.extend_from_slice(b"h");
+        let crc = ironbus_core::crc::crc32c(&expected);
+        expected.extend_from_slice(&crc.to_le_bytes());
+        assert_eq!(blob, expected);
+    }
+
+    #[test]
+    fn the_v1_op_format_is_byte_frozen() {
+        let blob = encode_op_meta(b"t", TxnOutcome::Committed, 0x0102_0304_0506_0708).unwrap();
+        let mut expected = Vec::new();
+        expected.extend_from_slice(b"TXNO");
+        expected.push(1); // version
+        expected.push(0); // op_kind = committed
+        expected.extend_from_slice(&1u16.to_le_bytes()); // txn_id_len
+        expected.extend_from_slice(&0x0102_0304_0506_0708u64.to_le_bytes()); // real_offset
+        expected.extend_from_slice(b"t");
+        let crc = ironbus_core::crc::crc32c(&expected);
+        expected.extend_from_slice(&crc.to_le_bytes());
+        assert_eq!(blob, expected);
+    }
+
+    #[test]
+    fn decode_rejects_a_corrupt_crc() {
+        let mut blob = encode_op_meta(b"tx1", TxnOutcome::Committed, 1).unwrap();
+        let n = blob.len();
+        blob[n - 5] ^= 0x01; // flip a body byte; the crc no longer matches
+        assert!(decode_meta(&blob).is_none());
+    }
+
+    #[test]
+    fn decode_rejects_an_unknown_version() {
+        let mut blob = encode_half_meta(b"t", "s", RecordFlags::EMPTY, b"h").unwrap();
+        blob[4] = TXN_FORMAT_VERSION + 1;
+        // Re-checksum so only the VERSION (not the crc) is the reason it is rejected.
+        let n = blob.len();
+        let crc = ironbus_core::crc::crc32c(&blob[..n - 4]);
+        blob[n - 4..].copy_from_slice(&crc.to_le_bytes());
+        assert!(decode_meta(&blob).is_none());
+    }
+
+    #[test]
+    fn decode_rejects_a_foreign_or_short_blob() {
+        assert!(decode_meta(b"XXXXrest").is_none());
+        assert!(decode_meta(b"TXN").is_none());
+        assert!(decode_meta(&[]).is_none());
+    }
+
+    #[test]
+    fn a_prepared_half_is_durable_and_invisible_on_reopen() {
+        let fs = InMemoryFs::new();
+        {
+            let mut s = store(&fs);
+            s.table_mut().prepare(b"tx1", 1).unwrap();
+            s.append_half(b"tx1", "orders", &half(b"the-payload"))
+                .unwrap();
+            assert_eq!(s.prepared_count(), 1);
+            assert_eq!(s.prepared_payload(b"tx1").unwrap().payload, b"the-payload");
+        }
+        // Reopen: the prepared half message comes back from the durable record alone.
+        let reopened = store(&fs);
+        assert_eq!(reopened.prepared_count(), 1);
+        let hm = reopened.prepared_payload(b"tx1").unwrap();
+        assert_eq!(hm.stream, "orders");
+        assert_eq!(hm.payload, b"the-payload");
+        assert_eq!(hm.key, b"k");
+        assert_eq!(hm.headers, b"orig-hdr");
+        assert_eq!(reopened.table().state(b"tx1"), Some(TxnState::Prepared));
+    }
+
+    #[test]
+    fn a_committed_txn_survives_restart_as_resolved() {
+        let fs = InMemoryFs::new();
+        {
+            let mut s = store(&fs);
+            s.table_mut().prepare(b"tx1", 1).unwrap();
+            s.append_half(b"tx1", "orders", &half(b"p")).unwrap();
+            // The engine would append to the real stream here; the store records the marker.
+            s.table_mut().commit(b"tx1", 2).unwrap();
+            s.mark_committed(b"tx1", 99).unwrap();
+            assert_eq!(s.prepared_count(), 0);
+            assert!(s.prepared_payload(b"tx1").is_none());
+        }
+        let reopened = store(&fs);
+        assert_eq!(reopened.prepared_count(), 0);
+        assert_eq!(
+            reopened.table().state(b"tx1"),
+            Some(TxnState::Resolved(TxnOutcome::Committed))
+        );
+        // The buffered payload is gone (resolved), so a redrive never re-appends it.
+        assert!(reopened.prepared_payload(b"tx1").is_none());
+    }
+
+    #[test]
+    fn a_rolled_back_txn_survives_restart_and_never_delivers() {
+        let fs = InMemoryFs::new();
+        {
+            let mut s = store(&fs);
+            s.table_mut().prepare(b"tx1", 1).unwrap();
+            s.append_half(b"tx1", "orders", &half(b"secret")).unwrap();
+            s.table_mut().rollback(b"tx1", 2).unwrap();
+            s.mark_rolled_back(b"tx1").unwrap();
+        }
+        let reopened = store(&fs);
+        assert_eq!(
+            reopened.table().state(b"tx1"),
+            Some(TxnState::Resolved(TxnOutcome::RolledBack))
+        );
+        // The payload was never moved to a real stream and is no longer buffered: never delivered.
+        assert!(reopened.prepared_payload(b"tx1").is_none());
+    }
+
+    #[test]
+    fn crash_after_prepare_before_op_replays_as_prepared() {
+        // The crash-window (a) case: only the half record is durable (no op marker). On reopen the
+        // txn is Prepared (recoverable, unresolved), so the back-check / redrive can resolve it.
+        let fs = InMemoryFs::new();
+        {
+            let mut s = store(&fs);
+            s.table_mut().prepare(b"tx1", 1).unwrap();
+            s.append_half(b"tx1", "orders", &half(b"p")).unwrap();
+            // CRASH: no commit/rollback op marker written.
+        }
+        let reopened = store(&fs);
+        assert_eq!(reopened.table().state(b"tx1"), Some(TxnState::Prepared));
+        assert_eq!(reopened.prepared_count(), 1);
+        // The buffered payload is recovered, so the redrive CAN commit it.
+        assert_eq!(reopened.prepared_payload(b"tx1").unwrap().payload, b"p");
+        // The back-check sees it as unresolved.
+        let unresolved = reopened.table().unresolved_before(u64::MAX);
+        assert_eq!(unresolved.len(), 1);
+        assert_eq!(unresolved[0].0, b"tx1");
+    }
+
+    #[test]
+    fn replay_applies_op_after_half_in_durable_order() {
+        // Multiple txns interleaved: replay order (segment+offset) makes each op marker supersede its
+        // half record, so the final state is exactly the resolved/prepared mix.
+        let fs = InMemoryFs::new();
+        {
+            let mut s = store(&fs);
+            for id in [b"a".as_slice(), b"b", b"c"] {
+                s.table_mut().prepare(id, 1).unwrap();
+                s.append_half(id, "s", &half(b"p")).unwrap();
+            }
+            s.table_mut().commit(b"a", 2).unwrap();
+            s.mark_committed(b"a", 10).unwrap();
+            s.table_mut().rollback(b"b", 3).unwrap();
+            s.mark_rolled_back(b"b").unwrap();
+            // c stays prepared.
+        }
+        let r = store(&fs);
+        assert_eq!(
+            r.table().state(b"a"),
+            Some(TxnState::Resolved(TxnOutcome::Committed))
+        );
+        assert_eq!(
+            r.table().state(b"b"),
+            Some(TxnState::Resolved(TxnOutcome::RolledBack))
+        );
+        assert_eq!(r.table().state(b"c"), Some(TxnState::Prepared));
+        assert_eq!(r.prepared_count(), 1);
+        assert!(r.prepared_payload(b"c").is_some());
+        assert!(r.prepared_payload(b"a").is_none());
+    }
+
+    #[test]
+    fn an_absent_txn_dir_is_detected_without_creating_it() {
+        let fs = InMemoryFs::new();
+        // No store opened yet: the txn/ subdir does not exist.
+        assert!(!TxnStore::<InMemoryFs, ManualClock>::dir_exists(&fs).unwrap());
+        // Probing must not have created it.
+        assert!(!TxnStore::<InMemoryFs, ManualClock>::dir_exists(&fs).unwrap());
+    }
+
+    #[test]
+    fn an_oversized_txn_id_at_the_cap_still_frames() {
+        // The store frames a txn id up to MAX_TXN_ID_LEN (the lifecycle table rejects longer ids
+        // before the store is ever reached).
+        let at_cap = vec![b'z'; MAX_ID];
+        let blob = encode_half_meta(&at_cap, "s", RecordFlags::EMPTY, b"").unwrap();
+        match decode_meta(&blob).unwrap() {
+            TxnRecordMeta::Half(h) => assert_eq!(h.txn_id, at_cap),
+            TxnRecordMeta::Op(_) => panic!("half expected"),
+        }
+    }
+}

--- a/docs/RECOVERY.md
+++ b/docs/RECOVERY.md
@@ -678,3 +678,83 @@ is clean, with the restored cursors/DLQ/log-head equal to the source. The **NATS
 a NATS snapshot has no offline whole-store consistency proof of cursors-vs-log-vs-DLQ; here
 the manifest self-check plus the `verify` oracle make "this backup restores to a consistent
 dir" a checkable property, not a hope.
+
+---
+
+## 9. Transactional messages (2PC): the half-message commit point and its durability scope (#640)
+
+A transactional half message (`prepare` → `commit`/`rollback`, the two-phase-commit
+core in #640) buffers a payload INVISIBLE to consumers under a producer-supplied
+`txn_id`, then either makes it visible at one durable commit point or discards it.
+The buffered half lives in the `txn/` subtree (its own log, never the real stream),
+so a consumer never sees a Prepared payload, and the `txn/` subtree is not even
+materialized until the first `prepare` (a non-transactional broker is byte-for-byte
+unchanged). This section ratifies the COMMIT-POINT crash ordering and — because the
+"SHIP-WITH-DOC" review turned on exactly this — states the THREE durability-scope
+caveats that keep the exactly-once claim honest. The engine code is
+`Engine::txn_commit` / `commit_real_append` / `flush_txn_commit_dedup` and the clamp
+`seed_producer_seq_from_recovered` in `crates/ironbus-server/src/engine.rs`; the
+on-disk op-marker fsync is `TxnStore::append_op` in
+`crates/ironbus-storage/src/txn.rs`.
+
+### 9.1 The commit-point ordering
+
+A fresh commit (or a crash-recovery redrive of a Prepared txn) runs four ordered
+steps, designed so the real append is exactly-once across a crash:
+
+- **A** — WRITE the buffered payload to the real stream, no fsync (assigns the
+  offset, records the txn-id seq high-water IN MEMORY), DEDUPED by the durable
+  txn-id producer-seq (#639) so a redrive re-write is a duplicate at the original
+  offset.
+- **A2** — fsync the producer-seq CHECKPOINT (`producer-seq.ckpt`), making the
+  dedup identity durable BEFORE the record.
+- **A3** — the COMMIT-BATCH covering fsync, making the real record durable.
+- **B** — append + fsync the COMMITTED op-marker (the COMMIT POINT, carrying the
+  real offset).
+
+The crash windows map onto the longest-valid-prefix model of sections 1–3:
+
+| Crash window | On reopen | Outcome |
+|---|---|---|
+| after `prepare`, before A | txn replays as Prepared (only the half record is durable) | a later commit is a FRESH resolve; still invisible |
+| after A3, before B | txn replays as Prepared (no op-marker), payload still buffered | recovery re-commits; A re-writes the SAME payload under the SAME txn-id seq, which the durable high-water (made durable in A2) recognizes as a DUPLICATE at the original offset → exactly once |
+| between A2 and A3 | high-water durable, real record LOST in the torn tail | recovery's `seed_producer_seq_from_recovered` CLAMPS a high-water whose offset is at/past the durable head and DROPS it, so the redrive re-writes FRESH at the real head → no double (the first write was lost), no loss (the redrive lands it) |
+| after B | txn replays as Committed | no replay work; a retried commit is a benign idempotent no-op returning the recorded offset |
+
+A2 is ordered BEFORE A3 specifically so the between-A2-and-A3 window degrades to the
+CLAMP (drop a phantom high-water), not to a double-append. This is the recovery half
+of the I2 ack-implies-durable contract (section 1.3 / [DURABILITY.md](DURABILITY.md)),
+specialized to the 2PC commit point.
+
+### 9.2 The three durability-scope caveats (post-review, stated honestly)
+
+**(a) Exactly-once is SCOPED to `DurabilityLevel::Sync` (the default).** The
+default-stream exactly-once / no-committed-empty guarantee rests on A3 (the real
+record's covering fsync) happening BEFORE B (the op-marker, which ALWAYS
+force-fsyncs). Under a RELAXED durability level (`interval`/`async`/`none`) A3 is a
+no-fsync `flush_no_sync` while the op-marker B still force-fsyncs — so a power cut can
+leave the lifecycle state Committed (B durable) while the unsynced real record is lost
+(committed-but-empty). This is consistent with the relaxed-level acked-loss waiver
+(I2 is already waived there, [DURABILITY.md](DURABILITY.md)), but it is a NEW
+asymmetry: the lifecycle marker is durable while its record is not. Use `sync` (the
+default) for the no-committed-empty guarantee.
+
+**(b) Named-stream commit redrive is at-least-once on crash.** Only the DEFAULT stream
+carries the durable txn-id seq dedup. A NAMED (non-default) target stream is
+exactly-once in NORMAL operation, but a crash-recovery redrive (a Prepared replay
+re-appending) can DUPLICATE at a new offset (never loss, never a double-append in
+normal operation). Closing this is a flagged follow-up: thread the engine producer-seq
+dedup through `StreamSet::append_to` with a per-stream-namespaced high-water.
+
+**(c) The dedup high-water can age out.** The txn-id dedup high-water shares the
+bounded (LRU, ~4096-entry) `producer-seq.ckpt` slot. A VERY late default-stream
+redrive whose high-water was EVICTED by newer producers before it runs degrades to
+at-least-once (safe — never loss, never a flipped outcome). An IMMEDIATE
+crash-recovery redrive is unaffected: the txn pseudo-ids were just written and sort to
+the front of the LRU, so they are still present when recovery replays the Prepared txn.
+
+All three caveats are SAFE failure modes (at-least-once or a refused conflict, never a
+silent loss and never a flipped commit/rollback outcome). They are pinned in the engine
+doc comments (the module-level crash-safety argument and the `txn_commit` /
+`commit_real_append` doc) and exercised by the engine txn tests (the clamp branch by
+`crash_between_a2_and_a3_clamps_the_phantom_high_water_and_redrives_fresh`).

--- a/docs/RECOVERY.md
+++ b/docs/RECOVERY.md
@@ -758,3 +758,24 @@ silent loss and never a flipped commit/rollback outcome). They are pinned in the
 doc comments (the module-level crash-safety argument and the `txn_commit` /
 `commit_real_append` doc) and exercised by the engine txn tests (the clamp branch by
 `crash_between_a2_and_a3_clamps_the_phantom_high_water_and_redrives_fresh`).
+
+### 9.3 Transaction-id choice across reconnects (auto-minted vs caller-supplied)
+
+The `txn_id` is the broker's IDEMPOTENCY KEY (it anchors the lifecycle, the dedup
+high-water, and the commit/rollback resolution). The client offers two ways to
+choose it (`crates/ironbus-client/src/lib.rs`):
+
+- **Auto-minted** (`Client::prepare`): `<local_addr>#<seq>` — the connection's local
+  socket address plus a monotonic per-connection counter. Unique WITHIN a connection
+  and across concurrently-open connections (distinct local addresses), but NOT durable
+  across a reconnect: an EPHEMERAL local port REUSED by a later connection whose
+  counter has reset to 0 can re-mint an id a still-prepared txn already holds. Because
+  the id is the idempotency key, this surfaces as a broker ERROR (a spent /
+  still-prepared id is refused) — NEVER a silent merge of two distinct half messages.
+- **Caller-supplied** (`Client::prepare_with_id`): a stable id you control (a UUID, a
+  snowflake, a content hash). This is the DURABLE choice for a transaction that must
+  survive a reconnect, or that derives its identity from the producer's own local
+  transaction — it makes the cross-connection idempotency explicit instead of relying
+  on the per-connection mint.
+
+For transactions that span a reconnect, prefer `prepare_with_id` with a stable id.


### PR DESCRIPTION
## Summary

PART 1 of 2 of #640: the **transactional half-message 2PC core** — the RocketMQ transactional-message model adapted to IronBus. A producer **prepares** a half message (durably stored, INVISIBLE to consumers), runs its local transaction, then **commits** (the half message is appended to the real target stream and becomes visible) or **rolls back** (discarded, never delivered). This is the durable 2PC core; **PART 2 (the broker back-check + producer transaction-listener + `transact()` runner) is a separate follow-up PR** that closes #640.

Refs #640 (does **not** close it — PART 2 does).

## Design

### Core state machine — `crates/ironbus-core/src/txn.rs` (IO-free)
The pure lifecycle `Prepared → {Committed, RolledBack}`: legal transitions, idempotency rules (re-commit/re-rollback of a resolved txn is a NO-OP returning the prior outcome; **commit-after-rollback and rollback-after-commit are REFUSED, never flipped**; re-prepare of a Prepared id is a benign duplicate; prepare of a spent id is refused). `unresolved_before(cutoff)` is PART 2's back-check seam: an O(unresolved) range scan over a prepare-ordered index, never a walk over resolved entries. Bounded memory: a **live half message is never evicted** (prepare over the cap is refused, not dropped); resolved tombstones are LRU-bounded for cross-restart idempotency. No IO, no clock (the caller injects monotonic `now`) — the `ironbus-core is IO-free` gate passes.

### Durable store — `crates/ironbus-storage/src/txn.rs` (`<data_dir>/txn/`)
A second segmented `Log` under `txn/` (modeled on the DLQ sink), interleaving two FROZEN, CRC32C'd, version-tagged record kinds (`TXN_FORMAT_VERSION = 1`):
- **HALF record** (`TXNH`): the prepared half message — txn id, real target stream, original headers/flags, with key/payload/timestamp preserved verbatim as the segment record's own fields.
- **OP record** (`TXNO`): the resolution marker — txn id, committed/rolled-back, and the real offset.

`append_half`/`mark_committed`/`mark_rolled_back` each append-and-**fsync before returning**. `replay()` on open rebuilds the `TxnTable` + buffered-payload index from both record kinds in durable order (an op-marker supersedes its half record); a foreign/corrupt/unknown-version record is skipped fail-closed. `txn/` is absent until the first transactional produce.

### Wire frames (proto, tags from 44)
`TxnPrepare = 44`, `TxnCommit = 45`, `TxnRollback = 46`; **47 is now next-free**. *(The issue brief said "43 next-free", but a concurrent merge slotted `CommittedHwQuery` into 43, so the txn verbs start at 44 — pinned by a frozen-tag test.)* `TxnPrepareBody` carries `txn_id` + `stream_id` (version+length-framed) then the verbatim `PubBody` tail (reuses the `PubBody` codec unchanged, like `PubTo`). `TxnResolveBody` is the shared commit/rollback body (just a `txn_id`); the `FrameType` disambiguates. txn ids are u16-length-prefixed and capped at 256 (cap-before-alloc).

### Server + client
Session dispatch routes the three verbs through the single-writer engine (`engine.with` → `Command::Run`). The engine holds `Option<TxnStore>`, opened lazily on the first prepare. Client API: `prepare(stream, payload) -> TxnId`, `commit(txn) -> offset`, `rollback(txn)`, plus `prepare_with_id` for a producer-supplied id.

## The crash-safety argument

`txn_commit`'s fresh-resolve ordering:
- **A.** WRITE the payload to the real stream (no fsync), DEDUPED by the **durable producer-SEQUENCE high-water** keyed on the txn id (`txn_dedup_producer_id(txn)`, seq 0) — assigns `real_offset`, records the high-water in memory.
- **A2.** FLUSH the producer-seq checkpoint (fsync the high-water) — **before** the record's own fsync.
- **A3.** `commit_batch` (fsync the record) — the real append is now durable.
- **B.** append + fsync the COMMITTED op-marker (the **commit point**), carrying `real_offset`.

A txn is committed iff its op-marker is durable. The crash windows:

| window | state on reopen | which test |
|---|---|---|
| **(a)** crash after prepare, before A | replays **Prepared** (recoverable, still invisible); a later commit is a fresh resolve | storage `crash_after_prepare_before_op_replays_as_prepared`; engine `crash_after_prepare_reopens_as_prepared_and_recoverable` |
| **(b)** crash after A3 (real record durable), before B | replays **Prepared**, payload buffered → recovery re-commits; step A re-WRITEs under the same txn-id seq, which the **durable** high-water (made durable in A2, restored from `producer-seq.ckpt` on open) recognizes as a **Duplicate** at the original offset — appends NOTHING. Exactly once. | engine `recommit_after_a_crash_before_the_op_marker_is_deduped_no_double_append` |
| **(c)** crash after B | replays **Committed**; no replay work; a retried commit is a benign idempotent no-op | engine `a_committed_txn_reopens_as_resolved_and_recommit_is_idempotent` |

**Why A2 is ordered before A3** (the two-fsync sub-window): the seq-high-water fsync precedes the record fsync, so either both are durable (the redrive dedups to the original offset) **or** the high-water is durable but the record is lost in the torn tail — in which case recovery's `seed_producer_seq_from_recovered` **CLAMPS** a high-water whose offset is at/past the durable head and drops it, so the redrive re-writes FRESH at the real head. No double (the first write was lost), no loss (the redrive lands it). Either way the default-stream commit is **exactly-once across a crash**.

**Honest caveat:** a NAMED target stream does not yet carry the durable txn dedup (a flagged follow-up), so a named-stream commit redrive after a crash is at-least-once; the default stream (the common case) is exactly-once.

## The invisibility invariant (test)
`a_prepared_half_message_is_invisible_until_commit` (engine) + `txn_prepare_is_invisible_then_commit_delivers_over_the_wire` (session) + `txn_prepare_commit_delivers_only_after_commit_against_a_real_server` (client): a Prepared-but-uncommitted half message is `Poll::Idle`/never in the `Deliver` stream/absent from a `fetch`; it appears in the target stream ONLY after commit; after rollback it NEVER appears. Asserted across the engine poll path, the session Flow/Deliver path, and a real TCP server fetch.

## Byte-identical-when-unused
The `txn/` subtree is absent until the first prepare (`the_txn_subdir_is_absent_until_the_first_prepare`); normal produce/consume never materializes it; the produce-gate is untouched (no new check on the hot path). 25 existing byte-identical/byte-for-byte tests still pass.

## Deferred to PART 2
The broker back-check (resolving producer-crash-orphaned prepared txns by scanning `unresolved_before(now - T)`), the producer transaction-listener, and the closure-style `transact()` auto-commit/rollback runner. PART 2 closes #640.

## Verification
- `cargo fmt --all --check` clean; SPDX on both new `.rs` files; `git grep -i butlr` empty; `ironbus-core is IO-free` AST check passes (no fs/net/io in `txn.rs`).
- Per-crate `cargo check` + `cargo clippy --all-targets -D warnings` clean (core, storage, proto, client, server).
- Tests: core txn 20/20, storage txn 14/14, proto 133/133, server txn 16/16 (11 engine + 4 session + 1 incidental), client txn 3/3 over a real server. Full-workspace test deferred to CI (local disk constraint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVWp2H2txnKGru4q2twxM3


---

## Durability scope & caveats (post-review)

An independent adversarial review returned **SHIP-WITH-DOC** (no code defect). These follow-up commits make the guarantee airtight and honest — 3 documentation caveats, 1 missing test, 2 minor fixes — all on this branch, no feature rewrite.

### The three durability-scope caveats (now documented honestly)

These are all **SAFE** failure modes (at-least-once or a refused conflict — never a silent loss, never a flipped commit/rollback outcome). Pinned in the engine doc comments (the module-level crash-safety argument + the `txn_commit` / `commit_real_append` docs), in `docs/RECOVERY.md` §9, and here:

- **(a) Exactly-once is scoped to `DurabilityLevel::Sync` (the default).** The default-stream exactly-once / no-committed-empty guarantee rests on A3 (the real record's covering fsync) running **before** B (the op-marker, which ALWAYS force-fsyncs). Under a **relaxed** level (`interval`/`async`/`none`) A3 is a no-fsync flush while B still fsyncs — so a power cut can leave the lifecycle **Committed** while the unsynced real record is lost (**committed-but-empty**). Consistent with the relaxed-level acked-loss waiver (I2 is already waived there), but a NEW asymmetry: the lifecycle marker is durable while its record is not. Use `sync` (the default) for the no-committed-empty guarantee.
- **(b) Named-stream commit redrive is at-least-once on crash.** Only the DEFAULT stream carries the durable txn-id seq dedup. A named (non-default) target stream is exactly-once in normal operation, but a crash-recovery redrive can **duplicate** at a new offset (never loss, never a double-append in normal op). Closing this is a flagged follow-up: thread the engine producer-seq dedup through `StreamSet::append_to` with a per-stream-namespaced high-water.
- **(c) The dedup high-water can age out.** The txn-id dedup high-water shares the bounded (LRU, ~4096-entry) `producer-seq.ckpt` slot; a **very late** default-stream redrive whose high-water was evicted degrades to at-least-once (safe). Immediate crash-recovery redrives are unaffected (the txn pseudo-ids were just written and sort to the front of the LRU).

### The missing clamp-branch test (the substantive gap)

The review found the A2↔A3 torn-tail **clamp branch** — real-stream record LOST but the seq-checkpoint high-water DURABLE, so recovery's clamp drops the phantom high-water and the redrive re-appends FRESH exactly once — had **no faithful test** (the in-memory FS syncs both, so the torn state was never constructed). Closed with the **preferred** (faithful) approach, not the fallback: `crash_between_a2_and_a3_clamps_the_phantom_high_water_and_redrives_fresh` (engine) uses the fault-injecting FS to run A (write, no fsync) + A2 (fsync the seq checkpoint) so the high-water is durable, then arms an fsync fault and runs A3 (`commit_batch`'s covering fsync), which fails and freezes the writer with the record still unsynced — precisely the mid-A2/A3 crash. A simulated power loss reverts the unsynced record while the fsync'd checkpoint survives; a clean reopen drives the clamp. Asserts the high-water is dropped (flushed head = 0) and the redrive re-appends fresh at offset 0 exactly once (no double, no loss). **Verified the test has teeth:** neutering the `>= flushed` clamp guard makes the redrive dedup to the phantom offset and silently lose the record, failing the exactly-one assertion.

### Frame bodies are now byte-frozen (claim corrected by adding the tests)

The 44/45/46 frame **tags** were byte-frozen, but the **bodies** were only round-trip-tested — yet this PR claimed "frozen snapshot tests." Rather than weaken the wording, the bodies are now genuinely byte-frozen: `the_txn_prepare_body_is_byte_frozen` and `the_txn_resolve_body_is_byte_frozen` (proto) pin the exact wire bytes of a fixed `TxnPrepareBody` / `TxnResolveBody` fixture, the frame-body twin of the TXNH/TXNO on-disk byte-freeze (the `TxnPrepare` `pub_body` is pinned as an opaque verbatim tail, so the freeze is independent of the shared `PubBody` codec).

### `mint_txn_id` collision note (minor)

Documented (on the `mint_txn_id` doc comment + `docs/RECOVERY.md` §9.3) that an auto-minted `<local_addr>#<seq>` id can collide if an ephemeral local port is reused across connections with a reset counter — surfacing as a **broker error, NEVER a silent merge** of two half messages — and that `prepare_with_id` (a stable caller-supplied id) is the durable choice for transactions that must survive reconnects. No code change.

### Post-review verification

Per touched crate (proto, server, client): `cargo fmt --check` clean, `cargo check` clean, `cargo clippy --all-targets --locked -D warnings` clean; the new/affected tests pass via targeted runs (proto txn 7/7 incl. the 2 byte-freeze, server txn + clamp green, client prepare 2/2). `ironbus-core` still IO-free; `git grep -i butlr` empty (only the `.github/forbidden-org-terms.txt` guard). #640 stays OPEN — part 2 closes it.
