### PR TITLE
fix(dlq): dedup dead-letters on exact source offset, not a high-water mark (#800)

### DIFF
--- a/crates/ironbus-server/src/engine.rs
+++ b/crates/ironbus-server/src/engine.rs
@@ -6499,11 +6499,11 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
     /// The ordering is the crash-safety contract: APPEND the poison record to the durable DLQ sink
     /// and FSYNC it, THEN commit the source cursor. A crash between the two leaves the source
     /// uncommitted (it redelivers and is re-poisoned on the next run) and the DLQ record already
-    /// durable; on reopen the per-group dead-lettered high-water mark, rebuilt from the DLQ itself,
-    /// makes the re-poison a no-op append so the message is committed-past WITHOUT a duplicate DLQ
-    /// write. The reconciliation key is `(group, source_offset, attempt)`: an offset at or below
-    /// the group's high-water mark is already in the sink, so it is committed-past without a second
-    /// append.
+    /// durable; on reopen the per-group EXACT dead-lettered set, rebuilt from the DLQ itself, makes
+    /// the re-poison a no-op append so the message is committed-past WITHOUT a duplicate DLQ write.
+    /// The reconciliation key is the EXACT `(group, source_offset)` (#800): an offset already in the
+    /// group's set is in the sink, so it is committed-past without a second append — but a genuinely
+    /// new lower offset (poison order is not ascending) is appended, never suppressed by a higher one.
     ///
     /// The lease has already been dropped by the caller, so on success the message holds no lease
     /// and never redelivers.
@@ -6514,10 +6514,10 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         attempt: u32,
         record: OwnedRecord,
     ) -> Result<Poll, EngineError> {
-        // Idempotency: if this (group, source offset) is already durably in the DLQ (at or below
-        // the group's recorded high-water mark), do NOT append a second copy. This is the path a
-        // redelivered-then-re-poisoned message takes after a crash that landed between the DLQ
-        // append and the cursor commit: the sink already has it, so we only commit past it.
+        // Idempotency: if this EXACT (group, source offset) is already durably in the DLQ, do NOT
+        // append a second copy (#800). This is the path a redelivered-then-re-poisoned message takes
+        // after a crash that landed between the DLQ append and the cursor commit: the sink already has
+        // this exact offset, so we only commit past it. A different (e.g. lower) offset is appended.
         let already = self.dlq_sink()?.already_dead_lettered(group, off.get());
         if !already {
             // APPEND to the DLQ and FSYNC, BEFORE committing the source cursor. A storage error
@@ -6609,8 +6609,8 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         attempt: u32,
         record: OwnedRecord,
     ) -> Result<Poll, EngineError> {
-        // Idempotency: a re-expired message already durably in the exchange (at or below the group's
-        // high-water mark) is committed-past WITHOUT a second append, exactly as the poison path.
+        // Idempotency: a re-expired message whose EXACT source offset is already durably in the
+        // exchange is committed-past WITHOUT a second append, exactly as the poison path (#800).
         let already = self.dlq_sink()?.already_dead_lettered(group, off.get());
         if !already {
             // APPEND the reason-carrying (TtlExpired) dead-letter and FSYNC, BEFORE committing the
@@ -6654,6 +6654,13 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         if group == self.confirm_group {
             self.confirm_registry
                 .terminate(off, ConfirmStatus::DeadLettered);
+        }
+        // #800: the cursor has committed past `off`, so prune the DLQ dedup set below the group's
+        // committed watermark — those source offsets can never redeliver or re-poison, so their
+        // exact-membership entries are no longer needed. This bounds each per-group set by the
+        // in-flight/ahead window. Only when the sink is already open (never lazily create it to prune).
+        if let Some(sink) = self.dlq.as_mut() {
+            sink.prune_below(group, committed);
         }
     }
 
@@ -12479,9 +12486,10 @@ mod tests {
 
     #[test]
     fn re_expiring_the_same_offset_to_the_dlx_does_not_double_write() {
-        // Idempotency for the TTL-DLX move, mirroring the poison idempotency (#551): a re-expired
-        // offset already at/below the group's high-water mark is committed-past WITHOUT a second
-        // append. Drive the move once, then re-run the move helper directly on the same offset.
+        // Idempotency for the TTL-DLX move, mirroring the poison idempotency (#551/#800): re-expiring
+        // the SAME exact source offset writes exactly one DLX record. A LOWER offset (0) is held
+        // leased/uncommitted so the committed watermark stays at 0 and offset 1's exact-membership
+        // entry is not pruned between the two moves.
         let clock = std::sync::Arc::new(ManualClock::at_unix_millis(0));
         let fs = InMemoryFs::new();
         let probe = fs.clone();
@@ -12491,49 +12499,125 @@ mod tests {
             config_with_dlx_for_expired(1_000, "dlx-expired"),
         )
         .unwrap();
-        let off = produce_with_ttl(&mut e, 0, Ttl::from_millis(1_000), b"once");
+        produce_with_ttl(&mut e, 0, Ttl::from_millis(1_000), b"zero");
+        let off1 = produce_with_ttl(&mut e, 0, Ttl::from_millis(1_000), b"one");
+        // Poll once BEFORE the deadline to materialize the group and LEASE offset 0 (it stays
+        // uncommitted, so the committed watermark stays at 0 and offset 1's entry is not pruned).
+        let _ = e.poll_now().unwrap();
         clock.set_unix_millis(1_000);
-        let record = e.log.read_from(off, 1).unwrap().into_iter().next().unwrap();
-        let _ = e
-            .expire_dead_letter_in(DEFAULT_GROUP, off, 1, record.clone())
+
+        let rec1 = e
+            .log
+            .read_from(off1, 1)
+            .unwrap()
+            .into_iter()
+            .next()
             .unwrap();
-        // A second move of the SAME offset must be a no-op append (idempotent high-water mark).
         let _ = e
-            .expire_dead_letter_in(DEFAULT_GROUP, off, 1, record)
+            .expire_dead_letter_in(DEFAULT_GROUP, off1, 1, rec1)
+            .unwrap();
+        // A second move of the SAME offset must be a no-op append (exact-offset idempotency).
+        let rec1_again = e
+            .log
+            .read_from(off1, 1)
+            .unwrap()
+            .into_iter()
+            .next()
+            .unwrap();
+        let _ = e
+            .expire_dead_letter_in(DEFAULT_GROUP, off1, 1, rec1_again)
             .unwrap();
         drop(e);
         let entries = read_dead_letter_entries(&probe, "dlx-expired").unwrap();
         assert_eq!(
             entries.len(),
             1,
-            "re-expiring the same offset writes exactly one DLX record"
+            "re-expiring the same exact offset writes exactly one DLX record"
         );
     }
 
     #[test]
-    fn re_poisoning_the_same_offset_does_not_double_write() {
-        // Idempotency at the API level: dead-lettering the SAME (group, offset) twice (e.g. a
-        // forced re-evaluation) writes exactly one DLQ record. We drive a second dead-letter of an
-        // offset already at the group's high-water mark by re-invoking the internal move directly.
+    fn dead_letter_dedup_is_exact_so_a_lower_offset_after_a_higher_one_is_not_dropped() {
+        // #800: dead-letter idempotency is EXACT-offset membership, NOT a high-water mark. Two poison
+        // messages: the HIGHER source offset (1) crosses max-deliver while the LOWER (0) is still
+        // leased (uncommitted), so the committed watermark stays at 0 and offset 1's dedup entry is
+        // retained. When the lower offset 0 later dead-letters it MUST still be written to the sink —
+        // pre-#800 `0 <= hwm(1)` read as "already present" and dropped it, leaving ZERO durable copies.
+        // Re-poisoning the SAME offset (the legitimate crash-window duplicate) still writes exactly
+        // once. The internal move is invoked directly to construct the lower-still-leased ordering
+        // deterministically, which the in-order poll scan cannot otherwise produce.
         let clock = std::sync::Arc::new(ManualClock::new());
         let fs = InMemoryFs::new();
         let probe = fs.clone();
         let mut e = Engine::open(fs, std::sync::Arc::clone(&clock), config(10, 1)).unwrap();
-        let off = poison_once(&mut e, &clock, b"p");
-        assert_eq!(e.dlq_records(), 1);
+        for p in [&b"p0"[..], b"p1"] {
+            e.produce(&Append {
+                timestamp_ms: 1,
+                flags: RecordFlags::EMPTY,
+                key: b"",
+                headers: b"",
+                payload: p,
+            })
+            .unwrap();
+        }
+        // Poll once to materialize the default group and LEASE offset 0: it stays UNCOMMITTED, so the
+        // committed watermark stays at 0 and offset 1's exact-membership entry is not pruned.
+        let _ = e.poll_now().unwrap();
 
-        // Read the source record back and re-run the dead-letter move for the SAME (group, offset,
-        // attempt). The high-water mark already covers `off`, so no second DLQ write happens.
-        let record = e.log.read_from(off, 1).unwrap().into_iter().next().unwrap();
-        let poll = e.dead_letter_in("", off, 2, record).unwrap();
-        assert!(matches!(poll, Poll::Parked { .. }));
+        // The HIGHER offset 1 dead-letters first (offset 0 is still leased/uncommitted).
+        let rec1 = e
+            .log
+            .read_from(Offset::new(1), 1)
+            .unwrap()
+            .into_iter()
+            .next()
+            .unwrap();
+        e.dead_letter_in("", Offset::new(1), 2, rec1).unwrap();
+        assert_eq!(e.dlq_records(), 1);
+        // Re-poison the SAME offset 1 (the crash-window duplicate): idempotent, still one record.
+        let rec1_again = e
+            .log
+            .read_from(Offset::new(1), 1)
+            .unwrap()
+            .into_iter()
+            .next()
+            .unwrap();
+        e.dead_letter_in("", Offset::new(1), 2, rec1_again).unwrap();
         assert_eq!(
             e.dlq_records(),
             1,
-            "re-poison is idempotent: still one record"
+            "re-poisoning the SAME exact offset writes exactly one record"
         );
+
+        // Now the LOWER offset 0 dead-letters: a genuinely-new source offset that MUST be written,
+        // never suppressed by the higher offset 1 already in the sink (the #800 fix). Pre-fix
+        // `already_dead_lettered("", 0)` returned true (0 <= 1) and this append was skipped.
+        let rec0 = e
+            .log
+            .read_from(Offset::new(0), 1)
+            .unwrap()
+            .into_iter()
+            .next()
+            .unwrap();
+        e.dead_letter_in("", Offset::new(0), 2, rec0).unwrap();
+        assert_eq!(
+            e.dlq_records(),
+            2,
+            "the lower offset is durably written, not dropped (#800)"
+        );
+
         drop(e);
-        assert_eq!(read_dlq_entries(&probe).unwrap().len(), 1);
+        let mut offsets: Vec<u64> = read_dlq_entries(&probe)
+            .unwrap()
+            .iter()
+            .map(|en| en.source_offset)
+            .collect();
+        offsets.sort_unstable();
+        assert_eq!(
+            offsets,
+            vec![0, 1],
+            "BOTH poison offsets are durably in the DLQ"
+        );
     }
 
     #[test]

--- a/crates/ironbus-server/src/engine.rs
+++ b/crates/ironbus-server/src/engine.rs
@@ -2573,7 +2573,7 @@ pub struct Engine<F: Filesystem, C: Clock> {
     /// holding every poison record for later inspection. Opened LAZILY on the first dead-letter
     /// (so a broker that never dead-letters never creates the subdirectory), or eagerly by
     /// [`Engine::open`] when the subdirectory already exists, so the per-group dead-lettered
-    /// high-water mark (the idempotency key) is rebuilt before the first poison redelivers.
+    /// offset set (the idempotency key) is rebuilt before the first poison redelivers.
     dlq: Option<DlqSink<F, C>>,
     /// The [`LogConfig`] the DLQ sink's log is opened with: the same segment sizing as the main
     /// log, but with NO total-byte cap (a poison record must never be shed, it is the durable
@@ -2909,7 +2909,7 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
             .as_deref()
             .unwrap_or(DLQ_SUBDIR)
             .to_string();
-        // Eagerly open (recovering its high-water mark) the dead-letter sink IF its subdirectory
+        // Eagerly open (recovering its dead-lettered offset set) the dead-letter sink IF its subdirectory
         // already exists from a prior run, so the idempotency key is present before the first poison
         // redelivers after a crash. A fresh data directory has no sink subdir yet, so the sink stays
         // unopened (lazy) and the no-dead-letter path never creates it.
@@ -3209,7 +3209,7 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
     /// Whether the dead-letter sink's `subdir` already exists, so a prior run dead-lettered at least
     /// one message there. `subdir` is the configured dead-letter EXCHANGE target (#551), or the
     /// default `dlq/`. Used by [`Engine::open`] to decide whether to eagerly open the sink (rebuilding
-    /// the idempotency high-water mark) versus deferring to the lazy open on the first dead-letter.
+    /// the idempotency offset set) versus deferring to the lazy open on the first dead-letter.
     /// This is a non-creating probe ([`Filesystem::subdir_exists`]), so `Engine::open` on a fresh
     /// data directory never materializes the sink subdirectory.
     fn dlq_dir_exists(log: &Log<F, C>, subdir: &str) -> bool {
@@ -6547,11 +6547,11 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         })
     }
 
-    /// Lazily opens (recovering its per-group high-water mark) the durable DLQ sink on first use,
-    /// returning a mutable borrow. The sink is created on the first dead-letter, so a broker that
+    /// Lazily opens (recovering its per-group dead-lettered offset set) the durable DLQ sink on first
+    /// use, returning a mutable borrow. The sink is created on the first dead-letter, so a broker that
     /// never dead-letters never creates the `dlq/` subdirectory (the no-poison path never touches
     /// it). After a restart that already has a `dlq/` directory, [`Engine::open`] eagerly opens it
-    /// so the high-water mark is present before the first poison redelivers.
+    /// so the dead-lettered offset set is present before the first poison redelivers.
     fn dlq_sink(&mut self) -> Result<&mut DlqSink<F, C>, EngineError> {
         if self.dlq.is_none() {
             // Route to the configured dead-letter EXCHANGE subdir (#551) when set, else the default
@@ -6600,8 +6600,9 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
     /// recording [`DeadLetterReason::TtlExpired`], then commits the source group's cursor past it and
     /// returns [`Poll::Parked`]. The ordering and idempotency are identical to [`Engine::dead_letter_in`]
     /// (APPEND+FSYNC the reason-carrying dead-letter record BEFORE the cursor commit; a redelivered
-    /// re-expired message is a no-op append at or below the per-group high-water mark), so an expiry is
-    /// a fully reported, exactly-once event. Used only when [`Engine::dead_letters_expired`] holds.
+    /// re-expired message whose EXACT source offset is already in the per-group dead-lettered set is a
+    /// no-op append, #800), so an expiry is a fully reported, exactly-once event. Used only when
+    /// [`Engine::dead_letters_expired`] holds.
     fn expire_dead_letter_in(
         &mut self,
         group: &str,
@@ -12626,8 +12627,8 @@ mod tests {
         // The crash window: the DLQ append+fsync is durable, but the source-cursor commit's
         // durability has NOT yet landed (it is only in memory, the checkpoint interval is high).
         // A power loss reverts the un-checkpointed source cursor (the poison redelivers) while the
-        // fsynced DLQ record survives. On reopen the per-group high-water mark, rebuilt from the
-        // durable DLQ, suppresses the duplicate append: EXACTLY ONE DLQ entry, and no loss.
+        // fsynced DLQ record survives. On reopen the per-group exact dead-lettered offset set, rebuilt
+        // from the durable DLQ, suppresses the duplicate append: EXACTLY ONE DLQ entry, and no loss.
         let clock = std::sync::Arc::new(ManualClock::new());
         let (faultfs, _control) = FaultFs::new(InMemoryFs::new());
         // Keep a probe to the underlying in-memory disk to drive the power loss and read the DLQ.

--- a/crates/ironbus-storage/src/dlq.rs
+++ b/crates/ironbus-storage/src/dlq.rs
@@ -338,8 +338,8 @@ impl<F: Filesystem, C: Clock> std::fmt::Debug for DlqSink<F, C> {
 
 impl<F: Filesystem, C: Clock> DlqSink<F, C> {
     /// Opens (recovering, or creating fresh) the dead-letter sink rooted at the `dlq/`
-    /// subdirectory of `parent_fs`, rebuilding the per-group dead-lettered high-water mark by
-    /// scanning the durable DLQ records. The subdirectory is created on demand by
+    /// subdirectory of `parent_fs`, rebuilding the per-group exact set of dead-lettered source
+    /// offsets by scanning the durable DLQ records. The subdirectory is created on demand by
     /// [`Filesystem::subdir`].
     ///
     /// # Errors
@@ -353,7 +353,7 @@ impl<F: Filesystem, C: Clock> DlqSink<F, C> {
     /// of `parent_fs` — the dead-letter EXCHANGE target (#551). [`DlqSink::open`] is this with the
     /// default [`DLQ_SUBDIR`], so the existing fixed-DLQ behavior is byte-identical; a configured DLX
     /// names a different `subdir` to route dead letters to a separate sink. The on-disk format and
-    /// the idempotent high-water-mark rebuild are identical for every target.
+    /// the idempotent exact-offset-set rebuild are identical for every target.
     ///
     /// # Errors
     /// Propagates a storage error from creating the subdirectory, opening the DLQ log, or scanning
@@ -451,10 +451,10 @@ impl<F: Filesystem, C: Clock> DlqSink<F, C> {
     }
 
     /// Appends one poison record to the sink and makes it durable (fsync) BEFORE returning, then
-    /// advances the in-memory high-water mark. This is the durable half of the crash-atomic move:
-    /// the caller appends-and-fsyncs HERE first, and only then commits the source group's cursor
-    /// past the message, so a crash between the two leaves the source uncommitted and the record
-    /// already durable in the DLQ; on reopen the high-water mark (rebuilt from this very record)
+    /// adds the source offset to the in-memory dead-lettered set. This is the durable half of the
+    /// crash-atomic move: the caller appends-and-fsyncs HERE first, and only then commits the source
+    /// group's cursor past the message, so a crash between the two leaves the source uncommitted and
+    /// the record already durable in the DLQ; on reopen the exact set (rebuilt from this very record)
     /// suppresses the duplicate append.
     ///
     /// The original record's `key`, `payload`, and `timestamp_ms` are preserved verbatim; the
@@ -465,7 +465,7 @@ impl<F: Filesystem, C: Clock> DlqSink<F, C> {
     /// Returns [`StorageError::SegmentFull`] if the metadata could not be framed (an original
     /// header or group name longer than `u16::MAX`, unreachable from the wire), or a storage error
     /// from the append or its durability barrier. On any error nothing is recorded as
-    /// dead-lettered (the high-water mark and count do not move), so the caller MUST NOT commit the
+    /// dead-lettered (the offset set and count do not move), so the caller MUST NOT commit the
     /// source cursor: the move did not happen.
     pub fn append_poison(
         &mut self,
@@ -490,8 +490,8 @@ impl<F: Filesystem, C: Clock> DlqSink<F, C> {
     /// default fixed-DLQ max-deliver path, so that path stays byte-identical.
     ///
     /// The crash-safety contract (append-and-fsync the dead-letter record HERE before the caller
-    /// commits the source cursor) and the idempotent per-group high-water mark are identical to
-    /// `append_poison`.
+    /// commits the source cursor) and the idempotent per-group dead-lettered offset set are identical
+    /// to `append_poison`.
     ///
     /// # Errors
     /// Same as [`append_poison`](Self::append_poison).
@@ -509,7 +509,8 @@ impl<F: Filesystem, C: Clock> DlqSink<F, C> {
     }
 
     /// Appends one dead-letter record (with its already-encoded metadata `headers` blob) to the sink,
-    /// fsyncs it BEFORE returning, and advances the per-group high-water mark + record count. This is
+    /// fsyncs it BEFORE returning, and adds the source offset to the per-group set + bumps the record
+    /// count. This is
     /// the shared durable core of [`append_poison`](Self::append_poison) and
     /// [`append_dead_letter`](Self::append_dead_letter); the only difference between them is the v1 vs
     /// v2 metadata encoding, computed by the caller.
@@ -717,7 +718,7 @@ mod tests {
         assert_eq!(sink.records(), 1);
         assert_eq!(sink.highest_for_group("orders"), Some(7));
 
-        // Reopen the sink: the high-water mark and count come back from the durable records alone.
+        // Reopen the sink: the dead-lettered offset set and count come back from the durable records alone.
         let reopened = DlqSink::open(&fs, ManualClock::new(), config()).unwrap();
         assert_eq!(reopened.records(), 1);
         assert_eq!(reopened.highest_for_group("orders"), Some(7));

--- a/crates/ironbus-storage/src/dlq.rs
+++ b/crates/ironbus-storage/src/dlq.rs
@@ -21,15 +21,20 @@
 //! exact byte layout). The DLQ record's `timestamp_ms`, `key`, and `payload` are the original's.
 //!
 //! ## Exactly-once across a crash (the idempotency key)
-//! The reconciliation key is `(group, source_offset, attempt)`. The DLQ Log itself is the durable
+//! The reconciliation key is the EXACT `(group, source_offset)`. The DLQ Log itself is the durable
 //! record of what has been dead-lettered: on open, [`DlqSink::open`] scans the DLQ segments and
-//! rebuilds, per group, the HIGHEST source offset already dead-lettered. The engine consults that
-//! high-water mark before appending: a `(group, offset)` already at or below the group's recorded
-//! high-water mark is NOT re-appended (it is already in the sink), so a message that was appended
-//! to the DLQ and then re-poisoned after a crash (because its source cursor commit had not yet
-//! become durable) is committed-past WITHOUT a duplicate DLQ write. There is therefore no separate
-//! sidecar file to keep consistent with the sink: the sink is the single source of truth, and a
-//! reopen reconstructs the high-water mark from it.
+//! rebuilds, per group, the SET of source offsets already dead-lettered. The engine consults that
+//! set before appending: a `(group, offset)` whose EXACT offset is already in the set is NOT
+//! re-appended (it is already in the sink), so a message that was appended to the DLQ and then
+//! re-poisoned after a crash (because its source cursor commit had not yet become durable) is
+//! committed-past WITHOUT a duplicate DLQ write. The membership is EXACT, never `offset <= max`
+//! (#800): poison messages do not cross the max-deliver threshold in ascending order, so a high-water
+//! mark would silently drop a lower offset dead-lettered after a higher one — leaving it in ZERO
+//! durable places, the exact loss the DLQ exists to prevent. Each per-group set is bounded by the
+//! source group's in-flight/ahead window: [`DlqSink::prune_below`] drops offsets below the source
+//! cursor's committed watermark (which can never redeliver or re-poison). There is therefore no
+//! separate sidecar file to keep consistent with the sink: the sink is the single source of truth,
+//! and a reopen reconstructs the exact set from it.
 
 use crate::fs::Filesystem;
 use crate::log::{Append, Log, LogConfig};
@@ -38,7 +43,7 @@ use crate::offline::OfflineReader;
 use crate::segment::{OwnedRecord, SegmentReader, StorageError};
 use ironbus_core::clock::Clock;
 use ironbus_core::types::{Offset, RecordFlags};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 /// The subdirectory of the data directory that holds the DEFAULT dead-letter sink's segments. A
 /// dead-letter EXCHANGE (V2-M4, #551) routes to a CONFIGURABLE subdir instead (the target name), so
@@ -299,14 +304,20 @@ pub fn decode_entry(record: &OwnedRecord) -> Option<DlqEntry> {
     })
 }
 
-/// The durable dead-letter sink: a second segmented [`Log`] plus the per-group high-water mark of
-/// the highest source offset already dead-lettered, for idempotent appends (#63).
+/// The durable dead-letter sink: a second segmented [`Log`] plus the per-group set of source
+/// offsets already dead-lettered, for idempotent appends (#63).
 pub struct DlqSink<F: Filesystem, C: Clock> {
     log: Log<F, C>,
-    /// The highest SOURCE offset already dead-lettered, per consumer group, reconstructed at open
-    /// from the durable DLQ records and advanced on each append. The engine consults this to skip
-    /// a duplicate append for a `(group, source_offset)` already in the sink.
-    highest_source_offset: BTreeMap<String, u64>,
+    /// The EXACT set of SOURCE offsets already dead-lettered, per consumer group, reconstructed at
+    /// open from the durable DLQ records and extended on each append (#800). The engine consults this
+    /// to skip a duplicate append for a `(group, source_offset)` already in the sink. It is EXACT
+    /// membership, NOT a high-water mark: poison messages do NOT cross the max-deliver (or TTL-expiry)
+    /// threshold in ascending source-offset order — a higher offset can be dead-lettered while a lower
+    /// one is still leased — so `offset <= max` would wrongly suppress the lower offset's append,
+    /// dropping it from the sink entirely (zero durable places). Each per-group set is bounded by the
+    /// source group's in-flight/ahead window (`max_in_flight`): [`DlqSink::prune_below`] drops every
+    /// offset below the source cursor's committed watermark, which can never redeliver or re-poison.
+    dead_lettered: BTreeMap<String, BTreeSet<u64>>,
     /// The number of records durably appended to the sink across its lifetime (the DLQ depth at
     /// open plus every append since), for the operator's `ironbus_dlq_records_total` metric.
     records: u64,
@@ -320,7 +331,7 @@ impl<F: Filesystem, C: Clock> std::fmt::Debug for DlqSink<F, C> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("DlqSink")
             .field("records", &self.records)
-            .field("highest_source_offset", &self.highest_source_offset)
+            .field("dead_lettered", &self.dead_lettered)
             .finish_non_exhaustive()
     }
 }
@@ -357,11 +368,11 @@ impl<F: Filesystem, C: Clock> DlqSink<F, C> {
         let log = Log::open(dlq_fs, clock, config)?;
         let mut sink = DlqSink {
             log,
-            highest_source_offset: BTreeMap::new(),
+            dead_lettered: BTreeMap::new(),
             records: 0,
             subdir: subdir.to_string(),
         };
-        sink.rebuild_high_water_mark()?;
+        sink.rebuild_dead_lettered_set()?;
         Ok(sink)
     }
 
@@ -372,11 +383,13 @@ impl<F: Filesystem, C: Clock> DlqSink<F, C> {
     }
 
     /// Scans every durable DLQ record (reusing the recovery decode path) and rebuilds the per-group
-    /// highest dead-lettered source offset plus the total record count. Called once at open; the
+    /// EXACT set of dead-lettered source offsets plus the total record count. Called once at open; the
     /// DLQ is the single durable source of truth for what has been dead-lettered, so this is what
-    /// makes the move idempotent across a crash without a separate sidecar.
-    fn rebuild_high_water_mark(&mut self) -> Result<(), StorageError> {
-        self.highest_source_offset.clear();
+    /// makes the move idempotent across a crash without a separate sidecar — and recovering the exact
+    /// set (not just a max) is what lets a lower offset re-poisoned after a crash be recognized as
+    /// already-present without suppressing a genuinely-new lower offset (#800).
+    fn rebuild_dead_lettered_set(&mut self) -> Result<(), StorageError> {
+        self.dead_lettered.clear();
         self.records = 0;
         let flushed = self.log.flushed_offset().get();
         if flushed == 0 {
@@ -394,27 +407,47 @@ impl<F: Filesystem, C: Clock> DlqSink<F, C> {
                 }
                 if let Some(meta) = decode_dlq_headers(&record.headers) {
                     self.records = self.records.saturating_add(1);
-                    let entry = self
-                        .highest_source_offset
+                    self.dead_lettered
                         .entry(meta.group)
-                        .or_insert(meta.source_offset);
-                    *entry = (*entry).max(meta.source_offset);
+                        .or_default()
+                        .insert(meta.source_offset);
                 }
             }
         }
         Ok(())
     }
 
-    /// Whether `(group, source_offset)` is ALREADY in the durable DLQ: true when `source_offset`
-    /// is at or below the group's recorded high-water mark. The engine calls this to make the move
-    /// idempotent: a redelivered-then-re-poisoned message already in the sink is committed-past
-    /// WITHOUT a second append. Source offsets only ever rise for a group, so the high-water mark
-    /// is a sound dedupe key.
+    /// Whether `(group, source_offset)` is ALREADY in the durable DLQ: true when this EXACT source
+    /// offset is in the group's dead-lettered set. The engine calls this to make the move idempotent:
+    /// a redelivered-then-re-poisoned message already in the sink is committed-past WITHOUT a second
+    /// append. The check is EXACT membership, NOT `offset <= max` (#800): the ONLY legitimate
+    /// duplicate is the SAME source offset re-poisoned after a crash that fsynced the DLQ record but
+    /// not the source cursor, so a lower offset never-yet-dead-lettered must return `false` even when
+    /// a HIGHER one is already recorded — otherwise it would be dropped from the sink entirely.
     #[must_use]
     pub fn already_dead_lettered(&self, group: &str, source_offset: u64) -> bool {
-        self.highest_source_offset
+        self.dead_lettered
             .get(group)
-            .is_some_and(|&hwm| source_offset <= hwm)
+            .is_some_and(|set| set.contains(&source_offset))
+    }
+
+    /// Drops every dead-lettered source offset BELOW `committed` for `group` (#800): once the source
+    /// group's cursor has committed past an offset, that record can never redeliver or re-poison, so
+    /// its exact-membership entry is no longer needed for idempotency. The engine calls this each time
+    /// it advances a group's cursor past a dead-letter, bounding each per-group set by the in-flight/
+    /// ahead window (`max_in_flight`) instead of letting it grow with every dead-letter ever written.
+    /// Pruning against the IN-MEMORY watermark is safe across a crash: the durable DLQ is the source of
+    /// truth and [`DlqSink::rebuild_dead_lettered_set`] restores the exact set on reopen.
+    pub fn prune_below(&mut self, group: &str, committed: u64) {
+        if let Some(set) = self.dead_lettered.get_mut(group) {
+            // Keep only offsets at or above the committed watermark (offsets `< committed` are durably
+            // committed-past). `split_off` returns the `>= committed` tail; the `< committed` head is
+            // dropped with the old set.
+            *set = set.split_off(&committed);
+            if set.is_empty() {
+                self.dead_lettered.remove(group);
+            }
+        }
     }
 
     /// Appends one poison record to the sink and makes it durable (fsync) BEFORE returning, then
@@ -502,11 +535,10 @@ impl<F: Filesystem, C: Clock> DlqSink<F, C> {
         // ordering is the crash-safety contract. A failed durability barrier freezes the DLQ writer
         // and is surfaced, so the caller does not commit the source past an un-fsynced record.
         self.log.sync()?;
-        let entry = self
-            .highest_source_offset
+        self.dead_lettered
             .entry(group.to_string())
-            .or_insert(source_offset);
-        *entry = (*entry).max(source_offset);
+            .or_default()
+            .insert(source_offset);
         self.records = self.records.saturating_add(1);
         Ok(offset)
     }
@@ -518,11 +550,14 @@ impl<F: Filesystem, C: Clock> DlqSink<F, C> {
         self.records
     }
 
-    /// The highest dead-lettered source offset recorded for `group`, or `None` if the group has
-    /// never had a message dead-lettered. For tests and inspection.
+    /// The highest dead-lettered source offset CURRENTLY tracked for `group` (the max of its
+    /// not-yet-pruned exact set), or `None` if the group has no tracked dead-letters. For tests and
+    /// inspection. Note this reflects the live (pruned) set, not an all-time high-water mark.
     #[must_use]
     pub fn highest_for_group(&self, group: &str) -> Option<u64> {
-        self.highest_source_offset.get(group).copied()
+        self.dead_lettered
+            .get(group)
+            .and_then(|set| set.iter().next_back().copied())
     }
 
     /// Borrows the underlying DLQ log (for inspection and tests).
@@ -735,21 +770,48 @@ mod tests {
     }
 
     #[test]
-    fn the_high_water_mark_is_per_group_and_takes_the_maximum() {
+    fn dedup_is_exact_offset_membership_not_a_high_water_mark() {
+        // #800: idempotency is EXACT-offset membership, not `offset <= max`. A lower source offset
+        // that was never dead-lettered must read `false` even after a HIGHER one is recorded — the
+        // poison-message order is not ascending (a higher offset can cross max-deliver while a lower
+        // one is still leased), so a high-water mark would drop the lower offset from the sink.
         let fs = InMemoryFs::new();
         let mut sink = DlqSink::open(&fs, ManualClock::new(), config()).unwrap();
-        sink.append_poison("a", &source_record(2, b"", b"", b"p"), 6)
-            .unwrap();
+        // Dead-letter the HIGHER offset 5 first (the lower offset 2 is still leased upstream).
         sink.append_poison("a", &source_record(5, b"", b"", b"p"), 6)
             .unwrap();
         sink.append_poison("b", &source_record(3, b"", b"", b"p"), 6)
             .unwrap();
-        assert_eq!(sink.highest_for_group("a"), Some(5));
-        assert_eq!(sink.highest_for_group("b"), Some(3));
-        // Idempotency reads against the per-group maximum.
+        // The exact offset 5 is in the sink; the never-dead-lettered lower offset 2 is NOT (pre-#800
+        // this returned `true` because 2 <= 5, silently suppressing offset 2's later append).
         assert!(sink.already_dead_lettered("a", 5));
-        assert!(sink.already_dead_lettered("a", 2));
+        assert!(
+            !sink.already_dead_lettered("a", 2),
+            "a lower never-dead-lettered offset is not suppressed by a higher recorded one"
+        );
         assert!(!sink.already_dead_lettered("a", 6));
         assert!(!sink.already_dead_lettered("b", 4));
+
+        // Now the lower offset 2 reaches dead-letter: it IS appended and becomes exact-present.
+        sink.append_poison("a", &source_record(2, b"", b"", b"p"), 6)
+            .unwrap();
+        assert!(sink.already_dead_lettered("a", 2));
+        assert_eq!(sink.records(), 3);
+        assert_eq!(sink.highest_for_group("a"), Some(5));
+
+        // Pruning below the source cursor's committed watermark bounds the set: once the cursor has
+        // committed past offsets < 3, only offset 5 remains tracked for "a".
+        sink.prune_below("a", 3);
+        assert!(
+            !sink.already_dead_lettered("a", 2),
+            "2 pruned below the watermark"
+        );
+        assert!(
+            sink.already_dead_lettered("a", 5),
+            "5 is still ahead of the watermark"
+        );
+        // Pruning past everything drops the group entry entirely.
+        sink.prune_below("a", 6);
+        assert_eq!(sink.highest_for_group("a"), None);
     }
 }


### PR DESCRIPTION
## What

Closes #800 (high). 3rd of the 16 high-severity audit findings in milestone #30.

DLQ idempotency was keyed on a per-group **monotonic high-water mark**, not exact membership: `already_dead_lettered(group, off)` returned true for any `off <= hwm`. The premise "source offsets only ever rise for a group" is false — poison messages do **not** cross the max-deliver (or TTL-expiry) threshold in ascending source-offset order. With two poison messages, the higher source offset can dead-letter first (the lower one still leased/in-flight, skipped by the in-order poll scan), setting `hwm` to the higher offset. The cursor is out-of-order tolerant, so the lower offset genuinely redelivers, re-poisons, and reaches the dead-letter path — where `lower <= hwm` read as "already in the sink", so it was committed-past **without a DLQ append**.

The poison ended up in **ZERO durable places**, violating the module's exactly-one-place invariant: silent, unbounded, unreported loss of the very records the DLQ exists to preserve. The TTL-expiry path shares the same map and key, so the suppression also crosses reasons and the DLX target.

## Fix

Replace the per-group high-water mark with an **exact set** of dead-lettered source offsets (`BTreeMap<String, BTreeSet<u64>>`):

- `already_dead_lettered` → exact membership (`set.contains(&off)`).
- `append_encoded` inserts the offset; `rebuild_dead_lettered_set` (was `rebuild_high_water_mark`) reconstructs the **exact** set from the durable DLQ records on open — so the only legitimate duplicate (the SAME offset re-poisoned after a crash that fsynced the DLQ record but not the source cursor) is still deduped, while a genuinely-new lower offset is never suppressed.
- The set is bounded by the source group's in-flight/ahead window via the new `DlqSink::prune_below`, called from `commit_dead_letter_past` to drop offsets below the committed watermark (they can never redeliver/re-poison). Pruning the in-memory set is crash-safe — the durable DLQ is the source of truth, rebuilt on reopen.

## Tests

- `dedup_is_exact_offset_membership_not_a_high_water_mark` (dlq.rs): a lower never-dead-lettered offset reads `false` even after a higher one is recorded; plus the `prune_below` bound.
- `dead_letter_dedup_is_exact_so_a_lower_offset_after_a_higher_one_is_not_dropped` (engine.rs, rewritten from the old `re_poisoning_…` test): with the lower offset held leased/uncommitted, the higher offset dead-letters + re-poisons (exactly one record), then the lower offset dead-letters and **is** written — both source offsets land durably in the DLQ (pre-fix: only the higher one). The internal move is invoked directly to construct the lower-still-leased ordering, which the in-order poll scan cannot otherwise produce.
- The TTL-DLX idempotency twin was updated the same way (hold a lower offset uncommitted so the prune doesn't remove the exact entry between the two moves).

## Verification

- `cargo fmt --check`, `cargo clippy -p ironbus-storage -p ironbus-server --all-targets -- -D warnings -W clippy::pedantic` clean
- `cargo test -p ironbus-storage` (411) green; `cargo test -p ironbus-server` green (incl. the new + updated DLQ tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
