### PR TITLE
fix(storage): roll back the segment writer on a mid-append spill-flush IO error (#859)

### DIFF
--- a/crates/ironbus-storage/src/log.rs
+++ b/crates/ironbus-storage/src/log.rs
@@ -5837,6 +5837,73 @@ mod tests {
     }
 
     #[test]
+    fn a_spill_flush_io_error_mid_append_does_not_corrupt_offsets_or_lose_acked_data() {
+        use crate::fault::FaultFs;
+        // #859 regression: a write error on the 256 KiB spill flush mid-append must NOT leave the writer
+        // TORN (write_pos advanced, record_count not bumped) - which would reuse this offset/seq on the
+        // next append and, when a later flush succeeds, write both frames under one count, corrupting the
+        // log and silently losing the acked record. A single > 256 KiB record makes its own pending
+        // buffer cross the spill cap, so its in-append flush fires; armed with a write fault it fails.
+        // After clearing the fault the next record must take the SAME offset (the failed one consumed
+        // none and left no torn frame), and the dense log must survive a reopen.
+        let (fs, control) = FaultFs::new(InMemoryFs::new());
+        let probe = fs.inner().clone();
+        {
+            let mut log = Log::open(fs, ManualClock::new(), LogConfig::default()).unwrap();
+            // Three durable records (offsets 0..=2, fsync clean).
+            for i in 0..3u64 {
+                assert_eq!(log.append(&rec(b"durable")).unwrap(), Offset::new(i));
+            }
+            log.sync().unwrap();
+            assert_eq!(log.flushed_offset(), Offset::new(3));
+
+            // A single record larger than the 256 KiB spill cap: its in-append flush fails under the
+            // armed write fault, so the append errors. Pre-fix this left the writer torn at offset 3.
+            let big = vec![b'x'; 300 * 1024];
+            control.set_fail_write(true);
+            assert!(
+                log.append(&rec(&big)).is_err(),
+                "the > 256 KiB record's spill flush fails under the armed write fault"
+            );
+
+            // Clear the fault and append the next record: with the roll-back fix it takes offset 3 (the
+            // failed append consumed NO offset and left no torn frame), not a skipped or reused one.
+            control.set_fail_write(false);
+            let after = log.append(&rec(b"survivor")).unwrap();
+            assert_eq!(
+                after,
+                Offset::new(3),
+                "after a rolled-back spill failure the next append reuses no offset and skips none"
+            );
+            log.sync().unwrap();
+
+            // Dense and no-duplicate in the live log.
+            let recs = log.read_from(Offset::ZERO, 1000).unwrap();
+            assert_eq!(
+                recs.len(),
+                4,
+                "record_count matches the frames on disk: no duplicate or skipped offset"
+            );
+            assert_eq!(&recs.last().unwrap().payload[..], &b"survivor"[..]);
+        }
+
+        // Reopen over the surviving disk: the post-fault record is durable and recovery finds a
+        // consistent, dense log (the torn-writer bug would have made dense-seq recovery truncate it).
+        let reopened = Log::open(probe, ManualClock::new(), LogConfig::default()).unwrap();
+        let recs = reopened.read_from(Offset::ZERO, 1000).unwrap();
+        assert_eq!(
+            recs.len(),
+            4,
+            "the dense log (incl. the post-fault record) survives reopen"
+        );
+        assert_eq!(
+            &recs.last().unwrap().payload[..],
+            &b"survivor"[..],
+            "the post-fault record survives a reopen"
+        );
+    }
+
+    #[test]
     fn a_fatal_fsync_freezes_the_writer_and_reads_keep_serving_the_flushed_prefix() {
         use crate::fault::FaultFs;
         let (fs, control) = FaultFs::new(InMemoryFs::new());

--- a/crates/ironbus-storage/src/log.rs
+++ b/crates/ironbus-storage/src/log.rs
@@ -5904,6 +5904,73 @@ mod tests {
     }
 
     #[test]
+    fn a_partial_spill_flush_write_mid_append_still_recovers_a_dense_consistent_log() {
+        use crate::fault::FaultFs;
+        // #859, the partial-write case: the clean-fail variant above proves the IN-MEMORY roll back; a
+        // real `write_all_at` can persist a PREFIX of the spill buffer and THEN error, leaving garbage
+        // on disk past the durable head. This asserts the fix is sound there too: after the roll back the
+        // next successful flush rewrites from the unchanged `pending_base`, overwriting the partial bytes,
+        // so the reopened log is dense and consistent with no torn-frame corruption and no lost ack.
+        let (fs, control) = FaultFs::new(InMemoryFs::new());
+        let probe = fs.inner().clone();
+        // A large survivor (4 KiB) whose frame dwarfs the 64-byte torn prefix, so its flush fully
+        // overwrites the persisted partial bytes - the recovered log carries no leftover garbage.
+        let survivor = vec![0xABu8; 4096];
+        {
+            let mut log = Log::open(fs, ManualClock::new(), LogConfig::default()).unwrap();
+            for i in 0..3u64 {
+                assert_eq!(log.append(&rec(b"durable")).unwrap(), Offset::new(i));
+            }
+            log.sync().unwrap();
+
+            // The > 256 KiB record's spill flush persists 64 bytes then errors (a torn write).
+            let big = vec![b'x'; 300 * 1024];
+            control.arm_torn_write(64);
+            assert!(
+                log.append(&rec(&big)).is_err(),
+                "the > 256 KiB record's spill flush tears (persists a prefix, then errors)"
+            );
+
+            // The roll back restored the writer; the survivor takes offset 3 and its flush overwrites the
+            // 64 torn bytes at the unchanged pending_base.
+            let after = log.append(&rec(&survivor)).unwrap();
+            assert_eq!(
+                after,
+                Offset::new(3),
+                "no offset reuse or skip after a torn spill flush"
+            );
+            log.sync().unwrap();
+
+            let recs = log.read_from(Offset::ZERO, 1000).unwrap();
+            assert_eq!(
+                recs.len(),
+                4,
+                "dense, no duplicate frame from the torn write"
+            );
+            assert_eq!(&recs.last().unwrap().payload[..], &survivor[..]);
+        }
+
+        // Reopen over the disk that carried the partial bytes: recovery yields exactly the dense log, the
+        // big record's torn prefix never resurfaces as a record, and the acked survivor is durable.
+        let reopened = Log::open(probe, ManualClock::new(), LogConfig::default()).unwrap();
+        let recs = reopened.read_from(Offset::ZERO, 1000).unwrap();
+        assert_eq!(
+            recs.len(),
+            4,
+            "the dense log survives reopen after a partial spill-flush write"
+        );
+        assert_eq!(
+            &recs.last().unwrap().payload[..],
+            &survivor[..],
+            "the post-fault record survives a reopen even when the failed flush left partial bytes"
+        );
+        assert!(
+            recs.iter().all(|r| r.payload.len() != 300 * 1024),
+            "the torn big record (the only 300 KiB payload) never becomes a readable record"
+        );
+    }
+
+    #[test]
     fn a_fatal_fsync_freezes_the_writer_and_reads_keep_serving_the_flushed_prefix() {
         use crate::fault::FaultFs;
         let (fs, control) = FaultFs::new(InMemoryFs::new());

--- a/crates/ironbus-storage/src/segment.rs
+++ b/crates/ironbus-storage/src/segment.rs
@@ -548,10 +548,18 @@ impl<F: RandomAccessFile> SegmentWriter<F> {
             self.pending.truncate(before);
             return Err(StorageError::SegmentFull);
         };
+        let pos_before = self.write_pos;
         self.write_pos = end;
         // Spill: bound the buffer regardless of the survivor count, one write per spill window.
         if self.pending.len() >= PENDING_SPILL_BYTES {
-            self.flush_pending()?;
+            if let Err(e) = self.flush_pending() {
+                // #859: same torn-writer roll back as `append` - a spill-flush IO error mid-append left
+                // `write_pos` advanced and the frame buffered with `record_count` un-bumped. Restore the
+                // pre-append state so the next survivor append cannot reuse this offset/seq, then propagate.
+                self.pending.truncate(before);
+                self.write_pos = pos_before;
+                return Err(e);
+            }
         }
         self.record_count += 1;
         self.last_seq = record.seq;
@@ -656,15 +664,29 @@ impl<F: RandomAccessFile> SegmentWriter<F> {
         }
         let len =
             u64::try_from(self.pending.len() - before).map_err(|_| StorageError::SegmentFull)?;
-        let end = self
-            .write_pos
+        let pos_before = self.write_pos;
+        let end = pos_before
             .checked_add(len)
             .ok_or(StorageError::SegmentFull)?;
         self.write_pos = end;
         // Spill: bound the buffer regardless of how long a relaxed durability level defers the
         // sync. One write per spill still reduces syscalls by spill/record-size to one.
         if self.pending.len() >= PENDING_SPILL_BYTES {
-            self.flush_pending()?;
+            if let Err(e) = self.flush_pending() {
+                // #859: the spill flush failed mid-append (ENOSPC / flash EIO). `write_pos` was already
+                // advanced and the just-encoded frame is still buffered, but `record_count`/`last_seq`
+                // have NOT been bumped yet - a TORN writer state. Left as-is, the NEXT append would reuse
+                // this offset/seq (`record_count` did not advance) and, when a later flush succeeds, write
+                // BOTH frames under one count - corrupting the log and silently losing the acked record.
+                // Roll back to the EXACT pre-append state (drop the encoded frame, restore `write_pos`) so
+                // the writer stays consistent and a retry is safe, then propagate the IO error so the
+                // producer is never acked. `flush_pending` leaves `pending` / `pending_base` untouched on
+                // error, so only the frame and `write_pos` need undoing; this mirrors the encode-failure
+                // roll back above.
+                self.pending.truncate(before);
+                self.write_pos = pos_before;
+                return Err(e);
+            }
         }
         self.record_count += 1;
         self.last_seq = record.seq;


### PR DESCRIPTION
## What

Closes #859 (3rd of the 3 critical audit findings in milestone #30).

`SegmentWriter::append` (and the compaction-path `append_at`) encode a record into the shared `pending` buffer, advance `write_pos`, then — if the buffer crossed the 256 KiB spill cap — flush it with one `write_all_at`. That flush is the **last fallible step before** `record_count`/`last_seq` are bumped. A flush error returned immediately and left the writer **torn**: `write_pos` already advanced and the just-encoded frame still buffered, yet `record_count` un-incremented.

Left torn, the **next** append reused the same offset/seq (`record_count` never moved) and, once a later flush succeeded, wrote **both** frames under one count — a corrupted, non-dense log that **silently dropped the record the producer had already been acked for** (an I2 / ack-implies-durable violation). Under a relaxed durability level a >256 KiB batch is exactly when the spill fires mid-append, so a transient ENOSPC / flash EIO triggers it.

## Fix

On a spill-flush error, roll back to the exact pre-append state — `pending.truncate(before)` to drop the encoded frame, restore `write_pos = pos_before` — then propagate the IO error so the producer is never acked. `flush_pending` leaves `pending`/`pending_base` untouched on error (the `?` fires before either is mutated), so only the frame and `write_pos` need undoing; this mirrors the existing encode-failure roll back. Applied to **both** `append` and `append_at`.

## Test

`a_spill_flush_io_error_mid_append_does_not_corrupt_offsets_or_lose_acked_data` (log.rs): three durable records (offsets 0..=2), then a single >256 KiB record whose spill flush fails under an armed write fault. After clearing the fault the next record takes the **same** offset (3 — the failed append consumed none), the live log is dense with no duplicate (4 records), and the survivor record survives a **reopen**.

## Verification

- `cargo fmt --check` clean
- `cargo clippy --workspace --all-targets -- -D warnings -W clippy::pedantic` clean
- `cargo test -p ironbus-storage` — 410 passed (incl. the new regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
