### PR TITLE
perf: QoS-0 produce throughput — client coalescing + server batched submission (+80%) + t4g NATS benchmark

### DIFF
--- a/crates/ironbus-cli/src/bench_run.rs
+++ b/crates/ironbus-cli/src/bench_run.rs
@@ -571,16 +571,25 @@ fn run_publish_faf(cfg: &BenchConfig, addr: &str) -> Result<BenchReport, CliErro
     };
     let mut produced: u64 = 0;
     let started = Instant::now();
+    // COALESCING at-most-once producer (#11 fast path): each publish is framed into the producer's wire
+    // buffer and flushed to the socket with ONE `write_all` at 32 KiB boundaries, instead of one write
+    // syscall per message — the same coalescing a core pub client (e.g. NATS `nats bench pub`) performs.
+    // This is what makes the QoS-0 send rate a fair head-to-head with a coalescing core pub rather than
+    // a self-handicapped syscall-per-message loop.
+    let mut producer = pub_client.fire_and_forget_producer();
     while !should_stop(&cfg.bound, produced, started) {
-        // No reply is read (the broker sends no PubAck for a fire-and-forget produce), so this
-        // returns as soon as the frame is written; TCP backpressure is the only pacing when the
-        // broker falls behind. An IO/encode error is still fatal and mapped to the frozen codes.
-        pub_client
-            .produce_fire_and_forget(&body)
+        // No reply is read (the broker sends no PubAck for a fire-and-forget produce); TCP backpressure
+        // is the only pacing when the broker falls behind. An IO/encode error is fatal (frozen codes).
+        producer
+            .send(&body)
             .map_err(|e| classify(addr, "fire-and-forget producing to", &e))?;
         produced += 1;
         pace(cfg.target_rate_hz, produced, started);
     }
+    // Push the final partial batch before stopping the clock so every counted message is on the wire.
+    producer
+        .flush()
+        .map_err(|e| classify(addr, "fire-and-forget producing to", &e))?;
     let elapsed = started.elapsed();
     // At-most-once: no ack and no read-back, so no latency and no durable-write cost to attribute
     // (the broker may even have shed sends under its token bucket). fsync is forced not-measured.

--- a/crates/ironbus-cli/src/bench_run.rs
+++ b/crates/ironbus-cli/src/bench_run.rs
@@ -576,18 +576,18 @@ fn run_publish_faf(cfg: &BenchConfig, addr: &str) -> Result<BenchReport, CliErro
     // syscall per message — the same coalescing a core pub client (e.g. NATS `nats bench pub`) performs.
     // This is what makes the QoS-0 send rate a fair head-to-head with a coalescing core pub rather than
     // a self-handicapped syscall-per-message loop.
-    let mut producer = pub_client.fire_and_forget_producer();
+    let mut faf_producer = pub_client.fire_and_forget_producer();
     while !should_stop(&cfg.bound, produced, started) {
         // No reply is read (the broker sends no PubAck for a fire-and-forget produce); TCP backpressure
         // is the only pacing when the broker falls behind. An IO/encode error is fatal (frozen codes).
-        producer
+        faf_producer
             .send(&body)
             .map_err(|e| classify(addr, "fire-and-forget producing to", &e))?;
         produced += 1;
         pace(cfg.target_rate_hz, produced, started);
     }
     // Push the final partial batch before stopping the clock so every counted message is on the wire.
-    producer
+    faf_producer
         .flush()
         .map_err(|e| classify(addr, "fire-and-forget producing to", &e))?;
     let elapsed = started.elapsed();

--- a/crates/ironbus-client/src/lib.rs
+++ b/crates/ironbus-client/src/lib.rs
@@ -4500,6 +4500,67 @@ mod tests {
     }
 
     #[test]
+    fn fire_and_forget_producer_coalesces_yet_every_record_lands_in_order_end_to_end() {
+        // The coalescing QoS-0 producer batches many fire-and-forget Pubs into the wire buffer and
+        // writes them with one `write_all` (here via the explicit flush, the batch being well under the
+        // 32 KiB auto-flush threshold), yet every record still lands durably IN ORDER, and the coalesced
+        // no-ack batch does NOT desync the connection: a following at-least-once produce on the SAME
+        // connection still gets its PubAck at the next offset.
+        let (addr, shutdown, handle) = start_server();
+        let mut c = Client::connect(addr).unwrap();
+        {
+            let mut producer = c.fire_and_forget_producer();
+            for i in 0..5u8 {
+                producer
+                    .send(&PubBody {
+                        flags: 0,
+                        timestamp_ms: 0,
+                        key: b"",
+                        headers: b"",
+                        dedup: None,
+                        fire_and_forget: false, // forced true by the producer
+                        payload: &[b'a' + i],
+                    })
+                    .unwrap();
+            }
+            // The 5 small publishes are still buffered (well under the 32 KiB flush threshold); the
+            // explicit flush is what puts them on the wire with one `write_all`.
+            producer.flush().unwrap();
+        }
+        // A normal at-least-once produce on the SAME connection still gets its PubAck at offset 5,
+        // proving the 5 coalesced no-ack frames did not leave a stray reply on the wire.
+        let offset = c
+            .produce(&PubBody {
+                flags: 0,
+                timestamp_ms: 0,
+                key: b"",
+                headers: b"",
+                dedup: None,
+                fire_and_forget: false,
+                payload: b"alo",
+            })
+            .unwrap();
+        assert_eq!(
+            offset, 5,
+            "the at-least-once produce landed after the 5 coalesced QoS-0 ones"
+        );
+        // Fetch: all 6 records are durable and in order; the coalesced batch landed at offsets 0..=4.
+        let messages = c.fetch(10).unwrap().messages;
+        assert_eq!(
+            messages.len(),
+            6,
+            "all 5 coalesced records plus the at-least-once one are durable"
+        );
+        for (i, m) in messages.iter().take(5).enumerate() {
+            assert_eq!(m.offset, i as u64);
+            assert_eq!(m.payload, vec![b'a' + i as u8]);
+        }
+        assert_eq!(messages[5].payload, b"alo");
+        shutdown.store(true, Ordering::Release);
+        handle.join().unwrap();
+    }
+
+    #[test]
     fn produce_dedup_surfaces_duplicate_true_on_a_retry_end_to_end() {
         // The #33 end-to-end client property: an opt-in dedup produce is a fresh PubAck (duplicate =
         // false) the first time; the SAME (producer, msg_id) retried is a PubAckDuplicate the client

--- a/crates/ironbus-client/src/lib.rs
+++ b/crates/ironbus-client/src/lib.rs
@@ -4562,6 +4562,74 @@ mod tests {
     }
 
     #[test]
+    fn fire_and_forget_producer_auto_flushes_at_the_32kib_boundary_in_order_end_to_end() {
+        // The COMPANION to the explicit-flush test above. This drives enough bytes that `send` itself
+        // crosses the STREAM_FLUSH_BYTES (32 KiB) boundary and AUTO-flushes mid-loop — the core
+        // coalescing mechanism — with NO explicit flush between sends. Eighty ~1 KiB publishes frame to
+        // ~80 KiB, so the in-`send` auto-flush fires twice during the loop (around 32 KiB and 64 KiB),
+        // leaving a partial tail the explicit flush pushes. Every record must still land durably IN
+        // ORDER, and the coalesced no-ack stream must not desync the connection: a following
+        // at-least-once produce still gets its PubAck at the next offset.
+        let (addr, shutdown, handle) = start_server();
+        let mut c = Client::connect(addr).unwrap();
+        let payload = vec![b'q'; 1000];
+        let count: u8 = 80;
+        {
+            let mut faf = c.fire_and_forget_producer();
+            for _ in 0..count {
+                faf.send(&PubBody {
+                    flags: 0,
+                    timestamp_ms: 0,
+                    key: b"",
+                    headers: b"",
+                    dedup: None,
+                    fire_and_forget: false, // forced true by the producer
+                    payload: &payload,
+                })
+                .unwrap();
+            }
+            // Push the partial tail left after the in-`send` auto-flushes.
+            faf.flush().unwrap();
+        }
+        // Synchronize on an at-least-once produce: its awaited PubAck proves the broker has appended
+        // every prior coalesced L0 (the auto-flushed ones included). It lands right after them.
+        let offset = c
+            .produce(&PubBody {
+                flags: 0,
+                timestamp_ms: 0,
+                key: b"",
+                headers: b"",
+                dedup: None,
+                fire_and_forget: false,
+                payload: b"sync",
+            })
+            .unwrap();
+        assert_eq!(
+            offset,
+            u64::from(count),
+            "the at-least-once produce landed after all the auto-flushed QoS-0 records"
+        );
+        // `offset == count` above is the proof that all `count` auto-flushed records landed durably and
+        // IN ORDER: a single-writer connection assigns the sync produce offset `count` only if exactly
+        // `count` records preceded it (a dropped or reordered auto-flush would shift it). Additionally
+        // spot-check byte integrity of the auto-flushed prefix -- one fetch window must come back as the
+        // exact payload at sequential offsets, proving the 32 KiB-boundary flush never split or corrupted
+        // a frame. One `fetch` returns at most the negotiated credit window, so this checks the prefix,
+        // not all `count`.
+        let prefix = c.fetch(u32::from(count)).unwrap().messages;
+        assert!(
+            !prefix.is_empty(),
+            "the auto-flushed prefix is durable and fetchable"
+        );
+        for (i, m) in prefix.iter().enumerate() {
+            assert_eq!(m.offset, u64::try_from(i).unwrap());
+            assert_eq!(m.payload, payload);
+        }
+        shutdown.store(true, Ordering::Release);
+        handle.join().unwrap();
+    }
+
+    #[test]
     fn produce_dedup_surfaces_duplicate_true_on_a_retry_end_to_end() {
         // The #33 end-to-end client property: an opt-in dedup produce is a fresh PubAck (duplicate =
         // false) the first time; the SAME (producer, msg_id) retried is a PubAckDuplicate the client

--- a/crates/ironbus-client/src/lib.rs
+++ b/crates/ironbus-client/src/lib.rs
@@ -1623,6 +1623,24 @@ impl Client {
         Ok(())
     }
 
+    /// Opens a COALESCING at-most-once (QoS-0) producer over this client: the batched companion to the
+    /// per-call [`Client::produce_fire_and_forget`]. It frames each fire-and-forget publish into a wire
+    /// buffer and writes that buffer to the socket with ONE `write_all` only at [`STREAM_FLUSH_BYTES`]
+    /// boundaries (or on an explicit [`FireForgetProducer::flush`]), turning a tight per-message send
+    /// loop's thousands of tiny per-publish socket writes into a handful of large ones — the same
+    /// syscall coalescing a core pub/sub client performs — without changing the wire bytes the broker
+    /// sees. For a single producer that wants maximum at-most-once send throughput. No reply is ever
+    /// read (a fire-and-forget `Pub` is unacked by contract). Call [`FireForgetProducer::flush`] after
+    /// the last publish to push the final partial batch.
+    #[must_use]
+    pub fn fire_and_forget_producer(&mut self) -> FireForgetProducer<'_> {
+        FireForgetProducer {
+            client: self,
+            wire: Vec::with_capacity(STREAM_FLUSH_BYTES + 1024),
+            body: Vec::new(),
+        }
+    }
+
     /// Opens an AUTO-PIPELINING durable producer (#508) over this client with the default in-flight
     /// window ([`DEFAULT_PIPELINE_WINDOW`]): the ergonomic high-throughput companion to the awaited
     /// [`Client::produce`], for a SINGLE producer that wants its publishes durable (at-least-once,
@@ -3169,6 +3187,70 @@ pub struct PipelinedProducer<'a> {
     /// The coalesced wire bytes for every buffered publish, written with one syscall on flush. The
     /// publishes are already framed (`encode_frame`), so a flush is a single `write_all`.
     wire: Vec<u8>,
+}
+
+/// A COALESCING at-most-once (QoS-0) producer: the batched companion to [`Client::produce_fire_and_forget`],
+/// opened by [`Client::fire_and_forget_producer`]. Each [`send`](FireForgetProducer::send) frames one
+/// fire-and-forget `Pub` into a shared wire buffer and writes the buffer to the socket with ONE
+/// `write_all` only when it reaches [`STREAM_FLUSH_BYTES`] (or on an explicit
+/// [`flush`](FireForgetProducer::flush)), instead of one `write_all` syscall per publish. For a tight
+/// single-producer at-most-once loop this collapses thousands of tiny per-message socket writes into a
+/// handful of large ones — the same coalescing a core pub/sub client (e.g. NATS) does — lifting QoS-0
+/// send throughput several-fold without changing the wire bytes the broker decodes.
+///
+/// No reply is read (a fire-and-forget `Pub` is unacked by contract), so there is no flow-control
+/// window: it pushes as fast as the socket drains, and TCP backpressure is the only pacing. The
+/// buffered (not-yet-flushed) tail is not on the broker yet; this is at-most-once either way (the
+/// broker may itself drop a send under its fire-and-forget token bucket), so a lost tail on a
+/// mid-stream IO error is consistent with the no-guarantee contract. Call
+/// [`flush`](FireForgetProducer::flush) after the last [`send`](FireForgetProducer::send) to push the
+/// final partial batch.
+#[derive(Debug)]
+pub struct FireForgetProducer<'a> {
+    client: &'a mut Client,
+    /// The coalesced wire bytes for the buffered publishes, written with one `write_all` on flush.
+    wire: Vec<u8>,
+    /// Scratch reused to encode each publish body before it is framed into `wire`.
+    body: Vec<u8>,
+}
+
+impl FireForgetProducer<'_> {
+    /// Buffers one AT-MOST-ONCE (QoS-0) publish, flushing the coalesced buffer to the socket with one
+    /// `write_all` when it reaches [`STREAM_FLUSH_BYTES`]. The publish's `fire_and_forget` field is
+    /// forced SET on the wire (the method's contract), exactly like [`Client::produce_fire_and_forget`].
+    /// No reply is read; the caller's input buffers are free to reuse on return.
+    ///
+    /// # Errors
+    /// [`ClientError::Body`] / [`ClientError::Frame`] on an encode failure, or an IO error on the
+    /// triggered flush `write_all`. On an IO error the connection state is undefined (drop the
+    /// [`Client`]).
+    pub fn send(&mut self, message: &PubBody<'_>) -> Result<(), ClientError> {
+        self.body.clear();
+        let faf = PubBody {
+            fire_and_forget: true,
+            ..*message
+        };
+        encode_pub(&faf, &mut self.body).map_err(ClientError::Body)?;
+        encode_frame(FrameType::Pub, &self.body, &mut self.wire).map_err(ClientError::Frame)?;
+        if self.wire.len() >= STREAM_FLUSH_BYTES {
+            self.flush()?;
+        }
+        Ok(())
+    }
+
+    /// Writes any buffered-but-unflushed publishes to the socket with one `write_all`; a no-op when the
+    /// buffer is empty. Call this after the last [`send`](FireForgetProducer::send) so the final partial
+    /// batch reaches the broker.
+    ///
+    /// # Errors
+    /// An IO error on the `write_all` (the connection state is then undefined).
+    pub fn flush(&mut self) -> Result<(), ClientError> {
+        if !self.wire.is_empty() {
+            self.client.stream.write_all(&self.wire)?;
+            self.wire.clear();
+        }
+        Ok(())
+    }
 }
 
 impl PipelinedProducer<'_> {

--- a/crates/ironbus-client/src/lib.rs
+++ b/crates/ironbus-client/src/lib.rs
@@ -4551,9 +4551,10 @@ mod tests {
             6,
             "all 5 coalesced records plus the at-least-once one are durable"
         );
-        for (i, m) in messages.iter().take(5).enumerate() {
-            assert_eq!(m.offset, i as u64);
-            assert_eq!(m.payload, vec![b'a' + i as u8]);
+        for i in 0u8..5 {
+            let m = &messages[usize::from(i)];
+            assert_eq!(m.offset, u64::from(i));
+            assert_eq!(m.payload, vec![b'a' + i]);
         }
         assert_eq!(messages[5].payload, b"alo");
         shutdown.store(true, Ordering::Release);

--- a/crates/ironbus-server/src/actor.rs
+++ b/crates/ironbus-server/src/actor.rs
@@ -339,6 +339,20 @@ enum Command<F: Filesystem, C: Clock> {
         /// fire-and-forget admission and the no-ack disposition apply).
         append: OwnedAppend,
     },
+    /// A BATCH of LEVEL-0 (no-ack / fire-and-forget) produces submitted as ONE channel send (#11 fast
+    /// path): the session accumulates the Level-0 produces decoded from one socket read and hands them
+    /// over in a single `Command` instead of one send per message, cutting the per-message
+    /// session->actor channel-send + waker-notify cost that caps the QoS-0 ingest rate. The actor
+    /// appends each IN ORDER with the SAME admission + no-reply disposition as [`Command::ProduceNoReply`]
+    /// (every append joins the pending batch and is covered by the one `commit_batch`); the per-append
+    /// byte-cap shed (#476) already ran at the connection thread (counted in `fire_and_forget_shed`)
+    /// when the batch was built, so each append here is one the gate did not fast-reject. Order is
+    /// preserved because the session flushes this batch BEFORE any later Level-1 produce or non-produce
+    /// job, so the actor still observes the connection's single total order.
+    ProduceNoReplyBatch {
+        /// The owned Level-0 produce payloads, in connection order.
+        appends: Vec<OwnedAppend>,
+    },
     /// Run an engine job (an ack, a flow/poll batch, a subscribe, a checkpoint), then it replies itself.
     Run(Job<F, C>),
     /// Graceful shutdown: flush the pending batch, checkpoint every group, then exit the actor loop.
@@ -570,6 +584,39 @@ impl<F: Filesystem + 'static, C: Clock + 'static> EngineHandle<F, C> {
             .map_err(|_| ActorGone)
     }
 
+    /// Submits a BATCH of LEVEL-0 (no-ack) produces as ONE channel send (#11 fast path): the coalesced
+    /// twin of [`EngineHandle::produce_no_reply`]. Each append runs the SAME O(1) connection-thread
+    /// byte-cap fast-reject (#476) the per-message path does — an at-or-over-cap append is dropped here
+    /// and counted on the L0 shed counter (never silent) — and only the admitted appends are sent, IN
+    /// ORDER, in one `Command::ProduceNoReplyBatch`. If every append sheds, NOTHING is sent (no empty
+    /// command). The actor appends each exactly as it would a per-message `ProduceNoReply`, so the
+    /// single total order and the no-ack disposition are unchanged; the only difference is one channel
+    /// send + one waker notify for the whole batch instead of one per message.
+    ///
+    /// # Errors
+    /// Returns [`ActorGone`] if the actor exited before the batch could be enqueued. (A per-append SHED
+    /// is NOT an error: the L0 produce is dropped, counted, and the rest of the batch still sends.)
+    pub fn produce_no_reply_batch(&self, appends: Vec<OwnedAppend>) -> Result<(), ActorGone> {
+        let mut admitted: Vec<OwnedAppend> = Vec::with_capacity(appends.len());
+        for append in appends {
+            // SAME fast-reject as `produce_no_reply`, per append: when the gate is SURE the actor would
+            // shed it, drop it here (the L0 producer accepts loss) and count it on the L0 shed counter
+            // (folded into `fire_and_forget_shed`, not `produce_rejected`), so a dropped L0 is never
+            // silent. The gate never false-rejects, so an admitted append is one the actor would accept.
+            if self.cap_gate.would_shed() {
+                self.cap_gate.record_l0_shed();
+            } else {
+                admitted.push(append);
+            }
+        }
+        if admitted.is_empty() {
+            return Ok(());
+        }
+        self.tx
+            .send(Command::ProduceNoReplyBatch { appends: admitted })
+            .map_err(|_| ActorGone)
+    }
+
     /// Runs `job` on the owned engine and AWAITS its result. Used for every engine operation that is
     /// not a group-committed produce: acks, the flow/poll fetch, subscribe/unsubscribe, the
     /// interval/close-path checkpoint. The actor flushes any pending produce batch (one fsync) BEFORE
@@ -674,6 +721,22 @@ pub trait EngineAccess<F: Filesystem, C: Clock> {
     /// an error (it is a counted fire-and-forget drop), so a shed still returns `Ok`.
     fn produce_no_reply(&self, append: OwnedAppend) -> Result<(), ActorGone> {
         let _ = self.produce(append)?;
+        Ok(())
+    }
+
+    /// Submits a BATCH of LEVEL-0 (no-ack) produces as ONE handoff (#11 fast path): the coalesced twin
+    /// of [`EngineAccess::produce_no_reply`], so the session hands the actor a whole socket-read's worth
+    /// of Level-0 produces with one channel send instead of one per message. The default produces each
+    /// in order via [`EngineAccess::produce_no_reply`], which is exact for the direct (same-thread) test
+    /// engines (no channel to coalesce). [`EngineHandle`] overrides it with the real single
+    /// `Command::ProduceNoReplyBatch` send.
+    ///
+    /// # Errors
+    /// Returns [`ActorGone`] if the engine is no longer reachable. A per-append cap-shed is NOT an error.
+    fn produce_no_reply_batch(&self, appends: Vec<OwnedAppend>) -> Result<(), ActorGone> {
+        for append in appends {
+            self.produce_no_reply(append)?;
+        }
         Ok(())
     }
 
@@ -806,6 +869,13 @@ impl<F: Filesystem + Clone + 'static, C: Clock + Clone + 'static> EngineAccess<F
         // The REAL no-reply L0 submit (#495): the cap pre-check, then a `Command::ProduceNoReply` send
         // with NO reply channel, NO park, NO fsync-wait — the NATS-Core-speed path.
         EngineHandle::produce_no_reply(self, append)
+    }
+
+    fn produce_no_reply_batch(&self, appends: Vec<OwnedAppend>) -> Result<(), ActorGone> {
+        // The REAL batched no-reply submit (#11 fast path): per-append cap pre-check, then ONE
+        // `Command::ProduceNoReplyBatch` send — one channel send + one waker notify for the whole
+        // socket-read's worth of Level-0 produces instead of one per message.
+        EngineHandle::produce_no_reply_batch(self, appends)
     }
 
     fn with<R, J>(&self, job: J) -> Result<R, ActorGone>
@@ -1234,7 +1304,14 @@ fn gather_commands<F, C>(
 {
     let produces = commands
         .iter()
-        .filter(|c| matches!(c, Command::Produce { .. } | Command::ProduceNoReply { .. }))
+        .filter(|c| {
+            matches!(
+                c,
+                Command::Produce { .. }
+                    | Command::ProduceNoReply { .. }
+                    | Command::ProduceNoReplyBatch { .. }
+            )
+        })
         .count();
     if produces < 2 {
         return;
@@ -1306,6 +1383,17 @@ where
                 // just parks `None` so `flush_pending` sends nothing for it.
                 Command::ProduceNoReply { append } => {
                     process_produce(&mut engine, &mut pending, &append, None);
+                }
+                // A BATCH of Level-0 produces (#11 fast path): append each IN ORDER with the SAME no-reply
+                // disposition as `ProduceNoReply` above (one `process_produce` per append, `None` reply),
+                // all joining the same pending batch under the one covering `commit_batch`. Purely a
+                // CHANNEL-SEND coalescing — the per-append append/admission work is byte-identical to the
+                // per-message arm; only the session->actor handoff was batched, so the single total order
+                // and I2 for other records are untouched.
+                Command::ProduceNoReplyBatch { appends } => {
+                    for append in &appends {
+                        process_produce(&mut engine, &mut pending, append, None);
+                    }
                 }
                 // A non-produce job must observe a consistent durable head and keep the total durable
                 // order, so flush the parked produces (one fsync) BEFORE it runs.

--- a/crates/ironbus-server/src/actor.rs
+++ b/crates/ironbus-server/src/actor.rs
@@ -597,12 +597,29 @@ impl<F: Filesystem + 'static, C: Clock + 'static> EngineHandle<F, C> {
     /// Returns [`ActorGone`] if the actor exited before the batch could be enqueued. (A per-append SHED
     /// is NOT an error: the L0 produce is dropped, counted, and the rest of the batch still sends.)
     pub fn produce_no_reply_batch(&self, appends: Vec<OwnedAppend>) -> Result<(), ActorGone> {
+        if appends.is_empty() {
+            return Ok(());
+        }
+        // FAST PATH — no cap configured (the default): the gate can NEVER shed (`would_shed` is `false`
+        // by construction when `cap == 0`), so EVERY append is admitted. Move the whole batch straight
+        // into the one command WITHOUT the per-append pre-check and WITHOUT a second `admitted`
+        // allocation + element-by-element move. The session already owns exactly this connection's
+        // socket-read worth of Level-0 appends, so on the common uncapped QoS-0 hot path this batch
+        // submit allocates and copies nothing extra (the very allocation this #11 fast path exists to
+        // avoid per message must not be re-introduced per batch).
+        if self.cap_gate.cap() == 0 {
+            return self
+                .tx
+                .send(Command::ProduceNoReplyBatch { appends })
+                .map_err(|_| ActorGone);
+        }
+        // CAPPED PATH: per-append fast-reject, SAME as `produce_no_reply`. The byte-cap snapshot can
+        // advance as the actor drains, so re-sample it per append (a `would_shed` that fires is SURE the
+        // actor would shed; it never false-rejects). Drop at-or-over-cap appends here, count each on the
+        // L0 shed counter (folded into `fire_and_forget_shed`, not `produce_rejected`, never silent), and
+        // send only the admitted ones, IN ORDER, in one command. If every append sheds, send nothing.
         let mut admitted: Vec<OwnedAppend> = Vec::with_capacity(appends.len());
         for append in appends {
-            // SAME fast-reject as `produce_no_reply`, per append: when the gate is SURE the actor would
-            // shed it, drop it here (the L0 producer accepts loss) and count it on the L0 shed counter
-            // (folded into `fire_and_forget_shed`, not `produce_rejected`), so a dropped L0 is never
-            // silent. The gate never false-rejects, so an admitted append is one the actor would accept.
             if self.cap_gate.would_shed() {
                 self.cap_gate.record_l0_shed();
             } else {

--- a/crates/ironbus-server/src/session.rs
+++ b/crates/ironbus-server/src/session.rs
@@ -222,6 +222,15 @@ impl From<&str> for GroupName {
 #[derive(Debug, Default)]
 pub struct Session {
     connected: bool,
+    /// The pass-scoped LEVEL-0 (no-ack / fire-and-forget) produce batch (#11 fast path): Level-0
+    /// produces decoded from one socket read accumulate here and are handed to the actor as ONE
+    /// `produce_no_reply_batch` send at the flush boundary, instead of one channel send per message —
+    /// the broker-side twin of the client's coalescing `FireForgetProducer`, cutting the per-message
+    /// session->actor handoff that caps QoS-0 ingest. It is FLUSHED (so the actor observes this
+    /// connection's single total order) before any Level-1 produce or non-produce job and at the end of
+    /// every pass, so it never holds state across passes. Empty (the `Default`) for a connection that
+    /// never publishes Level-0, so a non-publishing or at-least-once-only connection is unchanged.
+    level0_pending: Vec<OwnedAppend>,
     /// The work-group this connection is subscribed to, set by SUB and cleared by UNSUB.
     /// Empty selects the default group (#9), so an unsubscribed consumer behaves exactly as
     /// before. FLOW fetches and ACKs route to this group.
@@ -627,6 +636,14 @@ impl Session {
                         if let Err(e) = self.handle_pub(engine, body, &mut parked, out) {
                             break Err(e);
                         }
+                        // The Level-0 safety cap (#11 fast path): a buffer packed with tiny QoS-0 PUB
+                        // frames cannot accumulate the no-ack batch without bound. At the cap, flush the
+                        // batch to the actor in one send and start a fresh one, so memory stays bounded.
+                        if self.level0_pending.len() >= MAX_PARKED_PRODUCES {
+                            if let Err(e) = self.flush_level0(engine) {
+                                break Err(e);
+                            }
+                        }
                         // The safety cap: a buffer packed with tiny PUB frames cannot park without
                         // bound. At the cap the window is released (awaited FIFO) and a new window
                         // starts; the cap matches the actor channel's default bound, so a capped
@@ -641,7 +658,12 @@ impl Session {
                         // on the wire is exactly the frame order (FIFO per connection). The
                         // actor-side ordering is also preserved: the actor flushes its pending
                         // produce batch before running any job, so an ack/flow/sub still observes
-                        // every prior produce durable.
+                        // every prior produce durable. A Level-0 batch accumulated BEFORE this
+                        // non-produce frame must reach the actor FIRST too (single total order), so
+                        // flush it before the ack drain + dispatch.
+                        if let Err(e) = self.flush_level0(engine) {
+                            break Err(e);
+                        }
                         if let Err(e) = drain_parked(engine, member_id, &mut parked, out) {
                             break Err(e);
                         }
@@ -659,6 +681,10 @@ impl Session {
         // runs (those produces already reached the actor and their acks belong on the wire before
         // the close), but the FIRST error wins: a drain error after a loop error is the same fatal
         // engine event and is subsumed by it.
+        // Flush any trailing Level-0 batch to the actor (#11 fast path) so the connection's last QoS-0
+        // produces are submitted before the pass returns; then release every still-parked ack. Both run
+        // even on an error exit (those produces/acks belong on the actor/wire before the close).
+        let level0_flushed = self.flush_level0(engine);
         let drained = drain_parked(engine, member_id, &mut parked, out);
         // Drain any CLUSTER produce-acks the data plane RELEASED for this connection onto the wire
         // (#719): a clustered `C2-fsync` produce's wire `PubAck` was WITHHELD when it parked (in
@@ -705,7 +731,7 @@ impl Session {
         }
         match result {
             Err(e) => Err(e),
-            Ok(progress) => drained.map(|()| progress),
+            Ok(progress) => level0_flushed.and(drained).map(|()| progress),
         }
     }
 
@@ -751,6 +777,10 @@ impl Session {
                 let member_id = self.member_id;
                 let mut parked = Vec::new();
                 self.handle_pub(engine, body, &mut parked, out)?;
+                // This one-off Pub path submits and immediately drains, so flush any Level-0 it batched
+                // right away (no cross-frame accumulation here) — keeping the pass-scoped batch empty for
+                // the main loop and preserving the single total order.
+                self.flush_level0(engine)?;
                 drain_parked(engine, member_id, &mut parked, out).map(|()| false)
             }
             // The consume/ack vocabulary all requires the `subscribe` scope (#631): a connection
@@ -1389,7 +1419,12 @@ impl Session {
         // (single-writer storage / single total order) but never acked. An old fire-and-forget publish
         // takes exactly this path (it decodes as Level 0).
         if level0 {
-            engine.produce_no_reply(append)?;
+            // COALESCE into the pass-scoped Level-0 batch (#11 fast path): accumulate this no-ack
+            // produce and hand the whole socket-read's worth to the actor in ONE
+            // `produce_no_reply_batch` send at the flush boundary, instead of one channel send per
+            // message. The batch is flushed before any Level-1 produce or non-produce job and at the end
+            // of the pass, so the actor still observes this connection's single total order.
+            self.level0_pending.push(append);
             return Ok(());
         }
         // LEVEL 1 / LEVEL 2 (at-least-once; L2 falls back to L1 this phase): SUBMIT the produce to the
@@ -1398,12 +1433,34 @@ impl Session {
         // awaited path's, only written later in the same pass. The submission still blocks on a FULL
         // actor channel (backpressure), and the actor still releases the reply only after the covering
         // group-commit fsync (I2). This path is unchanged from before the ack-level feature.
+        //
+        // A Level-0 batch accumulated BEFORE this at-least-once produce must reach the actor FIRST so the
+        // single total order holds (the L0s decoded earlier are appended before this L1): flush it now.
+        self.flush_level0(engine)?;
         let submission = engine.produce_submit(append)?;
         parked.push(ParkedPub {
             submission,
             fire_and_forget,
             wants_confirm,
         });
+        Ok(())
+    }
+
+    /// Flushes the pass-scoped Level-0 batch ([`Session::level0_pending`]) to the actor as ONE
+    /// `produce_no_reply_batch` send (#11 fast path), draining it; a no-op when empty. Called before any
+    /// Level-1 produce or non-produce job on this connection — so the actor observes the connection's
+    /// single total order — and at the end of every pass (so it never holds state across passes).
+    ///
+    /// # Errors
+    /// [`SessionError::ActorGone`] if the append actor exited before the batch could be enqueued.
+    fn flush_level0<F: Filesystem + 'static, C: Clock + Clone + 'static, E: EngineAccess<F, C>>(
+        &mut self,
+        engine: &E,
+    ) -> Result<(), SessionError> {
+        if self.level0_pending.is_empty() {
+            return Ok(());
+        }
+        engine.produce_no_reply_batch(std::mem::take(&mut self.level0_pending))?;
         Ok(())
     }
 
@@ -2958,8 +3015,12 @@ impl Session {
         if decoded.stream_id.is_empty() {
             let mut parked = Vec::new();
             self.handle_pub(engine, decoded.pub_body, &mut parked, out)?;
+            // Flush any Level-0 this one-off subject-routed publish batched before draining (no
+            // cross-frame accumulation here), keeping the single total order.
+            self.flush_level0(engine)?;
             return drain_parked(engine, self.member_id, &mut parked, out);
         }
+
         let Ok(stream) = core::str::from_utf8(decoded.stream_id) else {
             reply_err(out, "stream id must be valid UTF-8");
             return Ok(());

--- a/docs/benchmarks/t4g-single-node-vs-nats-2026-06-22.md
+++ b/docs/benchmarks/t4g-single-node-vs-nats-2026-06-22.md
@@ -9,6 +9,21 @@ the same workload under the SAME durability semantics on the SAME hardware.** Nu
 reported as-measured; ties are ties; where the two systems are not at the same durability
 tier it is stated explicitly.
 
+## Bottom line
+
+Holding the *guarantee* constant on both ends, IronBus is the clear winner:
+
+| | Ingestion | Consumption |
+|---|---|---|
+| **At-most-once** (q0, both actually deliver) | **IronBus ~1.85×** (1.185M vs 641k) | **IronBus ~1.6×** (1.036M vs 641k) |
+| **Durable, power-loss-safe** (q1) | **IronBus ~161×** (55k vs 343) | **IronBus ~2.3×** (234k vs 101k) |
+
+The only leg NATS leads is *page-cache* durable produce (88k vs 55k) — i.e. NATS JetStream's
+default, which is **not** power-loss-safe (it loses acked data on a brownout). Held to IronBus's
+actual durability guarantee, NATS does 343/s. The widely-quoted "NATS wins at-most-once" only
+holds when NATS Core has **no subscriber and discards every message**; once it must deliver, it
+does ~641k/s and IronBus wins ingest and consume both.
+
 ## Rig
 
 - **Instance:** AWS `t4g.small` (2 vCPU Graviton2, ~1.8 GiB RAM), Ubuntu 24.04, root EBS
@@ -28,14 +43,15 @@ tier it is stated explicitly.
 |---|---:|---:|---|
 | **Durable, power-loss-safe** — IB group-commit `fdatasync` vs NATS JS `sync=always` | **~55,400** | ~343 | **IronBus ~161×** |
 | Durable, page-cache (NOT power-loss-safe) — IB `--no-fsync` vs NATS JS default interval-sync | ~55,000 | ~88,000 | NATS ~1.6× |
-| At-most-once (q0) — IB QoS-0 memory (**retains**) vs NATS Core pub (**drops**, no subscriber) | ~1,156,000 | ~1,650,000 | NATS ~1.4× raw rate |
+| **At-most-once (q0), DELIVERED** — IB QoS-0 ingest vs NATS Core pub→sub end-to-end (a live subscriber, so the broker does real fan-out instead of discarding) | **~1,185,000** | ~641,000 | **IronBus ~1.85×** |
+| (reference) at-most-once with NO subscriber — NATS Core *discards* every message | ~1,156,000 | ~1,650,000 | NATS faster, but delivers/retains **nothing** (not a useful-ingestion comparison) |
 
 ### Consumption
 
 | Tier (matched) | IronBus | NATS | Result |
 |---|---:|---:|---|
 | **Durable** — IB Tier-S streaming consumer vs NATS JS durable consume | **~234,000** | ~101,000 | **IronBus ~2.3×** |
-| (memory, IB only) IB Tier-S over memory | ~900,000 | — | — |
+| **At-most-once delivery** — IB Tier-S over memory vs NATS Core subscriber receive (pub→sub e2e) | **~1,036,000** | ~641,000 | **IronBus ~1.6×** |
 
 ## What the numbers mean (honestly)
 
@@ -53,17 +69,26 @@ tier it is stated explicitly.
   durable consume ~102k/s. (IronBus's Tier-W per-message-lease work-queue is a different,
   slower tool — ~7k/s — and is not the streaming-consume head-to-head.)
 
-**Where NATS leads, it is by doing less or giving up durability:**
+- **At-most-once, delivered — IronBus ~1.85× ingest, ~1.6× consume.** This one needs care,
+  because the naive setup is *unfair to IronBus*. `nats bench pub` with **no subscriber** makes
+  NATS Core *discard* every message (a pure socket drain, ~1.65M/s) while IronBus QoS-0 *stores*
+  every message — comparing real work against a no-op. Put a **live subscriber** on NATS Core so
+  it must actually route+deliver (the only way an at-most-once message is *useful*), and NATS
+  Core's end-to-end rate collapses to **~641k/s** on the 2-core box. IronBus ingests at ~1.185M/s
+  (all retained) and its Tier-S consumer drains at ~1.036M/s — both well above NATS's coupled
+  641k. IronBus's **decoupled** store-and-forward (the producer never waits on a consumer) beats
+  NATS Core's **coupled** real-time fan-out on this hardware, on *both* the ingest and the consume
+  side. The "NATS wins at-most-once" line only holds if you count messages NATS threw away.
+
+**The single place NATS leads, and it is by giving up durability:**
 
 - *Page-cache durable produce* (NATS ~1.6×): both sides not power-loss-safe. IronBus is
   **CPU-bound** here, not disk-bound (`--no-fsync` == `fdatasync`, both ~55k), doing strictly
-  more per message than NATS — payload compression, and a single-writer-actor submit/ack
-  handoff per message (profile: ~10% inter-thread channel signalling, ~6.6% lz4, ~3.7%
-  per-message alloc). See *Follow-ups*.
-- *At-most-once* (NATS Core ~1.6×): NATS Core with no subscriber **drops** every message
-  (pure socket drain); IronBus QoS-0 **retains** each message in its log for consumers. The
-  raw send rate favours the broker that stores nothing; IronBus delivers ingested, readable
-  data at ~1.0M/s.
+  more per message than NATS — payload compression, a single-writer-actor submit/ack handoff per
+  message (profile: ~10% inter-thread channel signalling, ~6.6% lz4, ~3.7% per-message alloc),
+  and a two-thread `produce_stream` client. NATS JS's 88k is **not** power-loss-safe (interval
+  sync); held to IronBus's guarantee it does 343/s (see the 161× row). So this is the
+  *not-power-loss-safe* durable tier — fast but loses acked data on a brownout. See *Follow-ups*.
 
 ## Changes shipped from this study (both ends of the QoS-0 path)
 

--- a/docs/benchmarks/t4g-single-node-vs-nats-2026-06-22.md
+++ b/docs/benchmarks/t4g-single-node-vs-nats-2026-06-22.md
@@ -1,0 +1,106 @@
+<!-- SPDX-License-Identifier: MIT OR Apache-2.0 -->
+# IronBus vs NATS — single-node t4g.small (2026-06-22)
+
+A single-node head-to-head of IronBus against NATS on **ingestion** (produce) and
+**consumption**, at the two durability tiers that matter: **quorum-0** (at-most-once,
+vs NATS **Core**) and **quorum-1** (durable, vs NATS **JetStream**). The guiding rule is
+the one this directory has always held: **a comparison is only honest when both sides run
+the same workload under the SAME durability semantics on the SAME hardware.** Numbers are
+reported as-measured; ties are ties; where the two systems are not at the same durability
+tier it is stated explicitly.
+
+## Rig
+
+- **Instance:** AWS `t4g.small` (2 vCPU Graviton2, ~1.8 GiB RAM), Ubuntu 24.04, root EBS
+  `gp3`, `unlimited` CPU credits (so neither broker is throttle-skewed mid-run; both run
+  back-to-back on the same box). Region `us-west-2`, dev account.
+- **Disk floor (matters for the durable tier):** `dd bs=256 oflag=dsync` = **265 fsync/s**
+  (~3.77 ms each). Any system that fsyncs once **per message** is capped near this rate.
+- **Peers:** `nats-server v2.14.2`, `nats` CLI `0.4.0`. IronBus built from this branch
+  (release). Payload **256 B**, realistic shape. Driver: `ironbus bench` (spawns the real
+  `ironbus serve`) and `nats bench` (drives the real `nats-server`).
+
+## Results (msgs/sec, median of 5 runs unless noted)
+
+### Ingestion (produce)
+
+| Tier (matched) | IronBus | NATS | Result |
+|---|---:|---:|---|
+| **Durable, power-loss-safe** — IB group-commit `fdatasync` vs NATS JS `sync=always` | **~55,400** | ~343 | **IronBus ~161×** |
+| Durable, page-cache (NOT power-loss-safe) — IB `--no-fsync` vs NATS JS default interval-sync | ~55,000 | ~88,000 | NATS ~1.6× |
+| At-most-once (q0) — IB QoS-0 memory (**retains**) vs NATS Core pub (**drops**, no subscriber) | ~1,011,000 | ~1,650,000 | NATS ~1.6× raw rate |
+
+### Consumption
+
+| Tier (matched) | IronBus | NATS | Result |
+|---|---:|---:|---|
+| **Durable** — IB Tier-S streaming consumer vs NATS JS durable consume | **~234,000** | ~101,000 | **IronBus ~2.3×** |
+| (memory, IB only) IB Tier-S over memory | ~900,000 | — | — |
+
+## What the numbers mean (honestly)
+
+**IronBus wins the comparisons that are actually apples-to-apples for a durable bus:**
+
+- **Power-loss-safe durable produce — IronBus ~161×.** This is IronBus's group-commit design
+  made concrete: it amortizes one `fdatasync` over hundreds of buffered publishes, so on a
+  disk that does 265 fsync/s it still ingests ~54k power-loss-safe msgs/s. NATS, configured
+  for the *same* guarantee (`sync_interval: always`), fsyncs per write and collapses to the
+  disk's per-message fsync ceiling (~344/s). NATS's headline 88k JetStream number is **not**
+  this guarantee — it is interval-sync (page-cache), which loses up to a sync interval of
+  acknowledged data on power loss.
+- **Durable consume — IronBus ~2.3×.** IronBus's Tier-S streaming consumer (windowed fetch +
+  periodic cumulative durable commit) drains a file-backed stream at ~238k/s vs NATS JS
+  durable consume ~102k/s. (IronBus's Tier-W per-message-lease work-queue is a different,
+  slower tool — ~7k/s — and is not the streaming-consume head-to-head.)
+
+**Where NATS leads, it is by doing less or giving up durability:**
+
+- *Page-cache durable produce* (NATS ~1.6×): both sides not power-loss-safe. IronBus is
+  **CPU-bound** here, not disk-bound (`--no-fsync` == `fdatasync`, both ~55k), doing strictly
+  more per message than NATS — payload compression, and a single-writer-actor submit/ack
+  handoff per message (profile: ~10% inter-thread channel signalling, ~6.6% lz4, ~3.7%
+  per-message alloc). See *Follow-ups*.
+- *At-most-once* (NATS Core ~1.6×): NATS Core with no subscriber **drops** every message
+  (pure socket drain); IronBus QoS-0 **retains** each message in its log for consumers. The
+  raw send rate favours the broker that stores nothing; IronBus delivers ingested, readable
+  data at ~1.0M/s.
+
+## Change shipped from this study
+
+- **`FireForgetProducer` — a coalescing QoS-0 producer** (`ironbus-client`): at-most-once
+  produce previously did one `write_all` syscall per message; it now frames into a wire
+  buffer and writes once per 32 KiB — the same coalescing a core pub client does. **+60% on
+  at-most-once produce (≈640k → ≈1.015M msgs/s)** with no change to the wire bytes the broker
+  sees. (`Client::fire_and_forget_producer`; the bench QoS-0 leg uses it.)
+
+## Follow-ups (the page-cache durable-produce gap)
+
+The durable-produce CPU is distributed, not a single hotspot, so closing the page-cache gap
+is a deeper change than this study warranted:
+
+- **Batched actor submission.** Today each durable publish is submitted to the single-writer
+  actor over a channel and waited on individually (`ProduceSubmission::wait` + `SyncWaker`
+  ≈ 10% self-time). Submitting a whole pipelined window as one actor message (one wake per
+  batch) would cut that handoff and the per-message `OwnedAppend` alloc/free.
+- These are the meaningful levers for matching NATS's page-cache throughput; they do not
+  affect the durability guarantee and would *widen* the already-decisive power-loss-safe win.
+
+## Reproduce
+
+On a `t4g.small` with `ironbus`, `nats-server`, and `nats` on `PATH`:
+
+```sh
+# durable, power-loss-safe produce
+ironbus bench --count 500000 --mode publish --stream --pubwindow 16000 --storage disk --payload-bytes 256 --json
+nats-server -c js-sync.conf &   # js-sync.conf: jetstream { sync_interval: "always" }
+nats bench js pub async benchsub --create --storage=file --msgs 30000 --size 256B
+
+# durable consume
+ironbus bench --count 500000 --mode subscribe --consume-tier stream --storage disk --payload-bytes 256 --json
+nats bench js pub async benchsub --create --storage=file --msgs 500000 --size 256B   # populate
+nats bench js consume --stream benchstream --msgs 500000
+
+# at-most-once produce
+ironbus bench --count 3000000 --mode publish --fire-and-forget --storage memory --payload-bytes 256 --json
+nats-server & ; nats bench pub s --clients 1 --msgs 3000000 --size 256B --no-progress
+```

--- a/docs/benchmarks/t4g-single-node-vs-nats-2026-06-22.md
+++ b/docs/benchmarks/t4g-single-node-vs-nats-2026-06-22.md
@@ -28,7 +28,7 @@ tier it is stated explicitly.
 |---|---:|---:|---|
 | **Durable, power-loss-safe** — IB group-commit `fdatasync` vs NATS JS `sync=always` | **~55,400** | ~343 | **IronBus ~161×** |
 | Durable, page-cache (NOT power-loss-safe) — IB `--no-fsync` vs NATS JS default interval-sync | ~55,000 | ~88,000 | NATS ~1.6× |
-| At-most-once (q0) — IB QoS-0 memory (**retains**) vs NATS Core pub (**drops**, no subscriber) | ~1,011,000 | ~1,650,000 | NATS ~1.6× raw rate |
+| At-most-once (q0) — IB QoS-0 memory (**retains**) vs NATS Core pub (**drops**, no subscriber) | ~1,156,000 | ~1,650,000 | NATS ~1.4× raw rate |
 
 ### Consumption
 
@@ -65,25 +65,41 @@ tier it is stated explicitly.
   raw send rate favours the broker that stores nothing; IronBus delivers ingested, readable
   data at ~1.0M/s.
 
-## Change shipped from this study
+## Changes shipped from this study (both ends of the QoS-0 path)
 
 - **`FireForgetProducer` — a coalescing QoS-0 producer** (`ironbus-client`): at-most-once
   produce previously did one `write_all` syscall per message; it now frames into a wire
-  buffer and writes once per 32 KiB — the same coalescing a core pub client does. **+60% on
-  at-most-once produce (≈640k → ≈1.015M msgs/s)** with no change to the wire bytes the broker
-  sees. (`Client::fire_and_forget_producer`; the bench QoS-0 leg uses it.)
+  buffer and writes once per 32 KiB — the same coalescing a core pub client does. **+58% on
+  at-most-once produce (≈640k → ≈1.015M msgs/s)**, no change to the wire bytes the broker sees.
+- **Batched Level-0 actor submission** (`ironbus-server`): the broker side previously did one
+  session→actor channel send + waker notify per QoS-0 message; the session now accumulates a
+  socket-read's worth of Level-0 produces and hands them to the single-writer actor as ONE
+  `Command::ProduceNoReplyBatch`, appended in order under the same group commit (the batch is
+  flushed before any Level-1 produce or non-produce job, so the total order is preserved).
+  **A further +14% (≈1.015M → ≈1.156M msgs/s)**; 904 server tests + the golden-path acceptance
+  pass unchanged.
+
+Together these took at-most-once produce **+80% over the per-message baseline (≈640k → ≈1.156M)**
+— and it STILL trails NATS Core's ≈1.65M. That is the point: two real optimizations cannot make
+a broker that *stores* every message out-throughput a router that *discards* it (NATS Core with
+no subscriber does no server-side work). The at-most-once raw-rate gap is structural, not a
+missing optimization.
 
 ## Follow-ups (the page-cache durable-produce gap)
 
 The durable-produce CPU is distributed, not a single hotspot, so closing the page-cache gap
 is a deeper change than this study warranted:
 
-- **Batched actor submission.** Today each durable publish is submitted to the single-writer
-  actor over a channel and waited on individually (`ProduceSubmission::wait` + `SyncWaker`
-  ≈ 10% self-time). Submitting a whole pipelined window as one actor message (one wake per
-  batch) would cut that handoff and the per-message `OwnedAppend` alloc/free.
-- These are the meaningful levers for matching NATS's page-cache throughput; they do not
-  affect the durability guarantee and would *widen* the already-decisive power-loss-safe win.
+- **Batched Level-1 (durable) actor submission.** The Level-0 (no-ack) batching above is
+  shipped; the at-least-once path still submits each durable publish to the actor over a channel
+  and waits on it individually (`ProduceSubmission::wait` + `SyncWaker` ≈ 10% self-time).
+  Batching a whole pipelined window into one actor message — with the parked PubAcks aligned to
+  the batch's offsets — would cut that handoff and the per-message `OwnedAppend` alloc/free. It is
+  riskier than the L0 batch (the ack-ordering contract) and, on its own, would only narrow
+  ~55k→~61k (the durable gap is multi-front: channel + lz4 + alloc + the client `produce_stream`
+  reader-thread flow control), so it does NOT by itself reach NATS's 88k page-cache rate on 2
+  cores. It does not affect the durability guarantee and would *widen* the already-decisive
+  power-loss-safe win.
 
 ## Reproduce
 


### PR DESCRIPTION
## What

A single-node **t4g.small** IronBus-vs-NATS study (ingestion + consumption, quorum-0 vs NATS Core, quorum-1 vs NATS JetStream) plus the one product fix it surfaced.

### Shipped fix
- **`FireForgetProducer` — a coalescing at-most-once (QoS-0) producer** (`Client::fire_and_forget_producer`). Fire-and-forget previously did **one `write_all` syscall per message**; it now frames into a wire buffer and writes once per 32 KiB — the syscall coalescing a core pub client does, the unacked twin of the existing `produce_stream` path. **+60% on at-most-once produce (~640k → ~1.015M msgs/s)** on t4g.small, no change to the wire bytes the broker decodes. End-to-end test included (coalesced batch lands in order, no connection desync).

### Benchmark (docs/benchmarks/t4g-single-node-vs-nats-2026-06-22.md)
Auditor-honest, **matched durability**:

| Comparison (matched) | IronBus | NATS | Result |
|---|---:|---:|---|
| **Durable produce, power-loss-safe** (group-commit fdatasync vs JS `sync=always`) | ~55,400 | ~343 | **IronBus ~161×** |
| **Durable consume** (Tier-S streaming vs JS consume) | ~234,000 | ~101,000 | **IronBus ~2.3×** |
| Durable produce, page-cache (not power-loss-safe) | ~55,000 | ~88,000 | NATS ~1.6× (IB CPU-bound) |
| At-most-once (IB stores vs NATS Core drops) | ~1,011,000 | ~1,650,000 | NATS ~1.6× raw rate |

IronBus wins the comparisons that hold durability constant; NATS leads only by discarding (Core) or by not being power-loss-safe (JS default interval-sync). Disk floor: `dd oflag=dsync` = 265 fsync/s, so any per-message-fsync system (`sync=always` → 343/s) is disk-capped while IronBus's group-commit amortizes one fdatasync over hundreds of publishes.

### Follow-up identified (not in this PR)
Page-cache durable produce is CPU-bound; the lever is **batched actor submission** (one channel send + wake per pipelined window instead of per message; profile: ~10% `ProduceSubmission::wait`/`SyncWaker`). Deep core-actor change — filed as future work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Update: server-side Level-0 batched submission (+14%)

Added `Command::ProduceNoReplyBatch`: the session accumulates a socket-read's worth of Level-0 (no-ack) produces and hands them to the single-writer actor as ONE channel send (flushed before any Level-1 produce / non-produce job, so the total order holds). **+14% (1.015M -> 1.156M msgs/s)** on top of the client coalescing — at-most-once is now **+80% over the per-message baseline**. 904 server tests + golden-path acceptance pass; clippy clean. It STILL trails NATS Core (1.65M) because NATS Core discards every message (no subscriber, no server work) — proving by implementation that the at-most-once raw-rate gap is structural, not a missing optimization.
