### PR TITLE
docs(mission,readme): declare KV store and object store explicit non-goals (#759)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 >
 > **Where this is going:** the v2 mission is for IronBus to be feature-rich and decisively better than NATS on every front, **single node or clustered**, with clustering a first-class goal (not post-1.0). Read **[docs/MISSION.md](docs/MISSION.md)** — it is scrupulously explicit about what is achieved and measured today versus what is v2 target, not yet built.
 
-IronBus is one durable, ordered queue (think a single AWS SQS queue) that lives on the device, survives power loss and corrupt files on its own, and fans out to many consumers. It ships as a single static binary you can drop onto a Raspberry Pi. It takes the best small, composable ideas from MQTT, NATS, Kafka, Pulsar, Redpanda, RocksDB, Redis Streams, and SQS, and leaves behind the operational weight and the silent durability footguns that do not survive a battery-less edge node. The single-node durable broker is what runs today; multi-stream, subjects, KV, an object store, and a real multi-node cluster are the v2 roadmap (see [docs/MISSION.md](docs/MISSION.md)).
+IronBus is one durable, ordered queue (think a single AWS SQS queue) that lives on the device, survives power loss and corrupt files on its own, and fans out to many consumers. It ships as a single static binary you can drop onto a Raspberry Pi. It takes the best small, composable ideas from MQTT, NATS, Kafka, Pulsar, Redpanda, RocksDB, Redis Streams, and SQS, and leaves behind the operational weight and the silent durability footguns that do not survive a battery-less edge node. The single-node durable broker is what runs today; multi-stream, subjects, and a real multi-node cluster are the v2 roadmap (see [docs/MISSION.md](docs/MISSION.md)). A KV store and an object store are non-goals: IronBus stays a pure message bus.
 
 ---
 
@@ -58,9 +58,9 @@ mission is for IronBus to be feature-rich and decisively better than NATS on eve
 cluster degrades to, not the ceiling:
 
 - **One log today; multi-stream, subjects, and a routing fabric are the v2 roadmap.** The shipped binary
-  is one durable ordered log. Multiple streams, subject routing, wildcards, a KV store, and an object
-  store are planned (v2 single-node milestones), not a non-goal. Until they land, multiple independent
-  queues can be run as separate instances.
+  is one durable ordered log. Multiple streams, subject routing, and wildcards are planned (v2
+  single-node milestones), not a non-goal. A KV store and an object store are non-goals: IronBus stays a
+  pure message bus. Until multi-stream lands, multiple independent queues can be run as separate instances.
 - **Single node today; a real cluster is the v2 roadmap, and clustering is first-class.** The shipped
   binary is single-node durable (`fdatasync` before ack). Replication is **not** a non-goal and **not**
   deferred to post-1.0: real multi-node clustering — leader/follower replication with NATS-cluster parity
@@ -72,6 +72,8 @@ cluster degrades to, not the ceiling:
 **IronBus is explicitly NOT (these are durable non-goals):**
 
 - Not exactly-once. At-least-once is the contract, with an optional fire-and-forget fast path. No exactly-once handshake.
+- Not a key/value store. A KV store (the NATS JetStream KV analog) is a different product category; IronBus stays a pure message bus.
+- Not an object store. Chunked object storage is out of scope. (Tiered storage of cold log segments to an object-storage backend is core log infrastructure and stays on the roadmap, which is distinct from being an object store.)
 - Not a Kafka wire-protocol clone, and not a Windows product in v1 (Windows fsync and path semantics differ enough to threaten the durability guarantee).
 
 ---
@@ -271,7 +273,7 @@ A fresh-eyes second pass over every issue resolved over one hundred design quest
 
 | Question | Decision |
 | --- | --- |
-| Logical scope | One durable ordered queue per instance today. Multi-stream, subjects, partitions, KV, and an object store are the v2 roadmap (see [docs/MISSION.md](docs/MISSION.md)), not a permanent non-goal. |
+| Logical scope | One durable ordered queue per instance today. Multi-stream, subjects, and partitions are the v2 roadmap (see [docs/MISSION.md](docs/MISSION.md)), not a permanent non-goal. A KV store and an object store are non-goals (IronBus stays a pure message bus). |
 | Delivery contract | At-least-once, pull-based in v1. SQS-style visibility-timeout leases (default 30s, hard cap 5 minutes), persisted redelivery count, default max-deliver 5, then dead-letter queue. |
 | Ordering | Total durable order of the log. Per-group at-least-once, not per-group strict in-order delivery. Exactly-once is a non-goal. |
 | Storage model | Log-is-WAL: a publish is one framed, checksummed, record-aligned append to the active segment, and that append is the durable record. No separate WAL file. The offset index is derived and rebuildable. |
@@ -345,7 +347,7 @@ The v1 design work was grouped into three milestones, and the single-node broker
 - **M1: Architecture Specification.** Vetted specs for every core subsystem: semantics, storage, record format, durability, recovery, corruption skip, consumers, backpressure, protocol, compression, retention, configuration, and the CLI.
 - **M2: Prototype-Ready Design.** The cross-cutting concerns that gate coding: observability, build and distribution, security, performance, edge constraints, verification, governance, and the end-to-end golden-path acceptance scenario.
 
-**Beyond the single node — the v2 mission.** IronBus's goal is to be feature-rich and decisively better than NATS on every front, single node **or clustered**, with clustering a first-class goal rather than a post-1.0 afterthought. The v2 single-node milestones (consume-beats-NATS, multi-stream + subjects, KV, object store, routing richness) and the first-class clustering milestones (metadata consensus, per-partition pull replication, `fsync`'d-on-a-quorum cluster acks, bounded self-healing divergence) are laid out — with an explicit achieved-vs-target honesty split — in **[docs/MISSION.md](docs/MISSION.md)**.
+**Beyond the single node — the v2 mission.** IronBus's goal is to be feature-rich and decisively better than NATS on every front, single node **or clustered**, with clustering a first-class goal rather than a post-1.0 afterthought. The v2 single-node milestones (consume-beats-NATS, multi-stream + subjects, routing richness) and the first-class clustering milestones (metadata consensus, per-partition pull replication, `fsync`'d-on-a-quorum cluster acks, bounded self-healing divergence) are laid out — with an explicit achieved-vs-target honesty split — in **[docs/MISSION.md](docs/MISSION.md)**.
 
 ---
 

--- a/docs/MISSION.md
+++ b/docs/MISSION.md
@@ -64,8 +64,6 @@ Everything here is the plan. It is **not** shipped, and is not claimed as a pres
 | --- | --- | --- |
 | Single-consumer durable consume beating NATS | **TARGET (the one axis we lose today)** | Today single-consumer durable consume is **~3–20x slower** than NATS — a design artifact (per-poll full-segment re-scan + reads on the write actor + a work-queue premium on every record), not fundamental. The fix is [V2-M1](#v2-roadmap-the-single-node-milestones). |
 | Multi-stream + subjects + wildcards | **TARGET** | Today IronBus is literally **one log**. Streams/subjects/partitions are [V2-M2](#v2-roadmap-the-single-node-milestones). |
-| KV store | **TARGET** | [V2-M5]. Not built. |
-| Object store | **TARGET** | [V2-M9]. Not built. |
 | Routing richness (TTL / DLX / priorities / delayed) | **TARGET** | [V2-M4]. Not built. |
 | **All clustering / replication** | **TARGET (first-class, but not yet built)** | The entire [cluster roadmap (V2-C1–V2-C8)](#v2-roadmap-the-clustering-milestones) is design + plan. **No multi-node code ships today.** The single node is the only thing that runs now. |
 
@@ -97,8 +95,12 @@ issues. This is a competitive map, not a claim that the gaps are closed.
 ### Feature + cluster gaps (target, not yet built)
 
 - Topics / subjects / wildcards (we are literally one log) → V2-M2.
-- KV → V2-M5; object store → V2-M9; routing richness (TTL/DLX/priorities/delayed) → V2-M4.
+- Routing richness (TTL/DLX/priorities/delayed) → V2-M4.
 - **Clustering / replication** → V2-C1–V2-C8 (first-class, not yet built).
+
+### Non-goals (deliberately not built)
+
+- **KV store** and **object store** are non-goals: IronBus stays a pure message bus and does not grow into adjacent datastore categories (a KV store like the NATS JetStream KV, or an object store). These were formerly the V2-M5 and V2-M9 roadmap slots, now retired. Tiered storage (V2-M10) is unaffected: offloading cold sealed log segments to an object-storage backend is core log infrastructure, not an object-store product.
 
 ---
 
@@ -183,15 +185,12 @@ replicas.
   delivery-count so the max-deliver→DLQ rule always fires.
 - **V2-M4 — Routing & queue richness.** Per-message/stream TTL, dead-letter exchanges, optional
   priorities, scheduled/delayed messages.
-- **V2-M5 — KV store.** A bucket over the compacted log, linearizable CAS, snapshot+resumable watch,
-  per-key TTL with bounded tombstone reclamation.
 - **V2-M6 — Observability + rich CLI + recovery-as-feature.** Latency histograms, recovery-event
   counters, an `ironbus verify` offline fsck, a first-class `repair`, backup/restore.
 - **V2-M7 — Security & DoS hardening.** TLS 1.3 fail-closed bind, three-mechanism auth × three scopes,
   pre-auth DoS defenses, graceful drain.
 - **V2-M8 — Reliability semantics.** Idempotent producer (PID + epoch + sequence), effectively-once
   survival across restart + long offline gap.
-- **V2-M9 — Object store.** Chunked objects with per-chunk CRC, range-get via the offset index.
 - **V2-M10 — Tiered storage (post-1.0).** Offload cold sealed segments to object storage behind the
   cursor abstraction.
 - **V2-M11 — (folded into the clustering milestones below).** The thin "replication done right" is


### PR DESCRIPTION
Reconciles the docs with the KV / object-store non-goal decision (the docs half of #759; the code was removed in #776). IronBus stays a pure message bus.

## MISSION.md
- Drop the `KV store` and `Object store` rows from the v2 "honesty" target table (section 2b).
- Remove KV / object store from the feature-gaps list (section 3).
- Remove the `V2-M5 - KV store` and `V2-M9 - Object store` milestone bullets (section 6).
- Add an explicit **Non-goals** subsection stating KV and object store are out of scope, and clarifying that tiered storage (V2-M10) is unaffected: offloading cold sealed log segments to an object-storage backend is core log infrastructure, not an object-store product.

## README.md
- Remove KV / object store from the v2 roadmap lead, the roadmap bullets, the decisions table, and the v2-mission paragraph.
- Add a key/value store and an object store to the **"explicitly NOT"** durable non-goals list.

## Verification
- The per-PR relative-link + anchor integrity gate passes locally (854 in-repo links, 0 problems).
- No other doc advertises a KV feature, and no `ironbus kv` CLI command exists (the merged KV bucket was never wired to the CLI).
- The NATS-KV-corruption reference in the NATS-shortfall section is kept (it cites a NATS durability flaw, not an IronBus feature).

## Scope
Strictly the KV / object-store non-goal. The clustering / multi-stream "honesty table" re-baseline (docs currently under-claim those shipped capabilities) is tracked separately in #760.

Refs #759.
