### PR TITLE
feat(reliability): broker back-check — resolve producer-crashed in-doubt transactions (part 2/2, Closes #640)

### DIFF
--- a/crates/ironbus-client/src/lib.rs
+++ b/crates/ironbus-client/src/lib.rs
@@ -29,13 +29,14 @@ use ironbus_proto::frame::{decode_frame, encode_frame, FrameDecode, FrameError, 
 use ironbus_proto::message::{
     decode_dead_letter, decode_deliver, decode_deliver_batch, decode_gap_marker, decode_info,
     decode_not_leader, decode_produce_confirm, decode_pub_ack, decode_stream_info_response,
-    decode_truncated, encode_ack, encode_connect, encode_cumulative_ack, encode_fetch, encode_pub,
-    encode_pub_to, encode_stream_commit, encode_stream_declare, encode_stream_fetch,
-    encode_stream_info, encode_sub, encode_sub_to, encode_txn_prepare, encode_txn_resolve,
-    produce_confirm_status, AckBody, AckLevel, AckOp, BodyError, ConnectBody, ConsumeTier,
-    CumulativeAckBody, DeliverBody, FetchBody, PubBody, PubToBody, StreamCommitBody,
-    StreamDeclareBody, StreamFetchBody, StreamInfoBody, SubBody, SubToBody, TxnPrepareBody,
-    TxnResolveBody, PUB_FLAG_ACK_LEVEL_MASK, PUB_FLAG_ACK_LEVEL_SHIFT,
+    decode_truncated, decode_txn_resolve, encode_ack, encode_connect, encode_cumulative_ack,
+    encode_fetch, encode_pub, encode_pub_to, encode_stream_commit, encode_stream_declare,
+    encode_stream_fetch, encode_stream_info, encode_sub, encode_sub_to, encode_txn_check_result,
+    encode_txn_listen, encode_txn_prepare, encode_txn_resolve, produce_confirm_status, AckBody,
+    AckLevel, AckOp, BodyError, ConnectBody, ConsumeTier, CumulativeAckBody, DeliverBody,
+    FetchBody, PubBody, PubToBody, StreamCommitBody, StreamDeclareBody, StreamFetchBody,
+    StreamInfoBody, SubBody, SubToBody, TxnCheckDecision, TxnCheckResultBody, TxnListenBody,
+    TxnPrepareBody, TxnResolveBody, PUB_FLAG_ACK_LEVEL_MASK, PUB_FLAG_ACK_LEVEL_SHIFT,
 };
 use std::io::{self, Read, Write};
 use std::net::{TcpStream, ToSocketAddrs};
@@ -58,6 +59,11 @@ pub enum ClientError {
     UnknownFrameType(u8),
     /// The response had the expected type but a malformed shape for the request.
     BadResponse(&'static str),
+    /// The producer's LOCAL transaction failed inside [`Client::transact`] (#640 part 2): the half
+    /// message was ROLLED BACK (discarded, never delivered) and the local transaction's error message is
+    /// carried here. The broker side is consistent (the half message is gone); this surfaces the local
+    /// failure to the caller after the clean rollback.
+    LocalTransaction(String),
     /// The connection closed before a complete response arrived.
     Closed,
     /// The server REDIRECTED a produce: the node this client is connected to holds a clustered replica
@@ -117,6 +123,12 @@ impl core::fmt::Display for ClientError {
                 write!(f, "unknown response frame type tag {tag}")
             }
             ClientError::BadResponse(why) => write!(f, "malformed response: {why}"),
+            ClientError::LocalTransaction(m) => {
+                write!(
+                    f,
+                    "local transaction failed (half message rolled back): {m}"
+                )
+            }
             ClientError::Closed => write!(f, "connection closed mid-response"),
             ClientError::Decompress { source, offset, .. } => {
                 write!(
@@ -750,6 +762,36 @@ impl TxnId {
     #[must_use]
     pub fn as_bytes(&self) -> &[u8] {
         &self.0
+    }
+}
+
+/// A producer's transaction-state listener's answer to a broker back-check (#640 part 2): the
+/// resolution the broker should apply to an in-doubt half message. Returned by the `check_transaction`
+/// callback a producer passes to [`Client::transact`] / [`Client::register_transaction_listener`]. The
+/// client-facing mirror of the wire [`TxnCheckDecision`] (the proto type), so a caller never depends on
+/// the proto crate directly.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TxnDecision {
+    /// The producer's local transaction COMMITTED: the broker should commit the half message (it
+    /// becomes visible), exactly once, via the part-1 path.
+    Commit,
+    /// The producer's local transaction ROLLED BACK (or never committed): the broker should discard the
+    /// half message (never delivered).
+    Rollback,
+    /// The producer CANNOT decide yet (its local state is still in-doubt): the broker reschedules a
+    /// later back-check and, after the bounded attempt cap, applies the SAFE terminal default
+    /// (rollback/discard).
+    Unknown,
+}
+
+impl TxnDecision {
+    /// Maps to the wire [`TxnCheckDecision`].
+    fn to_wire(self) -> TxnCheckDecision {
+        match self {
+            TxnDecision::Commit => TxnCheckDecision::Commit,
+            TxnDecision::Rollback => TxnCheckDecision::Rollback,
+            TxnDecision::Unknown => TxnCheckDecision::Unknown,
+        }
     }
 }
 
@@ -2597,6 +2639,148 @@ impl Client {
         TxnId(format!("{seed}#{seq}").into_bytes())
     }
 
+    /// Registers this connection as the transaction-state LISTENER for the stable `group` (#640
+    /// part 2, the `TxnListen` verb): the broker binds the group to this connection so a back-check
+    /// [`crate::FrameType::TxnCheck`] for an in-doubt half message this producer prepared (under this
+    /// group) is routed here — even after a CRASH and reconnect (the producer reconnects and calls this
+    /// again with the SAME group to re-point the route). After registering, the producer prepares its
+    /// transactions on this connection (their half messages record the group as owner) and drives the
+    /// back-check by calling [`Client::transact`] (or [`Client::run_transaction_listener`]) so an
+    /// inbound `TxnCheck` is answered. A stable, producer-chosen group (e.g. the producer's durable id)
+    /// is what makes the route survive a reconnect; an EMPTY group is rejected by the broker.
+    ///
+    /// # Errors
+    /// Returns [`ClientError::Server`] if the broker rejects the registration (an empty group, or the
+    /// `publish` scope is missing), [`ClientError::Body`] on an over-large group, or a frame/connection
+    /// error.
+    pub fn register_transaction_listener(&mut self, group: &[u8]) -> Result<(), ClientError> {
+        let mut body = Vec::new();
+        encode_txn_listen(&TxnListenBody { group }, &mut body).map_err(ClientError::Body)?;
+        self.send(FrameType::TxnListen, &body)?;
+        match self.read_frame()? {
+            (FrameType::Ok, _) => Ok(()),
+            (FrameType::Err, body) => {
+                Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
+            }
+            (other, _) => Err(ClientError::Unexpected(other)),
+        }
+    }
+
+    /// Answers one inbound `TxnCheck` (#640 part 2): decode the txn id, run the producer's
+    /// `check_transaction` callback to decide the resolution, and reply a `TxnCheckResult`. The broker
+    /// then resolves the in-doubt half message through the part-1 idempotent path (a `Commit` commits it
+    /// exactly once, a `Rollback` discards it, an `Unknown` reschedules). Used by the listener loop.
+    fn answer_txn_check<L: FnMut(&[u8]) -> TxnDecision>(
+        &mut self,
+        check_body: &[u8],
+        listener: &mut L,
+    ) -> Result<(), ClientError> {
+        let decoded = decode_txn_resolve(check_body)
+            .map_err(|_| ClientError::BadResponse("malformed txn-check body"))?;
+        let decision = listener(decoded.txn_id).to_wire();
+        let mut body = Vec::new();
+        encode_txn_check_result(
+            &TxnCheckResultBody {
+                txn_id: decoded.txn_id,
+                decision,
+            },
+            &mut body,
+        )
+        .map_err(ClientError::Body)?;
+        self.send(FrameType::TxnCheckResult, &body)?;
+        Ok(())
+    }
+
+    /// Runs the producer's transaction-state listener for up to `timeout` (#640 part 2): it DRIVES
+    /// broker passes by interleaving lightweight `Ping`s (exactly like [`Client::produce_confirmed`]),
+    /// and for every inbound `TxnCheck` it runs `check_transaction(txn_id)` and replies the answer — so
+    /// the broker's back-check resolves this producer's in-doubt half messages (e.g. ones it prepared
+    /// before a crash, now recovered after this reconnect). Returns the number of `TxnCheck`s answered.
+    ///
+    /// A producer that crashed mid-transaction reconnects, calls
+    /// [`Client::register_transaction_listener`] with its stable group, then calls this to settle any
+    /// in-doubt transactions. The callback should consult the producer's OWN durable local-transaction
+    /// state for `txn_id` and return [`TxnDecision::Commit`] / [`TxnDecision::Rollback`], or
+    /// [`TxnDecision::Unknown`] if it cannot yet decide (the broker retries, then safely rolls back).
+    ///
+    /// # Errors
+    /// A frame/connection error, or [`ClientError::Server`] if a `Ping` is answered with an `Err`.
+    pub fn run_transaction_listener<L: FnMut(&[u8]) -> TxnDecision>(
+        &mut self,
+        mut check_transaction: L,
+        timeout: Duration,
+    ) -> Result<usize, ClientError> {
+        let deadline = std::time::Instant::now() + timeout;
+        let mut answered = 0;
+        loop {
+            // Drive a broker pass: a Ping makes the connection do a `process` pass, which runs the
+            // back-check scan and flushes any TxnChecks routed to this connection alongside the Pong.
+            self.send(FrameType::Ping, &[])?;
+            loop {
+                match self.read_frame_or_timeout()? {
+                    Some((FrameType::TxnCheck, body)) => {
+                        self.answer_txn_check(&body, &mut check_transaction)?;
+                        answered += 1;
+                    }
+                    // Round-ending cases (stop reading, re-check the deadline, re-Ping): a read timeout
+                    // with no frame, or the Pong flush boundary (every routed check precedes or
+                    // accompanies it in the same flush).
+                    None | Some((FrameType::Pong, _)) => break,
+                    Some((FrameType::Err, body)) => {
+                        return Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
+                    }
+                    // A stray frame (e.g. an Ok reply to a TxnCheckResult, or another frame on a mixed
+                    // connection) is not what this loop is for: ignore it and keep draining the round.
+                    Some(_) => {}
+                }
+            }
+            if std::time::Instant::now() >= deadline {
+                return Ok(answered);
+            }
+        }
+    }
+
+    /// Runs a full local transaction with the broker 2PC (#640 part 2): PREPARE a half message,
+    /// run `local_txn_fn`, then COMMIT if it succeeded or ROLLBACK if it failed (or panicked-as-`Err`).
+    /// This is the ergonomic transactional path: the half message is invisible until the local
+    /// transaction commits, and if this producer CRASHES between prepare and resolve, the broker's
+    /// back-check later asks this producer's registered listener
+    /// ([`Client::register_transaction_listener`] + [`Client::run_transaction_listener`]) to settle the
+    /// in-doubt transaction — so no half message is ever stuck, lost, or double-delivered.
+    ///
+    /// `txn` is the producer-supplied STABLE transaction id (use a UUID / snowflake / content hash so
+    /// it survives a reconnect — the listener answers a back-check by THIS id). `local_txn_fn` runs the
+    /// producer's own local transaction and returns `Ok(())` to commit or `Err(_)` to roll back; its
+    /// error is propagated after the rollback. Returns the committed offset on a commit.
+    ///
+    /// # Errors
+    /// Returns [`ClientError::LocalTransaction`] (wrapping the `local_txn_fn` error) after a successful
+    /// rollback, [`ClientError::Server`] / a frame error from the prepare/commit/rollback, or
+    /// [`ClientError::Body`] on an over-large field.
+    pub fn transact<T: FnOnce() -> Result<(), E>, E: std::fmt::Display>(
+        &mut self,
+        txn: &TxnId,
+        stream: &str,
+        message: &PubBody<'_>,
+        local_txn_fn: T,
+    ) -> Result<u64, ClientError> {
+        // PREPARE the half message (durable, invisible) under the stable id.
+        self.prepare_with_id(txn, stream, message)?;
+        // Run the producer's local transaction.
+        match local_txn_fn() {
+            Ok(()) => {
+                // The local transaction committed: make the half message visible (exactly once).
+                self.commit(txn)
+            }
+            Err(e) => {
+                // The local transaction failed: discard the half message. Propagate the original error
+                // after the rollback (a rollback failure supersedes it — the connection is in trouble).
+                self.rollback(txn)?;
+                Err(ClientError::LocalTransaction(e.to_string()))
+            }
+        }
+    }
+
     /// Subscribes this connection's consume path to a NAMED stream's work-group (#588, M2-I10): the
     /// `SubTo` verb, the stream-addressed twin of [`Client::subscribe`]. Subsequent [`Client::fetch`] /
     /// [`Client::flow`] and [`Client::ack`] consume from and commit to THAT stream's own competing
@@ -3241,6 +3425,79 @@ mod tests {
             },
         )
         .unwrap();
+        spawn_serving(engine)
+    }
+
+    /// Like [`start_server_with`] but configures a SHORT back-check schedule (#640 part 2) so an
+    /// over-the-wire test can drive the broker back-check WITHOUT waiting out the production 30 s
+    /// timeout: a 0-nanosecond timeout (a Prepared half is immediately eligible) and a 1-attempt cap (the
+    /// terminal default fires on the first attempt), with a roomy default credit. The server runs on the
+    /// real `SystemClock`, so the schedule is driven by the producer's own listener-loop passes.
+    fn start_server_with_back_check(
+        timeout: u64,
+        max_attempts: u32,
+    ) -> (
+        std::net::SocketAddr,
+        Arc<AtomicBool>,
+        std::thread::JoinHandle<()>,
+    ) {
+        let mut engine = Engine::open(
+            InMemoryFs::new(),
+            SystemClock::new(),
+            EngineConfig {
+                log: LogConfig::default(),
+                lease: LeaseConfig::default(),
+                delivery: DeliveryConfig::new(5, false, vec![]).unwrap(),
+                max_in_flight: 16,
+                consumer_credit: 64,
+                consumer_credit_bytes: 0,
+                checkpoint_interval: 1024,
+                max_retained_bytes: 0,
+                max_age_ms: 0,
+                max_messages: 0,
+                max_groups: DEFAULT_MAX_GROUPS,
+                group_idle_evict_ms: DEFAULT_GROUP_IDLE_EVICT_MS,
+                ram_ceiling_bytes: 0,
+                disk_full_policy: DiskFullPolicy::DropNew,
+                dedup: ironbus_core::dedup::DedupConfig::default(),
+                durability_level: ironbus_server::engine::DurabilityLevel::Sync,
+                flush_interval_ms: 0,
+                flush_max_bytes: 0,
+                codel_target_ms: 0,
+                codel_interval_ms: 0,
+                retry_budget_ratio_per_million: 0,
+                retry_budget_window_ms: 0,
+                fire_and_forget_msg_rate: 0,
+                fire_and_forget_byte_rate: 0,
+                fire_and_forget_refill_ms: 0,
+                egress_limit: 0,
+                wal_fsync_headroom_bytes: 0,
+                compression: ironbus_core::compress::Codec::None,
+                default_message_ttl_ms: 0,
+                dead_letter_exchange: None,
+                dead_letter_expired: false,
+            },
+        )
+        .unwrap();
+        engine.set_back_check_config(ironbus_core::txn::BackCheckConfig {
+            timeout,
+            retry: 1, // floored to 1; with a real clock every scan pass is past the 1 ns retry
+            max_attempts,
+            batch: 256,
+        });
+        spawn_serving(engine)
+    }
+
+    /// Spawns the append actor over `engine` and the wire serve loop on a fresh ephemeral port,
+    /// returning the bound address, the shutdown flag, and the serve thread handle (shared by the
+    /// `start_server_*` helpers).
+    fn spawn_serving(
+        engine: Engine<InMemoryFs, SystemClock>,
+    ) -> (
+        std::net::SocketAddr,
+        Arc<AtomicBool>,
+        std::thread::JoinHandle<()>,
+    ) {
         // The engine is owned by the append actor (#177); the wire server reaches it through the
         // handle. The actor join handle is detached (these client tests drive the broker only over the
         // wire and never inspect the engine): when the server thread drops its handle on stop, the
@@ -6930,6 +7187,133 @@ mod tests {
         let mut consumer = Client::connect(addr).unwrap();
         assert_eq!(consumer.fetch(10).unwrap().messages.len(), 1);
         drop(producer);
+        drop(consumer);
+        shutdown.store(true, Ordering::Release);
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn transact_commits_a_successful_local_transaction_and_rolls_back_a_failed_one() {
+        // #640 part 2: the `transact` runner — a successful local transaction commits the half message
+        // (visible), a failed one rolls it back (never delivered, the local error surfaced).
+        let (addr, shutdown, handle) = start_server();
+        let mut producer = Client::connect(addr).unwrap();
+        // A successful local transaction: commit -> visible.
+        let ok_txn = TxnId::new(b"txn-ok".to_vec());
+        let off = producer
+            .transact(&ok_txn, "", &txn_pub(b"committed"), || Ok::<(), String>(()))
+            .unwrap();
+        assert_eq!(off, 0);
+        // A failed local transaction: rollback -> never delivered, the error surfaces.
+        let bad_txn = TxnId::new(b"txn-bad".to_vec());
+        let err = producer
+            .transact(&bad_txn, "", &txn_pub(b"discarded"), || {
+                Err::<(), String>("local failure".to_string())
+            })
+            .unwrap_err();
+        assert!(
+            matches!(err, ClientError::LocalTransaction(m) if m.contains("local failure")),
+            "a failed local transaction rolls back and surfaces the error"
+        );
+        // Only the committed record is visible.
+        let mut consumer = Client::connect(addr).unwrap();
+        let messages = consumer.fetch(10).unwrap().messages;
+        assert_eq!(messages.len(), 1, "only the committed half is delivered");
+        assert_eq!(messages[0].payload, b"committed");
+        drop(producer);
+        drop(consumer);
+        shutdown.store(true, Ordering::Release);
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn the_headline_back_check_resolves_a_crashed_producers_half_over_the_wire() {
+        // THE HEADLINE over the REAL wire: producer A registers a listener (group "svc"), prepares a half
+        // message with a STABLE id, then DISCONNECTS before resolving (a crash). Producer B reconnects,
+        // re-registers the SAME group, and runs its transaction-state listener; the broker's back-check
+        // routes a TxnCheck to it, the listener answers Commit, and the half message is committed exactly
+        // once — a consumer then sees it. A 0-timeout back-check makes the half immediately eligible so
+        // the test does not wait out the production window.
+        let (addr, shutdown, handle) = start_server_with_back_check(0, 5);
+        let txn_id = b"order-stable-uuid".to_vec();
+        // Producer A: register the listener, prepare, then "crash" (drop the connection without
+        // resolving).
+        {
+            let mut a = Client::connect(addr).unwrap();
+            a.register_transaction_listener(b"svc").unwrap();
+            a.prepare_with_id(&TxnId::new(txn_id.clone()), "", &txn_pub(b"order-42"))
+                .unwrap();
+            // CRASH: drop A without commit/rollback. Its half message is now in-doubt.
+        }
+        // Producer B: the SAME producer reconnecting. Re-register the SAME group, then run the listener
+        // loop, which answers the broker's back-check for the in-doubt txn with Commit.
+        let mut b = Client::connect(addr).unwrap();
+        b.register_transaction_listener(b"svc").unwrap();
+        let answered = b
+            .run_transaction_listener(
+                |id| {
+                    // The producer's durable local state says this transaction committed.
+                    if id == txn_id.as_slice() {
+                        TxnDecision::Commit
+                    } else {
+                        TxnDecision::Unknown
+                    }
+                },
+                Duration::from_secs(5),
+            )
+            .unwrap();
+        assert!(answered >= 1, "the back-check was answered at least once");
+        // The half message is now committed exactly once: a consumer sees it.
+        let mut consumer = Client::connect(addr).unwrap();
+        let mut delivered = Vec::new();
+        for _ in 0..20 {
+            let messages = consumer.fetch(10).unwrap().messages;
+            for m in messages {
+                delivered.push(m.payload.clone());
+                consumer.ack(m.offset, m.generation).unwrap();
+            }
+            if !delivered.is_empty() {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        assert_eq!(
+            delivered,
+            vec![b"order-42".to_vec()],
+            "the crashed producer's half is committed exactly once by the back-check"
+        );
+        drop(b);
+        drop(consumer);
+        shutdown.store(true, Ordering::Release);
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn the_back_check_rollback_answer_never_delivers_over_the_wire() {
+        // The sibling of the headline: the reconnected listener answers Rollback -> the in-doubt half is
+        // discarded and never delivered.
+        let (addr, shutdown, handle) = start_server_with_back_check(0, 5);
+        let txn_id = b"abort-stable-uuid".to_vec();
+        {
+            let mut a = Client::connect(addr).unwrap();
+            a.register_transaction_listener(b"svc").unwrap();
+            a.prepare_with_id(&TxnId::new(txn_id.clone()), "", &txn_pub(b"secret"))
+                .unwrap();
+        }
+        let mut b = Client::connect(addr).unwrap();
+        b.register_transaction_listener(b"svc").unwrap();
+        b.run_transaction_listener(|_id| TxnDecision::Rollback, Duration::from_secs(5))
+            .unwrap();
+        // The half is discarded: a consumer sees nothing even after a few fetch attempts.
+        let mut consumer = Client::connect(addr).unwrap();
+        for _ in 0..10 {
+            assert!(
+                consumer.fetch(10).unwrap().messages.is_empty(),
+                "a rolled-back half is never delivered"
+            );
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        drop(b);
         drop(consumer);
         shutdown.store(true, Ordering::Release);
         handle.join().unwrap();

--- a/crates/ironbus-core/src/txn.rs
+++ b/crates/ironbus-core/src/txn.rs
@@ -562,6 +562,253 @@ impl TxnTable {
     }
 }
 
+// ===================================================================================
+// THE BACK-CHECK BOOK (V2-M8, #640 part 2): the PURE, IO-free per-Prepared-txn back-check
+// schedule + attempt count. When a producer prepares a half message then CRASHES before
+// commit/rollback, the half message is stuck Prepared (invisible, undelivered) forever. The
+// broker's back-check resolves it: it periodically asks the producer "what is the state of txn X?"
+// and resolves on the answer; after a bounded number of unanswered attempts it applies the SAFE
+// TERMINAL default (rollback/discard — never deliver a message whose outcome is unknowable).
+//
+// THIS structure owns only the SCHEDULING bookkeeping (per-txn attempt count + next-eligible
+// instant) and the pure DECISIONS over it (which txns are due, when to give up). It reads NO clock
+// (the caller injects every `now`), holds NO payload, and does NO IO; the durable persistence of the
+// bookkeeping (so the schedule + count survive a broker restart) lives in `ironbus-storage`, and the
+// actual TxnCheck push + resolution live in `ironbus-server`. It is EMPTY until a txn is enrolled, so
+// a non-transactional broker pays nothing.
+// ===================================================================================
+
+/// The default back-check TIMEOUT: a Prepared half message unresolved for at least this long
+/// (monotonic) is eligible for its FIRST back-check (#640 part 2). The broker enrolls a fresh prepare
+/// with a first-eligible instant of `prepared_at + back_check_timeout`, so a normal commit/rollback
+/// that lands inside the window is never back-checked at all. Thirty seconds is comfortably above a
+/// real local-transaction latency yet finite, so a genuinely crashed producer's half message is
+/// resolved promptly. Expressed in the same monotonic unit the lifecycle's `now` uses.
+pub const DEFAULT_BACK_CHECK_TIMEOUT_NANOS: u64 = 30 * 1_000_000_000;
+
+/// The default delay between successive back-check ATTEMPTS for one txn (#640 part 2): after an
+/// attempt that does not resolve (the producer is unreachable, or answered `Unknown`), the txn's
+/// next-eligible instant advances by this much, so the broker does not hammer a single in-doubt txn.
+/// Combined with the global rate cap, this bounds the back-check load (no storm). Fifteen seconds.
+pub const DEFAULT_BACK_CHECK_RETRY_NANOS: u64 = 15 * 1_000_000_000;
+
+/// The default cap on back-check ATTEMPTS before the broker gives up and applies the SAFE TERMINAL
+/// default (rollback/discard) (#640 part 2). After this many attempts have been recorded for a txn
+/// with no resolution, the next [`BackCheckBook::record_attempt`] reports the terminal default is due.
+/// Five attempts over the retry cadence is a generous bounded window for a producer to reconnect and
+/// re-register its listener before the half message is safely discarded.
+pub const DEFAULT_MAX_BACK_CHECK_ATTEMPTS: u32 = 5;
+
+/// The default cap on how many `TxnCheck`s the scan issues in ONE pass (#640 part 2): a global rate cap
+/// so a backlog of due in-doubt txns is back-checked in bounded batches rather than a single storm of
+/// pushes. The remaining due txns wait for the next scan pass.
+pub const DEFAULT_BACK_CHECK_BATCH: usize = 256;
+
+/// Tunables for a [`BackCheckBook`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct BackCheckConfig {
+    /// How long (monotonic) a half message stays Prepared before its FIRST back-check is eligible.
+    /// `0` makes a fresh prepare immediately eligible (used in deterministic tests).
+    pub timeout: u64,
+    /// The delay (monotonic) added to a txn's next-eligible instant after an unresolved attempt.
+    /// Floored to 1 by [`BackCheckBook::new`] so a txn always advances (no busy-loop on one txn).
+    pub retry: u64,
+    /// The cap on back-check ATTEMPTS before the terminal default fires. Floored to 1 by
+    /// [`BackCheckBook::new`].
+    pub max_attempts: u32,
+    /// The cap on `TxnCheck`s issued in one scan pass (the global rate cap). Floored to 1 by
+    /// [`BackCheckBook::new`].
+    pub batch: usize,
+}
+
+impl Default for BackCheckConfig {
+    fn default() -> BackCheckConfig {
+        BackCheckConfig {
+            timeout: DEFAULT_BACK_CHECK_TIMEOUT_NANOS,
+            retry: DEFAULT_BACK_CHECK_RETRY_NANOS,
+            max_attempts: DEFAULT_MAX_BACK_CHECK_ATTEMPTS,
+            batch: DEFAULT_BACK_CHECK_BATCH,
+        }
+    }
+}
+
+/// What recording a back-check attempt for a txn decided (the pure terminal-default gate).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AttemptOutcome {
+    /// The attempt was recorded and the txn rescheduled for a later retry: more attempts remain
+    /// before the terminal default. The caller has pushed (or will push) a `TxnCheck` and waits for
+    /// the producer's `TxnCheckResult`.
+    Rescheduled,
+    /// This attempt reached the attempt cap with no resolution: the caller MUST now apply the SAFE
+    /// TERMINAL default (rollback/discard) for this txn via the part-1 idempotent `txn_rollback` path.
+    /// The txn is left enrolled until the caller's rollback calls [`BackCheckBook::forget`] (so the
+    /// terminal default is driven by the same resolve path as a producer-driven rollback, inheriting
+    /// the `AlreadyResolved` idempotency).
+    TerminalDefault,
+}
+
+/// One enrolled txn's back-check bookkeeping: how many attempts have been made and when it is next
+/// eligible for a (first or retry) back-check. No payload, no clock — pure schedule state.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct BackCheckEntry {
+    /// The number of back-check attempts recorded so far (0 before the first push).
+    attempts: u32,
+    /// The monotonic instant at or after which this txn is next eligible for a back-check.
+    next_eligible: u64,
+}
+
+/// The PURE, IO-free back-check schedule + attempt-count book for the broker's in-doubt-transaction
+/// resolver (V2-M8, #640 part 2). It tracks, per still-`Prepared` txn, how many `TxnCheck`s have been
+/// issued and when the txn is next eligible, and answers the two scan questions — "which txns are due
+/// now?" ([`BackCheckBook::due`]) and "has this txn exhausted its attempts?"
+/// ([`BackCheckBook::record_attempt`]) — without reading a clock (the caller injects `now`) or doing
+/// any IO (the durable persistence of the bookkeeping lives in `ironbus-storage`).
+///
+/// EMPTY until a txn is [`BackCheckBook::enroll`]ed, so a broker no producer ever runs a transaction
+/// on pays nothing: the scan's [`BackCheckBook::due`] is an O(1) "is the book empty?" no-op. Bounded
+/// by the same `max_prepared` cap as the unresolved set (the engine enrolls exactly the
+/// still-`Prepared` txns), so it never grows without bound.
+#[derive(Clone, Debug)]
+pub struct BackCheckBook {
+    config: BackCheckConfig,
+    /// Every enrolled (still-`Prepared`, under-back-check) txn's bookkeeping, keyed by `txn_id`.
+    entries: HashMap<Vec<u8>, BackCheckEntry>,
+}
+
+impl BackCheckBook {
+    /// A fresh, empty book with `config`. The `retry`, `max_attempts`, and `batch` are floored to 1.
+    #[must_use]
+    pub fn new(config: BackCheckConfig) -> BackCheckBook {
+        BackCheckBook {
+            config: BackCheckConfig {
+                timeout: config.timeout,
+                retry: config.retry.max(1),
+                max_attempts: config.max_attempts.max(1),
+                batch: config.batch.max(1),
+            },
+            entries: HashMap::new(),
+        }
+    }
+
+    /// The active config (with the floors applied).
+    #[must_use]
+    pub fn config(&self) -> BackCheckConfig {
+        self.config
+    }
+
+    /// The number of currently-enrolled (under-back-check) txns.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Whether no txn is enrolled — the scan's hot-path no-op gate (a broker with no in-doubt txns
+    /// does ZERO back-check work).
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// This txn's current `(attempts, next_eligible)` bookkeeping, or `None` if not enrolled. For the
+    /// durable snapshot, observability, and tests.
+    #[must_use]
+    pub fn bookkeeping(&self, txn_id: &[u8]) -> Option<(u32, u64)> {
+        self.entries
+            .get(txn_id)
+            .map(|e| (e.attempts, e.next_eligible))
+    }
+
+    /// Enrolls a still-`Prepared` txn for back-checking with a `first_eligible` instant (the engine
+    /// passes `prepared_at + config.timeout`), idempotently: a re-enroll of an already-tracked txn is a
+    /// NO-OP that preserves its existing attempt count + schedule (so a duplicate enroll — e.g. a
+    /// re-prepare, or a second scan before the first resolves — never resets the back-check progress).
+    /// The first push will happen once `now >= first_eligible`.
+    pub fn enroll(&mut self, txn_id: &[u8], first_eligible: u64) {
+        self.entries
+            .entry(txn_id.to_vec())
+            .or_insert(BackCheckEntry {
+                attempts: 0,
+                next_eligible: first_eligible,
+            });
+    }
+
+    /// Removes a txn from the book — called when it RESOLVES (a producer commit/rollback, a back-check
+    /// resolution, or the terminal default), so a resolved txn is never back-checked again. Idempotent:
+    /// forgetting an untracked txn is a no-op. Returns whether an entry was removed.
+    pub fn forget(&mut self, txn_id: &[u8]) -> bool {
+        self.entries.remove(txn_id).is_some()
+    }
+
+    /// Restores one txn's back-check bookkeeping from a durable replay (the storage layer's back-check
+    /// op-record replay at open), so the attempt count + schedule SURVIVE a broker restart and the scan
+    /// resumes exactly where it left off. Trusted recovered state: it never errors and is not bounded
+    /// (the durable log is authoritative). A later restore for the same id supersedes an earlier one
+    /// (the op-records replay in durable order, newest last).
+    pub fn restore(&mut self, txn_id: &[u8], attempts: u32, next_eligible: u64) {
+        self.entries.insert(
+            txn_id.to_vec(),
+            BackCheckEntry {
+                attempts,
+                next_eligible,
+            },
+        );
+    }
+
+    /// Every enrolled txn whose `next_eligible` is at or before `now`, in ascending `(next_eligible,
+    /// txn_id)` order, capped at the configured `batch` (the global rate cap so a backlog is
+    /// back-checked in bounded passes, never a storm). O(1) when the book is empty (the scan's
+    /// no-in-doubt-txns hot path). For each returned txn the caller issues a `TxnCheck` and then calls
+    /// [`BackCheckBook::record_attempt`].
+    ///
+    /// This does a single bounded pass to find the due txns; the book is keyed by `txn_id` (not a
+    /// secondary by-time index) because the enrolled set is the bounded unresolved set
+    /// (`max_prepared`), so a per-pass scan over it is already O(unresolved) and the batch cap bounds
+    /// the RESULT — keeping the structure simple (one map) without a second index to keep in lockstep.
+    #[must_use]
+    pub fn due(&self, now: u64) -> Vec<Vec<u8>> {
+        if self.entries.is_empty() {
+            return Vec::new();
+        }
+        let mut due: Vec<(&u64, &Vec<u8>)> = self
+            .entries
+            .iter()
+            .filter(|(_, e)| e.next_eligible <= now)
+            .map(|(id, e)| (&e.next_eligible, id))
+            .collect();
+        // Oldest-eligible first, then by id for a deterministic, stable order (so a backlog is drained
+        // FIFO-ish by schedule and the batch cap takes the most-overdue txns first).
+        due.sort_unstable();
+        due.into_iter()
+            .take(self.config.batch)
+            .map(|(_, id)| id.clone())
+            .collect()
+    }
+
+    /// Records that a back-check attempt was issued for `txn_id` at `now`, bumping its attempt count
+    /// and rescheduling it `config.retry` later, and reports whether the attempt cap is now reached.
+    ///
+    /// - [`AttemptOutcome::Rescheduled`]: attempts remain; the caller waits for the producer's
+    ///   `TxnCheckResult` (or the next eligible retry). The txn stays enrolled.
+    /// - [`AttemptOutcome::TerminalDefault`]: this attempt reached `config.max_attempts` with no
+    ///   resolution; the caller MUST apply the SAFE terminal default (rollback/discard) for this txn
+    ///   via the part-1 idempotent `txn_rollback` path, then [`BackCheckBook::forget`] it.
+    ///
+    /// A no-op (`Rescheduled`) for an untracked txn (it resolved between the `due` scan and here — a
+    /// benign race), so the caller never issues a terminal default against a forgotten txn.
+    pub fn record_attempt(&mut self, txn_id: &[u8], now: u64) -> AttemptOutcome {
+        let Some(entry) = self.entries.get_mut(txn_id) else {
+            return AttemptOutcome::Rescheduled;
+        };
+        entry.attempts = entry.attempts.saturating_add(1);
+        entry.next_eligible = now.saturating_add(self.config.retry);
+        if entry.attempts >= self.config.max_attempts {
+            AttemptOutcome::TerminalDefault
+        } else {
+            AttemptOutcome::Rescheduled
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -881,5 +1128,166 @@ mod tests {
             assert!(t.resolved_tombstone_count() <= max);
         }
         assert_eq!(t.resolved_tombstone_count(), max);
+    }
+
+    // ---- the back-check book (#640 part 2) ----
+
+    fn book() -> BackCheckBook {
+        // A deterministic book: a small retry/timeout and a 3-attempt cap for compact tests.
+        BackCheckBook::new(BackCheckConfig {
+            timeout: 100,
+            retry: 50,
+            max_attempts: 3,
+            batch: 256,
+        })
+    }
+
+    #[test]
+    fn an_empty_book_is_a_no_op_scan() {
+        // The byte-identical-when-unused property: a broker with no in-doubt txns does ZERO back-check
+        // work (an empty book's `due` returns nothing without touching a clock or allocating a scan).
+        let b = book();
+        assert!(b.is_empty());
+        assert_eq!(b.len(), 0);
+        assert!(b.due(u64::MAX).is_empty());
+    }
+
+    #[test]
+    fn a_txn_is_not_due_until_its_first_eligible_instant() {
+        let mut b = book();
+        // Enrolled at prepared_at(10) + timeout(100) = first eligible 110.
+        b.enroll(b"tx1", 110);
+        assert_eq!(b.len(), 1);
+        // Before the first-eligible instant: not due.
+        assert!(b.due(109).is_empty());
+        // At/after it: due.
+        assert_eq!(b.due(110), vec![b"tx1".to_vec()]);
+        assert_eq!(b.due(200), vec![b"tx1".to_vec()]);
+        assert_eq!(b.bookkeeping(b"tx1"), Some((0, 110)));
+    }
+
+    #[test]
+    fn enroll_is_idempotent_and_preserves_progress() {
+        let mut b = book();
+        b.enroll(b"tx1", 110);
+        // One attempt advances the schedule + count.
+        assert_eq!(b.record_attempt(b"tx1", 120), AttemptOutcome::Rescheduled);
+        assert_eq!(b.bookkeeping(b"tx1"), Some((1, 170)));
+        // A re-enroll (a re-prepare, or a second scan) must NOT reset the attempt count or schedule.
+        b.enroll(b"tx1", 999);
+        assert_eq!(
+            b.bookkeeping(b"tx1"),
+            Some((1, 170)),
+            "re-enroll preserved progress, did not reset it"
+        );
+    }
+
+    #[test]
+    fn record_attempt_bumps_count_reschedules_and_fires_terminal_at_the_cap() {
+        let mut b = book(); // max_attempts = 3
+        b.enroll(b"tx1", 110);
+        // Attempt 1 at 110: count 1, next eligible 110 + retry(50) = 160.
+        assert_eq!(b.record_attempt(b"tx1", 110), AttemptOutcome::Rescheduled);
+        assert_eq!(b.bookkeeping(b"tx1"), Some((1, 160)));
+        // Not due before 160; due at 160 (the retry schedule is respected — no storm).
+        assert!(b.due(159).is_empty());
+        assert_eq!(b.due(160), vec![b"tx1".to_vec()]);
+        // Attempt 2 at 160: count 2, still rescheduled.
+        assert_eq!(b.record_attempt(b"tx1", 160), AttemptOutcome::Rescheduled);
+        assert_eq!(b.bookkeeping(b"tx1"), Some((2, 210)));
+        // Attempt 3 at 210 reaches the cap: the SAFE terminal default is due.
+        assert_eq!(
+            b.record_attempt(b"tx1", 210),
+            AttemptOutcome::TerminalDefault
+        );
+        // The caller now rolls back + forgets it.
+        assert!(b.forget(b"tx1"));
+        assert!(b.is_empty());
+    }
+
+    #[test]
+    fn forget_removes_a_resolved_txn_so_it_is_never_back_checked_again() {
+        let mut b = book();
+        b.enroll(b"tx1", 110);
+        assert!(b.forget(b"tx1"));
+        // Forgetting again is a benign no-op.
+        assert!(!b.forget(b"tx1"));
+        assert!(b.due(u64::MAX).is_empty());
+    }
+
+    #[test]
+    fn record_attempt_on_a_forgotten_txn_is_a_benign_reschedule_not_a_terminal() {
+        // The benign race: a txn resolves (and is forgotten) between the `due` scan and `record_attempt`
+        // — the attempt must NOT report a terminal default against a txn that is already gone.
+        let mut b = book();
+        assert_eq!(
+            b.record_attempt(b"ghost", 100),
+            AttemptOutcome::Rescheduled,
+            "an untracked txn never fires the terminal default"
+        );
+    }
+
+    #[test]
+    fn due_returns_oldest_eligible_first_and_respects_the_batch_cap() {
+        let mut b = BackCheckBook::new(BackCheckConfig {
+            timeout: 0,
+            retry: 10,
+            max_attempts: 5,
+            batch: 2, // a tiny global rate cap
+        });
+        // Three txns all eligible, with distinct next-eligible instants.
+        b.enroll(b"a", 30);
+        b.enroll(b"b", 10);
+        b.enroll(b"c", 20);
+        // At now=100 all three are due, but the batch cap returns only the two OLDEST-eligible (b, c).
+        let due = b.due(100);
+        assert_eq!(due, vec![b"b".to_vec(), b"c".to_vec()]);
+        // A txn whose eligible instant is in the future is excluded.
+        b.enroll(b"future", 1_000);
+        let due2 = b.due(100);
+        assert_eq!(due2.len(), 2, "still capped, future txn excluded");
+        assert!(!due2.contains(&b"future".to_vec()));
+    }
+
+    #[test]
+    fn restore_rebuilds_the_attempt_count_and_schedule_across_a_restart() {
+        // Durability seam: the storage layer replays a back-check op-record into the book so the count +
+        // schedule survive a restart and the scan resumes.
+        let mut b = book();
+        b.restore(b"tx1", 2, 210);
+        assert_eq!(b.bookkeeping(b"tx1"), Some((2, 210)));
+        // The next attempt (at the cap) fires the terminal default exactly as if the attempts had been
+        // recorded live before the restart.
+        assert_eq!(b.due(210), vec![b"tx1".to_vec()]);
+        assert_eq!(
+            b.record_attempt(b"tx1", 210),
+            AttemptOutcome::TerminalDefault
+        );
+    }
+
+    #[test]
+    fn the_book_floors_its_caps_to_one() {
+        let b = BackCheckBook::new(BackCheckConfig {
+            timeout: 0,
+            retry: 0,
+            max_attempts: 0,
+            batch: 0,
+        });
+        assert_eq!(b.config().retry, 1);
+        assert_eq!(b.config().max_attempts, 1);
+        assert_eq!(b.config().batch, 1);
+    }
+
+    #[test]
+    fn a_single_attempt_cap_fires_terminal_on_the_first_attempt() {
+        // With max_attempts floored to 1, the first attempt already exhausts the budget.
+        let mut b = BackCheckBook::new(BackCheckConfig {
+            timeout: 0,
+            retry: 10,
+            max_attempts: 1,
+            batch: 8,
+        });
+        b.enroll(b"tx1", 0);
+        assert_eq!(b.record_attempt(b"tx1", 0), AttemptOutcome::TerminalDefault);
     }
 }

--- a/crates/ironbus-core/src/txn.rs
+++ b/crates/ironbus-core/src/txn.rs
@@ -696,6 +696,20 @@ impl BackCheckBook {
         self.config
     }
 
+    /// Replaces the config (re-applying the floors), leaving the enrolled entries untouched. The
+    /// schedule decisions for already-enrolled txns use the NEW config from here on (a longer/shorter
+    /// retry, a different attempt cap). Used to set a deployment's back-check tunables (and by tests to
+    /// pick a short, deterministic timeout); a per-txn entry's recorded `next_eligible`/`attempts` are
+    /// not rewritten — only future `due`/`record_attempt` decisions adopt the new config.
+    pub fn set_config(&mut self, config: BackCheckConfig) {
+        self.config = BackCheckConfig {
+            timeout: config.timeout,
+            retry: config.retry.max(1),
+            max_attempts: config.max_attempts.max(1),
+            batch: config.batch.max(1),
+        };
+    }
+
     /// The number of currently-enrolled (under-back-check) txns.
     #[must_use]
     pub fn len(&self) -> usize {
@@ -1276,6 +1290,24 @@ mod tests {
         assert_eq!(b.config().retry, 1);
         assert_eq!(b.config().max_attempts, 1);
         assert_eq!(b.config().batch, 1);
+    }
+
+    #[test]
+    fn set_config_replaces_tunables_and_re_floors() {
+        let mut b = book();
+        b.set_config(BackCheckConfig {
+            timeout: 5,
+            retry: 0,        // re-floored to 1
+            max_attempts: 0, // re-floored to 1
+            batch: 0,        // re-floored to 1
+        });
+        assert_eq!(b.config().timeout, 5);
+        assert_eq!(b.config().retry, 1);
+        assert_eq!(b.config().max_attempts, 1);
+        assert_eq!(b.config().batch, 1);
+        // A new attempt uses the new (1-attempt) cap immediately.
+        b.enroll(b"tx1", 0);
+        assert_eq!(b.record_attempt(b"tx1", 0), AttemptOutcome::TerminalDefault);
     }
 
     #[test]

--- a/crates/ironbus-proto/src/frame.rs
+++ b/crates/ironbus-proto/src/frame.rs
@@ -451,6 +451,33 @@ pub enum FrameType {
     /// unchanged. Body: a [`crate::message::TxnResolveBody`] (the same shape as `TxnCommit`: a
     /// `txn_id` u16-length name in a version/length-framed block).
     TxnRollback,
+    /// Broker → producer TRANSACTIONAL BACK-CHECK (#640 part 2, V2-M8, wire tag 47). The broker pushes
+    /// this UNSOLICITED to a producer whose half message has been `Prepared` (durably buffered,
+    /// invisible) for longer than the back-check timeout WITHOUT a `TxnCommit`/`TxnRollback` — the
+    /// producer is presumed to have CRASHED between prepare and resolve. It asks "what is the state of
+    /// transaction `txn_id`?"; the producer's registered transaction-state listener answers with a
+    /// [`FrameType::TxnCheckResult`] (`Commit`/`Rollback`/`Unknown`). This is the server→producer
+    /// async-PUSH mechanism modeled on the Level-2 [`FrameType::ProduceConfirm`] (tag 22): the broker
+    /// only writes a producer's socket from that producer's own pass, so the producer's listener loop
+    /// drives passes (interleaving `Ping`s, exactly like `produce_confirmed`) and drains this frame. It
+    /// is a NEW append-only tag a non-back-checking client never sees; tags 1-46 are byte-for-byte
+    /// unchanged. Body: a [`crate::message::TxnResolveBody`] (the same shape as `TxnCommit`: a `txn_id`
+    /// u16-length name in a version/length-framed block).
+    TxnCheck,
+    /// Producer → broker TRANSACTIONAL BACK-CHECK RESULT (#640 part 2, V2-M8, wire tag 48). The
+    /// producer's transaction-state listener answers a [`FrameType::TxnCheck`]: it reports the
+    /// transaction's resolution (`Commit`/`Rollback`/`Unknown`). A `Commit` drives the broker through
+    /// the SAME idempotent [`FrameType::TxnCommit`] path (the half message becomes visible exactly
+    /// once); a `Rollback` through the SAME `TxnRollback` path (discarded, never delivered); an
+    /// `Unknown` means "I cannot decide yet" — the back-check schedules a later retry, and after a
+    /// bounded number of attempts the broker applies the SAFE TERMINAL default (Rollback/discard, never
+    /// delivering a message whose outcome is unknowable). IDEMPOTENT/SAFE: a result that arrives after
+    /// the txn already resolved (e.g. the producer answered `Commit` after the terminal Rollback fired,
+    /// or a duplicate result) is refused/no-op by the part-1 `AlreadyResolved` rule — never a flip,
+    /// never a double-resolve. A NEW append-only tag a non-back-checking client never sends; tags 1-47
+    /// are byte-for-byte unchanged. Body: a [`crate::message::TxnCheckResultBody`] (`body_version: u8`,
+    /// `field_len: u16` over `txn_id` u16-length name then a `decision: u8`).
+    TxnCheckResult,
 }
 
 impl FrameType {
@@ -504,6 +531,8 @@ impl FrameType {
             FrameType::TxnPrepare => 44,
             FrameType::TxnCommit => 45,
             FrameType::TxnRollback => 46,
+            FrameType::TxnCheck => 47,
+            FrameType::TxnCheckResult => 48,
         }
     }
 
@@ -558,6 +587,8 @@ impl FrameType {
             44 => FrameType::TxnPrepare,
             45 => FrameType::TxnCommit,
             46 => FrameType::TxnRollback,
+            47 => FrameType::TxnCheck,
+            48 => FrameType::TxnCheckResult,
             _ => return None,
         })
     }
@@ -801,6 +832,8 @@ mod tests {
         assert_eq!(FrameType::TxnPrepare.as_u8(), 44);
         assert_eq!(FrameType::TxnCommit.as_u8(), 45);
         assert_eq!(FrameType::TxnRollback.as_u8(), 46);
+        assert_eq!(FrameType::TxnCheck.as_u8(), 47);
+        assert_eq!(FrameType::TxnCheckResult.as_u8(), 48);
     }
 
     #[test]
@@ -820,8 +853,9 @@ mod tests {
         // cross-cluster MirrorPull (#623, V2-C7-I1); 41 is the edge leaf-spoke LeafPush write-through
         // (#625, V2-C7-I3); 42 is the cluster NotLeader produce-redirect (#735); 43 is the follower-read
         // dirty-tier CommittedHwQuery confirm (#739); 44-46 are the transactional half-message verbs
-        // TxnPrepare/TxnCommit/TxnRollback (#640, V2-M8); 47 is now the next-free (still unknown) tag,
-        // so it frames but is not known.
+        // TxnPrepare/TxnCommit/TxnRollback (#640, V2-M8); 47-48 are the back-check verbs
+        // TxnCheck/TxnCheckResult (#640 part 2); 49 is now the next-free (still unknown) tag, so it
+        // frames but is not known.
         assert_eq!(FrameType::from_u8(37), Some(FrameType::AckReplicated));
         assert_eq!(
             FrameType::from_u8(38),
@@ -835,7 +869,9 @@ mod tests {
         assert_eq!(FrameType::from_u8(44), Some(FrameType::TxnPrepare));
         assert_eq!(FrameType::from_u8(45), Some(FrameType::TxnCommit));
         assert_eq!(FrameType::from_u8(46), Some(FrameType::TxnRollback));
-        assert_eq!(FrameType::from_u8(47), None);
+        assert_eq!(FrameType::from_u8(47), Some(FrameType::TxnCheck));
+        assert_eq!(FrameType::from_u8(48), Some(FrameType::TxnCheckResult));
+        assert_eq!(FrameType::from_u8(49), None);
         for ty in [
             FrameType::BindSubject,
             FrameType::PubSubject,
@@ -879,8 +915,9 @@ mod tests {
         // divergence-query (#599); 39 is the cluster SegmentFingerprints divergence-advertisement
         // (#611); 40 is the cross-cluster MirrorPull (#623); 41 is the edge leaf-spoke LeafPush (#625);
         // 42 is the cluster NotLeader produce-redirect (#735); 43 is the follower-read dirty-tier
-        // CommittedHwQuery confirm (#739); 44-46 are the transactional half-message verbs (#640); 47 is
-        // the next-free (still unknown) tag.
+        // CommittedHwQuery confirm (#739); 44-46 are the transactional half-message verbs (#640); 47-48
+        // are the back-check verbs TxnCheck/TxnCheckResult (#640 part 2); 49 is the next-free (still
+        // unknown) tag.
         assert_eq!(FrameType::from_u8(37), Some(FrameType::AckReplicated));
         assert_eq!(
             FrameType::from_u8(38),
@@ -894,7 +931,9 @@ mod tests {
         assert_eq!(FrameType::from_u8(44), Some(FrameType::TxnPrepare));
         assert_eq!(FrameType::from_u8(45), Some(FrameType::TxnCommit));
         assert_eq!(FrameType::from_u8(46), Some(FrameType::TxnRollback));
-        assert_eq!(FrameType::from_u8(47), None);
+        assert_eq!(FrameType::from_u8(47), Some(FrameType::TxnCheck));
+        assert_eq!(FrameType::from_u8(48), Some(FrameType::TxnCheckResult));
+        assert_eq!(FrameType::from_u8(49), None);
         for ty in [
             FrameType::StreamDeclare,
             FrameType::StreamInfo,
@@ -941,19 +980,45 @@ mod tests {
         // TxnRollback (46) take the next FREE tags after the follower-read CommittedHwQuery confirm
         // (43). Pinned here so a future reorder breaks a test, not a deployed protocol. They are
         // ADDITIVE: tags 1-43 are byte-for-byte unchanged, and a non-transactional client never sends
-        // them; 47 is the next-free (still unknown) tag.
+        // them; 47-48 are the back-check verbs (#640 part 2), 49 is the next-free (still unknown) tag.
         assert_eq!(FrameType::TxnPrepare.as_u8(), 44);
         assert_eq!(FrameType::TxnCommit.as_u8(), 45);
         assert_eq!(FrameType::TxnRollback.as_u8(), 46);
         assert_eq!(FrameType::from_u8(44), Some(FrameType::TxnPrepare));
         assert_eq!(FrameType::from_u8(45), Some(FrameType::TxnCommit));
         assert_eq!(FrameType::from_u8(46), Some(FrameType::TxnRollback));
-        assert_eq!(FrameType::from_u8(47), None);
+        assert_eq!(FrameType::from_u8(47), Some(FrameType::TxnCheck));
         for ty in [
             FrameType::TxnPrepare,
             FrameType::TxnCommit,
             FrameType::TxnRollback,
         ] {
+            let mut buf = Vec::new();
+            encode_frame(ty, b"\x01\x02", &mut buf).unwrap();
+            match decode_frame(&buf).unwrap() {
+                FrameDecode::Frame { type_tag, body, .. } => {
+                    assert_eq!(FrameType::from_u8(type_tag), Some(ty));
+                    assert_eq!(body, b"\x01\x02");
+                }
+                FrameDecode::Incomplete { .. } => panic!("complete"),
+            }
+        }
+    }
+
+    #[test]
+    fn txn_back_check_tags_are_the_next_free_tags_after_txn_rollback() {
+        // #640 part 2 (V2-M8): the broker back-check verbs TxnCheck (47, broker→producer) and
+        // TxnCheckResult (48, producer→broker) take the next FREE tags after the part-1 transactional
+        // half-message verbs (44-46). Pinned here so a future reorder breaks a test, not a deployed
+        // protocol. They are ADDITIVE: tags 1-46 are byte-for-byte unchanged, and a client that never
+        // registers a transaction-state listener never sees or sends them; 49 is the next-free (still
+        // unknown) tag, so it frames but is not a known type.
+        assert_eq!(FrameType::TxnCheck.as_u8(), 47);
+        assert_eq!(FrameType::TxnCheckResult.as_u8(), 48);
+        assert_eq!(FrameType::from_u8(47), Some(FrameType::TxnCheck));
+        assert_eq!(FrameType::from_u8(48), Some(FrameType::TxnCheckResult));
+        assert_eq!(FrameType::from_u8(49), None);
+        for ty in [FrameType::TxnCheck, FrameType::TxnCheckResult] {
             let mut buf = Vec::new();
             encode_frame(ty, b"\x01\x02", &mut buf).unwrap();
             match decode_frame(&buf).unwrap() {
@@ -1021,7 +1086,9 @@ mod tests {
         assert_eq!(FrameType::from_u8(44), Some(FrameType::TxnPrepare));
         assert_eq!(FrameType::from_u8(45), Some(FrameType::TxnCommit));
         assert_eq!(FrameType::from_u8(46), Some(FrameType::TxnRollback));
-        assert_eq!(FrameType::from_u8(47), None);
+        assert_eq!(FrameType::from_u8(47), Some(FrameType::TxnCheck));
+        assert_eq!(FrameType::from_u8(48), Some(FrameType::TxnCheckResult));
+        assert_eq!(FrameType::from_u8(49), None);
         for ty in [FrameType::StreamFetch, FrameType::StreamCommit] {
             let mut buf = Vec::new();
             encode_frame(ty, b"\x07\x08", &mut buf).unwrap();
@@ -1067,7 +1134,9 @@ mod tests {
         assert_eq!(FrameType::from_u8(44), Some(FrameType::TxnPrepare));
         assert_eq!(FrameType::from_u8(45), Some(FrameType::TxnCommit));
         assert_eq!(FrameType::from_u8(46), Some(FrameType::TxnRollback));
-        assert_eq!(FrameType::from_u8(47), None);
+        assert_eq!(FrameType::from_u8(47), Some(FrameType::TxnCheck));
+        assert_eq!(FrameType::from_u8(48), Some(FrameType::TxnCheckResult));
+        assert_eq!(FrameType::from_u8(49), None);
         let mut buf = Vec::new();
         encode_frame(FrameType::DeliverBatch, b"\x09\x0a", &mut buf).unwrap();
         match decode_frame(&buf).unwrap() {
@@ -1262,7 +1331,7 @@ mod tests {
         /// An unknown type tag still decodes at the envelope level (forward compatibility):
         /// the body and length are recovered; only `from_u8` reports it unknown.
         #[test]
-        fn an_unknown_type_tag_still_frames(tag in 47u8..=255, body in prop::collection::vec(any::<u8>(), 0..256)) {
+        fn an_unknown_type_tag_still_frames(tag in 49u8..=255, body in prop::collection::vec(any::<u8>(), 0..256)) {
             let frame_len = 1u32 + u32::try_from(body.len()).unwrap();
             let mut buf = frame_len.to_le_bytes().to_vec();
             buf.push(tag);

--- a/crates/ironbus-proto/src/frame.rs
+++ b/crates/ironbus-proto/src/frame.rs
@@ -478,6 +478,19 @@ pub enum FrameType {
     /// are byte-for-byte unchanged. Body: a [`crate::message::TxnCheckResultBody`] (`body_version: u8`,
     /// `field_len: u16` over `txn_id` u16-length name then a `decision: u8`).
     TxnCheckResult,
+    /// Producer → broker TRANSACTION-LISTENER REGISTRATION (#640 part 2, V2-M8, wire tag 49). A
+    /// producer that runs transactions registers (or re-registers, after a reconnect) the STABLE
+    /// listener GROUP its transaction-state listener answers for, so the broker can ROUTE a
+    /// [`FrameType::TxnCheck`] for an in-doubt half message to whatever connection currently holds that
+    /// group's listener — even a DIFFERENT connection than the one that prepared the half message (the
+    /// crash-and-reconnect case). The group is a producer-chosen stable byte string (e.g. its durable
+    /// producer id); the half message records its owning group at prepare time, and this frame binds the
+    /// group to THIS connection (superseding any prior binding, so a reconnect re-points the route). The
+    /// SUCCESS reply is a body-less [`FrameType::Ok`]; a malformed/over-long group is an
+    /// [`FrameType::Err`]. A NEW append-only tag a non-transactional client never sends; tags 1-48 are
+    /// byte-for-byte unchanged. Body: a [`crate::message::TxnListenBody`] (`body_version: u8`,
+    /// `field_len: u16` over a `group` u16-length name).
+    TxnListen,
 }
 
 impl FrameType {
@@ -533,6 +546,7 @@ impl FrameType {
             FrameType::TxnRollback => 46,
             FrameType::TxnCheck => 47,
             FrameType::TxnCheckResult => 48,
+            FrameType::TxnListen => 49,
         }
     }
 
@@ -589,6 +603,7 @@ impl FrameType {
             46 => FrameType::TxnRollback,
             47 => FrameType::TxnCheck,
             48 => FrameType::TxnCheckResult,
+            49 => FrameType::TxnListen,
             _ => return None,
         })
     }
@@ -834,6 +849,7 @@ mod tests {
         assert_eq!(FrameType::TxnRollback.as_u8(), 46);
         assert_eq!(FrameType::TxnCheck.as_u8(), 47);
         assert_eq!(FrameType::TxnCheckResult.as_u8(), 48);
+        assert_eq!(FrameType::TxnListen.as_u8(), 49);
     }
 
     #[test]
@@ -853,8 +869,8 @@ mod tests {
         // cross-cluster MirrorPull (#623, V2-C7-I1); 41 is the edge leaf-spoke LeafPush write-through
         // (#625, V2-C7-I3); 42 is the cluster NotLeader produce-redirect (#735); 43 is the follower-read
         // dirty-tier CommittedHwQuery confirm (#739); 44-46 are the transactional half-message verbs
-        // TxnPrepare/TxnCommit/TxnRollback (#640, V2-M8); 47-48 are the back-check verbs
-        // TxnCheck/TxnCheckResult (#640 part 2); 49 is now the next-free (still unknown) tag, so it
+        // TxnPrepare/TxnCommit/TxnRollback (#640, V2-M8); 47-49 are the back-check verbs
+        // TxnCheck/TxnCheckResult/TxnListen (#640 part 2); 50 is now the next-free (still unknown) tag, so it
         // frames but is not known.
         assert_eq!(FrameType::from_u8(37), Some(FrameType::AckReplicated));
         assert_eq!(
@@ -871,7 +887,8 @@ mod tests {
         assert_eq!(FrameType::from_u8(46), Some(FrameType::TxnRollback));
         assert_eq!(FrameType::from_u8(47), Some(FrameType::TxnCheck));
         assert_eq!(FrameType::from_u8(48), Some(FrameType::TxnCheckResult));
-        assert_eq!(FrameType::from_u8(49), None);
+        assert_eq!(FrameType::from_u8(49), Some(FrameType::TxnListen));
+        assert_eq!(FrameType::from_u8(50), None);
         for ty in [
             FrameType::BindSubject,
             FrameType::PubSubject,
@@ -916,8 +933,8 @@ mod tests {
         // (#611); 40 is the cross-cluster MirrorPull (#623); 41 is the edge leaf-spoke LeafPush (#625);
         // 42 is the cluster NotLeader produce-redirect (#735); 43 is the follower-read dirty-tier
         // CommittedHwQuery confirm (#739); 44-46 are the transactional half-message verbs (#640); 47-48
-        // are the back-check verbs TxnCheck/TxnCheckResult (#640 part 2); 49 is the next-free (still
-        // unknown) tag.
+        // are the back-check verbs TxnCheck/TxnCheckResult/TxnListen (#640 part 2); 50 is the
+        // next-free (still unknown) tag.
         assert_eq!(FrameType::from_u8(37), Some(FrameType::AckReplicated));
         assert_eq!(
             FrameType::from_u8(38),
@@ -933,7 +950,8 @@ mod tests {
         assert_eq!(FrameType::from_u8(46), Some(FrameType::TxnRollback));
         assert_eq!(FrameType::from_u8(47), Some(FrameType::TxnCheck));
         assert_eq!(FrameType::from_u8(48), Some(FrameType::TxnCheckResult));
-        assert_eq!(FrameType::from_u8(49), None);
+        assert_eq!(FrameType::from_u8(49), Some(FrameType::TxnListen));
+        assert_eq!(FrameType::from_u8(50), None);
         for ty in [
             FrameType::StreamDeclare,
             FrameType::StreamInfo,
@@ -980,7 +998,7 @@ mod tests {
         // TxnRollback (46) take the next FREE tags after the follower-read CommittedHwQuery confirm
         // (43). Pinned here so a future reorder breaks a test, not a deployed protocol. They are
         // ADDITIVE: tags 1-43 are byte-for-byte unchanged, and a non-transactional client never sends
-        // them; 47-48 are the back-check verbs (#640 part 2), 49 is the next-free (still unknown) tag.
+        // them; 47-49 are the back-check verbs (#640 part 2), 50 is the next-free (still unknown) tag.
         assert_eq!(FrameType::TxnPrepare.as_u8(), 44);
         assert_eq!(FrameType::TxnCommit.as_u8(), 45);
         assert_eq!(FrameType::TxnRollback.as_u8(), 46);
@@ -1007,18 +1025,25 @@ mod tests {
 
     #[test]
     fn txn_back_check_tags_are_the_next_free_tags_after_txn_rollback() {
-        // #640 part 2 (V2-M8): the broker back-check verbs TxnCheck (47, broker→producer) and
-        // TxnCheckResult (48, producer→broker) take the next FREE tags after the part-1 transactional
-        // half-message verbs (44-46). Pinned here so a future reorder breaks a test, not a deployed
-        // protocol. They are ADDITIVE: tags 1-46 are byte-for-byte unchanged, and a client that never
-        // registers a transaction-state listener never sees or sends them; 49 is the next-free (still
-        // unknown) tag, so it frames but is not a known type.
+        // #640 part 2 (V2-M8): the broker back-check verbs TxnCheck (47, broker→producer),
+        // TxnCheckResult (48, producer→broker), and TxnListen (49, the producer's listener-group
+        // registration) take the next FREE tags after the part-1 transactional half-message verbs
+        // (44-46). Pinned here so a future reorder breaks a test, not a deployed protocol. They are
+        // ADDITIVE: tags 1-46 are byte-for-byte unchanged, and a client that never registers a
+        // transaction-state listener never sees or sends them; 50 is the next-free (still unknown) tag,
+        // so it frames but is not a known type.
         assert_eq!(FrameType::TxnCheck.as_u8(), 47);
         assert_eq!(FrameType::TxnCheckResult.as_u8(), 48);
+        assert_eq!(FrameType::TxnListen.as_u8(), 49);
         assert_eq!(FrameType::from_u8(47), Some(FrameType::TxnCheck));
         assert_eq!(FrameType::from_u8(48), Some(FrameType::TxnCheckResult));
-        assert_eq!(FrameType::from_u8(49), None);
-        for ty in [FrameType::TxnCheck, FrameType::TxnCheckResult] {
+        assert_eq!(FrameType::from_u8(49), Some(FrameType::TxnListen));
+        assert_eq!(FrameType::from_u8(50), None);
+        for ty in [
+            FrameType::TxnCheck,
+            FrameType::TxnCheckResult,
+            FrameType::TxnListen,
+        ] {
             let mut buf = Vec::new();
             encode_frame(ty, b"\x01\x02", &mut buf).unwrap();
             match decode_frame(&buf).unwrap() {
@@ -1088,7 +1113,8 @@ mod tests {
         assert_eq!(FrameType::from_u8(46), Some(FrameType::TxnRollback));
         assert_eq!(FrameType::from_u8(47), Some(FrameType::TxnCheck));
         assert_eq!(FrameType::from_u8(48), Some(FrameType::TxnCheckResult));
-        assert_eq!(FrameType::from_u8(49), None);
+        assert_eq!(FrameType::from_u8(49), Some(FrameType::TxnListen));
+        assert_eq!(FrameType::from_u8(50), None);
         for ty in [FrameType::StreamFetch, FrameType::StreamCommit] {
             let mut buf = Vec::new();
             encode_frame(ty, b"\x07\x08", &mut buf).unwrap();
@@ -1136,7 +1162,8 @@ mod tests {
         assert_eq!(FrameType::from_u8(46), Some(FrameType::TxnRollback));
         assert_eq!(FrameType::from_u8(47), Some(FrameType::TxnCheck));
         assert_eq!(FrameType::from_u8(48), Some(FrameType::TxnCheckResult));
-        assert_eq!(FrameType::from_u8(49), None);
+        assert_eq!(FrameType::from_u8(49), Some(FrameType::TxnListen));
+        assert_eq!(FrameType::from_u8(50), None);
         let mut buf = Vec::new();
         encode_frame(FrameType::DeliverBatch, b"\x09\x0a", &mut buf).unwrap();
         match decode_frame(&buf).unwrap() {
@@ -1331,7 +1358,7 @@ mod tests {
         /// An unknown type tag still decodes at the envelope level (forward compatibility):
         /// the body and length are recovered; only `from_u8` reports it unknown.
         #[test]
-        fn an_unknown_type_tag_still_frames(tag in 49u8..=255, body in prop::collection::vec(any::<u8>(), 0..256)) {
+        fn an_unknown_type_tag_still_frames(tag in 50u8..=255, body in prop::collection::vec(any::<u8>(), 0..256)) {
             let frame_len = 1u32 + u32::try_from(body.len()).unwrap();
             let mut buf = frame_len.to_le_bytes().to_vec();
             buf.push(tag);

--- a/crates/ironbus-proto/src/message.rs
+++ b/crates/ironbus-proto/src/message.rs
@@ -2574,6 +2574,115 @@ pub fn decode_txn_resolve(body: &[u8]) -> Result<TxnResolveBody<'_>, BodyError> 
     Ok(TxnResolveBody { txn_id })
 }
 
+/// The producer's answer to a broker `TxnCheck` back-check (#640 part 2): the in-doubt transaction's
+/// resolution, as decided by the producer's registered transaction-state listener. The `TxnCheck`
+/// frame itself (broker→producer) reuses the [`TxnResolveBody`] shape (just the `txn_id`), so it has
+/// no dedicated body type — only the RESULT carries the extra `decision` byte.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TxnCheckDecision {
+    /// The producer's local transaction COMMITTED: the broker should commit the half message (it
+    /// becomes visible), via the SAME idempotent commit path as a producer-driven `TxnCommit`. Wire
+    /// byte `0`.
+    Commit,
+    /// The producer's local transaction ROLLED BACK (or never committed): the broker should roll back
+    /// the half message (discarded, never delivered), via the SAME idempotent rollback path. Wire byte
+    /// `1`.
+    Rollback,
+    /// The producer CANNOT decide yet (its local transaction state is still in-doubt, e.g. its own
+    /// downstream commit has not resolved): the broker schedules a later back-check retry, and after a
+    /// bounded number of attempts applies the SAFE TERMINAL default (rollback/discard). Wire byte `2`.
+    Unknown,
+}
+
+impl TxnCheckDecision {
+    /// The raw wire byte this decision encodes to (`0` = Commit, `1` = Rollback, `2` = Unknown).
+    #[must_use]
+    pub fn as_u8(self) -> u8 {
+        match self {
+            TxnCheckDecision::Commit => 0,
+            TxnCheckDecision::Rollback => 1,
+            TxnCheckDecision::Unknown => 2,
+        }
+    }
+
+    /// Folds a raw wire byte into a [`TxnCheckDecision`]: `0` = Commit, `1` = Rollback, and EVERYTHING
+    /// else — `2` (the explicit Unknown encoding) and any reserved future value — folds to the SAFE
+    /// `Unknown` (the broker then retries and eventually applies the terminal default), so the field
+    /// can grow without a wire break and an unrecognized decision never forces a commit/rollback the
+    /// producer did not intend.
+    #[must_use]
+    pub fn from_u8(raw: u8) -> TxnCheckDecision {
+        match raw {
+            0 => TxnCheckDecision::Commit,
+            1 => TxnCheckDecision::Rollback,
+            _ => TxnCheckDecision::Unknown,
+        }
+    }
+}
+
+/// A producer's TRANSACTIONAL BACK-CHECK RESULT (the `TxnCheckResult` frame body, tag 48, #640 part 2):
+/// it names the `txn_id` the broker back-checked and the listener's [`TxnCheckDecision`]. The broker
+/// resolves the in-doubt half message accordingly (a `Commit`/`Rollback` reuses the part-1 idempotent
+/// path; an `Unknown` reschedules), so a producer that crashed between prepare and resolve, then
+/// reconnected and re-registered its listener, settles the transaction exactly once.
+///
+/// Layout (version+length framed, forward-compatible): `body_version: u8`
+/// ([`STREAM_WIRE_BODY_VERSION`]), `field_len: u16` (the length of the v1 block), then the v1 block:
+/// `txn_id: u16-len + bytes`, `decision: u8`. Bytes past `field_len` (a future version's appended
+/// fields) are TOLERATED and ignored.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TxnCheckResultBody<'a> {
+    /// The transaction id the back-check named (capped at [`MAX_TXN_ID_LEN`]).
+    pub txn_id: &'a [u8],
+    /// The listener's decision for this transaction.
+    pub decision: TxnCheckDecision,
+}
+
+/// Encodes a `TxnCheckResult` body onto the end of `out` (#640 part 2): the version byte, the
+/// field-block length over the `txn_id` + the `decision` byte, then the `txn_id` and the decision.
+///
+/// # Errors
+/// Returns [`BodyError::FieldTooLarge`] if the txn id (or its framed block) exceeds the `u16` wire
+/// limit.
+pub fn encode_txn_check_result(
+    req: &TxnCheckResultBody<'_>,
+    out: &mut Vec<u8>,
+) -> Result<(), BodyError> {
+    let id_len = u16::try_from(req.txn_id.len()).map_err(|_| BodyError::FieldTooLarge)?;
+    // The block is the u16-len-prefixed txn id (2 + txn_id) plus the 1-byte decision.
+    let field_len =
+        u16::try_from(2 + req.txn_id.len() + 1).map_err(|_| BodyError::FieldTooLarge)?;
+    out.push(STREAM_WIRE_BODY_VERSION);
+    out.extend_from_slice(&field_len.to_le_bytes());
+    out.extend_from_slice(&id_len.to_le_bytes());
+    out.extend_from_slice(req.txn_id);
+    out.push(req.decision.as_u8());
+    Ok(())
+}
+
+/// Decodes a `TxnCheckResult` body (#640 part 2) into its `txn_id` + `decision`, cap-before-alloc and
+/// panic-free. A body too short for its declared block, or a txn id over [`MAX_TXN_ID_LEN`], is a typed
+/// [`BodyError`] (fail-closed). An unrecognized decision byte folds to the SAFE
+/// [`TxnCheckDecision::Unknown`] (never a forced commit). An EMPTY body is NOT valid
+/// ([`BodyError::Truncated`]).
+///
+/// # Errors
+/// [`BodyError::Truncated`] for a short body, [`BodyError::BadLength`] for an over-cap id, or
+/// [`BodyError::BadHandshakeVersion`] for an unknown body version.
+pub fn decode_txn_check_result(body: &[u8]) -> Result<TxnCheckResultBody<'_>, BodyError> {
+    let mut r = Reader::new(body);
+    let version = r.u8()?;
+    if version != STREAM_WIRE_BODY_VERSION {
+        return Err(BodyError::BadHandshakeVersion { version });
+    }
+    let field_len = r.u16()? as usize;
+    let block = r.take(field_len)?;
+    let mut fr = Reader::new(block);
+    let txn_id = read_txn_id(&mut fr)?;
+    let decision = TxnCheckDecision::from_u8(fr.u8()?);
+    Ok(TxnCheckResultBody { txn_id, decision })
+}
+
 // ===================================================================================
 // SUBJECT-ADDRESSED WIRE BODIES (#585, V2-M2-I9): the subject->stream binding + subject-addressed
 // pub/sub verbs that complete the SUBJECTS story — BindSubject (tag 34), PubSubject (tag 35), SubSubject
@@ -4977,6 +5086,99 @@ mod tests {
         assert_eq!(
             buf, expected,
             "the v1 TxnResolve body wire format is frozen"
+        );
+    }
+
+    #[test]
+    fn txn_check_result_round_trips_id_and_every_decision() {
+        // #640 part 2: TxnCheckResult carries the txn id + the listener's decision, round-tripping for
+        // every decision variant.
+        for decision in [
+            TxnCheckDecision::Commit,
+            TxnCheckDecision::Rollback,
+            TxnCheckDecision::Unknown,
+        ] {
+            for txn in [b"tx-1".as_slice(), b"a-very-distinct-uuid-1234"] {
+                let mut buf = Vec::new();
+                encode_txn_check_result(
+                    &TxnCheckResultBody {
+                        txn_id: txn,
+                        decision,
+                    },
+                    &mut buf,
+                )
+                .unwrap();
+                assert_eq!(buf[0], STREAM_WIRE_BODY_VERSION);
+                let decoded = decode_txn_check_result(&buf).unwrap();
+                assert_eq!(decoded.txn_id, txn);
+                assert_eq!(decoded.decision, decision);
+            }
+        }
+    }
+
+    #[test]
+    fn txn_check_result_decision_byte_is_safe_under_an_unknown_value() {
+        // An empty body is truncated (no version byte).
+        assert_eq!(decode_txn_check_result(&[]), Err(BodyError::Truncated));
+        // A wrong body version fails closed.
+        let mut buf = Vec::new();
+        encode_txn_check_result(
+            &TxnCheckResultBody {
+                txn_id: b"t",
+                decision: TxnCheckDecision::Commit,
+            },
+            &mut buf,
+        )
+        .unwrap();
+        buf[0] = STREAM_WIRE_BODY_VERSION + 1;
+        assert!(matches!(
+            decode_txn_check_result(&buf),
+            Err(BodyError::BadHandshakeVersion { .. })
+        ));
+        // A RESERVED future decision byte folds to the SAFE Unknown (never a forced commit): mutate the
+        // last byte (the decision) of a fresh Commit body to 0x09 and decode.
+        let mut buf2 = Vec::new();
+        encode_txn_check_result(
+            &TxnCheckResultBody {
+                txn_id: b"t",
+                decision: TxnCheckDecision::Commit,
+            },
+            &mut buf2,
+        )
+        .unwrap();
+        let last = buf2.len() - 1;
+        buf2[last] = 0x09; // an unrecognized future decision
+        assert_eq!(
+            decode_txn_check_result(&buf2).unwrap().decision,
+            TxnCheckDecision::Unknown,
+            "an unknown decision byte folds to the safe Unknown, never a forced commit"
+        );
+    }
+
+    #[test]
+    fn the_txn_check_result_body_is_byte_frozen() {
+        // #640 part 2: pin the EXACT bytes a v1 TxnCheckResult body produces, so an accidental
+        // wire-format drift breaks a test here, not a deployed back-check. Layout: version,
+        // field_len(u16 LE over the block), txn_id(u16-len + bytes), decision(u8).
+        let mut buf = Vec::new();
+        encode_txn_check_result(
+            &TxnCheckResultBody {
+                txn_id: b"tx",
+                decision: TxnCheckDecision::Rollback,
+            },
+            &mut buf,
+        )
+        .unwrap();
+        let mut expected = Vec::new();
+        expected.push(1); // STREAM_WIRE_BODY_VERSION
+                          // field_len = 2 (id-len field) + 2 (id bytes) + 1 (decision) = 5.
+        expected.extend_from_slice(&5u16.to_le_bytes());
+        expected.extend_from_slice(&2u16.to_le_bytes()); // txn_id len
+        expected.extend_from_slice(b"tx");
+        expected.push(1); // decision = Rollback
+        assert_eq!(
+            buf, expected,
+            "the v1 TxnCheckResult body wire format is frozen"
         );
     }
 

--- a/crates/ironbus-proto/src/message.rs
+++ b/crates/ironbus-proto/src/message.rs
@@ -2683,6 +2683,68 @@ pub fn decode_txn_check_result(body: &[u8]) -> Result<TxnCheckResultBody<'_>, Bo
     Ok(TxnCheckResultBody { txn_id, decision })
 }
 
+/// The hard cap on a transaction-listener GROUP byte length the proto codecs enforce at the wire
+/// boundary (#640 part 2): the group is a producer-chosen stable routing key (e.g. its durable
+/// producer id), so this fails a hostile/oversized group closed at decode time BEFORE it crosses into
+/// the server. Sized identically to [`MAX_TXN_ID_LEN`] (256), generous for any real producer identity.
+pub const MAX_TXN_LISTEN_GROUP_LEN: usize = MAX_TXN_ID_LEN;
+
+/// A producer's TRANSACTION-LISTENER REGISTRATION (the `TxnListen` frame body, tag 49, #640 part 2):
+/// the stable listener GROUP this connection's transaction-state listener answers for. The broker binds
+/// the group to this connection so a [`crate::frame::FrameType::TxnCheck`] for an in-doubt half message
+/// owned by the group is routed to this connection — even after the original preparing connection
+/// crashed and a NEW connection re-registered the same group (the crash-and-reconnect route).
+///
+/// Layout (version+length framed, forward-compatible): `body_version: u8`
+/// ([`STREAM_WIRE_BODY_VERSION`]), `field_len: u16` (the length of the v1 block), then the v1 block:
+/// `group: u16-len + bytes`. Bytes past `field_len` (a future version's appended fields) are TOLERATED
+/// and ignored.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TxnListenBody<'a> {
+    /// The stable listener group to bind to this connection (capped at [`MAX_TXN_LISTEN_GROUP_LEN`]).
+    pub group: &'a [u8],
+}
+
+/// Encodes a `TxnListen` body onto the end of `out` (#640 part 2): the version byte, the field-block
+/// length over the `group`, then the `group`.
+///
+/// # Errors
+/// Returns [`BodyError::FieldTooLarge`] if the group exceeds the `u16` wire limit.
+pub fn encode_txn_listen(req: &TxnListenBody<'_>, out: &mut Vec<u8>) -> Result<(), BodyError> {
+    let group_len = u16::try_from(req.group.len()).map_err(|_| BodyError::FieldTooLarge)?;
+    let field_len = u16::try_from(2 + req.group.len()).map_err(|_| BodyError::FieldTooLarge)?;
+    out.push(STREAM_WIRE_BODY_VERSION);
+    out.extend_from_slice(&field_len.to_le_bytes());
+    out.extend_from_slice(&group_len.to_le_bytes());
+    out.extend_from_slice(req.group);
+    Ok(())
+}
+
+/// Decodes a `TxnListen` body (#640 part 2) into its `group`, cap-before-alloc and panic-free. A body
+/// too short for its declared block, or a group over [`MAX_TXN_LISTEN_GROUP_LEN`], is a typed
+/// [`BodyError`] (fail-closed). An EMPTY body is NOT valid ([`BodyError::Truncated`]); an empty GROUP
+/// inside a well-formed body IS valid (the broker rejects an empty group at the verb boundary).
+///
+/// # Errors
+/// [`BodyError::Truncated`] for a short body, [`BodyError::BadLength`] for an over-cap group, or
+/// [`BodyError::BadHandshakeVersion`] for an unknown body version.
+pub fn decode_txn_listen(body: &[u8]) -> Result<TxnListenBody<'_>, BodyError> {
+    let mut r = Reader::new(body);
+    let version = r.u8()?;
+    if version != STREAM_WIRE_BODY_VERSION {
+        return Err(BodyError::BadHandshakeVersion { version });
+    }
+    let field_len = r.u16()? as usize;
+    let block = r.take(field_len)?;
+    let mut fr = Reader::new(block);
+    let group_len = fr.u16()? as usize;
+    if group_len > MAX_TXN_LISTEN_GROUP_LEN {
+        return Err(BodyError::BadLength);
+    }
+    let group = fr.take(group_len)?;
+    Ok(TxnListenBody { group })
+}
+
 // ===================================================================================
 // SUBJECT-ADDRESSED WIRE BODIES (#585, V2-M2-I9): the subject->stream binding + subject-addressed
 // pub/sub verbs that complete the SUBJECTS story — BindSubject (tag 34), PubSubject (tag 35), SubSubject
@@ -5180,6 +5242,55 @@ mod tests {
             buf, expected,
             "the v1 TxnCheckResult body wire format is frozen"
         );
+    }
+
+    #[test]
+    fn txn_listen_round_trips_the_group() {
+        // #640 part 2: TxnListen carries the listener group, round-tripping (including an empty group,
+        // which the codec accepts and the verb boundary rejects).
+        for group in [b"".as_slice(), b"prod-payments-svc", b"a-uuid-1234"] {
+            let mut buf = Vec::new();
+            encode_txn_listen(&TxnListenBody { group }, &mut buf).unwrap();
+            assert_eq!(buf[0], STREAM_WIRE_BODY_VERSION);
+            assert_eq!(decode_txn_listen(&buf).unwrap().group, group);
+        }
+    }
+
+    #[test]
+    fn txn_listen_rejects_malformed_and_oversized_input() {
+        // An empty body is truncated (no version byte).
+        assert_eq!(decode_txn_listen(&[]), Err(BodyError::Truncated));
+        // A wrong body version fails closed.
+        let mut buf = Vec::new();
+        encode_txn_listen(&TxnListenBody { group: b"g" }, &mut buf).unwrap();
+        buf[0] = STREAM_WIRE_BODY_VERSION + 1;
+        assert!(matches!(
+            decode_txn_listen(&buf),
+            Err(BodyError::BadHandshakeVersion { .. })
+        ));
+        // An over-cap group is rejected by the inner cap check (cap-before-alloc).
+        let over = u16::try_from(MAX_TXN_LISTEN_GROUP_LEN + 1).unwrap();
+        let mut bad = Vec::new();
+        bad.push(STREAM_WIRE_BODY_VERSION);
+        let field_len = 2u16 + over;
+        bad.extend_from_slice(&field_len.to_le_bytes());
+        bad.extend_from_slice(&over.to_le_bytes());
+        bad.extend_from_slice(&vec![0u8; over as usize]);
+        assert_eq!(decode_txn_listen(&bad), Err(BodyError::BadLength));
+    }
+
+    #[test]
+    fn the_txn_listen_body_is_byte_frozen() {
+        // #640 part 2: pin the EXACT bytes a v1 TxnListen body produces. Layout: version,
+        // field_len(u16 LE), group(u16-len + bytes).
+        let mut buf = Vec::new();
+        encode_txn_listen(&TxnListenBody { group: b"svc" }, &mut buf).unwrap();
+        let mut expected = Vec::new();
+        expected.push(1); // STREAM_WIRE_BODY_VERSION
+        expected.extend_from_slice(&5u16.to_le_bytes()); // field_len = 2 (len field) + 3 (group bytes)
+        expected.extend_from_slice(&3u16.to_le_bytes()); // group len
+        expected.extend_from_slice(b"svc");
+        assert_eq!(buf, expected, "the v1 TxnListen body wire format is frozen");
     }
 
     #[test]

--- a/crates/ironbus-server/src/codes.rs
+++ b/crates/ironbus-server/src/codes.rs
@@ -174,6 +174,12 @@ impl ErrorCode {
     /// too many prepared, or an over-long id. Maps [`EngineError::Txn`].
     pub const ERR_TXN: ErrorCode = ErrorCode("ERR_TXN");
 
+    /// A back-check answer (`TxnCheckResult`, #640 part 2) was REFUSED on ownership: the answering
+    /// connection does not own the in-doubt txn's listener group (it registered no listener, or a
+    /// different group), so it may not resolve it. The txn is left Prepared on its back-check schedule.
+    /// Maps [`EngineError::TxnCheckUnauthorized`].
+    pub const ERR_TXN_CHECK_UNAUTHORIZED: ErrorCode = ErrorCode("ERR_TXN_CHECK_UNAUTHORIZED");
+
     /// Maps an [`EngineError`] to its stable code. The single source of truth the conformance
     /// vectors and any wire error-code scheme share. A storage error is split into the two named
     /// outcomes ([`Self::ERR_AT_CAPACITY`] for the byte-cap shed) plus the residual
@@ -199,6 +205,7 @@ impl ErrorCode {
             EngineError::MissingRecord { .. } => Self::ERR_MISSING_RECORD,
             EngineError::ZeroMaxInFlight => Self::ERR_ZERO_MAX_IN_FLIGHT,
             EngineError::Txn(_) => Self::ERR_TXN,
+            EngineError::TxnCheckUnauthorized => Self::ERR_TXN_CHECK_UNAUTHORIZED,
             EngineError::Storage(_) if error.is_at_capacity() => Self::ERR_AT_CAPACITY,
             EngineError::Storage(_) => Self::ERR_STORAGE,
         }
@@ -246,6 +253,10 @@ mod tests {
         );
         assert_eq!(ErrorCode::DUPLICATE.as_str(), "DUPLICATE");
         assert_eq!(ErrorCode::OK.as_str(), "OK");
+        assert_eq!(
+            ErrorCode::ERR_TXN_CHECK_UNAUTHORIZED.as_str(),
+            "ERR_TXN_CHECK_UNAUTHORIZED"
+        );
     }
 
     #[test]
@@ -349,6 +360,10 @@ mod tests {
                     cap: 32,
                 }),
                 ErrorCode::ERR_AT_CAPACITY,
+            ),
+            (
+                EngineError::TxnCheckUnauthorized,
+                ErrorCode::ERR_TXN_CHECK_UNAUTHORIZED,
             ),
             (
                 EngineError::Storage(StorageError::WriterFrozen),

--- a/crates/ironbus-server/src/engine.rs
+++ b/crates/ironbus-server/src/engine.rs
@@ -1640,6 +1640,141 @@ fn txn_store_error_to_engine(e: TxnStoreError) -> EngineError {
     }
 }
 
+/// One `TxnCheck` the broker's back-check scan has queued for delivery to a producer connection (#640
+/// part 2): the producer connection (`member`) to push it to, and the `txn_id` to ask about. Drained
+/// onto the wire on that producer's own serve pass (the thread-per-connection server only writes a
+/// connection's socket from that connection's pass), exactly like a Level-2 `ReadyConfirm`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReadyCheck {
+    /// The producer connection (`MemberId` raw value) the `TxnCheck` is routed to.
+    pub member: u64,
+    /// The in-doubt transaction id to ask the producer's listener about.
+    pub txn_id: Vec<u8>,
+}
+
+/// The default cap on QUEUED-but-undrained `TxnCheck`s the broker holds at once (#640 part 2): the
+/// global ready-queue bound, the same drop-oldest discipline as the Level-2 confirm ready queue. A
+/// producer that registered a listener but never drives a pass (so its `TxnCheck`s never leave the
+/// queue) cannot grow it without bound; an over-cap push drops the oldest queued check (the txn stays
+/// Prepared and is re-checked on a later scan, so nothing is lost).
+const DEFAULT_MAX_PENDING_CHECKS: usize = 65_536;
+
+/// The broker-side back-check ROUTER (#640 part 2): the in-memory, session-scoped routing + delivery
+/// state that turns the durable [`ironbus_core::txn::BackCheckBook`] schedule into a `TxnCheck` pushed
+/// to the right (re)connected producer. It holds three small maps, all EMPTY until a producer both
+/// runs transactions and registers a listener — so a non-transactional (or non-back-checking) broker
+/// pays nothing and the hot path is byte-for-byte unchanged.
+///
+/// - `group_listener`: the live route — each registered listener GROUP to the producer connection
+///   (`MemberId`) that currently holds it. A reconnecting producer re-registers the same group,
+///   superseding the stale binding, so the route follows the producer across a crash.
+/// - `txn_owner`: each still-`Prepared` txn to the listener group that owns it (recorded at prepare),
+///   so the scan knows which connection to route a txn's `TxnCheck` to. A txn with no owning group (a
+///   producer that prepared without registering a listener) is simply not routable — its back-check
+///   waits, and the bounded attempt cap eventually applies the SAFE terminal default (rollback), so a
+///   listener-less producer's crashed half message is still never stuck forever.
+/// - `pending`: the FIFO queue of [`ReadyCheck`]s awaiting drain by their producer connection, bounded
+///   drop-oldest like the confirm ready queue.
+#[derive(Clone, Debug, Default)]
+pub struct TxnBackCheck {
+    /// Each registered listener group to the live producer connection (`MemberId` raw) holding it.
+    group_listener: std::collections::HashMap<Vec<u8>, u64>,
+    /// Each still-`Prepared` txn id to its owning listener group (recorded at prepare, removed on
+    /// resolve), so the scan routes a `TxnCheck` to the group's current listener.
+    txn_owner: std::collections::HashMap<Vec<u8>, Vec<u8>>,
+    /// The FIFO queue of `TxnCheck`s awaiting drain by their producer connection, oldest first.
+    pending: std::collections::VecDeque<ReadyCheck>,
+    /// The cap on queued-but-undrained `TxnCheck`s (drop-oldest past it).
+    max_pending: usize,
+}
+
+impl TxnBackCheck {
+    /// A fresh, empty router at the default queue cap.
+    fn new() -> TxnBackCheck {
+        TxnBackCheck {
+            group_listener: std::collections::HashMap::new(),
+            txn_owner: std::collections::HashMap::new(),
+            pending: std::collections::VecDeque::new(),
+            max_pending: DEFAULT_MAX_PENDING_CHECKS,
+        }
+    }
+
+    /// Binds `group` to the producer connection `member` (the `TxnListen` registration), superseding any
+    /// prior binding so a reconnecting producer re-points the route to its NEW connection.
+    fn register_listener(&mut self, group: &[u8], member: u64) {
+        self.group_listener.insert(group.to_vec(), member);
+    }
+
+    /// Records that the still-`Prepared` `txn_id` is owned by the listener `group` (called at prepare),
+    /// so the scan can route the txn's `TxnCheck`. A no-op for an empty group (an unrouted txn).
+    fn set_owner(&mut self, txn_id: &[u8], group: &[u8]) {
+        if !group.is_empty() {
+            self.txn_owner.insert(txn_id.to_vec(), group.to_vec());
+        }
+    }
+
+    /// Drops a resolved txn's owner mapping (called on commit/rollback/terminal-default), so a settled
+    /// txn is never routed again.
+    fn forget_owner(&mut self, txn_id: &[u8]) {
+        self.txn_owner.remove(txn_id);
+    }
+
+    /// The live listener connection for `txn_id`'s owning group, or `None` if the txn has no owning
+    /// group (a listener-less prepare) or no connection currently holds that group (the producer has
+    /// not yet reconnected + re-registered). `None` means "not routable right now" — the scan records
+    /// no attempt and waits for the producer to (re)appear.
+    fn route_for(&self, txn_id: &[u8]) -> Option<u64> {
+        let group = self.txn_owner.get(txn_id)?;
+        self.group_listener.get(group).copied()
+    }
+
+    /// Queues a `TxnCheck` for delivery to `member`, bounded drop-oldest (an over-cap push drops the
+    /// oldest queued check; its txn stays Prepared and is re-checked on a later scan).
+    fn enqueue(&mut self, member: u64, txn_id: &[u8]) {
+        while self.pending.len() >= self.max_pending {
+            self.pending.pop_front();
+        }
+        self.pending.push_back(ReadyCheck {
+            member,
+            txn_id: txn_id.to_vec(),
+        });
+    }
+
+    /// Drains every queued `TxnCheck` for `member` (a producer connection draining on its own pass), in
+    /// oldest-first order, leaving other producers' queued checks in place.
+    fn drain_for(&mut self, member: u64) -> Vec<ReadyCheck> {
+        if self.pending.is_empty() {
+            return Vec::new();
+        }
+        let mut mine = Vec::new();
+        let mut others = std::collections::VecDeque::with_capacity(self.pending.len());
+        for c in self.pending.drain(..) {
+            if c.member == member {
+                mine.push(c);
+            } else {
+                others.push_back(c);
+            }
+        }
+        self.pending = others;
+        mine
+    }
+
+    /// Removes a disconnected producer connection's listener bindings and queued checks. Its
+    /// `group_listener` entries (those still pointing at THIS member) are cleared so a stale route is
+    /// never used, and its queued checks are dropped (nobody is on that connection to receive them — the
+    /// txns stay Prepared and are re-routed once the producer reconnects + re-registers).
+    fn drop_member(&mut self, member: u64) {
+        self.group_listener.retain(|_, m| *m != member);
+        self.pending.retain(|c| c.member != member);
+    }
+
+    /// Whether the router has any state at all — the scan's hot-path no-op gate combined with the book
+    /// being empty (a broker with no in-doubt txns and no listeners does ZERO work).
+    fn is_idle(&self) -> bool {
+        self.group_listener.is_empty() && self.txn_owner.is_empty() && self.pending.is_empty()
+    }
+}
+
 /// The build version string for the metric registry's `ironbus_build_info` (#97), the crate
 /// version baked in at compile time.
 fn crate_version() -> &'static str {
@@ -2433,6 +2568,13 @@ pub struct Engine<F: Filesystem, C: Clock> {
     /// with NO total-byte cap (a half message / op-marker must never be shed — a prepared half message
     /// is an undelivered durable payload, and a resolution is the durable record of the commit/rollback).
     txn_config: LogConfig,
+    /// The broker-side back-check ROUTER (V2-M8, #640 part 2): the in-memory routing + delivery state
+    /// that turns the durable back-check schedule into a `TxnCheck` pushed to the right (re)connected
+    /// producer's listener. EMPTY until a producer both runs transactions and registers a listener, so a
+    /// non-back-checking broker pays nothing. The DURABLE half of the back-check (the schedule + attempt
+    /// count) lives in the txn store's [`ironbus_core::txn::BackCheckBook`]; this is only the (lost-on-
+    /// restart, rebuilt-by-re-registration) routing.
+    txn_back_check: TxnBackCheck,
     /// The per-STREAM default message TTL (V2-M4, #549): a record reached on the poll path whose
     /// EFFECTIVE TTL (the lower of this and the record's own per-message TTL) has passed against the
     /// WALL-clock seam (anchored to the record's durable producer `timestamp_ms`) is EXPIRED — skipped
@@ -2774,6 +2916,7 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
                 log.clock_clone(),
                 txn_config,
                 ironbus_core::txn::TxnConfig::default(),
+                ironbus_core::txn::BackCheckConfig::default(),
             )?)
         } else {
             None
@@ -2849,6 +2992,11 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
             // non-transactional broker keeps this `None`, so the produce/consume hot path is unchanged.
             txn,
             txn_config,
+            // The back-check router (#640 part 2): empty until a producer registers a transaction
+            // listener, so a non-back-checking broker pays nothing. The durable schedule it drives lives
+            // in the txn store; this routing is rebuilt by the producers' re-registration after a
+            // restart (a reconnecting producer re-sends `TxnListen`).
+            txn_back_check: TxnBackCheck::new(),
             // Empty by default: no group is key_shared until an operator configures one (#64), so an
             // unconfigured engine is plain competing everywhere and unchanged.
             key_shared_groups: std::collections::BTreeSet::new(),
@@ -3914,6 +4062,7 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
                 self.log.clock_clone(),
                 self.txn_config,
                 ironbus_core::txn::TxnConfig::default(),
+                ironbus_core::txn::BackCheckConfig::default(),
             )
             .map_err(EngineError::Storage)?;
             self.txn = Some(store);
@@ -3935,8 +4084,13 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         txn_id: &[u8],
         stream: &str,
         message: &Append<'_>,
+        listener_group: &[u8],
     ) -> Result<(), EngineError> {
         let now = self.log.now_monotonic();
+        let back_check_timeout = {
+            let store = self.ensure_txn_store()?;
+            store.back_check().config().timeout
+        };
         let store = self.ensure_txn_store()?;
         // Decide FIRST on the pure lifecycle (no IO): a fresh prepare durably buffers; a benign
         // duplicate re-acks without a second half record; a spent/over-cap id is refused.
@@ -3945,19 +4099,38 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
             .prepare(txn_id, now)
             .map_err(EngineError::Txn)?
         {
-            ironbus_core::txn::PrepareDecision::AlreadyPrepared => Ok(()),
+            ironbus_core::txn::PrepareDecision::AlreadyPrepared => {
+                // A benign duplicate: the half message (and its back-check enrollment) is already
+                // tracked. Refresh the owning listener group in case a re-prepare arrived on a new
+                // connection that registered a different group (the owner follows the latest prepare).
+                self.txn_back_check.set_owner(txn_id, listener_group);
+                Ok(())
+            }
             ironbus_core::txn::PrepareDecision::Prepared => {
                 // Durably append + fsync the half record. If the durable write fails, ROLL BACK the
                 // in-memory prepared state so the table and the durable log stay consistent (the
                 // prepare did not happen), and surface the error.
                 match store.append_half(txn_id, stream, message) {
-                    Ok(()) => Ok(()),
+                    Ok(()) => {
+                        // Enroll the fresh half message for back-checking: it becomes eligible for its
+                        // first `TxnCheck` once it has been Prepared (undelivered) for the back-check
+                        // timeout. The schedule + count are made durable only when the FIRST attempt is
+                        // recorded (a never-back-checked txn writes no extra record), so a normal
+                        // prepare→commit produces zero back-check IO. Record the owning listener group so
+                        // the scan can route the check to the producer.
+                        store
+                            .back_check_mut()
+                            .enroll(txn_id, now.saturating_add(back_check_timeout));
+                        self.txn_back_check.set_owner(txn_id, listener_group);
+                        Ok(())
+                    }
                     Err(e) => {
                         // The half record is NOT durable: undo the in-memory prepare (mark it rolled
                         // back in memory only — no op record is written, and on reopen there is no half
                         // record either, so the txn is simply absent). We use the table's rollback to
                         // clear the prepared entry; the durable log never saw this txn.
                         let _ = store.table_mut().rollback(txn_id, now);
+                        store.back_check_mut().forget(txn_id);
                         Err(txn_store_error_to_engine(e))
                     }
                 }
@@ -4031,6 +4204,11 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
                 store
                     .mark_committed(txn_id, real_offset.get())
                     .map_err(txn_store_error_to_engine)?;
+                // The txn is resolved: drop its back-check bookkeeping (never back-check it again) and
+                // its routing owner. The durable BACK record (if any was written) is superseded by the
+                // committed op-marker on a future replay, so no durable cleanup is needed here.
+                store.back_check_mut().forget(txn_id);
+                self.txn_back_check.forget_owner(txn_id);
                 Ok(real_offset)
             }
         }
@@ -4149,11 +4327,11 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
     pub fn txn_rollback(&mut self, txn_id: &[u8]) -> Result<(), EngineError> {
         let now = self.log.now_monotonic();
         let store = self.ensure_txn_store()?;
-        match store
+        let decision = store
             .table_mut()
             .rollback(txn_id, now)
-            .map_err(EngineError::Txn)?
-        {
+            .map_err(EngineError::Txn)?;
+        match decision {
             // A retried rollback of an already-rolled-back txn: benign no-op (the op-marker is durable).
             ironbus_core::txn::ResolveDecision::AlreadyResolved => Ok(()),
             ironbus_core::txn::ResolveDecision::Resolved => {
@@ -4161,7 +4339,13 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
                 // dropped by the store; it never reaches the real stream.
                 store
                     .mark_rolled_back(txn_id)
-                    .map_err(txn_store_error_to_engine)
+                    .map_err(txn_store_error_to_engine)?;
+                // The txn is resolved: drop its back-check bookkeeping (never back-check it again) and
+                // its routing owner. (Same cleanup as the commit path; the rolled-back op-marker
+                // supersedes any durable BACK record on a future replay.)
+                store.back_check_mut().forget(txn_id);
+                self.txn_back_check.forget_owner(txn_id);
+                Ok(())
             }
         }
     }
@@ -4171,6 +4355,166 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
     #[must_use]
     pub fn txn_prepared_count(&self) -> usize {
         self.txn.as_ref().map_or(0, TxnStore::prepared_count)
+    }
+
+    /// The count of currently-enrolled (under-back-check) txns (#640 part 2), for observability.
+    /// `0` when no txn store is open.
+    #[must_use]
+    pub fn txn_under_back_check(&self) -> usize {
+        self.txn.as_ref().map_or(0, TxnStore::under_back_check)
+    }
+
+    /// Registers (or re-registers, after a reconnect) producer connection `member` as the live listener
+    /// for transaction `listener_group` (#640 part 2, the `TxnListen` verb). A reconnecting producer
+    /// re-sends this with the SAME group to re-point a back-check route to its NEW connection, so a
+    /// `TxnCheck` for a half message the producer prepared on a now-dead connection reaches its current
+    /// connection. Superseding (not additive): one connection owns a group at a time.
+    pub fn register_txn_listener(&mut self, listener_group: &[u8], member: MemberId) {
+        self.txn_back_check
+            .register_listener(listener_group, member.get());
+    }
+
+    /// Removes a disconnected producer connection's back-check listener bindings and queued `TxnCheck`s
+    /// (#640 part 2). Called from the connection close path alongside [`Engine::drop_l2_confirms`]: a
+    /// stale route is never used, and an in-doubt txn whose listener just vanished stays Prepared and is
+    /// re-routed once the producer reconnects + re-registers (or, after the bounded attempt cap, is
+    /// safely rolled back). A no-op for a connection that never registered a listener.
+    pub fn drop_txn_listener(&mut self, member: MemberId) {
+        self.txn_back_check.drop_member(member.get());
+    }
+
+    /// Drains every queued `TxnCheck` for producer connection `member` (#640 part 2), oldest-first, so
+    /// the connection writes them onto its own pass (the thread-per-connection server only writes a
+    /// connection's socket from that connection's pass — the same cross-thread hand-off as the L2
+    /// confirm drain). Returns `(member, txn_id)` pairs (here just the `txn_id`s, all for `member`). A
+    /// no-op (empty) for a connection with no queued checks.
+    pub fn drain_txn_checks(&mut self, member: MemberId) -> Vec<ReadyCheck> {
+        self.txn_back_check.drain_for(member.get())
+    }
+
+    /// The back-check SCAN TICK (#640 part 2): the cheap periodic task that finds every in-doubt
+    /// half message DUE for a back-check, pushes a `TxnCheck` to the (re)connected producer's listener,
+    /// records the attempt DURABLY, and — after the bounded attempt cap — applies the SAFE TERMINAL
+    /// default (rollback/discard, never delivering a message whose outcome is unknowable). Returns the
+    /// number of `TxnCheck`s queued this pass (for tests/observability).
+    ///
+    /// CHEAP-WHEN-UNUSED: returns immediately with ZERO work when no txn store is open OR the back-check
+    /// book is empty (no in-doubt txns) — no lock, no alloc, no syscall. It rides the engine's existing
+    /// maintenance tick (the produce/poll seam), so it adds no new timer. BOUNDED: the book's `due`
+    /// query is capped at the global per-pass batch (no storm), and each due txn respects its durable
+    /// per-txn next-eligible schedule.
+    ///
+    /// The terminal default is driven through the SAME idempotent [`Engine::txn_rollback`] path as a
+    /// producer-driven rollback, so it inherits part 1's `AlreadyResolved` rule: if the producer's
+    /// `TxnCheckResult` lands in the same window, whichever resolve wins is terminal and the other is a
+    /// benign duplicate / refused flip — never a double-resolve.
+    ///
+    /// # Errors
+    /// Propagates a storage error from the durable attempt record or the terminal-default rollback.
+    pub fn txn_back_check_tick(&mut self) -> Result<usize, EngineError>
+    where
+        F: Clone,
+    {
+        // HOT-PATH NO-OP: no txn store, or no in-doubt txns AND no router state, means nothing to do.
+        let Some(store) = self.txn.as_ref() else {
+            return Ok(0);
+        };
+        if store.back_check().is_empty() && self.txn_back_check.is_idle() {
+            return Ok(0);
+        }
+        let now = self.log.now_monotonic();
+        // The pure schedule decides which txns are DUE (bounded by the global batch cap — no storm).
+        let due = self
+            .txn
+            .as_ref()
+            .map(|s| s.back_check().due(now))
+            .unwrap_or_default();
+        if due.is_empty() {
+            return Ok(0);
+        }
+        let mut issued = 0;
+        for txn_id in due {
+            // Defensive: a txn that resolved between the `due` scan and here is no longer Prepared; skip
+            // it (its book entry is already forgotten, so `due` won't return it again).
+            let still_prepared = self.txn.as_ref().is_some_and(|s| {
+                matches!(
+                    s.table().state(&txn_id),
+                    Some(ironbus_core::txn::TxnState::Prepared)
+                )
+            });
+            if !still_prepared {
+                continue;
+            }
+            // Record the attempt DURABLY first (the attempt count is the terminal-default gate; it must
+            // survive a restart). A crash after this but before the push simply re-checks the txn on the
+            // next scan — a safe at-least-once back-check whose resolution is idempotent.
+            let outcome = {
+                let store = self.ensure_txn_store()?;
+                let outcome = store.back_check_mut().record_attempt(&txn_id, now);
+                let (attempts, next_eligible) =
+                    store.back_check().bookkeeping(&txn_id).unwrap_or((0, now));
+                store
+                    .append_back_check(&txn_id, attempts, next_eligible)
+                    .map_err(txn_store_error_to_engine)?;
+                outcome
+            };
+            match outcome {
+                ironbus_core::txn::AttemptOutcome::TerminalDefault => {
+                    // The bounded attempt cap is reached with no resolution: apply the SAFE terminal
+                    // default — ROLLBACK (discard, never deliver a message whose outcome is unknowable).
+                    // Through the part-1 idempotent path, so a late producer `Commit` afterward is a
+                    // REFUSED flip (never a double-resolve). `txn_rollback` forgets the book + owner.
+                    self.txn_rollback(&txn_id)?;
+                }
+                ironbus_core::txn::AttemptOutcome::Rescheduled => {
+                    // Attempts remain: route a `TxnCheck` to the producer's live listener, if one is
+                    // currently registered for the txn's owning group. If not routable right now (the
+                    // producer has not yet reconnected + re-registered), the attempt was still recorded
+                    // (so the bounded cap still advances toward the terminal default) and the txn waits.
+                    if let Some(member) = self.txn_back_check.route_for(&txn_id) {
+                        self.txn_back_check.enqueue(member, &txn_id);
+                        issued += 1;
+                    }
+                }
+            }
+        }
+        Ok(issued)
+    }
+
+    /// Resolves an in-doubt transaction from a producer's `TxnCheckResult` back-check answer (#640
+    /// part 2): a `Commit` drives the SAME idempotent [`Engine::txn_commit`] path (the half message
+    /// becomes visible EXACTLY ONCE), a `Rollback` the SAME [`Engine::txn_rollback`] path (discarded,
+    /// never delivered), and an `Unknown` is a no-op (the back-check reschedules and the bounded attempt
+    /// cap eventually applies the terminal default). The back-check NEVER introduces a new commit path,
+    /// so part 1's exactly-once + `AlreadyResolved` guarantees are inherited: a `Commit` for a txn the
+    /// terminal default already rolled back is a REFUSED flip (returned as the typed error), a duplicate
+    /// `Commit` is a benign no-op returning the recorded offset, and a result for an unknown/never-seen
+    /// txn is a benign no-op.
+    ///
+    /// # Errors
+    /// [`EngineError::Txn`] for a conflicting flip (a `Commit` after a rollback or vice-versa — the
+    /// outcome is immutable), or a storage error from the resolve.
+    pub fn resolve_txn_check(
+        &mut self,
+        txn_id: &[u8],
+        decision: ironbus_proto::message::TxnCheckDecision,
+    ) -> Result<(), EngineError>
+    where
+        F: Clone,
+    {
+        use ironbus_proto::message::TxnCheckDecision;
+        // A result for a txn that is no longer Prepared (already resolved by a racing terminal default,
+        // a producer-driven resolve, or never seen) is a benign no-op for Commit/Rollback ONLY when it
+        // matches; the part-1 path itself enforces the AlreadyResolved rule, so we route straight
+        // through it and let it decide (idempotent duplicate vs refused flip vs fresh resolve).
+        match decision {
+            TxnCheckDecision::Commit => self.txn_commit(txn_id).map(|_offset| ()),
+            TxnCheckDecision::Rollback => self.txn_rollback(txn_id),
+            // The producer cannot decide yet: do nothing. The book already rescheduled this txn on the
+            // attempt that pushed the check, and the bounded attempt cap will eventually apply the
+            // terminal default if the producer never settles.
+            TxnCheckDecision::Unknown => Ok(()),
+        }
     }
 
     /// CREATE-OR-ENSURE the named stream `stream` WITHOUT producing to it (#588, M2-I10): the
@@ -15978,7 +16322,7 @@ mod tests {
         // THE INVISIBILITY INVARIANT: a Prepared-but-uncommitted half message is NEVER returned by the
         // consume path; it appears in the target stream ONLY after commit.
         let mut e = open(config(10, 5));
-        e.txn_prepare(b"tx1", "", &txn_half(b"half")).unwrap();
+        e.txn_prepare(b"tx1", "", &txn_half(b"half"), b"").unwrap();
         assert_eq!(e.txn_prepared_count(), 1);
         // The consumer sees NOTHING (the half message lives in txn/, not the real stream).
         assert!(
@@ -16001,7 +16345,8 @@ mod tests {
     fn a_rolled_back_half_message_is_never_delivered() {
         // After rollback the half message NEVER appears in the real stream.
         let mut e = open(config(10, 5));
-        e.txn_prepare(b"tx1", "", &txn_half(b"secret")).unwrap();
+        e.txn_prepare(b"tx1", "", &txn_half(b"secret"), b"")
+            .unwrap();
         e.txn_rollback(b"tx1").unwrap();
         assert_eq!(e.txn_prepared_count(), 0);
         assert!(
@@ -16022,7 +16367,7 @@ mod tests {
         // committed record lands at its own offset after the earlier normal produces.
         let mut e = open(config(10, 5));
         assert_eq!(produce(&mut e, b"n0"), Offset::new(0));
-        e.txn_prepare(b"tx1", "", &txn_half(b"txn")).unwrap();
+        e.txn_prepare(b"tx1", "", &txn_half(b"txn"), b"").unwrap();
         assert_eq!(produce(&mut e, b"n1"), Offset::new(1));
         // So far only the two normal produces are visible.
         // (Peek without acking is awkward; instead assert the txn commit lands at offset 2.)
@@ -16042,7 +16387,7 @@ mod tests {
     fn recommit_is_idempotent_returning_the_same_offset() {
         // A retried commit of an already-committed txn returns the SAME offset and appends nothing.
         let mut e = open(config(10, 5));
-        e.txn_prepare(b"tx1", "", &txn_half(b"v")).unwrap();
+        e.txn_prepare(b"tx1", "", &txn_half(b"v"), b"").unwrap();
         let off1 = e.txn_commit(b"tx1").unwrap();
         let off2 = e.txn_commit(b"tx1").unwrap();
         let off3 = e.txn_commit(b"tx1").unwrap();
@@ -16056,11 +16401,11 @@ mod tests {
     fn commit_after_rollback_and_rollback_after_commit_are_refused() {
         let mut e = open(config(10, 5));
         // commit-after-rollback is refused, never flipped.
-        e.txn_prepare(b"a", "", &txn_half(b"a")).unwrap();
+        e.txn_prepare(b"a", "", &txn_half(b"a"), b"").unwrap();
         e.txn_rollback(b"a").unwrap();
         assert!(matches!(e.txn_commit(b"a"), Err(EngineError::Txn(_))));
         // rollback-after-commit is refused too.
-        e.txn_prepare(b"b", "", &txn_half(b"b")).unwrap();
+        e.txn_prepare(b"b", "", &txn_half(b"b"), b"").unwrap();
         e.txn_commit(b"b").unwrap();
         assert!(matches!(e.txn_rollback(b"b"), Err(EngineError::Txn(_))));
         // Only b's committed record is visible (a was rolled back).
@@ -16071,7 +16416,7 @@ mod tests {
     fn an_unknown_commit_or_rollback_is_rejected() {
         let mut e = open(config(10, 5));
         // Open the txn store first (so a real store exists), then resolve a ghost.
-        e.txn_prepare(b"real", "", &txn_half(b"r")).unwrap();
+        e.txn_prepare(b"real", "", &txn_half(b"r"), b"").unwrap();
         assert!(matches!(e.txn_commit(b"ghost"), Err(EngineError::Txn(_))));
         assert!(matches!(e.txn_rollback(b"ghost"), Err(EngineError::Txn(_))));
     }
@@ -16083,7 +16428,7 @@ mod tests {
         let fs = InMemoryFs::new();
         {
             let mut e = Engine::open(fs.clone(), ManualClock::new(), config(10, 5)).unwrap();
-            e.txn_prepare(b"tx1", "", &txn_half(b"half")).unwrap();
+            e.txn_prepare(b"tx1", "", &txn_half(b"half"), b"").unwrap();
             // CRASH: no commit/rollback.
         }
         let mut reopened = Engine::open(fs.clone(), ManualClock::new(), config(10, 5)).unwrap();
@@ -16115,7 +16460,8 @@ mod tests {
         let fs = InMemoryFs::new();
         {
             let mut e = Engine::open(fs.clone(), ManualClock::new(), config(10, 5)).unwrap();
-            e.txn_prepare(b"tx1", "", &txn_half(b"committed")).unwrap();
+            e.txn_prepare(b"tx1", "", &txn_half(b"committed"), b"")
+                .unwrap();
             e.txn_commit(b"tx1").unwrap();
             // CLEAN shutdown after the durable commit.
         }
@@ -16152,7 +16498,7 @@ mod tests {
         let committed_off;
         {
             let mut e = Engine::open(fs.clone(), ManualClock::new(), config(10, 5)).unwrap();
-            e.txn_prepare(b"tx1", "", &txn_half(b"once")).unwrap();
+            e.txn_prepare(b"tx1", "", &txn_half(b"once"), b"").unwrap();
             committed_off = e.txn_commit(b"tx1").unwrap();
         }
         // Reopen: the producer-seq high-water for the txn id is restored from producer-seq.ckpt.
@@ -16201,7 +16547,7 @@ mod tests {
         let probe = faultfs.inner().clone();
         {
             let mut e = Engine::open(faultfs, ManualClock::new(), config(10, 5)).unwrap();
-            e.txn_prepare(b"tx1", "", &txn_half(b"once")).unwrap();
+            e.txn_prepare(b"tx1", "", &txn_half(b"once"), b"").unwrap();
             // The buffered half (durably fsync'd at prepare) is what a redrive re-appends. Pull it
             // exactly as `txn_commit` does, then run the commit ordering by hand so we can inject the
             // fault precisely BETWEEN A2 and A3.
@@ -16271,9 +16617,9 @@ mod tests {
     #[test]
     fn re_prepare_of_a_prepared_id_is_a_benign_duplicate() {
         let mut e = open(config(10, 5));
-        e.txn_prepare(b"tx1", "", &txn_half(b"v")).unwrap();
+        e.txn_prepare(b"tx1", "", &txn_half(b"v"), b"").unwrap();
         // A retried prepare is a benign no-op: no second half record buffered.
-        e.txn_prepare(b"tx1", "", &txn_half(b"v")).unwrap();
+        e.txn_prepare(b"tx1", "", &txn_half(b"v"), b"").unwrap();
         assert_eq!(e.txn_prepared_count(), 1);
         // Commit still delivers exactly one record.
         e.txn_commit(b"tx1").unwrap();
@@ -16298,10 +16644,273 @@ mod tests {
             "normal produce/consume never materializes txn/"
         );
         // Only the first prepare creates it.
-        e.txn_prepare(b"tx1", "", &txn_half(b"v")).unwrap();
+        e.txn_prepare(b"tx1", "", &txn_half(b"v"), b"").unwrap();
         assert!(
             ironbus_storage::txn::TxnStore::<InMemoryFs, ManualClock>::dir_exists(&fs).unwrap(),
             "the first prepare materializes txn/"
         );
+    }
+
+    // ---- the broker BACK-CHECK (#640 part 2) ----
+
+    /// The default back-check timeout in nanoseconds, so a test can advance the clock past it.
+    const BC_TIMEOUT: u64 = ironbus_core::txn::DEFAULT_BACK_CHECK_TIMEOUT_NANOS;
+
+    /// Drain-and-ack every visible default-group record, generic over the clock so the back-check tests
+    /// (which use an `Arc<ManualClock>` engine to advance the monotonic clock) can assert visibility.
+    fn drain_visible_generic<C: Clock + Clone + 'static>(
+        e: &mut Engine<InMemoryFs, C>,
+    ) -> Vec<Vec<u8>> {
+        let mut seen = Vec::new();
+        loop {
+            match e.poll(0).unwrap() {
+                Poll::Message(d) => {
+                    seen.push(d.record.payload.to_vec());
+                    e.ack(&d.token);
+                }
+                Poll::Idle => break,
+                other => panic!("unexpected poll outcome: {other:?}"),
+            }
+        }
+        seen
+    }
+
+    #[test]
+    fn the_back_check_scan_is_a_no_op_when_no_txn_is_in_doubt() {
+        // BYTE-IDENTICAL-WHEN-UNUSED: the scan does ZERO work on a broker with no in-doubt txns. With no
+        // txn store at all it returns 0; even after a prepare-then-commit (no in-doubt txn left) it is a
+        // no-op.
+        let mut e = open(config(10, 5));
+        assert_eq!(e.txn_back_check_tick().unwrap(), 0, "no txn store: no-op");
+        e.txn_prepare(b"tx1", "", &txn_half(b"v"), b"svc").unwrap();
+        e.txn_commit(b"tx1").unwrap();
+        assert_eq!(e.txn_under_back_check(), 0);
+        assert_eq!(
+            e.txn_back_check_tick().unwrap(),
+            0,
+            "no in-doubt txn: scan is a no-op"
+        );
+    }
+
+    #[test]
+    fn a_prepared_half_is_not_back_checked_before_the_timeout() {
+        // The scan respects the back-check timeout: a freshly-prepared half message (well within a
+        // normal local-transaction window) is NOT back-checked.
+        let clock = std::sync::Arc::new(ManualClock::new());
+        let mut e = open_with_clock(config(10, 5), clock.clone());
+        e.register_txn_listener(b"svc", MemberId::new(7));
+        e.txn_prepare(b"tx1", "", &txn_half(b"v"), b"svc").unwrap();
+        // Just under the timeout: nothing due, no check issued.
+        clock.advance_monotonic_nanos(BC_TIMEOUT - 1);
+        assert_eq!(e.txn_back_check_tick().unwrap(), 0, "not due yet");
+        assert!(e.drain_txn_checks(MemberId::new(7)).is_empty());
+    }
+
+    #[test]
+    fn the_headline_crash_reconnect_back_check_commit_delivers_exactly_once() {
+        // THE HEADLINE: a producer PREPAREs a half message under listener group "svc", then DISCONNECTS
+        // before commit (simulated crash) — the listener for "svc" is dropped. It RECONNECTS as a NEW
+        // connection and re-registers the SAME group. The back-check scan finds the in-doubt half, routes
+        // a TxnCheck to the reconnected listener, and the producer answers Commit → the half message is
+        // committed EXACTLY ONCE via the part-1 path.
+        let clock = std::sync::Arc::new(ManualClock::new());
+        let mut e = open_with_clock(config(10, 5), clock.clone());
+        // The original (soon-to-crash) connection: member 1 registers the listener and prepares.
+        e.register_txn_listener(b"svc", MemberId::new(1));
+        e.txn_prepare(b"tx1", "", &txn_half(b"order-42"), b"svc")
+            .unwrap();
+        assert_eq!(e.txn_under_back_check(), 1);
+        // CRASH: the original connection disconnects before resolving — its listener route is dropped.
+        e.drop_txn_listener(MemberId::new(1));
+        // Time passes past the back-check timeout. A scan now finds the in-doubt half, but the producer
+        // has NOT reconnected yet, so there is no live route: the attempt is recorded (the bounded cap
+        // advances) but no TxnCheck is delivered.
+        clock.advance_monotonic_nanos(BC_TIMEOUT + 1);
+        assert_eq!(
+            e.txn_back_check_tick().unwrap(),
+            0,
+            "no live listener yet: nothing routed"
+        );
+        // The producer RECONNECTS as a NEW connection (member 2) and re-registers the SAME group.
+        e.register_txn_listener(b"svc", MemberId::new(2));
+        // The next scan (after the retry cadence) routes a TxnCheck to the reconnected listener.
+        clock.advance_monotonic_nanos(ironbus_core::txn::DEFAULT_BACK_CHECK_RETRY_NANOS + 1);
+        assert_eq!(
+            e.txn_back_check_tick().unwrap(),
+            1,
+            "the reconnected listener is back-checked"
+        );
+        let checks = e.drain_txn_checks(MemberId::new(2));
+        assert_eq!(checks.len(), 1);
+        assert_eq!(checks[0].txn_id, b"tx1");
+        // The producer's listener answers Commit → committed exactly once via the part-1 path.
+        e.resolve_txn_check(b"tx1", ironbus_proto::message::TxnCheckDecision::Commit)
+            .unwrap();
+        assert_eq!(e.txn_prepared_count(), 0);
+        assert_eq!(e.txn_under_back_check(), 0);
+        // The half message is now VISIBLE exactly once.
+        assert_eq!(drain_visible_generic(&mut e), vec![b"order-42".to_vec()]);
+        // A duplicate Commit result (a retried answer) is a benign no-op (idempotent), never a second
+        // delivery.
+        e.resolve_txn_check(b"tx1", ironbus_proto::message::TxnCheckDecision::Commit)
+            .unwrap();
+        assert!(
+            drain_visible_generic(&mut e).is_empty(),
+            "no second delivery"
+        );
+    }
+
+    #[test]
+    fn the_back_check_rollback_answer_discards_the_half_never_delivered() {
+        // The sibling of the headline: the reconnected listener answers Rollback → the half message is
+        // discarded and never delivered.
+        let clock = std::sync::Arc::new(ManualClock::new());
+        let mut e = open_with_clock(config(10, 5), clock.clone());
+        e.register_txn_listener(b"svc", MemberId::new(1));
+        e.txn_prepare(b"tx1", "", &txn_half(b"abort-me"), b"svc")
+            .unwrap();
+        clock.advance_monotonic_nanos(BC_TIMEOUT + 1);
+        assert_eq!(e.txn_back_check_tick().unwrap(), 1);
+        let checks = e.drain_txn_checks(MemberId::new(1));
+        assert_eq!(checks[0].txn_id, b"tx1");
+        e.resolve_txn_check(b"tx1", ironbus_proto::message::TxnCheckDecision::Rollback)
+            .unwrap();
+        assert_eq!(e.txn_prepared_count(), 0);
+        assert!(
+            drain_visible_generic(&mut e).is_empty(),
+            "a rolled-back half is never delivered"
+        );
+    }
+
+    #[test]
+    fn an_unreachable_producer_is_terminally_rolled_back_after_the_attempt_cap() {
+        // THE SAFE TERMINAL DEFAULT: a producer that never reconnects (no listener ever re-registered)
+        // is back-checked up to the attempt cap, then the half message is SAFELY rolled back (discarded,
+        // never delivered) — never a message whose outcome is unknowable is delivered.
+        let clock = std::sync::Arc::new(ManualClock::new());
+        let mut e = open_with_clock(config(10, 5), clock.clone());
+        // No listener is ever registered (the producer crashed and never came back), but the half owns a
+        // group, so it is enrolled and the bounded attempt cap still advances on each scan.
+        e.register_txn_listener(b"svc", MemberId::new(1));
+        e.txn_prepare(b"tx1", "", &txn_half(b"orphan"), b"svc")
+            .unwrap();
+        e.drop_txn_listener(MemberId::new(1)); // crash: no live listener
+        let max = ironbus_core::txn::DEFAULT_MAX_BACK_CHECK_ATTEMPTS;
+        // Run one scan per retry window up to the cap. Each records an attempt (no route, so no check
+        // delivered); the LAST one fires the terminal default (rollback).
+        clock.advance_monotonic_nanos(BC_TIMEOUT + 1);
+        for _ in 0..max {
+            e.txn_back_check_tick().unwrap();
+            clock.advance_monotonic_nanos(ironbus_core::txn::DEFAULT_BACK_CHECK_RETRY_NANOS + 1);
+        }
+        // The half message has been terminally rolled back: no longer prepared, never delivered.
+        assert_eq!(e.txn_prepared_count(), 0, "terminally resolved");
+        assert_eq!(e.txn_under_back_check(), 0);
+        assert!(
+            drain_visible_generic(&mut e).is_empty(),
+            "the unknowable half is never delivered"
+        );
+    }
+
+    #[test]
+    fn a_commit_answer_after_the_terminal_rollback_is_refused_not_flipped() {
+        // IDEMPOTENCY/SAFETY: if the terminal default (rollback) already fired, a LATE producer Commit
+        // answer is REFUSED (the part-1 AlreadyResolved rule), never a flip, never a double-resolve.
+        let clock = std::sync::Arc::new(ManualClock::new());
+        let mut e = open_with_clock(config(10, 5), clock.clone());
+        e.register_txn_listener(b"svc", MemberId::new(1));
+        e.txn_prepare(b"tx1", "", &txn_half(b"late"), b"svc")
+            .unwrap();
+        e.drop_txn_listener(MemberId::new(1));
+        // Drive the scan to the terminal rollback.
+        let max = ironbus_core::txn::DEFAULT_MAX_BACK_CHECK_ATTEMPTS;
+        clock.advance_monotonic_nanos(BC_TIMEOUT + 1);
+        for _ in 0..max {
+            e.txn_back_check_tick().unwrap();
+            clock.advance_monotonic_nanos(ironbus_core::txn::DEFAULT_BACK_CHECK_RETRY_NANOS + 1);
+        }
+        assert_eq!(e.txn_prepared_count(), 0, "terminally rolled back");
+        // A late Commit answer is REFUSED (the outcome is immutable), surfaced as a typed error.
+        let err = e
+            .resolve_txn_check(b"tx1", ironbus_proto::message::TxnCheckDecision::Commit)
+            .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                EngineError::Txn(ironbus_core::txn::TxnError::AlreadyResolved {
+                    outcome: ironbus_core::txn::TxnOutcome::RolledBack
+                })
+            ),
+            "a commit after the terminal rollback is refused, not flipped: {err:?}"
+        );
+        // Still never delivered.
+        assert!(drain_visible_generic(&mut e).is_empty());
+    }
+
+    #[test]
+    fn an_unknown_answer_reschedules_and_does_not_resolve() {
+        // An Unknown back-check answer leaves the half Prepared (the producer cannot decide yet); the
+        // scan reschedules and the bounded cap eventually applies the terminal default.
+        let clock = std::sync::Arc::new(ManualClock::new());
+        let mut e = open_with_clock(config(10, 5), clock.clone());
+        e.register_txn_listener(b"svc", MemberId::new(1));
+        e.txn_prepare(b"tx1", "", &txn_half(b"pending"), b"svc")
+            .unwrap();
+        clock.advance_monotonic_nanos(BC_TIMEOUT + 1);
+        e.txn_back_check_tick().unwrap();
+        let checks = e.drain_txn_checks(MemberId::new(1));
+        assert_eq!(checks[0].txn_id, b"tx1");
+        // The producer answers Unknown: the half stays Prepared (not resolved), still invisible.
+        e.resolve_txn_check(b"tx1", ironbus_proto::message::TxnCheckDecision::Unknown)
+            .unwrap();
+        assert_eq!(e.txn_prepared_count(), 1, "still in-doubt after Unknown");
+        assert!(
+            matches!(e.poll(0).unwrap(), Poll::Idle),
+            "still invisible under back-check"
+        );
+    }
+
+    #[test]
+    fn the_back_check_schedule_resumes_after_a_restart() {
+        // DURABILITY: a prepared half with one recorded back-check attempt replays after a restart with
+        // its attempt count preserved and is immediately eligible, so the scan resumes (and reaches the
+        // terminal default in the remaining attempts).
+        let fs = InMemoryFs::new();
+        {
+            let clock = std::sync::Arc::new(ManualClock::new());
+            let mut e = Engine::open(fs.clone(), clock.clone(), config(10, 5)).unwrap();
+            e.register_txn_listener(b"svc", MemberId::new(1));
+            e.txn_prepare(b"tx1", "", &txn_half(b"survive"), b"svc")
+                .unwrap();
+            e.drop_txn_listener(MemberId::new(1));
+            // One scan records one attempt durably (no route, so no check delivered).
+            clock.advance_monotonic_nanos(BC_TIMEOUT + 1);
+            e.txn_back_check_tick().unwrap();
+            assert_eq!(e.txn_under_back_check(), 1);
+        }
+        // Reopen the SAME fs (with an advanceable Arc clock): the half is still Prepared and still under
+        // back-check with its attempt count replayed.
+        let clock = std::sync::Arc::new(ManualClock::new());
+        let mut e = Engine::open(fs, clock.clone(), config(10, 5)).unwrap();
+        assert_eq!(e.txn_prepared_count(), 1);
+        assert_eq!(
+            e.txn_under_back_check(),
+            1,
+            "the back-check enrollment survived the restart"
+        );
+        // It is immediately eligible (rebased to 0), and the REMAINING attempts (one was already recorded
+        // before the restart, count carried across) still drive it to the terminal rollback (no listener
+        // ever re-registered). Advance the clock between scans so each is due past the retry cadence.
+        let max = ironbus_core::txn::DEFAULT_MAX_BACK_CHECK_ATTEMPTS;
+        for _ in 0..max {
+            e.txn_back_check_tick().unwrap();
+            clock.advance_monotonic_nanos(ironbus_core::txn::DEFAULT_BACK_CHECK_RETRY_NANOS + 1);
+        }
+        assert_eq!(
+            e.txn_prepared_count(),
+            0,
+            "the resumed scan reached the terminal default"
+        );
+        assert!(drain_visible_generic(&mut e).is_empty());
     }
 }

--- a/crates/ironbus-server/src/engine.rs
+++ b/crates/ironbus-server/src/engine.rs
@@ -2575,6 +2575,11 @@ pub struct Engine<F: Filesystem, C: Clock> {
     /// count) lives in the txn store's [`ironbus_core::txn::BackCheckBook`]; this is only the (lost-on-
     /// restart, rebuilt-by-re-registration) routing.
     txn_back_check: TxnBackCheck,
+    /// The back-check tunables (V2-M8, #640 part 2): applied to the txn store's `BackCheckBook` at open
+    /// AND whenever set via [`Engine::set_back_check_config`], so a deployment (or a test) can pick the
+    /// timeout / retry cadence / attempt cap. Defaults to [`ironbus_core::txn::BackCheckConfig::default`]
+    /// (a 30 s timeout, a 15 s retry, a 5-attempt cap), the production-safe schedule.
+    back_check_config: ironbus_core::txn::BackCheckConfig,
     /// The per-STREAM default message TTL (V2-M4, #549): a record reached on the poll path whose
     /// EFFECTIVE TTL (the lower of this and the record's own per-message TTL) has passed against the
     /// WALL-clock seam (anchored to the record's durable producer `timestamp_ms`) is EXPIRED — skipped
@@ -2997,6 +3002,9 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
             // in the txn store; this routing is rebuilt by the producers' re-registration after a
             // restart (a reconnecting producer re-sends `TxnListen`).
             txn_back_check: TxnBackCheck::new(),
+            // The back-check tunables (#640 part 2): the production-safe default schedule until an
+            // operator (or a test) overrides it via `set_back_check_config`.
+            back_check_config: ironbus_core::txn::BackCheckConfig::default(),
             // Empty by default: no group is key_shared until an operator configures one (#64), so an
             // unconfigured engine is plain competing everywhere and unchanged.
             key_shared_groups: std::collections::BTreeSet::new(),
@@ -4062,7 +4070,7 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
                 self.log.clock_clone(),
                 self.txn_config,
                 ironbus_core::txn::TxnConfig::default(),
-                ironbus_core::txn::BackCheckConfig::default(),
+                self.back_check_config,
             )
             .map_err(EngineError::Storage)?;
             self.txn = Some(store);
@@ -4362,6 +4370,19 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
     #[must_use]
     pub fn txn_under_back_check(&self) -> usize {
         self.txn.as_ref().map_or(0, TxnStore::under_back_check)
+    }
+
+    /// Sets the back-check tunables (#640 part 2): the timeout before a Prepared half message is first
+    /// back-checked, the retry cadence, the attempt cap, and the per-pass batch cap. Server-side only
+    /// (NOT on the wire), like [`Engine::set_confirm_group`]. Applied to the open txn store's book
+    /// immediately (so it takes effect without a reopen) AND remembered for a later lazy open. A
+    /// deployment configures it once at boot; the default is the production-safe 30 s/15 s/5-attempt
+    /// schedule.
+    pub fn set_back_check_config(&mut self, config: ironbus_core::txn::BackCheckConfig) {
+        self.back_check_config = config;
+        if let Some(store) = self.txn.as_mut() {
+            store.back_check_mut().set_config(config);
+        }
     }
 
     /// Registers (or re-registers, after a reconnect) producer connection `member` as the live listener

--- a/crates/ironbus-server/src/engine.rs
+++ b/crates/ironbus-server/src/engine.rs
@@ -680,6 +680,15 @@ pub enum EngineError {
     /// txn id. Carries the typed [`ironbus_core::txn::TxnError`] reason. Fail-closed at the boundary;
     /// the half message's durable state is never corrupted by a rejected verb.
     Txn(ironbus_core::txn::TxnError),
+    /// A back-check answer (`TxnCheckResult`, #640 part 2) was REFUSED on OWNERSHIP: the answering
+    /// `Publish` connection does not own the txn's listener group, so it may not resolve it. This fires
+    /// when the connection registered NO txn listener, or its registered group does not EQUAL the group
+    /// that owns the in-doubt txn (recorded at `prepare`). The txn is left exactly as it was —
+    /// `Prepared` and on its back-check schedule — so a LEGITIMATE owner's answer can still arrive; the
+    /// connection is NOT errored (it is a typed refusal, never a flip, never a panic). This closes the
+    /// forged-cross-producer-resolution hole: a connection cannot commit/discard another producer's
+    /// in-doubt txn with a forged `TxnCheckResult{txn_id, decision}`.
+    TxnCheckUnauthorized,
 }
 
 impl core::fmt::Display for EngineError {
@@ -749,6 +758,11 @@ impl core::fmt::Display for EngineError {
                  resolve to exactly one stream; overlap fan-out is opt-in)"
             ),
             EngineError::Txn(e) => write!(f, "transaction error: {e}"),
+            EngineError::TxnCheckUnauthorized => write!(
+                f,
+                "back-check answer refused: the connection does not own this transaction's listener \
+                 group (it registered no listener, or a different group), so it may not resolve it"
+            ),
         }
     }
 }
@@ -1726,6 +1740,15 @@ impl TxnBackCheck {
     fn route_for(&self, txn_id: &[u8]) -> Option<u64> {
         let group = self.txn_owner.get(txn_id)?;
         self.group_listener.get(group).copied()
+    }
+
+    /// The listener GROUP that owns `txn_id` (recorded at prepare), or `None` if the txn has no owning
+    /// group (a listener-less prepare) or was never seen. This is the back-check OWNERSHIP authority:
+    /// `resolve_txn_check` requires an answering connection's registered group to EQUAL this, so a
+    /// `Publish` connection cannot resolve another producer's in-doubt txn with a forged answer
+    /// (`route_for` reads the same map for OUTBOUND routing; this is the INBOUND authorization read).
+    fn owner_group(&self, txn_id: &[u8]) -> Option<&[u8]> {
+        self.txn_owner.get(txn_id).map(Vec::as_slice)
     }
 
     /// Queues a `TxnCheck` for delivery to `member`, bounded drop-oldest (an over-cap push drops the
@@ -4512,18 +4535,62 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
     /// `Commit` is a benign no-op returning the recorded offset, and a result for an unknown/never-seen
     /// txn is a benign no-op.
     ///
+    /// OWNERSHIP (#640 part 2, BLOCKER 1): `answering_group` is the answering connection's registered
+    /// `TxnListen` group (EMPTY when the connection never registered a listener). A back-check answer may
+    /// resolve an in-doubt (`Prepared`) txn ONLY when the answering connection OWNS the txn's listener
+    /// group — i.e. it registered a listener (a non-empty group) AND that group EQUALS the group recorded
+    /// as the txn's owner at `prepare`. Otherwise the answer is REFUSED ([`EngineError::TxnCheckUnauthorized`]):
+    /// the txn is left exactly as it was (`Prepared`, on its back-check schedule), so a LEGITIMATE
+    /// owner's answer can still arrive, and the connection is not errored. This closes the forged
+    /// cross-producer resolution hole — a `Publish` connection cannot commit/discard another producer's
+    /// in-doubt txn. A txn that is NOT currently `Prepared` (already resolved, or never seen) has nothing
+    /// in-doubt to protect, so it falls straight through to the part-1 idempotent path (a duplicate
+    /// answer is a benign no-op, a flip is the inherited `AlreadyResolved` refusal) — the ownership gate
+    /// adds NO change to those already-settled paths. The headline reconnect case still passes: the
+    /// producer prepared under group "B", reconnected, re-registered `TxnListen{group:"B"}`, so owner "B"
+    /// == its answering group "B" → ALLOWED.
+    ///
+    /// SECURITY RESIDUAL (documented in `docs/RECOVERY.md` §9): the listener group is capability-bearing
+    /// — a malicious client that knows a victim's group name could register that group and answer for it,
+    /// the same class as "any client on a no-auth broker can do anything". When auth is enabled the group
+    /// should be bound to the authenticated principal; "two producers must not share a group" remains a
+    /// requirement. The group-MATCH gate here is the in-scope fix; the hijack residual is an auth-layer
+    /// concern.
+    ///
     /// # Errors
-    /// [`EngineError::Txn`] for a conflicting flip (a `Commit` after a rollback or vice-versa — the
-    /// outcome is immutable), or a storage error from the resolve.
+    /// [`EngineError::TxnCheckUnauthorized`] when the answering connection does not own an in-doubt txn's
+    /// group (refused, never resolved); [`EngineError::Txn`] for a conflicting flip (a `Commit` after a
+    /// rollback or vice-versa — the outcome is immutable); or a storage error from the resolve.
     pub fn resolve_txn_check(
         &mut self,
         txn_id: &[u8],
         decision: ironbus_proto::message::TxnCheckDecision,
+        answering_group: &[u8],
     ) -> Result<(), EngineError>
     where
         F: Clone,
     {
         use ironbus_proto::message::TxnCheckDecision;
+        // OWNERSHIP GATE (BLOCKER 1): only an in-doubt (`Prepared`) txn carries forgery exposure — its
+        // resolution is still pending. Require the answering connection to OWN its listener group before
+        // resolving such a txn: (a) a registered listener (a non-empty answering group), AND (b) the
+        // txn's recorded owner group EQUALS it. A listener-less in-doubt txn (owner `None`) matches no
+        // non-empty answering group, so it too is refused here (its only resolvers are the producer's own
+        // direct commit/rollback verbs or the terminal default — never a back-check answer). A REFUSAL
+        // leaves the txn untouched on its schedule so a legitimate owner can still answer.
+        let still_prepared = self.txn.as_ref().is_some_and(|s| {
+            matches!(
+                s.table().state(txn_id),
+                Some(ironbus_core::txn::TxnState::Prepared)
+            )
+        });
+        if still_prepared {
+            let owns = !answering_group.is_empty()
+                && self.txn_back_check.owner_group(txn_id) == Some(answering_group);
+            if !owns {
+                return Err(EngineError::TxnCheckUnauthorized);
+            }
+        }
         // A result for a txn that is no longer Prepared (already resolved by a racing terminal default,
         // a producer-driven resolve, or never seen) is a benign no-op for Commit/Rollback ONLY when it
         // matches; the part-1 path itself enforces the AlreadyResolved rule, so we route straight
@@ -16764,17 +16831,27 @@ mod tests {
         let checks = e.drain_txn_checks(MemberId::new(2));
         assert_eq!(checks.len(), 1);
         assert_eq!(checks[0].txn_id, b"tx1");
-        // The producer's listener answers Commit → committed exactly once via the part-1 path.
-        e.resolve_txn_check(b"tx1", ironbus_proto::message::TxnCheckDecision::Commit)
-            .unwrap();
+        // The producer's listener answers Commit → committed exactly once via the part-1 path. The
+        // answering connection OWNS the txn's group ("svc"), so the ownership gate allows it.
+        e.resolve_txn_check(
+            b"tx1",
+            ironbus_proto::message::TxnCheckDecision::Commit,
+            b"svc",
+        )
+        .unwrap();
         assert_eq!(e.txn_prepared_count(), 0);
         assert_eq!(e.txn_under_back_check(), 0);
         // The half message is now VISIBLE exactly once.
         assert_eq!(drain_visible_generic(&mut e), vec![b"order-42".to_vec()]);
         // A duplicate Commit result (a retried answer) is a benign no-op (idempotent), never a second
-        // delivery.
-        e.resolve_txn_check(b"tx1", ironbus_proto::message::TxnCheckDecision::Commit)
-            .unwrap();
+        // delivery. The txn is no longer Prepared, so the ownership gate is bypassed and the part-1
+        // idempotent path returns the recorded offset.
+        e.resolve_txn_check(
+            b"tx1",
+            ironbus_proto::message::TxnCheckDecision::Commit,
+            b"svc",
+        )
+        .unwrap();
         assert!(
             drain_visible_generic(&mut e).is_empty(),
             "no second delivery"
@@ -16794,8 +16871,13 @@ mod tests {
         assert_eq!(e.txn_back_check_tick().unwrap(), 1);
         let checks = e.drain_txn_checks(MemberId::new(1));
         assert_eq!(checks[0].txn_id, b"tx1");
-        e.resolve_txn_check(b"tx1", ironbus_proto::message::TxnCheckDecision::Rollback)
-            .unwrap();
+        // The owner ("svc") answers Rollback → discarded; the ownership gate allows the owner.
+        e.resolve_txn_check(
+            b"tx1",
+            ironbus_proto::message::TxnCheckDecision::Rollback,
+            b"svc",
+        )
+        .unwrap();
         assert_eq!(e.txn_prepared_count(), 0);
         assert!(
             drain_visible_generic(&mut e).is_empty(),
@@ -16851,9 +16933,15 @@ mod tests {
             clock.advance_monotonic_nanos(ironbus_core::txn::DEFAULT_BACK_CHECK_RETRY_NANOS + 1);
         }
         assert_eq!(e.txn_prepared_count(), 0, "terminally rolled back");
-        // A late Commit answer is REFUSED (the outcome is immutable), surfaced as a typed error.
+        // A late Commit answer is REFUSED (the outcome is immutable), surfaced as a typed error. The txn
+        // is no longer Prepared, so the ownership gate is bypassed and the part-1 AlreadyResolved refusal
+        // (not an unauthorized refusal) is what surfaces — proving the gate does not mask the flip rule.
         let err = e
-            .resolve_txn_check(b"tx1", ironbus_proto::message::TxnCheckDecision::Commit)
+            .resolve_txn_check(
+                b"tx1",
+                ironbus_proto::message::TxnCheckDecision::Commit,
+                b"svc",
+            )
             .unwrap_err();
         assert!(
             matches!(
@@ -16881,9 +16969,14 @@ mod tests {
         e.txn_back_check_tick().unwrap();
         let checks = e.drain_txn_checks(MemberId::new(1));
         assert_eq!(checks[0].txn_id, b"tx1");
-        // The producer answers Unknown: the half stays Prepared (not resolved), still invisible.
-        e.resolve_txn_check(b"tx1", ironbus_proto::message::TxnCheckDecision::Unknown)
-            .unwrap();
+        // The producer answers Unknown: the half stays Prepared (not resolved), still invisible. The
+        // owner ("svc") answers, so the ownership gate allows it; Unknown is a no-op regardless.
+        e.resolve_txn_check(
+            b"tx1",
+            ironbus_proto::message::TxnCheckDecision::Unknown,
+            b"svc",
+        )
+        .unwrap();
         assert_eq!(e.txn_prepared_count(), 1, "still in-doubt after Unknown");
         assert!(
             matches!(e.poll(0).unwrap(), Poll::Idle),
@@ -16922,6 +17015,158 @@ mod tests {
         // It is immediately eligible (rebased to 0), and the REMAINING attempts (one was already recorded
         // before the restart, count carried across) still drive it to the terminal rollback (no listener
         // ever re-registered). Advance the clock between scans so each is due past the retry cadence.
+        // ATTEMPT COUNT PRESERVED: one attempt was recorded before the restart, so only `max - 1` more
+        // scans are needed to reach the terminal default. If the count had RESET to 0 on replay, the txn
+        // would still be Prepared after `max - 1` scans — so this exact bound proves the count survived.
+        let max = ironbus_core::txn::DEFAULT_MAX_BACK_CHECK_ATTEMPTS;
+        for _ in 0..(max - 1) {
+            e.txn_back_check_tick().unwrap();
+            clock.advance_monotonic_nanos(ironbus_core::txn::DEFAULT_BACK_CHECK_RETRY_NANOS + 1);
+        }
+        assert_eq!(
+            e.txn_prepared_count(),
+            0,
+            "the resumed scan reached the terminal default in the REMAINING attempts (count preserved)"
+        );
+        assert!(drain_visible_generic(&mut e).is_empty());
+    }
+
+    #[test]
+    fn a_forged_back_check_answer_from_a_non_owner_is_refused_and_leaves_the_txn_prepared() {
+        // BLOCKER 1 (a): a `Publish` connection that does NOT own a txn's listener group CANNOT resolve
+        // it. A forged `TxnCheckResult{tx1, Commit}` answered with the WRONG group (or no group) is
+        // REFUSED with the typed `TxnCheckUnauthorized`, the txn stays Prepared + invisible, and a later
+        // LEGITIMATE owner answer still commits it exactly once.
+        let clock = std::sync::Arc::new(ManualClock::new());
+        let mut e = open_with_clock(config(10, 5), clock.clone());
+        // The legitimate producer registers group "victim" and prepares under it.
+        e.register_txn_listener(b"victim", MemberId::new(1));
+        e.txn_prepare(b"tx1", "", &txn_half(b"funds"), b"victim")
+            .unwrap();
+        assert_eq!(e.txn_prepared_count(), 1);
+
+        // FORGERY 1: an attacker connection registered a DIFFERENT group "attacker" and forges a Commit
+        // for the victim's txn. Refused: the answering group does not own tx1.
+        let err = e
+            .resolve_txn_check(
+                b"tx1",
+                ironbus_proto::message::TxnCheckDecision::Commit,
+                b"attacker",
+            )
+            .unwrap_err();
+        assert!(
+            matches!(err, EngineError::TxnCheckUnauthorized),
+            "a non-owner group is refused: {err:?}"
+        );
+        // FORGERY 2: a connection with NO registered listener (empty group) forges a Rollback. Refused.
+        let err = e
+            .resolve_txn_check(
+                b"tx1",
+                ironbus_proto::message::TxnCheckDecision::Rollback,
+                b"",
+            )
+            .unwrap_err();
+        assert!(
+            matches!(err, EngineError::TxnCheckUnauthorized),
+            "a listener-less connection is refused: {err:?}"
+        );
+        // The txn is UNTOUCHED by either forgery: still Prepared, still invisible, still under back-check.
+        assert_eq!(
+            e.txn_prepared_count(),
+            1,
+            "forged answers did not resolve it"
+        );
+        assert!(
+            matches!(e.poll(0).unwrap(), Poll::Idle),
+            "still invisible after the forged answers"
+        );
+
+        // The LEGITIMATE owner ("victim") answers Commit → it commits exactly once via the part-1 path.
+        e.resolve_txn_check(
+            b"tx1",
+            ironbus_proto::message::TxnCheckDecision::Commit,
+            b"victim",
+        )
+        .unwrap();
+        assert_eq!(e.txn_prepared_count(), 0);
+        assert_eq!(
+            drain_visible_generic(&mut e),
+            vec![b"funds".to_vec()],
+            "the owner's commit delivers exactly once after the forgeries were refused"
+        );
+    }
+
+    #[test]
+    fn the_owner_group_can_resolve_its_own_back_checked_txn() {
+        // BLOCKER 1 (b): the legitimate owner group CAN resolve — commit makes the half visible exactly
+        // once; rollback discards a second txn. (The headline reconnect case is covered separately by
+        // `the_headline_crash_reconnect_back_check_commit_delivers_exactly_once`.)
+        let clock = std::sync::Arc::new(ManualClock::new());
+        let mut e = open_with_clock(config(10, 5), clock.clone());
+        e.register_txn_listener(b"svc", MemberId::new(1));
+        e.txn_prepare(b"commit-me", "", &txn_half(b"yes"), b"svc")
+            .unwrap();
+        e.txn_prepare(b"abort-me", "", &txn_half(b"no"), b"svc")
+            .unwrap();
+        // Owner commits the first and rolls back the second.
+        e.resolve_txn_check(
+            b"commit-me",
+            ironbus_proto::message::TxnCheckDecision::Commit,
+            b"svc",
+        )
+        .unwrap();
+        e.resolve_txn_check(
+            b"abort-me",
+            ironbus_proto::message::TxnCheckDecision::Rollback,
+            b"svc",
+        )
+        .unwrap();
+        assert_eq!(e.txn_prepared_count(), 0, "both resolved by the owner");
+        assert_eq!(
+            drain_visible_generic(&mut e),
+            vec![b"yes".to_vec()],
+            "only the committed half is delivered, exactly once"
+        );
+    }
+
+    #[test]
+    fn a_prepare_then_restart_before_any_attempt_is_re_enrolled_and_terminal_defaults() {
+        // BLOCKER 2: prepare → broker RESTART within the first timeout window (NO back-check attempt yet,
+        // so NO durable BACK record) must NOT orphan the half forever. On reopen the still-Prepared txn is
+        // RE-ENROLLED into the back-check book (driven off all_prepared(), not the BACK records), so the
+        // scan finds it and, unanswered, terminal-defaults to Rollback after the cap — never stuck.
+        let fs = InMemoryFs::new();
+        {
+            let clock = std::sync::Arc::new(ManualClock::new());
+            let mut e = Engine::open(fs.clone(), clock.clone(), config(10, 5)).unwrap();
+            e.register_txn_listener(b"svc", MemberId::new(1));
+            e.txn_prepare(b"tx1", "", &txn_half(b"orphan"), b"svc")
+                .unwrap();
+            // CRASH IMMEDIATELY: no clock advance, no scan, so NO back-check attempt and NO BACK record.
+            assert_eq!(
+                e.txn_under_back_check(),
+                1,
+                "enrolled in memory only (no BACK record yet)"
+            );
+        }
+        // Reopen: BEFORE this fix the book rebuilt only from BACK records, so this txn (which never had
+        // one) would be Prepared but NOT under back-check — orphaned forever. After the fix it is
+        // re-enrolled fresh at 0 attempts and immediately eligible.
+        let clock = std::sync::Arc::new(ManualClock::new());
+        let mut e = Engine::open(fs, clock.clone(), config(10, 5)).unwrap();
+        assert_eq!(
+            e.txn_prepared_count(),
+            1,
+            "the half survived the restart, still Prepared"
+        );
+        assert_eq!(
+            e.txn_under_back_check(),
+            1,
+            "the orphan was RE-ENROLLED on open (driven off all_prepared, not the BACK records)"
+        );
+        // The scan now back-checks it; unanswered (no listener re-registered), it terminal-defaults to
+        // Rollback after the FULL attempt cap (fresh 0 attempts), and is never stuck Prepared.
+        clock.advance_monotonic_nanos(BC_TIMEOUT + 1);
         let max = ironbus_core::txn::DEFAULT_MAX_BACK_CHECK_ATTEMPTS;
         for _ in 0..max {
             e.txn_back_check_tick().unwrap();
@@ -16930,8 +17175,11 @@ mod tests {
         assert_eq!(
             e.txn_prepared_count(),
             0,
-            "the resumed scan reached the terminal default"
+            "the re-enrolled orphan reached the terminal default — never stuck forever"
         );
-        assert!(drain_visible_generic(&mut e).is_empty());
+        assert!(
+            drain_visible_generic(&mut e).is_empty(),
+            "the orphan was discarded, never delivered"
+        );
     }
 }

--- a/crates/ironbus-server/src/server.rs
+++ b/crates/ironbus-server/src/server.rs
@@ -472,6 +472,16 @@ where
     if session.produced_l2() {
         let _ = engine.with(move |e| e.drop_l2_confirms(member_id));
     }
+    // Drop this connection's back-check listener bindings + queued `TxnCheck`s (#640 part 2): a producer
+    // that registered a transaction listener then disconnected leaves a stale route, so the engine clears
+    // its `group -> member` bindings and any undrained checks. The in-doubt half messages it owned stay
+    // Prepared and are re-routed once the producer reconnects + re-registers (or, after the bounded
+    // attempt cap, safely rolled back). GATED on `registered_txn_listener` so a non-back-checking
+    // connection never routes this through the actor. This is the back-check twin of the L2-confirm
+    // "producer disconnect" cleanup above.
+    if session.registered_txn_listener() {
+        let _ = engine.with(move |e| e.drop_txn_listener(member_id));
+    }
     // Drop any released-but-undrained CLUSTER produce-acks for this connection (#719): a producer that
     // parked a `C2-fsync` ack, had it quorum-released into its outbox, then disconnected before draining
     // it leaves nothing to flush, so the gate's outbox entry is cleared rather than leaked. Off-actor (a

--- a/crates/ironbus-server/src/session.rs
+++ b/crates/ironbus-server/src/session.rs
@@ -3332,7 +3332,14 @@ impl Session {
         }
         let txn_id = Bytes::copy_from_slice(decoded.txn_id);
         let decision = decoded.decision;
-        let outcome = engine.with(move |e| e.resolve_txn_check(&txn_id, decision))?;
+        // OWNERSHIP (#640 part 2, BLOCKER 1): pass THIS connection's registered listener group so the
+        // engine can verify the answerer OWNS the txn's group before resolving an in-doubt half message.
+        // EMPTY when the connection never registered a `TxnListen` listener — which the engine treats as
+        // "does not own", so a forged `TxnCheckResult` from a non-owner is REFUSED (a typed `Err`, not a
+        // flip and not a connection close), leaving the txn Prepared so its real owner can still answer.
+        let answering_group = self.txn_listener_group.clone().unwrap_or_default();
+        let outcome =
+            engine.with(move |e| e.resolve_txn_check(&txn_id, decision, &answering_group))?;
         match outcome {
             Ok(()) => {
                 reply(out, FrameType::Ok, &[]);

--- a/crates/ironbus-server/src/session.rs
+++ b/crates/ironbus-server/src/session.rs
@@ -40,13 +40,14 @@ use ironbus_proto::message::{
     decode_ack, decode_bind_subject, decode_connect, decode_cumulative_ack, decode_fetch,
     decode_pub, decode_pub_subject, decode_pub_to, decode_stream_commit, decode_stream_declare,
     decode_stream_fetch, decode_stream_info, decode_sub, decode_sub_subject, decode_sub_to,
-    decode_txn_prepare, decode_txn_resolve, encode_dead_letter, encode_deliver,
-    encode_deliver_batch, encode_gap_marker, encode_info, encode_not_leader,
-    encode_produce_confirm, encode_pub_ack, encode_stream_info_response, encode_truncated,
-    gap_reason, parse_connect_auth, produce_confirm_status, pub_ack_level, AckLevel, AckOp,
-    ConsumeTier, CreditAdvert, DeadLetterBody, DeliverBatchHeader, DeliverBody, GapMarkerBody,
-    InfoBody, NotLeaderBody, ProduceConfirmBody, PubAckBody, StreamInfoResponseBody, TruncatedBody,
-    DEAD_LETTER_MAX_DELIVER, PUB_WIRE_ONLY_FLAGS,
+    decode_txn_check_result, decode_txn_listen, decode_txn_prepare, decode_txn_resolve,
+    encode_dead_letter, encode_deliver, encode_deliver_batch, encode_gap_marker, encode_info,
+    encode_not_leader, encode_produce_confirm, encode_pub_ack, encode_stream_info_response,
+    encode_truncated, encode_txn_resolve, gap_reason, parse_connect_auth, produce_confirm_status,
+    pub_ack_level, AckLevel, AckOp, ConsumeTier, CreditAdvert, DeadLetterBody, DeliverBatchHeader,
+    DeliverBody, GapMarkerBody, InfoBody, NotLeaderBody, ProduceConfirmBody, PubAckBody,
+    StreamInfoResponseBody, TruncatedBody, TxnResolveBody, DEAD_LETTER_MAX_DELIVER,
+    PUB_WIRE_ONLY_FLAGS,
 };
 use ironbus_storage::fs::Filesystem;
 use ironbus_storage::log::Append;
@@ -363,6 +364,15 @@ pub struct Session {
     /// connection that did not. `false` by default, so an L0/L1-only connection is byte-for-byte
     /// unchanged.
     produced_l2: bool,
+    /// The transaction-LISTENER group this connection registered (#640 part 2, via `TxnListen`), or
+    /// `None` if it never registered one. When `Some`, the connection has opted into back-checking: it
+    /// drives the periodic back-check scan and drains any `TxnCheck`s the broker routed to it on its own
+    /// pass — exactly the `produced_l2` discipline, so a connection that never registers a listener
+    /// never touches the back-check path and is byte-for-byte unchanged (a ping-only/consumer connection
+    /// answers a `Ping` without the scan). It is ALSO the group every `TxnPrepare` on this connection
+    /// records as the half message's back-check owner, so the broker can route a `TxnCheck` to this
+    /// producer's listener even after a reconnect. `None` by default.
+    txn_listener_group: Option<Vec<u8>>,
     /// The per-connection, generation-guarded subject-resolve cache (#585, M2-I9): caches a literal
     /// subject's single-home resolution (the bound [`StreamId`]) so a hot publisher to the same subject
     /// routes in O(1) — a hash lookup, no trie walk — after the first publish. It is consulted INSIDE
@@ -524,6 +534,16 @@ impl Session {
         self.produced_l2
     }
 
+    /// Whether this connection registered a transaction-state LISTENER (#640 part 2, via `TxnListen`).
+    /// The per-pass back-check scan + `TxnCheck` drain are GATED on this, so a connection that never
+    /// registers a listener never touches the back-check path (byte-for-byte unchanged). The
+    /// connection-cleanup path also consults it so only a back-checking connection routes the listener
+    /// cleanup through the actor.
+    #[must_use]
+    pub fn registered_txn_listener(&self) -> bool {
+        self.txn_listener_group.is_some()
+    }
+
     /// Processes the complete frames at the front of `input`, dispatching each to the engine (via
     /// the append actor `engine`) and appending response frames to `out`. Returns a [`Progress`]:
     /// the number of input bytes consumed, plus the `needed` hint, the minimum TOTAL input length
@@ -671,6 +691,18 @@ impl Session {
         if self.produced_l2 {
             drain_produce_confirms(engine, member_id, out);
         }
+        // Drive the back-check scan + drain any routed `TxnCheck`s for THIS producer connection (#640
+        // part 2), so a producer that registered a transaction listener (and is interleaving Pings via
+        // its `transact`/listener loop) (a) advances the periodic in-doubt-txn scan and (b) receives any
+        // `TxnCheck` the broker routed to its group on its own pass — the only place the
+        // thread-per-connection server may write this socket, exactly like the L2 confirm drain above.
+        // GATED on `registered_txn_listener`: a connection that never registered a listener never runs
+        // the scan or the drain, so a ping-only/consumer/non-transactional connection is byte-for-byte
+        // unchanged (no actor round-trip for the scan). The scan itself is a no-op when there are no
+        // in-doubt txns, so even a back-checking broker with nothing prepared pays ~nothing.
+        if self.registered_txn_listener() {
+            drive_back_check(engine, member_id, out);
+        }
         match result {
             Err(e) => Err(e),
             Ok(progress) => drained.map(|()| progress),
@@ -683,6 +715,7 @@ impl Session {
     /// stalled produce fsync cannot block it, #177); a produce advances the durable head but not a
     /// COMMITTED cursor. An `Ack`/`Flow`/`Unsub` returns `true` (an ack commits, a flow can commit
     /// past a dead-letter, an unsub may evict a caught-up group).
+    #[allow(clippy::too_many_lines)] // one match arm per wire verb; splitting it would obscure the dispatch
     fn dispatch<
         F: Filesystem + Clone + 'static,
         C: Clock + Clone + 'static,
@@ -827,6 +860,20 @@ impl Session {
             Some(FrameType::TxnRollback) => {
                 self.require_scope(crate::auth::Scope::Publish, "TxnRollback", out)?;
                 self.handle_txn_rollback(engine, body, out).map(|()| false)
+            }
+            // The BACK-CHECK verbs (#640 part 2): TxnListen registers this connection as the listener
+            // for a group (so the broker can route a TxnCheck to it), and TxnCheckResult answers a
+            // broker back-check (resolving an in-doubt half message through the part-1 path). Both are
+            // producer-side, so they require the `publish` scope. Neither advances a committed consumer
+            // cursor, so each returns `false`.
+            Some(FrameType::TxnListen) => {
+                self.require_scope(crate::auth::Scope::Publish, "TxnListen", out)?;
+                self.handle_txn_listen(engine, body, out).map(|()| false)
+            }
+            Some(FrameType::TxnCheckResult) => {
+                self.require_scope(crate::auth::Scope::Publish, "TxnCheckResult", out)?;
+                self.handle_txn_check_result(engine, body, out)
+                    .map(|()| false)
             }
             Some(FrameType::Unsub) => {
                 self.require_scope(crate::auth::Scope::Subscribe, "Unsub", out)?;
@@ -3079,6 +3126,11 @@ impl Session {
         let key = Bytes::copy_from_slice(msg.key);
         let headers = Bytes::copy_from_slice(msg.headers);
         let payload = Bytes::copy_from_slice(msg.payload);
+        // The half message's back-check OWNER is this connection's registered listener group (#640
+        // part 2), so the broker can route a `TxnCheck` to this producer's listener even after a
+        // reconnect. Empty when the connection never registered a listener — such a half message is not
+        // back-check-routable, but the bounded attempt cap still rolls it back safely if it is crashed.
+        let listener_group = self.txn_listener_group.clone().unwrap_or_default();
         let outcome = engine.with(move |e| {
             let view = Append {
                 timestamp_ms,
@@ -3087,7 +3139,7 @@ impl Session {
                 headers: &headers,
                 payload: &payload,
             };
-            e.txn_prepare(&txn_id, &stream, &view)
+            e.txn_prepare(&txn_id, &stream, &view, &listener_group)
         })?;
         match outcome {
             Ok(()) => {
@@ -3196,6 +3248,104 @@ impl Session {
                 Err(SessionError::EngineFatal(e))
             }
             Err(e) => {
+                reply_err(out, &e.to_string());
+                Ok(())
+            }
+        }
+    }
+
+    /// Handles a `TxnListen` (#640 part 2, V2-M8): register THIS connection as the live transaction-state
+    /// listener for a stable `group`, so the broker can ROUTE a `TxnCheck` for an in-doubt half message
+    /// owned by the group to this connection — even after the original preparing connection crashed and
+    /// this NEW connection re-registered the same group (the crash-and-reconnect route). It also opts the
+    /// connection into the per-pass back-check scan + drain (so its `transact`/listener loop drives the
+    /// resolution), and binds the group every subsequent `TxnPrepare` on this connection records as the
+    /// half message's back-check owner. Replies a body-less `Ok`. Idempotent: re-registering the same (or
+    /// a new) group supersedes the binding. Routes through the single-writer engine; fail-closed at the
+    /// boundary, never panics.
+    fn handle_txn_listen<
+        F: Filesystem + Clone + 'static,
+        C: Clock + Clone + 'static,
+        E: EngineAccess<F, C>,
+    >(
+        &mut self,
+        engine: &E,
+        body: &[u8],
+        out: &mut Vec<u8>,
+    ) -> Result<(), SessionError> {
+        if !self.connected {
+            reply_err(out, "not connected");
+            return Ok(());
+        }
+        let Ok(decoded) = decode_txn_listen(body) else {
+            reply_err(out, "malformed txn-listen body");
+            return Ok(());
+        };
+        // A listener group must have a stable identity to route against; an empty group is refused (it
+        // could not distinguish two producers and would not survive as a routable owner on prepare).
+        if decoded.group.is_empty() {
+            reply_err(out, "listener group must not be empty");
+            return Ok(());
+        }
+        let group = decoded.group.to_vec();
+        // Bind the group to this connection in the engine's back-check router (superseding any prior
+        // binding), and remember it on the session so future prepares record it as the half message
+        // owner and the per-pass scan/drain is enabled for this connection.
+        let member_id = self.member_id;
+        let group_for_engine = group.clone();
+        engine.with(move |e| e.register_txn_listener(&group_for_engine, member_id))?;
+        self.txn_listener_group = Some(group);
+        reply(out, FrameType::Ok, &[]);
+        Ok(())
+    }
+
+    /// Handles a `TxnCheckResult` (#640 part 2, V2-M8): the producer's listener's answer to a broker
+    /// `TxnCheck`. A `Commit` drives the SAME idempotent `TxnCommit` path (the half message becomes
+    /// visible EXACTLY ONCE), a `Rollback` the SAME `TxnRollback` path (discarded, never delivered), and
+    /// an `Unknown` is a no-op (the back-check reschedules; the bounded attempt cap eventually applies
+    /// the terminal default). Replies a body-less `Ok` on a clean resolve (or a benign duplicate /
+    /// no-op), or an `Err` for a conflicting flip (a `Commit` of an already-rolled-back txn, or
+    /// vice-versa — the part-1 `AlreadyResolved` rule). The back-check NEVER introduces a new commit
+    /// path, so part 1's exactly-once guarantee is inherited. Routes through the single-writer engine;
+    /// fail-closed at the boundary, never panics.
+    fn handle_txn_check_result<
+        F: Filesystem + Clone + 'static,
+        C: Clock + Clone + 'static,
+        E: EngineAccess<F, C>,
+    >(
+        &mut self,
+        engine: &E,
+        body: &[u8],
+        out: &mut Vec<u8>,
+    ) -> Result<(), SessionError> {
+        if !self.connected {
+            reply_err(out, "not connected");
+            return Ok(());
+        }
+        let Ok(decoded) = decode_txn_check_result(body) else {
+            reply_err(out, "malformed txn-check-result body");
+            return Ok(());
+        };
+        if decoded.txn_id.is_empty() {
+            reply_err(out, "txn_id must not be empty");
+            return Ok(());
+        }
+        let txn_id = Bytes::copy_from_slice(decoded.txn_id);
+        let decision = decoded.decision;
+        let outcome = engine.with(move |e| e.resolve_txn_check(&txn_id, decision))?;
+        match outcome {
+            Ok(()) => {
+                reply(out, FrameType::Ok, &[]);
+                Ok(())
+            }
+            Err(e) if e.is_fatal() => {
+                reply_err(out, "fatal storage error");
+                Err(SessionError::EngineFatal(e))
+            }
+            Err(e) => {
+                // A conflicting flip (a Commit after the terminal default already rolled it back, or a
+                // racing producer-driven resolve) is refused by the part-1 path — surfaced as an Err, not
+                // a flip. The producer's listener treats this as "already settled", which is correct.
                 reply_err(out, &e.to_string());
                 Ok(())
             }
@@ -3882,6 +4032,49 @@ fn drain_produce_confirms<
     };
     for confirm in ready {
         write_produce_confirm(&confirm, out);
+    }
+}
+
+/// Writes one `TxnCheck` frame (#640 part 2) asking the producer's listener about an in-doubt
+/// transaction. Reuses the frozen [`encode_txn_resolve`] codec (the same `txn_id`-only body shape as
+/// `TxnCommit`/`TxnRollback`), so the wire body cannot drift from the proto definition.
+fn write_txn_check(txn_id: &[u8], out: &mut Vec<u8>) {
+    let mut body = Vec::new();
+    // The encode only fails for a txn id over the u16 wire cap, which the lifecycle bounds to 256, so
+    // this is infallible in practice; on the unreachable error we simply emit no frame (the txn is
+    // re-checked on a later scan).
+    if encode_txn_resolve(&TxnResolveBody { txn_id }, &mut body).is_ok() {
+        reply(out, FrameType::TxnCheck, &body);
+    }
+}
+
+/// Drives the broker back-check for a producer connection that registered a transaction listener (#640
+/// part 2): runs ONE periodic scan tick (find in-doubt txns due for a back-check, push a `TxnCheck`,
+/// record the attempt durably, apply the terminal default after the bounded attempt cap), then drains
+/// every `TxnCheck` the broker routed to THIS connection onto the wire, FIFO. The scan + drain both run
+/// through the single-writer engine; a gone actor is a no-op. The scan is a no-op when there are no
+/// in-doubt txns, so a back-checking connection on an idle broker pays ~nothing. A storage error in the
+/// scan is swallowed here (the connection is mid-pass and the next scan retries); it never desyncs the
+/// wire because no partial frame is written on the scan path.
+fn drive_back_check<
+    F: Filesystem + Clone + 'static,
+    C: Clock + Clone + 'static,
+    E: EngineAccess<F, C>,
+>(
+    engine: &E,
+    member_id: MemberId,
+    out: &mut Vec<u8>,
+) {
+    // Run one scan tick (single-writer). A gone actor or a storage error both mean "skip this pass".
+    let _ = engine.with(move |e| {
+        let _ = e.txn_back_check_tick();
+    });
+    // Drain the `TxnCheck`s routed to this connection and write them onto its own pass.
+    let Ok(checks) = engine.with(move |e| e.drain_txn_checks(member_id)) else {
+        return; // a gone actor: the connection is ending, nothing to deliver
+    };
+    for check in checks {
+        write_txn_check(&check.txn_id, out);
     }
 }
 

--- a/crates/ironbus-storage/src/txn.rs
+++ b/crates/ironbus-storage/src/txn.rs
@@ -567,19 +567,23 @@ impl<F: Filesystem, C: Clock> TxnStore<F, C> {
                 }
             }
         }
-        // Apply the back-check bookkeeping to the book for every txn that is STILL Prepared after the
-        // half/op settle (a BACK record whose txn resolved was already removed from `restored_attempts`
-        // by its OP record). The schedule is rebased to "eligible now" (the live monotonic now is read
-        // by the engine, which re-enrolls on open; here, with no live clock, we use 0 as the
-        // replay-stable floor so the engine's first scan after open finds it due — the engine clamps
-        // against its real `now`). The attempt count is preserved EXACTLY.
-        for (txn_id, attempts) in restored_attempts {
-            if matches!(self.table.state(&txn_id), Some(TxnState::Prepared)) {
-                // next_eligible = 0: immediately eligible on the engine's first post-open scan (which
-                // passes a real monotonic `now`); the preserved attempt count drives the terminal
-                // default exactly as before the restart.
-                self.back_check.restore(&txn_id, attempts, 0);
-            }
+        // RE-ENROLL every still-`Prepared` txn into the back-check book, driven off the lifecycle table's
+        // `all_prepared()` — NOT the BACK records (#640 part 2, BLOCKER 2 fix). The old loop iterated
+        // `restored_attempts` (only txns that had a durable BACK record, written on the FIRST back-check
+        // attempt), so a txn that was prepared then survived a restart WITHIN the first timeout window
+        // (no attempt yet, so no BACK record) was Prepared but NOT in the book — never scanned, never
+        // back-checked, never terminal-defaulted: stuck Prepared (invisible, undelivered) FOREVER, the
+        // exact orphan this feature exists to clean up. Driving off `all_prepared()` re-enrolls THAT txn
+        // too. The preserved attempt count comes from its BACK record if it had one (the terminal-default
+        // gate, kept EXACTLY); a txn with no BACK record enrolls FRESH at 0 attempts. `restore` is
+        // idempotent (last write wins on the same id), so there is no double-enroll, and a resolved txn
+        // is absent from `all_prepared()` so it is never re-enrolled. The schedule is rebased to "eligible
+        // now" via `next_eligible = 0` (the persisted absolute monotonic instant is meaningless after a
+        // reboot — the monotonic origin resets), so the engine's first post-open scan (which passes a real
+        // monotonic `now` and clamps against it) finds every recovered in-doubt txn promptly due.
+        for (txn_id, _prepared_at) in self.table.all_prepared() {
+            let attempts = restored_attempts.get(&txn_id).copied().unwrap_or(0);
+            self.back_check.restore(&txn_id, attempts, 0);
         }
         Ok(())
     }
@@ -1178,5 +1182,39 @@ mod tests {
         // No back-check bookkeeping survives for the resolved txn.
         assert_eq!(reopened.under_back_check(), 0);
         assert!(reopened.back_check().bookkeeping(b"tx1").is_none());
+    }
+
+    #[test]
+    fn a_prepared_txn_with_no_back_record_is_re_enrolled_on_replay() {
+        // BLOCKER 2: a txn prepared then left in-doubt across a restart WITHIN the first timeout window
+        // (no back-check attempt fired, so NO durable BACK record) must STILL be re-enrolled into the
+        // book on replay — driven off `all_prepared()`, not the BACK records. Before the fix the replay
+        // rebuilt the book only from BACK records, so this txn would be Prepared but NOT under back-check
+        // (orphaned forever). It must re-enroll FRESH at 0 attempts and be immediately due.
+        let fs = InMemoryFs::new();
+        {
+            let mut s = back_store(&fs);
+            s.table_mut().prepare(b"tx1", 1).unwrap();
+            s.append_half(b"tx1", "orders", &half(b"p")).unwrap();
+            // Enroll in memory only (as `txn_prepare` does) — but NEVER record_attempt, so NO BACK
+            // record is appended. This is the prepare-then-restart-before-first-attempt orphan.
+            s.back_check_mut().enroll(b"tx1", 0);
+            assert_eq!(s.under_back_check(), 1);
+        }
+        // Reopen: the half is still Prepared AND re-enrolled fresh at 0 attempts, immediately due — the
+        // scan will back-check it and, unanswered, terminal-default it. Never stuck.
+        let reopened = back_store(&fs);
+        assert_eq!(reopened.table().state(b"tx1"), Some(TxnState::Prepared));
+        assert_eq!(
+            reopened.under_back_check(),
+            1,
+            "the no-BACK-record prepared txn was re-enrolled off all_prepared(), not orphaned"
+        );
+        assert_eq!(
+            reopened.back_check().bookkeeping(b"tx1"),
+            Some((0, 0)),
+            "re-enrolled fresh at 0 attempts, immediately eligible"
+        );
+        assert_eq!(reopened.back_check().due(0), vec![b"tx1".to_vec()]);
     }
 }

--- a/crates/ironbus-storage/src/txn.rs
+++ b/crates/ironbus-storage/src/txn.rs
@@ -44,7 +44,9 @@ use crate::log::{Append, Log, LogConfig};
 use crate::naming::segment_file_name;
 use crate::segment::{SegmentReader, StorageError};
 use ironbus_core::clock::Clock;
-use ironbus_core::txn::{TxnConfig, TxnOutcome, TxnState, TxnTable};
+use ironbus_core::txn::{
+    BackCheckBook, BackCheckConfig, TxnConfig, TxnOutcome, TxnState, TxnTable,
+};
 use ironbus_core::types::RecordFlags;
 use std::collections::HashMap;
 
@@ -64,6 +66,13 @@ pub const TXN_HALF_MAGIC: [u8; 4] = *b"TXNH";
 
 /// The 4-byte magic that opens an OP (resolution-marker) record's metadata header.
 pub const TXN_OP_MAGIC: [u8; 4] = *b"TXNO";
+
+/// The 4-byte magic that opens a BACK (back-check bookkeeping) record's metadata header (#640 part 2).
+/// A back-check record durably persists a still-`Prepared` txn's back-check schedule + attempt count
+/// so they SURVIVE a broker restart and the scan resumes; on replay it rebuilds the in-memory
+/// [`BackCheckBook`]. A `headers` blob that does not begin with a recognized txn magic is foreign to
+/// this store and is skipped, never misread.
+pub const TXN_BACK_MAGIC: [u8; 4] = *b"TXNB";
 
 /// The op-marker kind byte: the transaction COMMITTED (its half message is appended to the real
 /// stream and becomes visible). The marker also carries the real offset the payload landed at.
@@ -99,6 +108,10 @@ const HALF_FIXED_LEN: usize = 4 + 1 + 2 + 2 + 2 + 1;
 /// The fixed-size prefix of an OP record's metadata blob: `magic`(4) + `version`(1) + `op_kind`(1) +
 /// `txn_id_len`(2) + `real_offset`(8).
 const OP_FIXED_LEN: usize = 4 + 1 + 1 + 2 + 8;
+
+/// The fixed-size prefix of a BACK record's metadata blob (#640 part 2): `magic`(4) + `version`(1) +
+/// `txn_id_len`(2) + `attempts`(4) + `next_eligible`(8).
+const BACK_FIXED_LEN: usize = 4 + 1 + 2 + 4 + 8;
 
 /// Encodes the HALF (prepared) record's metadata blob (the segment record's `headers` field): the
 /// fixed prefix, then `txn_id`, the `stream` name, and the original headers, then a trailing crc32c
@@ -153,6 +166,26 @@ pub fn encode_op_meta(txn_id: &[u8], outcome: TxnOutcome, real_offset: u64) -> O
     Some(out)
 }
 
+/// Encodes a BACK (back-check bookkeeping) record's metadata blob (#640 part 2): the fixed prefix
+/// (magic, version, `txn_id_len`, `attempts`, `next_eligible`), then `txn_id`, then a trailing crc32c.
+/// This durably pins a still-`Prepared` txn's back-check schedule + attempt count so they survive a
+/// restart. Returns `None` if `txn_id` overflows its `u16` length (unreachable from the bounded wire
+/// path).
+#[must_use]
+pub fn encode_back_meta(txn_id: &[u8], attempts: u32, next_eligible: u64) -> Option<Vec<u8>> {
+    let txn_len = u16::try_from(txn_id.len()).ok()?;
+    let mut out = Vec::with_capacity(BACK_FIXED_LEN + txn_id.len() + 4);
+    out.extend_from_slice(&TXN_BACK_MAGIC);
+    out.push(TXN_FORMAT_VERSION);
+    out.extend_from_slice(&txn_len.to_le_bytes());
+    out.extend_from_slice(&attempts.to_le_bytes());
+    out.extend_from_slice(&next_eligible.to_le_bytes());
+    out.extend_from_slice(txn_id);
+    let crc = ironbus_core::crc::crc32c(&out);
+    out.extend_from_slice(&crc.to_le_bytes());
+    Some(out)
+}
+
 /// A decoded HALF record's metadata (the txn id, the real stream, the original flags + the byte range
 /// of the original headers within the blob).
 struct HalfMeta {
@@ -169,11 +202,19 @@ struct OpMeta {
     real_offset: u64,
 }
 
+/// A decoded BACK (back-check bookkeeping) record's metadata (#640 part 2).
+struct BackMeta {
+    txn_id: Vec<u8>,
+    attempts: u32,
+    next_eligible: u64,
+}
+
 /// What a single durable txn record decoded to (or `None` for a foreign / corrupt blob, which is
 /// skipped on replay rather than misread).
 enum TxnRecordMeta {
     Half(HalfMeta),
     Op(OpMeta),
+    Back(BackMeta),
 }
 
 /// Reads a little-endian `u16` at `at` as a `usize`, or `None` if `blob` is too short.
@@ -222,6 +263,8 @@ fn decode_meta(blob: &[u8]) -> Option<TxnRecordMeta> {
         decode_half_meta(blob).map(TxnRecordMeta::Half)
     } else if magic == TXN_OP_MAGIC {
         decode_op_meta(blob).map(TxnRecordMeta::Op)
+    } else if magic == TXN_BACK_MAGIC {
+        decode_back_meta(blob).map(TxnRecordMeta::Back)
     } else {
         None
     }
@@ -290,6 +333,33 @@ fn decode_op_meta(blob: &[u8]) -> Option<OpMeta> {
     })
 }
 
+/// Decodes a BACK (back-check bookkeeping) record's metadata blob (#640 part 2, see
+/// [`encode_back_meta`]). The version must match [`TXN_FORMAT_VERSION`] (an unknown version fails
+/// closed), the crc must validate, and the declared txn-id span must fit exactly within the blob.
+fn decode_back_meta(blob: &[u8]) -> Option<BackMeta> {
+    let body = verify_crc(blob)?;
+    if body.len() < BACK_FIXED_LEN {
+        return None;
+    }
+    if *body.get(4)? != TXN_FORMAT_VERSION {
+        return None;
+    }
+    let txn_len = read_u16(body, 5)?;
+    let attempts = read_u32_le(body, 7)?;
+    let next_eligible = read_u64(body, 11)?;
+    let txn_start = BACK_FIXED_LEN;
+    let txn_end = txn_start.checked_add(txn_len)?;
+    if body.len() != txn_end {
+        return None;
+    }
+    let txn_id = body.get(txn_start..txn_end)?.to_vec();
+    Some(BackMeta {
+        txn_id,
+        attempts,
+        next_eligible,
+    })
+}
+
 /// The durable transactional half-message store: a segmented [`Log`] under `txn/` holding the half
 /// records and op markers, plus the in-memory [`TxnTable`] lifecycle and the buffered prepared
 /// payloads, rebuilt at open by replaying the durable records (V2-M8, #640).
@@ -297,6 +367,11 @@ pub struct TxnStore<F: Filesystem, C: Clock> {
     log: Log<F, C>,
     /// The pure lifecycle state machine, rebuilt at open from the replayed records.
     table: TxnTable,
+    /// The pure back-check schedule + attempt-count book (#640 part 2), rebuilt at open from the
+    /// replayed BACK records (clamped against the live clock — see [`TxnStore::replay`]) so the scan
+    /// resumes after a restart. EMPTY when no txn is under back-check, so a non-transactional broker
+    /// pays nothing.
+    back_check: BackCheckBook,
     /// The buffered prepared payloads, keyed by `txn_id`, for every CURRENTLY-`Prepared` txn: the
     /// half message the engine appends to the real stream on a commit. An entry is inserted on a
     /// fresh prepare and removed on resolve (commit OR rollback). Bounded by the table's
@@ -306,6 +381,9 @@ pub struct TxnStore<F: Filesystem, C: Clock> {
     half_records: u64,
     /// The number of op markers durably written across this store's lifetime (for observability).
     op_records: u64,
+    /// The number of back-check bookkeeping records durably written across this store's lifetime
+    /// (#640 part 2, for observability).
+    back_records: u64,
 }
 
 impl<F: Filesystem, C: Clock> std::fmt::Debug for TxnStore<F, C> {
@@ -316,8 +394,10 @@ impl<F: Filesystem, C: Clock> std::fmt::Debug for TxnStore<F, C> {
                 "resolved_tombstones",
                 &self.table.resolved_tombstone_count(),
             )
+            .field("under_back_check", &self.back_check.len())
             .field("half_records", &self.half_records)
             .field("op_records", &self.op_records)
+            .field("back_records", &self.back_records)
             .finish_non_exhaustive()
     }
 }
@@ -359,8 +439,8 @@ impl From<StorageError> for TxnStoreError {
 
 impl<F: Filesystem, C: Clock> TxnStore<F, C> {
     /// Opens (recovering, or creating fresh) the txn store rooted at the `txn/` subdirectory of
-    /// `parent_fs`, rebuilding the in-memory lifecycle table and the buffered prepared payloads by
-    /// replaying the durable half + op records in order.
+    /// `parent_fs`, rebuilding the in-memory lifecycle table, the buffered prepared payloads, and the
+    /// back-check book by replaying the durable half + op + back records in order.
     ///
     /// # Errors
     /// Propagates a storage error from creating the subdirectory, opening the txn log, or scanning
@@ -370,15 +450,18 @@ impl<F: Filesystem, C: Clock> TxnStore<F, C> {
         clock: C,
         config: LogConfig,
         txn_config: TxnConfig,
+        back_check_config: BackCheckConfig,
     ) -> Result<TxnStore<F, C>, StorageError> {
         let txn_fs = parent_fs.subdir(TXN_SUBDIR).map_err(StorageError::Io)?;
         let log = Log::open(txn_fs, clock, config)?;
         let mut store = TxnStore {
             log,
             table: TxnTable::new(txn_config),
+            back_check: BackCheckBook::new(back_check_config),
             prepared_payloads: HashMap::new(),
             half_records: 0,
             op_records: 0,
+            back_records: 0,
         };
         store.replay()?;
         Ok(store)
@@ -405,13 +488,26 @@ impl<F: Filesystem, C: Clock> TxnStore<F, C> {
     /// never misread.
     fn replay(&mut self) -> Result<(), StorageError> {
         self.table = TxnTable::new(self.table.config());
+        self.back_check = BackCheckBook::new(self.back_check.config());
         self.prepared_payloads.clear();
         self.half_records = 0;
         self.op_records = 0;
+        self.back_records = 0;
         let flushed = self.log.flushed_offset().get();
         if flushed == 0 {
             return Ok(());
         }
+        // The durable BACK records carry the LAST persisted attempt count per txn (the op-records are
+        // replayed in durable order, so a later BACK record supersedes an earlier one for the same
+        // txn). We collect them into `restored_attempts` during the scan and apply them to the book
+        // AFTER the half/op replay has settled which txns are still Prepared, so a BACK record for a
+        // txn that later resolved (its op-marker followed) is correctly dropped. `next_eligible` is
+        // REBASED against the live monotonic clock at open (a persisted absolute monotonic instant is
+        // meaningless after a reboot — the monotonic origin resets), so a recovered txn is promptly
+        // re-eligible for its next back-check WITHOUT a from-a-previous-boot instant either starving the
+        // scan (a far-future value) or storming it: the ATTEMPT COUNT (the terminal-default gate) is
+        // what is preserved exactly; the schedule merely resumes.
+        let mut restored_attempts: HashMap<Vec<u8>, u32> = HashMap::new();
         let ids = crate::naming::segment_ids(self.log.filesystem()).map_err(StorageError::Io)?;
         for id in ids {
             let scan =
@@ -454,11 +550,35 @@ impl<F: Filesystem, C: Clock> TxnStore<F, C> {
                         self.table
                             .restore(&o.txn_id, TxnState::Resolved(o.outcome), instant);
                         // A resolved txn no longer needs its buffered payload (it was either appended
-                        // to the real stream on commit, or discarded on rollback).
+                        // to the real stream on commit, or discarded on rollback), nor its back-check
+                        // bookkeeping (it is settled — never back-check it again).
                         self.prepared_payloads.remove(&o.txn_id);
+                        restored_attempts.remove(&o.txn_id);
                         let _ = o.real_offset; // recorded for inspection; the engine dedups the append
                     }
+                    TxnRecordMeta::Back(b) => {
+                        self.back_records = self.back_records.saturating_add(1);
+                        // Record the last persisted attempt count for this txn; a later BACK record (or
+                        // an OP record) supersedes it. `next_eligible` from the record is NOT trusted
+                        // (rebased below against the live clock), only `attempts`.
+                        restored_attempts.insert(b.txn_id, b.attempts);
+                        let _ = b.next_eligible;
+                    }
                 }
+            }
+        }
+        // Apply the back-check bookkeeping to the book for every txn that is STILL Prepared after the
+        // half/op settle (a BACK record whose txn resolved was already removed from `restored_attempts`
+        // by its OP record). The schedule is rebased to "eligible now" (the live monotonic now is read
+        // by the engine, which re-enrolls on open; here, with no live clock, we use 0 as the
+        // replay-stable floor so the engine's first scan after open finds it due — the engine clamps
+        // against its real `now`). The attempt count is preserved EXACTLY.
+        for (txn_id, attempts) in restored_attempts {
+            if matches!(self.table.state(&txn_id), Some(TxnState::Prepared)) {
+                // next_eligible = 0: immediately eligible on the engine's first post-open scan (which
+                // passes a real monotonic `now`); the preserved attempt count drives the terminal
+                // default exactly as before the restart.
+                self.back_check.restore(&txn_id, attempts, 0);
             }
         }
         Ok(())
@@ -474,6 +594,26 @@ impl<F: Filesystem, C: Clock> TxnStore<F, C> {
     /// Mutably borrows the pure lifecycle table (the engine drives prepare/commit/rollback on it).
     pub fn table_mut(&mut self) -> &mut TxnTable {
         &mut self.table
+    }
+
+    /// Borrows the pure back-check book (#640 part 2; for the engine's scan `due` query and tests).
+    #[must_use]
+    pub fn back_check(&self) -> &BackCheckBook {
+        &self.back_check
+    }
+
+    /// Mutably borrows the pure back-check book (#640 part 2; the engine enrolls/forgets txns and
+    /// records attempts on it). A back-check enroll/attempt that must SURVIVE a restart also calls
+    /// [`TxnStore::append_back_check`] to durably persist the bookkeeping.
+    pub fn back_check_mut(&mut self) -> &mut BackCheckBook {
+        &mut self.back_check
+    }
+
+    /// The number of currently-enrolled (under-back-check) txns (#640 part 2), for observability and
+    /// the scan's hot-path no-op gate.
+    #[must_use]
+    pub fn under_back_check(&self) -> usize {
+        self.back_check.len()
     }
 
     /// The buffered prepared payload for `txn_id`, or `None` if the txn is not currently prepared
@@ -582,6 +722,44 @@ impl<F: Filesystem, C: Clock> TxnStore<F, C> {
         Ok(())
     }
 
+    /// Durably appends a BACK (back-check bookkeeping) record for `txn_id` (#640 part 2) recording its
+    /// current `attempts` count and `next_eligible` instant, and fsyncs it BEFORE returning, so the
+    /// back-check schedule + attempt count SURVIVE a broker restart and the scan resumes. The caller
+    /// (the engine) writes this AFTER it bumps the in-memory [`BackCheckBook`] for an issued attempt, so
+    /// a crash after the bump but before this append simply re-checks the txn (a safe at-least-once
+    /// back-check; the resolution is idempotent), and a crash after this append replays the recorded
+    /// attempt count (the terminal-default gate is preserved). It is a NO-OP on the real stream and the
+    /// lifecycle — pure bookkeeping — so it never affects delivery.
+    ///
+    /// `next_eligible` is persisted but treated as advisory on replay: a monotonic instant is rebased
+    /// against the live clock at open (see [`TxnStore::replay`]), so only `attempts` is authoritative
+    /// across a restart. The append is its own framed, CRC'd, version-tagged record in the same `txn/`
+    /// log, interleaved with the half/op records by durable order.
+    ///
+    /// # Errors
+    /// [`TxnStoreError::Unframable`] (unreachable from the bounded wire path) or a storage error from
+    /// the append or its durability barrier.
+    pub fn append_back_check(
+        &mut self,
+        txn_id: &[u8],
+        attempts: u32,
+        next_eligible: u64,
+    ) -> Result<(), TxnStoreError> {
+        let meta =
+            encode_back_meta(txn_id, attempts, next_eligible).ok_or(TxnStoreError::Unframable)?;
+        self.log.append(&Append {
+            timestamp_ms: self.log.now_unix_millis(),
+            flags: RecordFlags::EMPTY,
+            key: &[],
+            headers: &meta,
+            payload: &[],
+        })?;
+        // fsync the back-check record BEFORE returning: the recorded attempt count survives a restart.
+        self.log.sync()?;
+        self.back_records = self.back_records.saturating_add(1);
+        Ok(())
+    }
+
     /// The number of currently-`Prepared` (unresolved) half messages.
     #[must_use]
     pub fn prepared_count(&self) -> usize {
@@ -599,6 +777,13 @@ impl<F: Filesystem, C: Clock> TxnStore<F, C> {
     #[must_use]
     pub fn op_records(&self) -> u64 {
         self.op_records
+    }
+
+    /// The number of back-check bookkeeping records durably written across this store's lifetime
+    /// (#640 part 2), for observability.
+    #[must_use]
+    pub fn back_records(&self) -> u64 {
+        self.back_records
     }
 
     /// Borrows the underlying txn log (for inspection and tests).
@@ -621,7 +806,14 @@ mod tests {
     }
 
     fn store(fs: &InMemoryFs) -> TxnStore<InMemoryFs, ManualClock> {
-        TxnStore::open(fs, ManualClock::new(), config(), TxnConfig::default()).unwrap()
+        TxnStore::open(
+            fs,
+            ManualClock::new(),
+            config(),
+            TxnConfig::default(),
+            BackCheckConfig::default(),
+        )
+        .unwrap()
     }
 
     fn half(payload: &[u8]) -> Append<'static> {
@@ -646,7 +838,7 @@ mod tests {
                 assert_eq!(h.orig_flags, RecordFlags::COMPRESSED);
                 assert_eq!(h.orig_headers, b"hh");
             }
-            TxnRecordMeta::Op(_) => panic!("expected a half record"),
+            _ => panic!("expected a half record"),
         }
     }
 
@@ -661,8 +853,24 @@ mod tests {
                     assert_eq!(o.outcome, outcome);
                     assert_eq!(o.real_offset, off);
                 }
-                TxnRecordMeta::Half(_) => panic!("expected an op record"),
+                _ => panic!("expected an op record"),
             }
+        }
+    }
+
+    #[test]
+    fn back_meta_round_trips() {
+        // #640 part 2: a back-check record carries the txn id, attempt count, and next-eligible instant.
+        let blob = encode_back_meta(b"tx1", 3, 0x0102_0304).unwrap();
+        assert_eq!(&blob[0..4], &TXN_BACK_MAGIC);
+        assert_eq!(blob[4], TXN_FORMAT_VERSION);
+        match decode_meta(&blob).unwrap() {
+            TxnRecordMeta::Back(b) => {
+                assert_eq!(b.txn_id, b"tx1");
+                assert_eq!(b.attempts, 3);
+                assert_eq!(b.next_eligible, 0x0102_0304);
+            }
+            _ => panic!("expected a back record"),
         }
     }
 
@@ -862,7 +1070,113 @@ mod tests {
         let blob = encode_half_meta(&at_cap, "s", RecordFlags::EMPTY, b"").unwrap();
         match decode_meta(&blob).unwrap() {
             TxnRecordMeta::Half(h) => assert_eq!(h.txn_id, at_cap),
-            TxnRecordMeta::Op(_) => panic!("half expected"),
+            _ => panic!("half expected"),
         }
+    }
+
+    #[test]
+    fn the_v1_back_format_is_byte_frozen() {
+        // #640 part 2: pin the EXACT bytes a v1 back-check record produces, so an accidental format
+        // drift breaks a test here, not a deployed store. magic + version + txn_id_len + attempts +
+        // next_eligible + txn_id + crc.
+        let blob = encode_back_meta(b"t", 0x0203_0405, 0x0607_0809_0a0b_0c0d).unwrap();
+        let mut expected = Vec::new();
+        expected.extend_from_slice(b"TXNB");
+        expected.push(1); // version
+        expected.extend_from_slice(&1u16.to_le_bytes()); // txn_id_len
+        expected.extend_from_slice(&0x0203_0405u32.to_le_bytes()); // attempts
+        expected.extend_from_slice(&0x0607_0809_0a0b_0c0du64.to_le_bytes()); // next_eligible
+        expected.extend_from_slice(b"t");
+        let crc = ironbus_core::crc::crc32c(&expected);
+        expected.extend_from_slice(&crc.to_le_bytes());
+        assert_eq!(blob, expected);
+    }
+
+    #[test]
+    fn decode_rejects_a_corrupt_back_crc() {
+        let mut blob = encode_back_meta(b"tx1", 2, 5).unwrap();
+        let n = blob.len();
+        blob[n - 5] ^= 0x01; // flip a body byte; the crc no longer matches
+        assert!(decode_meta(&blob).is_none());
+    }
+
+    /// A store with a deterministic back-check config (retry 50, 3-attempt cap, timeout 0) so a test
+    /// can pin the in-memory schedule exactly.
+    fn back_store(fs: &InMemoryFs) -> TxnStore<InMemoryFs, ManualClock> {
+        TxnStore::open(
+            fs,
+            ManualClock::new(),
+            config(),
+            TxnConfig::default(),
+            BackCheckConfig {
+                timeout: 0,
+                retry: 50,
+                max_attempts: 3,
+                batch: 256,
+            },
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn the_back_check_schedule_and_attempt_count_survive_a_restart() {
+        // The durability headline (#640 part 2): a back-check record persists the attempt count so it
+        // replays after a restart, and the scan resumes (the recovered txn is still Prepared, enrolled,
+        // and immediately due on the engine's next scan with its preserved count).
+        let fs = InMemoryFs::new();
+        {
+            let mut s = back_store(&fs);
+            s.table_mut().prepare(b"tx1", 1).unwrap();
+            s.append_half(b"tx1", "orders", &half(b"p")).unwrap();
+            // Enroll + record TWO back-check attempts durably (as the engine's scan would). The
+            // in-memory schedule advances by the config retry (50); the durable append persists the
+            // matching (attempts, next_eligible) pair.
+            s.back_check_mut().enroll(b"tx1", 0);
+            s.back_check_mut().record_attempt(b"tx1", 10); // -> (1, 60)
+            let (a1, ne1) = s.back_check().bookkeeping(b"tx1").unwrap();
+            s.append_back_check(b"tx1", a1, ne1).unwrap();
+            assert_eq!((a1, ne1), (1, 60));
+            s.back_check_mut().record_attempt(b"tx1", 70); // -> (2, 120)
+            let (a2, ne2) = s.back_check().bookkeeping(b"tx1").unwrap();
+            s.append_back_check(b"tx1", a2, ne2).unwrap();
+            assert_eq!((a2, ne2), (2, 120));
+            assert_eq!(s.under_back_check(), 1);
+        }
+        // Reopen: the txn is still Prepared, the back-check book is rebuilt with the LAST persisted
+        // attempt count (2), and it is immediately eligible (next_eligible rebased to 0 against the live
+        // clock) so the scan resumes.
+        let reopened = back_store(&fs);
+        assert_eq!(reopened.table().state(b"tx1"), Some(TxnState::Prepared));
+        assert_eq!(reopened.under_back_check(), 1);
+        assert_eq!(reopened.back_check().bookkeeping(b"tx1"), Some((2, 0)));
+        // It is due on the next scan (eligible at instant 0), and one more attempt (the 3rd, at the cap)
+        // fires the terminal default — the count carried across the restart exactly.
+        assert_eq!(reopened.back_check().due(0), vec![b"tx1".to_vec()]);
+    }
+
+    #[test]
+    fn a_resolved_txns_back_check_record_is_dropped_on_replay() {
+        // A back-check record for a txn that LATER committed (its op-marker followed in durable order)
+        // must NOT re-enroll the resolved txn on replay — it is settled, never back-check it again.
+        let fs = InMemoryFs::new();
+        {
+            let mut s = store(&fs);
+            s.table_mut().prepare(b"tx1", 1).unwrap();
+            s.append_half(b"tx1", "orders", &half(b"p")).unwrap();
+            s.back_check_mut().enroll(b"tx1", 0);
+            s.back_check_mut().record_attempt(b"tx1", 10);
+            s.append_back_check(b"tx1", 1, 60).unwrap();
+            // The producer reconnected and committed: the op-marker supersedes the back-check record.
+            s.table_mut().commit(b"tx1", 70).unwrap();
+            s.mark_committed(b"tx1", 99).unwrap();
+        }
+        let reopened = store(&fs);
+        assert_eq!(
+            reopened.table().state(b"tx1"),
+            Some(TxnState::Resolved(TxnOutcome::Committed))
+        );
+        // No back-check bookkeeping survives for the resolved txn.
+        assert_eq!(reopened.under_back_check(), 0);
+        assert!(reopened.back_check().bookkeeping(b"tx1").is_none());
     }
 }

--- a/docs/RECOVERY.md
+++ b/docs/RECOVERY.md
@@ -824,6 +824,38 @@ re-eligible with its count preserved and the scan resumes. A `TXNB` record whose
 txn later resolved is superseded by the commit/rolled-back op-marker on replay
 (never re-enrolled).
 
+**Re-enroll on open — no orphan across a restart-before-first-attempt.** The
+`TXNB` record is written only on the FIRST back-check ATTEMPT, so a txn that was
+`prepare`d and then survived a restart WITHIN the first timeout window (no attempt
+fired yet, no `TXNB` record) would, if the book were rebuilt only from `TXNB`
+records, come back `Prepared` but NOT enrolled — never scanned, never
+back-checked, never terminal-defaulted: stuck `Prepared` (invisible, undelivered)
+FOREVER, the exact orphan this feature exists to clean up. So replay RE-ENROLLS
+**every** still-`Prepared` txn into the back-check book, driven off the lifecycle
+table's `all_prepared()` (NOT the `TXNB` records): a txn that had a `TXNB` record
+keeps its persisted attempt count exactly; a txn with none enrolls FRESH at 0
+attempts. The re-enroll is idempotent (a resolved txn is absent from
+`all_prepared()`, so it is never re-enrolled) and runs only when there ARE prepared
+txns on open, so a non-transactional broker is byte-for-byte unchanged. The code is
+the `all_prepared()`-driven loop in `TxnStore::replay`
+(`crates/ironbus-storage/src/txn.rs`), proven by
+`a_prepared_txn_with_no_back_record_is_re_enrolled_on_replay` (storage) and
+`a_prepare_then_restart_before_any_attempt_is_re_enrolled_and_terminal_defaults`
+(engine, end-to-end through the terminal default).
+
+**The concrete commit-loss window (the DEFAULT schedule).** A producer that does
+not answer a back-check — i.e. does not reconnect and re-register its listener in
+time — within roughly `timeout + (max_attempts − 1) × retry` will have its
+commit-intent half message terminal-**ROLLED BACK** (discarded, never delivered,
+all-or-nothing — never torn). At the production defaults (`timeout` 30 s, `retry`
+15 s, `max_attempts` 5) that window is ≈ 30 + 4×15 = **90 s**: after ~90 s of an
+unanswered in-doubt txn, the broker safely discards it. Discard is the safe default
+— the broker NEVER delivers a message whose outcome it cannot confirm. **Operators
+with long local transactions** (a producer that may legitimately take longer than
+this to commit/recover) MUST raise `timeout` / `max_attempts` (and/or `retry`) via
+`Engine::set_back_check_config` so a slow-but-alive producer is not rolled back out
+from under a commit it was about to make.
+
 **Routing to the (re)connected producer.** The broker only writes a producer's
 socket from that producer's own pass (thread-per-connection), so the back-check
 push rides the producer's listener loop exactly like the L2 confirm drain. The
@@ -864,3 +896,41 @@ never given the chance to commit it, which is the correct conservative default).
 The routing GROUP is the unit of identity: two producers that (mis)register the
 SAME group share a listener route, so a deployment must give each producer a
 distinct stable group (e.g. its durable producer id).
+
+**Ownership of a back-check answer (the resolve gate).** A `TxnCheckResult` answer
+may resolve an in-doubt (`Prepared`) txn ONLY when the answering connection OWNS
+the txn's listener group: it must have a REGISTERED listener (a non-empty group via
+`TxnListen`) AND that group must EQUAL the group recorded as the txn's owner at
+`prepare`. Otherwise the answer is REFUSED (`ERR_TXN_CHECK_UNAUTHORIZED`,
+`EngineError::TxnCheckUnauthorized`) and the txn is left exactly as it was —
+`Prepared`, on its back-check schedule — so a LEGITIMATE owner's answer can still
+arrive; the answering connection is NOT torn down (it is a typed refusal, never a
+flip, never a panic). Without this gate, ANY `Publish` connection could
+commit/discard ANY producer's in-doubt txn with one forged
+`TxnCheckResult{txn_id, decision}` — a cross-producer data-integrity hole. The
+headline reconnect case is unaffected: a producer that prepared under group "B",
+crashed, reconnected and re-registered `TxnListen{group:"B"}` answers for its own
+txn → owner "B" == its group "B" → ALLOWED; a different connection (group "A" or
+none) answering for "B"'s txn → REFUSED. A txn that is already resolved (or was
+never seen) has nothing in-doubt to protect, so it bypasses the gate straight into
+the part-1 idempotent path (a duplicate answer is a benign no-op, a flip is the
+inherited `AlreadyResolved` refusal). The gate is a pure in-memory map lookup
+keyed off the already-recorded `txn_owner`, so it adds NO hot-path cost to
+non-transactional traffic. Code: `Engine::resolve_txn_check` in
+`crates/ironbus-server/src/engine.rs` (gated on `TxnBackCheck::owner_group`), proven
+by `a_forged_back_check_answer_from_a_non_owner_is_refused_and_leaves_the_txn_prepared`
+and `the_owner_group_can_resolve_its_own_back_checked_txn`.
+
+**The listener group is capability-bearing (the auth-layer residual).** The
+group-MATCH gate above proves OWNERSHIP, not IDENTITY: a malicious client that
+already KNOWS a victim's group name could register that group via `TxnListen` and
+then answer (hijack) for the victim's txns. This is the SAME class as "any client
+on a no-auth broker can do anything" — the broker's transport, not the back-check,
+is the trust boundary. So the listener group must be treated as a **capability**:
+when auth is enabled, a deployment SHOULD bind the listener group to the
+authenticated principal (reject a `TxnListen` for a group the principal is not
+entitled to), and the standing requirement that **two producers must never share a
+group** (each uses a distinct stable group, e.g. its durable producer id) is what
+keeps ownership unambiguous. The group-MATCH gate is the in-scope fix here; binding
+the group to an authenticated principal is the auth-layer follow-up, out of scope
+for the no-auth back-check core.

--- a/docs/RECOVERY.md
+++ b/docs/RECOVERY.md
@@ -779,3 +779,88 @@ choose it (`crates/ironbus-client/src/lib.rs`):
   on the per-connection mint.
 
 For transactions that span a reconnect, prefer `prepare_with_id` with a stable id.
+
+### 9.4 The broker back-check: resolving a producer-crashed in-doubt txn (#640 part 2)
+
+Part 1 leaves one hole: if a producer sends a half message (`prepare`) then
+CRASHES before `commit`/`rollback`, the half message is stuck `Prepared`
+(invisible, undelivered) forever. The **back-check** closes it. The broker
+periodically scans for `Prepared` half messages older than a timeout and asks the
+producer "what is the state of transaction X?"; the producer's registered
+transaction-state listener answers `Commit` / `Rollback` / `Unknown`, and the
+broker resolves accordingly. If the producer is unreachable after a bounded number
+of attempts, the broker applies a SAFE TERMINAL default. The engine code is
+`Engine::txn_back_check_tick` / `resolve_txn_check` / `register_txn_listener` and
+the `TxnBackCheck` router in `crates/ironbus-server/src/engine.rs`; the pure
+schedule is `ironbus_core::txn::BackCheckBook`; the durable bookkeeping is the
+`TXNB` op-record + `TxnStore::append_back_check` in
+`crates/ironbus-storage/src/txn.rs`.
+
+**The scan loop.** A cheap periodic task (riding the producer's serve passes, the
+same per-pass seam as the Level-2 `ProduceConfirm` drain, gated on the connection
+having registered a listener) queries `BackCheckBook::due(now)` — every enrolled
+`Prepared` txn whose next-eligible instant has passed, capped at a global per-pass
+batch (no storm). For each due txn it records the attempt durably FIRST, then
+pushes a `TxnCheck` to the producer's live listener; after the bounded
+`max_back_check_attempts` with no resolution it applies the SAFE TERMINAL default
+= **Rollback/discard** (never deliver a message whose outcome is unknowable). The
+scan is a no-op (zero work) when no txn is in-doubt, so a broker that does not use
+transactions is byte-for-byte unchanged.
+
+**The new frames + tags.** `TxnCheck` (tag 47, broker→producer, "state of txn X?",
+reusing the frozen `TxnResolveBody` shape), `TxnCheckResult` (tag 48,
+producer→broker, `txn_id` + a `Commit`/`Rollback`/`Unknown` decision byte), and
+`TxnListen` (tag 49, producer→broker, the listener-group registration). All
+version-tagged, length-framed, cap-before-alloc, and pinned by byte-freeze
+snapshot tests. An unrecognized decision byte folds to the SAFE `Unknown`.
+
+**Durable bookkeeping + recovery.** The back-check schedule + attempt count are
+persisted as a new `TXNB` op-record (CRC32C'd, version-tagged, frozen) so they
+SURVIVE a broker restart. On replay the attempt count is restored EXACTLY (it is
+the terminal-default gate), while the `next_eligible` instant is REBASED against
+the live monotonic clock — a persisted absolute monotonic instant is meaningless
+across a reboot (the monotonic origin resets), so a recovered txn is promptly
+re-eligible with its count preserved and the scan resumes. A `TXNB` record whose
+txn later resolved is superseded by the commit/rolled-back op-marker on replay
+(never re-enrolled).
+
+**Routing to the (re)connected producer.** The broker only writes a producer's
+socket from that producer's own pass (thread-per-connection), so the back-check
+push rides the producer's listener loop exactly like the L2 confirm drain. The
+per-connection `MemberId` changes across a reconnect, so routing is keyed by a
+STABLE producer-chosen listener GROUP: a producer registers it via `TxnListen`
+(re-registering after a reconnect re-points the route to its new connection); each
+half message records its owning group at `prepare`; the scan routes a `TxnCheck`
+to whatever connection currently holds that group's listener. THE HEADLINE CASE:
+a producer prepares, disconnects before resolve (crash), reconnects and
+re-registers its listener, the scan back-checks it, the listener replies `Commit`
+→ the half is committed EXACTLY ONCE via the part-1 path (proven by
+`the_headline_crash_reconnect_back_check_commit_delivers_exactly_once` in
+`engine.rs` and `the_headline_back_check_resolves_a_crashed_producers_half_over_the_wire`
+end-to-end in `ironbus-client`).
+
+**Resolution reuses part 1 (the inherited exactly-once + immutability).** A
+back-check `Commit` goes through the SAME idempotent `Engine::txn_commit` path
+(default-stream exactly-once preserved); a `Rollback` through the same
+`txn_rollback`; the back-check NEVER introduces a new commit path. So part 1's
+`AlreadyResolved` rule covers every race:
+
+| Race | Outcome |
+|---|---|
+| producer answers `Commit` twice | the second is a benign idempotent no-op (returns the recorded offset); no second delivery |
+| producer answers `Commit` AFTER the terminal `Rollback` already fired | REFUSED (`AlreadyResolved { RolledBack }`) — never a flip, never a double-resolve |
+| a duplicate `TxnCheckResult` | a no-op (the txn is already resolved/forgotten) |
+| the producer never returns | after `max_back_check_attempts` → terminal `Rollback` (discarded, never delivered) |
+
+**The terminal-default safety net + its limits.** The terminal default is
+ALWAYS `Rollback` (discard), never `Commit`: a half message whose outcome is
+unknowable is never delivered. It fires through the same idempotent `txn_rollback`,
+so a producer's later `Commit` is the refused-flip above, not a double-resolve. A
+half message prepared by a producer that NEVER registered a listener is not
+routable (the broker cannot reach it), but is still enrolled — the bounded attempt
+cap still advances on each scan and the terminal `Rollback` still safely discards
+it, so a listener-less producer's crashed half is never stuck forever (it is just
+never given the chance to commit it, which is the correct conservative default).
+The routing GROUP is the unit of identity: two producers that (mis)register the
+SAME group share a listener route, so a deployment must give each producer a
+distinct stable group (e.g. its durable producer id).


### PR DESCRIPTION
## Summary

PART 2 of 2 of the RocketMQ transactional-message model — the broker **BACK-CHECK** — which **Closes #640**. Part 1 (the durable 2PC core: prepare/commit/rollback, invisible-until-commit, crash-safe exactly-once) is already merged on `main`. When a producer prepares a half message then CRASHES before commit/rollback, the half message is stuck `Prepared` (invisible, undelivered) forever. The back-check resolves it: the broker periodically scans for stale `Prepared` half messages, asks the (re)connected producer "what is the state of txn X?", and resolves on the answer — or, after a bounded number of attempts, applies a SAFE TERMINAL default.

## Design

**Scan loop** (`Engine::txn_back_check_tick`, `crates/ironbus-server/src/engine.rs`): a cheap periodic task riding the producer's serve passes (the same per-pass seam as the L2 `ProduceConfirm` drain, gated on the connection having registered a listener). It queries `BackCheckBook::due(now)` (oldest-eligible first, capped at a global per-pass batch — no storm), records each attempt durably FIRST, then pushes a `TxnCheck`; after `max_back_check_attempts` it applies the terminal default = **Rollback/discard**. ~0 cost when no txn is in-doubt (the scan is a no-op).

**New frames + tags** (`crates/ironbus-proto`): `TxnCheck` (tag 47, broker→producer, reuses the frozen `TxnResolveBody`), `TxnCheckResult` (tag 48, producer→broker, `txn_id` + a `Commit`/`Rollback`/`Unknown` decision byte), `TxnListen` (tag 49, the producer's listener-group registration). Version-tagged, length-framed, cap-before-alloc, pinned by byte-freeze snapshot tests; an unrecognized decision byte folds to the SAFE `Unknown`.

**Durable bookkeeping + recovery** (`TXNB` op-record, `crates/ironbus-storage/src/txn.rs`): per-Prepared-txn `(attempts, next_eligible)` persisted (CRC32C'd, version-tagged, frozen) so the schedule + count SURVIVE a restart. `replay()` rebuilds the `BackCheckBook`: the attempt count (the terminal-default gate) is restored EXACTLY, while `next_eligible` is REBASED against the live monotonic clock (a persisted absolute monotonic instant is meaningless across a reboot), so the scan resumes promptly with the count preserved. A `TXNB` record whose txn later resolved is superseded by its op-marker (never re-enrolled).

**Routing to the producer's listener** (the crash-and-reconnect case): the per-connection `MemberId` changes across a reconnect, so routing is keyed by a STABLE producer-chosen listener GROUP. A producer registers it via `TxnListen` (re-registering after a reconnect re-points the route); each half message records its owning group at `prepare`; the scan routes a `TxnCheck` to whatever connection currently holds that group's listener. The `TxnBackCheck` router (group→member, txn→group, FIFO pending-check queue, drop-oldest) is in-memory session-scoped; the durable schedule lives in the `BackCheckBook`.

**Client** (`crates/ironbus-client`): `register_transaction_listener`, `run_transaction_listener` (drives broker passes with Pings, answers each `TxnCheck` via the `check_transaction` callback), and `transact()` (prepare → run `local_txn_fn` → commit/rollback). The part-1 prepare/commit/rollback API is unchanged.

## The headline crash-recovery scenario

A producer prepares a half message under listener group `svc`, DISCONNECTS before resolving (simulated crash), RECONNECTS as a NEW connection and re-registers `svc`, the broker's scan back-checks it, the listener replies `Commit` → the half message is committed **EXACTLY ONCE** via the part-1 path. Proven by `the_headline_crash_reconnect_back_check_commit_delivers_exactly_once` (engine, injected clock) and `the_headline_back_check_resolves_a_crashed_producers_half_over_the_wire` (end-to-end over real TCP).

## Idempotency / safety (resolution reuses part 1's exactly-once path)

A back-check `Commit` goes through the SAME idempotent `txn_commit`; a `Rollback` through the same `txn_rollback`; the back-check NEVER introduces a new commit path. Part 1's `AlreadyResolved` rule covers every race:

| Race | Outcome | Test |
|---|---|---|
| `Commit` twice | benign idempotent no-op, no second delivery | `..._commit_delivers_exactly_once` |
| `Commit` AFTER the terminal `Rollback` fired | REFUSED (`AlreadyResolved`), never a flip | `a_commit_answer_after_the_terminal_rollback_is_refused_not_flipped` |
| duplicate `TxnCheckResult` | no-op | (engine resolve path) |
| producer never returns | terminal `Rollback` after the attempt cap | `an_unreachable_producer_is_terminally_rolled_back_after_the_attempt_cap` |

## Byte-identical-when-unused

The per-pass scan + drain are GATED on `registered_txn_listener` (the `produced_l2` discipline), and the scan is an O(1) no-op when no txn is in-doubt, so a non-back-checking connection never touches the path. The conformance corpus + all 901 server lib tests pass unchanged; `the_back_check_scan_is_a_no_op_when_no_txn_is_in_doubt` pins it.

## Tests

- Headline crash→reconnect→back-check→`Commit` exactly-once (engine + e2e) and the `Rollback` sibling (discarded, never delivered).
- Unreachable producer → terminal `Rollback` after the attempt cap (never delivered).
- Durability: attempt count + schedule survive a restart, scan resumes (storage + engine).
- Idempotency: `Commit`-after-terminal-`Rollback` refused-not-flipped; duplicate answer a no-op.
- Invisibility under back-check; `Unknown` reschedules without resolving.
- Frozen formats: byte-freeze the new frame bodies + the `TXNB` op-record.
- Determinism: injected clock; core stays IO-free (verified).

## Verification

- `cargo fmt --all --check` clean; `cargo clippy -p <crate> --all-targets --locked -- -D warnings` clean on all 5 touched crates.
- Targeted txn/back-check tests pass: proto (14), core (31), storage (19), server txn (7) + back-check (8), client e2e (3). Full server lib suite: **901 passed**. Conformance corpus: 8 passed.
- `ironbus-core` IO-free gate passes; no new dependencies; SPDX present on every file (all edits to existing files); `git grep -i butlr` empty (only the deny-list file itself).
- Full-workspace test relied on CI (the pre-push hook ENOSPCs the dev machine).

## Honest caveats

- **Listener-group routing.** Routing identity is the producer-chosen GROUP, not the connection. A half message prepared by a producer that never registered a listener is not routable (the broker cannot reach it), but is still enrolled — the bounded attempt cap still advances and the terminal `Rollback` still safely discards it, so it is never stuck forever (just never given the chance to commit, the correct conservative default). Two producers that (mis)register the SAME group share a route, so a deployment must give each producer a distinct stable group.
- **Terminal default is always Rollback** (discard), never Commit — a message whose outcome is unknowable is never delivered. It fires through the same idempotent `txn_rollback`, so a producer's later `Commit` is the refused-flip above, not a double-resolve. The idempotency against the terminal default IS achievable (it is the inherited part-1 `AlreadyResolved` rule) and is proven by `a_commit_answer_after_the_terminal_rollback_is_refused_not_flipped`.
- **Back-check timeout default** is 30 s / 15 s retry / 5 attempts; settable server-side via `Engine::set_back_check_config` (not on the wire).

## Post-review fixes

An adversarial review of this PR found two FIX-FIRST defects; both are now fixed on this branch (the 2PC core and the feature shape are unchanged).

**BLOCKER 1 — Forged cross-producer resolution (data-integrity/security).** `resolve_txn_check` did NO ownership check: any `Publish` connection could commit/discard ANY producer's in-doubt txn with one forged `TxnCheckResult{txn_id, decision}`. The `txn_owner[txn_id]` group association existed but was read only for OUTBOUND routing (`route_for`). Now a back-check answer resolves an in-doubt (`Prepared`) txn ONLY when the answering connection OWNS the txn's listener group — it must have a REGISTERED listener (a non-empty `TxnListen` group) AND that group must EQUAL the group recorded as the txn's owner at `prepare`. Otherwise the answer is REFUSED with the typed `EngineError::TxnCheckUnauthorized` (wire code `ERR_TXN_CHECK_UNAUTHORIZED`): the txn is left exactly as it was (`Prepared`, on its back-check schedule) so a legitimate owner can still answer, and the connection is NOT torn down (a typed `reply_err`, never a flip, never a panic). A txn that is already resolved / never seen bypasses the gate into the part-1 idempotent path, so duplicate-answer and refused-flip semantics are unchanged and there is no hot-path cost for non-txn traffic. The headline reconnect path still passes: owner "B" reconnects, re-registers `TxnListen{group:"B"}`, answers its own txn → ALLOWED; a different/none group → REFUSED.
- code path: `Engine::resolve_txn_check` (`crates/ironbus-server/src/engine.rs`, gated on the new `TxnBackCheck::owner_group` inbound-authorization reader); `EngineError::TxnCheckUnauthorized` variant; `ErrorCode::ERR_TXN_CHECK_UNAUTHORIZED` (`crates/ironbus-server/src/codes.rs`); the session passes the connection's `txn_listener_group` from `Session::handle_txn_check_result` (`crates/ironbus-server/src/session.rs`).
- refusal behavior: typed non-fatal `Err` → benign `reply_err` (connection stays open, txn stays Prepared/invisible), never a resolve, never a flip.
- residual (documented, not solved): a malicious client that knows a victim's group name could register that group and hijack it — the same class as "any client on a no-auth broker can do anything". The listener group is **capability-bearing**; when auth is enabled it should be bound to the authenticated principal, and "two producers must not share a group" remains a requirement. Documented in `docs/RECOVERY.md` §9.4 ("The listener group is capability-bearing").
- tests: `a_forged_back_check_answer_from_a_non_owner_is_refused_and_leaves_the_txn_prepared`, `the_owner_group_can_resolve_its_own_back_checked_txn` (engine); the existing wire-e2e headline and all prior back-check tests stay green.

**BLOCKER 2 — Orphan-forever: prepare-then-restart before the first back-check attempt.** The durable `TXNB` record is written only on the first ATTEMPT, so `TxnStore::replay` rebuilt the `BackCheckBook` ONLY from txns that had a `TXNB` record. A txn prepared then surviving a restart WITHIN the first timeout window (no attempt yet → no `TXNB` record) came back `Prepared` but NOT enrolled → never scanned, never back-checked, never terminal-defaulted → stuck `Prepared` forever, the exact orphan this feature exists to clean up. Fixed: replay now RE-ENROLLS every still-`Prepared` txn into the book, driven off the lifecycle table's `all_prepared()` (NOT the `TXNB` records). A txn that had a `TXNB` record keeps its persisted attempt count EXACTLY; a txn with none enrolls FRESH at 0 attempts (`next_eligible` rebased to 0 → immediately due, clamped against the live clock). `restore` is idempotent and a resolved txn is absent from `all_prepared()`, so no double-enroll and no re-enroll of a settled txn; it runs only when there ARE prepared txns on open (non-transactional broker byte-for-byte unchanged).
- re-enroll site: the `all_prepared()`-driven loop at the end of `TxnStore::replay` (`crates/ironbus-storage/src/txn.rs`).
- the orphan-forever test now passes: `a_prepare_then_restart_before_any_attempt_is_re_enrolled_and_terminal_defaults` (engine, end-to-end through the terminal default) and `a_prepared_txn_with_no_back_record_is_re_enrolled_on_replay` (storage). The existing `the_back_check_schedule_resumes_after_a_restart` (attempt-before-restart) stays green and now asserts the attempt count is preserved (it reaches the terminal default in `max_attempts − 1` remaining scans).

**Area 3 — commit-loss window doc.** `docs/RECOVERY.md` §9.4 now states the concrete window of the DEFAULT schedule: an unanswered in-doubt txn is terminal-ROLLED-BACK (discarded, never delivered, never torn) after roughly `timeout + (max_attempts − 1) × retry` (≈90 s at the 30 s / 15 s / 5 defaults); operators with long local transactions must raise `timeout` / `max_attempts` via `Engine::set_back_check_config`. Discard is the safe default.

**Per-crate local verification (disk-safe):** `cargo fmt --all` (committed), `cargo check` + `cargo clippy --all-targets --locked -- -D warnings` clean on `ironbus-storage`, `ironbus-server`, `ironbus-client`. Targeted tests green: server back-check (7) + full engine txn suite (242) + codes (2) + session txn (143); storage txn (20); client headline-wire + transact. `git grep -i butlr` empty (only the deny-list file), `ironbus-core` untouched (IO-free), no new dependency, no new files. Full-workspace gate left to CI (the pre-push hook ENOSPCs the dev machine).


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVWp2H2txnKGru4q2twxM3
