### PR TITLE
feat(client-async): nack / term / progress consume-settle verbs

### DIFF
--- a/crates/ironbus-client-async/src/lib.rs
+++ b/crates/ironbus-client-async/src/lib.rs
@@ -80,8 +80,8 @@ use tokio::net::{TcpStream, ToSocketAddrs};
 // directly. They are the SYNC client's types, shared unchanged — the wire contract is identical.
 #[doc(no_inline)]
 pub use ironbus_client::{
-    ClientConfig, ClientError, DeadLetter, Fetch, Gap, Message, ProduceAck, StreamBatch,
-    StreamConsumerConfig, Truncation, TxnId, DEFAULT_STREAM_COMMIT_EVERY_BATCHES,
+    ClientConfig, ClientError, DeadLetter, Fetch, Gap, Message, ProduceAck, ProgressOutcome,
+    StreamBatch, StreamConsumerConfig, Truncation, TxnId, DEFAULT_STREAM_COMMIT_EVERY_BATCHES,
     DEFAULT_STREAM_FETCH_RECORDS,
 };
 
@@ -787,6 +787,117 @@ impl AsyncClient {
         match first_err {
             Some(e) => Err(e),
             None => Ok(statuses),
+        }
+    }
+
+    /// Negatively-acks a fetched message so the broker requeues it for redelivery. `delay_ms`
+    /// caps the redelivery backoff for this attempt; `None` lets the broker apply its configured
+    /// backoff schedule. Returns `true` if the broker requeued it, `false` if the token was fenced
+    /// (stale: it already redelivered, was acked, or you nacked it before; either way do not drop
+    /// local state). The async port of [`ironbus_client::Client::nack`].
+    ///
+    /// # Errors
+    /// Returns a [`ClientError`] on an IO error, a server error, or a wrong-shape reply.
+    pub async fn nack(
+        &mut self,
+        offset: u64,
+        generation: u64,
+        delay_ms: Option<u64>,
+    ) -> Result<bool, ClientError> {
+        let mut body = Vec::new();
+        encode_ack(
+            &AckBody {
+                op: AckOp::Nack,
+                offset,
+                generation,
+                // u64::MAX is the wire sentinel for "no explicit delay, use the server schedule".
+                delay_ms: delay_ms.unwrap_or(u64::MAX),
+            },
+            &mut body,
+        );
+        self.send(FrameType::Ack, &body).await?;
+        match self.read_frame().await? {
+            (FrameType::AckStatus, body) => match body.as_slice() {
+                [status] => Ok(*status == 1),
+                _ => Err(ClientError::BadResponse(
+                    "nack reply was not a one-byte status",
+                )),
+            },
+            (FrameType::Err, body) => {
+                Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
+            }
+            (other, _) => Err(ClientError::Unexpected(other)),
+        }
+    }
+
+    /// Terminates delivery of a fetched message: an intentional drop. The broker commits past it so
+    /// it never redelivers and is NOT dead-lettered. Returns `true` if it was dropped, `false` if the
+    /// token was fenced (stale: it already redelivered or was acked). The async port of
+    /// [`ironbus_client::Client::term`].
+    ///
+    /// # Errors
+    /// Returns a [`ClientError`] on an IO error, a server error, or a wrong-shape reply.
+    pub async fn term(&mut self, offset: u64, generation: u64) -> Result<bool, ClientError> {
+        let mut body = Vec::new();
+        encode_ack(
+            &AckBody {
+                op: AckOp::Term,
+                offset,
+                generation,
+                delay_ms: 0,
+            },
+            &mut body,
+        );
+        self.send(FrameType::Ack, &body).await?;
+        match self.read_frame().await? {
+            (FrameType::AckStatus, body) => match body.as_slice() {
+                [status] => Ok(*status == 1),
+                _ => Err(ClientError::BadResponse(
+                    "term reply was not a one-byte status",
+                )),
+            },
+            (FrameType::Err, body) => {
+                Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
+            }
+            (other, _) => Err(ClientError::Unexpected(other)),
+        }
+    }
+
+    /// Reports that work on a fetched message is still in progress, extending its lease by one
+    /// visibility window so it is not redelivered while the consumer keeps working. The async port
+    /// of [`ironbus_client::Client::progress`].
+    ///
+    /// # Errors
+    /// Returns a [`ClientError`] on an IO error, a server error, or a wrong-shape reply.
+    pub async fn progress(
+        &mut self,
+        offset: u64,
+        generation: u64,
+    ) -> Result<ProgressOutcome, ClientError> {
+        let mut body = Vec::new();
+        encode_ack(
+            &AckBody {
+                op: AckOp::Progress,
+                offset,
+                generation,
+                delay_ms: 0,
+            },
+            &mut body,
+        );
+        self.send(FrameType::Ack, &body).await?;
+        match self.read_frame().await? {
+            (FrameType::AckStatus, body) => match body.as_slice() {
+                [1] => Ok(ProgressOutcome::Extended),
+                [2] => Ok(ProgressOutcome::CapReached),
+                [0] => Ok(ProgressOutcome::Fenced),
+                _ => Err(ClientError::BadResponse(
+                    "progress reply was not a known one-byte status",
+                )),
+            },
+            (FrameType::Err, body) => {
+                Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
+            }
+            (other, _) => Err(ClientError::Unexpected(other)),
         }
     }
 

--- a/crates/ironbus-client-async/tests/roundtrip.rs
+++ b/crates/ironbus-client-async/tests/roundtrip.rs
@@ -8,7 +8,7 @@
 //! This proves the async client speaks the same wire as the broker, end to end.
 
 use ironbus_client_async::proto::{ConsumeTier, PubBody};
-use ironbus_client_async::{AsyncClient, ClientConfig, StreamConsumerConfig};
+use ironbus_client_async::{AsyncClient, ClientConfig, ProgressOutcome, StreamConsumerConfig};
 use ironbus_core::clock::Clock;
 use ironbus_core::delivery::DeliveryConfig;
 use ironbus_core::lease::LeaseConfig;
@@ -323,6 +323,126 @@ async fn async_produce_window_returns_fifo_offsets_against_a_real_server() {
         assert_eq!(fetched.messages[i].payload, *payload);
         assert_eq!(fetched.messages[i].offset, i as u64);
     }
+
+    shutdown.store(true, Ordering::Release);
+    handle.join().unwrap();
+}
+
+/// The consume-settle NAK path end to end: produce a record, subscribe, fetch it, NAK it (the broker
+/// requeues it), then a re-fetch REDELIVERS it under a fresh generation — proving the async `nack`
+/// requeued it. The stale (nacked) token can no longer ack; the fresh one commits and drains. The async
+/// port of the sync client's `a_nacked_message_is_redelivered_against_a_real_server`.
+#[tokio::test]
+async fn async_nack_redelivers_a_message_against_a_real_server() {
+    let (addr, shutdown, handle) = start_server();
+
+    let mut c = AsyncClient::connect(addr).await.unwrap();
+    let off = c
+        .produce(&PubBody {
+            flags: 0,
+            timestamp_ms: 0,
+            key: b"",
+            headers: b"",
+            dedup: None,
+            fire_and_forget: false,
+            payload: b"retry-me",
+        })
+        .await
+        .unwrap();
+
+    c.subscribe("workers").await.unwrap();
+    let first = c.fetch(10).await.unwrap().messages;
+    assert_eq!(first.len(), 1);
+    assert_eq!(first[0].payload, b"retry-me");
+
+    // Nack with no explicit delay: the default 30s visibility means the record would not otherwise
+    // redeliver within this test, so the nack is what brings it back. The in-process server has an
+    // empty backoff schedule, so `None` requeues it immediately.
+    assert!(c
+        .nack(first[0].offset, first[0].generation, None)
+        .await
+        .unwrap());
+
+    let second = c.fetch(10).await.unwrap().messages;
+    assert_eq!(second.len(), 1, "the nacked record is redelivered");
+    assert_eq!(second[0].offset, off);
+    assert_eq!(second[0].payload, b"retry-me");
+    assert_ne!(
+        second[0].generation, first[0].generation,
+        "redelivery fences the old generation"
+    );
+
+    // The stale (nacked) token can no longer commit; the fresh one does.
+    assert!(
+        !c.ack(first[0].offset, first[0].generation).await.unwrap(),
+        "the nacked generation is fenced"
+    );
+    assert!(
+        c.ack(second[0].offset, second[0].generation).await.unwrap(),
+        "the redelivered generation commits"
+    );
+    assert!(
+        c.fetch(10).await.unwrap().messages.is_empty(),
+        "the committed record is not redelivered"
+    );
+
+    shutdown.store(true, Ordering::Release);
+    handle.join().unwrap();
+}
+
+/// The consume-settle TERM and PROGRESS paths end to end: produce two records, fetch both, extend the
+/// first's lease with `progress` (Extended), `term` the second (an intentional drop — committed past,
+/// never redelivered), then ack the first so the whole prefix is committed and nothing remains. A
+/// `progress`/`term` on a now-stale token is fenced. The async port of the sync client's
+/// `term_drops_a_message_and_progress_extends_a_lease`.
+#[tokio::test]
+async fn async_term_drops_and_progress_extends_against_a_real_server() {
+    let (addr, shutdown, handle) = start_server();
+
+    let mut c = AsyncClient::connect(addr).await.unwrap();
+    for p in [&b"keep"[..], b"drop"] {
+        c.produce(&PubBody {
+            flags: 0,
+            timestamp_ms: 0,
+            key: b"",
+            headers: b"",
+            dedup: None,
+            fire_and_forget: false,
+            payload: p,
+        })
+        .await
+        .unwrap();
+    }
+
+    c.subscribe("workers").await.unwrap();
+    let msgs = c.fetch(10).await.unwrap().messages;
+    assert_eq!(msgs.len(), 2);
+
+    // Progress on the first: the lease is extended.
+    assert_eq!(
+        c.progress(msgs[0].offset, msgs[0].generation)
+            .await
+            .unwrap(),
+        ProgressOutcome::Extended
+    );
+    // Term the second: an intentional drop (committed past, never redelivered, not dead-lettered).
+    assert!(c.term(msgs[1].offset, msgs[1].generation).await.unwrap());
+
+    // Ack the first; now the whole prefix is committed and nothing remains.
+    assert!(c.ack(msgs[0].offset, msgs[0].generation).await.unwrap());
+    assert!(
+        c.fetch(10).await.unwrap().messages.is_empty(),
+        "the termed record never redelivers"
+    );
+
+    // A progress or term on a now-stale token is fenced.
+    assert_eq!(
+        c.progress(msgs[0].offset, msgs[0].generation)
+            .await
+            .unwrap(),
+        ProgressOutcome::Fenced
+    );
+    assert!(!c.term(msgs[1].offset, msgs[1].generation).await.unwrap());
 
     shutdown.store(true, Ordering::Release);
     handle.join().unwrap();


### PR DESCRIPTION
Adds the **consume-settle verbs** to the async IronBus client crate `crates/ironbus-client-async` — async ports of the same-named methods on the sync `crates/ironbus-client`. A downstream async consumer needs `nack` to NAK a failed record for redelivery; `term` and `progress` round out the settle surface.

Each method mirrors its sync twin exactly (same `AckOp` / `AckBody` encode, same one-byte `AckStatus` reply parsing as the async `ack`), differing only in the IO `await`s. No types are redefined; `ProgressOutcome` is re-exported from `ironbus-client` verbatim, like the crate's other shared public types.

## Methods added (async ports)

- `async fn nack(&mut self, offset: u64, generation: u64, delay_ms: Option<u64>) -> Result<bool, ClientError>` — NAKs a fetched record so the broker requeues it (`AckOp::Nack`; `delay_ms` `None` → `u64::MAX` wire sentinel = server backoff schedule). `true` = requeued, `false` = fenced.
- `async fn term(&mut self, offset: u64, generation: u64) -> Result<bool, ClientError>` — intentional drop, committed past, never redelivered, not dead-lettered (`AckOp::Term`). `true` = dropped, `false` = fenced.
- `async fn progress(&mut self, offset: u64, generation: u64) -> Result<ProgressOutcome, ClientError>` — extends a lease by one visibility window (`AckOp::Progress`). Returns `Extended` / `CapReached` / `Fenced`.

## Test (real-broker round-trip)

Extends `tests/roundtrip.rs` (the `start_server` real-`ironbus-server` pattern):

- `async_nack_redelivers_a_message_against_a_real_server` — produce → subscribe → fetch → `nack` (assert requeued) → re-fetch **REDELIVERS** the record under a fresh generation (the stale nacked token then fences on `ack`; the fresh one commits and drains). Proves the NAK requeued it.
- `async_term_drops_and_progress_extends_against_a_real_server` — fetch two; `progress` the first (`Extended`), `term` the second (dropped, never redelivers); ack the first; a `progress`/`term` on the now-stale tokens is `Fenced`.

All 8 roundtrip tests pass (6 existing + 2 new) plus the doc-test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVWp2H2txnKGru4q2twxM3