### PR TITLE
fix(ci): skip shell-variable placeholder URLs in the external-link check (#699)

### DIFF
--- a/scripts/ci/external-link-check.sh
+++ b/scripts/ci/external-link-check.sh
@@ -92,9 +92,12 @@ is_skipped_host() {
 # a skipped URL is NEVER a failure; the match reason is logged.
 #   - .../issues/N : the ADR template's literal `#N` placeholder
 #     (docs/adr/template.md), meant to be replaced per ADR, not a real issue.
+#   - any URL containing a shell variable (e.g. `http://$addr/healthz` in a usage
+#     snippet, docs/OPERATIONS.md): a fill-in-the-blank token, not a real endpoint.
 is_skipped_url() {
 	case "$1" in
 	*github.com/*/*/issues/N | *github.com/*/*/issues/N/) echo "ADR template placeholder (#N), filled in per ADR"; return 0 ;;
+	*'$'*) echo 'shell-variable placeholder (e.g. $addr) in a usage snippet, not a real endpoint'; return 0 ;;
 	esac
 	return 1
 }


### PR DESCRIPTION
Closes #699 (an auto-filed false positive).

The weekly external-link check flagged `http://$addr/healthz` and `http://$addr/readyz` as dead links. These are usage snippets in `docs/OPERATIONS.md` where `$addr` is a shell variable (a fill-in-the-blank token), not real endpoints.

**Fix:** add a skip pattern to `is_skipped_url` in `scripts/ci/external-link-check.sh` for any URL containing a `$`, mirroring the existing ADR `issues/N` placeholder skip. A skip is never a failure and is logged with its reason.

**Verified:** the new pattern skips both placeholder URLs and still checks real `https://github.com/...` URLs; `sh -n` is clean; the change follows the existing skip-list style. `external-link-check.sh` runs only in the weekly `docs-link-check` cron (not a per-PR gate), so the next weekly run stops re-filing this.