### PR TITLE
fix(engine): cap resident named-stream count to stop an fd/inode/RAM exhaustion crash (Closes #863)

### DIFF
--- a/crates/ironbus-bench/src/inproc.rs
+++ b/crates/ironbus-bench/src/inproc.rs
@@ -84,6 +84,8 @@ fn engine_config_with_credit(consumer_credit: u32, max_in_flight: u32) -> Engine
         dead_letter_exchange: None,
         dead_letter_expired: false,
         max_groups: DEFAULT_MAX_GROUPS,
+        // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
+        max_streams: 0,
         group_idle_evict_ms: DEFAULT_GROUP_IDLE_EVICT_MS,
         disk_full_policy: DiskFullPolicy::DropNew,
         // The RAM-headroom ceiling is off in the bench broker (#118): the bench samples real RSS

--- a/crates/ironbus-cli/src/admin.rs
+++ b/crates/ironbus-cli/src/admin.rs
@@ -682,6 +682,7 @@ mod tests {
                 max_age_ms: 0,
                 max_messages: 0,
                 max_groups: 1024,
+                max_streams: 0,
                 group_idle_evict_ms: 0,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,

--- a/crates/ironbus-cli/src/main.rs
+++ b/crates/ironbus-cli/src/main.rs
@@ -242,6 +242,15 @@ const DEFAULT_MAX_MESSAGES: u64 = 0;
 /// endless groups. `0` = unlimited (the cap is off); the default is non-zero (1024).
 const DEFAULT_MAX_GROUPS: usize = ironbus_server::engine::DEFAULT_MAX_GROUPS;
 
+/// The default cap on the number of resident NAMED streams for `serve` (refs #863), aliased to the
+/// engine's [`ironbus_server::engine::DEFAULT_MAX_STREAMS`] so the CLI default and the engine default
+/// are a single source of truth and cannot drift. Each named stream pins its own log: open file
+/// descriptors, an inode/directory entry, and per-stream buffers, so an unauthenticated client that
+/// can name streams could otherwise exhaust fds/inodes/RAM and abort the broker by naming endless
+/// streams. `0` = unlimited (the cap is off); the default is non-zero (1024). The default stream is
+/// never counted against it.
+const DEFAULT_MAX_STREAMS: usize = ironbus_server::engine::DEFAULT_MAX_STREAMS;
+
 /// The default idle window after which an idle, fully-caught-up, lease-free NAMED work-group is
 /// evicted for `serve` (refs #277, #240), in MILLISECONDS, aliased to the engine's
 /// [`ironbus_server::engine::DEFAULT_GROUP_IDLE_EVICT_MS`] so the CLI and engine default are a single
@@ -638,6 +647,10 @@ struct ProfilePreset {
     max_connections: usize,
     /// `backpressure.max_groups` (`--max-groups`).
     max_groups: usize,
+    /// `backpressure.max_streams` (`--max-streams`): the cap on resident NAMED streams (#863).
+    /// `edge-tiny` LOWERS it (a tiny node should pin few logs); `balanced`/`throughput` mirror their
+    /// group budgets. `0` = unlimited.
+    max_streams: usize,
     /// `backpressure.max_in_flight` (`--max-in-flight`).
     max_in_flight: u32,
     /// `backpressure.disk_full_policy` (`--disk-full-policy`).
@@ -669,6 +682,9 @@ const EDGE_TINY_PRESET: ProfilePreset = ProfilePreset {
     consumer_credit_bytes: 256 * 1024,
     max_connections: 32,
     max_groups: 64,
+    // LOWERED named-stream cap (#863): a tiny edge node should pin only a handful of logs (each a
+    // distinct fd/inode/buffer set), so 64 named streams — matching its group budget — is the bound.
+    max_streams: 64,
     max_in_flight: 256,
     disk_full_policy: DiskFullPolicyArg::DropNew,
     checkpoint_interval: 1024,
@@ -698,6 +714,7 @@ const BALANCED_PRESET: ProfilePreset = ProfilePreset {
     consumer_credit_bytes: DEFAULT_CONSUMER_CREDIT_BYTES,
     max_connections: DEFAULT_MAX_CONNECTIONS,
     max_groups: DEFAULT_MAX_GROUPS,
+    max_streams: DEFAULT_MAX_STREAMS,
     max_in_flight: DEFAULT_MAX_IN_FLIGHT,
     disk_full_policy: DiskFullPolicyArg::DropNew,
     checkpoint_interval: DEFAULT_CHECKPOINT_INTERVAL,
@@ -722,6 +739,7 @@ const THROUGHPUT_PRESET: ProfilePreset = ProfilePreset {
     consumer_credit_bytes: 64 * 1024 * 1024,
     max_connections: 1024,
     max_groups: 4096,
+    max_streams: 4096,
     max_in_flight: 8192,
     disk_full_policy: DiskFullPolicyArg::DropOldest,
     checkpoint_interval: 4096,
@@ -811,7 +829,7 @@ USAGE:
                   [--consumer-credit <n>] [--consumer-credit-bytes <n>]
                   [--max-segment-bytes <n>] [--max-total-bytes <bytes>]
                   [--max-retained-bytes <bytes>] [--max-age-ms <ms>] [--max-messages <n>]
-                  [--max-groups <n>] [--group-idle-evict-ms <ms>]
+                  [--max-groups <n>] [--max-streams <n>] [--group-idle-evict-ms <ms>]
                   [--disk-full-policy <drop-new|drop-oldest>]
                   [--key-shared-group <name>]... [--broadcast-group <name>]...
                   [--visibility-timeout-ms <n>] [--health-addr <host:port>] [--enable-admin]
@@ -936,6 +954,10 @@ Notes:
     --max-groups (default 1024, 0 = unlimited) caps the number of live work-groups, including the
     default group, so once the wire can name groups a client cannot exhaust memory by naming
     endless groups. A new named group past the cap is rejected; the default group is never counted.
+    --max-streams (default 1024, 0 = unlimited) caps the number of resident NAMED streams. Each
+    stream pins its own log: an open file descriptor, an inode/directory entry, and per-stream
+    buffers, so once the wire can name streams a client cannot exhaust fds/inodes/RAM by naming
+    endless streams. A new named stream past the cap is rejected; the default stream is never counted.
     --group-idle-evict-ms (default 0 = disabled) evicts an idle NAMED work-group from memory after
     it has been idle this many milliseconds, reclaiming its slot against --max-groups. Only a
     fully-caught-up (committed at the head, no acked-ahead set), lease-free, non-key-shared named
@@ -2177,6 +2199,8 @@ struct ServeFlags {
     /// like `allow_unlimited_deliver`.
     compact: bool,
     max_groups: Option<usize>,
+    /// The resident NAMED-stream cap (#863); `None` falls back to the profile preset. `0` = unlimited.
+    max_streams: Option<usize>,
     group_idle_evict_ms: Option<u64>,
     /// The refuse-to-boot RAM ceiling in bytes (#115); `None` falls back to the profile preset (`0`
     /// = off for `balanced`/`throughput`, 64 MiB for `edge-tiny`). When set, the broker refuses to
@@ -2462,6 +2486,7 @@ fn collect_serve_flags(args: &[String]) -> Result<ServeFlags, CliError> {
                 f.max_messages = Some(take_number("--max-messages", args, &mut i)?);
             }
             "--max-groups" => f.max_groups = Some(take_number("--max-groups", args, &mut i)?),
+            "--max-streams" => f.max_streams = Some(take_number("--max-streams", args, &mut i)?),
             "--group-idle-evict-ms" => {
                 f.group_idle_evict_ms = Some(take_number("--group-idle-evict-ms", args, &mut i)?);
             }
@@ -2982,6 +3007,7 @@ fn parse_serve_flags_with_env_and_reader(
             // changelog policy), so it resolves from the `--compact` flag / `IRONBUS_COMPACT` env only.
             compact: resolve_bool("--compact", f.compact, env)?,
             max_groups: resolve_number("--max-groups", f.max_groups, env, preset.max_groups)?,
+            max_streams: resolve_number("--max-streams", f.max_streams, env, preset.max_streams)?,
             group_idle_evict_ms: resolve_number(
                 "--group-idle-evict-ms",
                 f.group_idle_evict_ms,
@@ -4683,6 +4709,12 @@ struct ServeConfig {
     /// cannot exhaust memory by naming endless groups. `0` = unlimited (the cap is off); the
     /// default is non-zero (1024). A new named group past the cap is rejected by the engine.
     max_groups: usize,
+    /// The cap on the number of resident NAMED streams (refs #863): each named stream pins its own
+    /// log (an fd, an inode/directory entry, and per-stream buffers), so an unauthenticated client
+    /// that can name streams could otherwise exhaust fds/inodes/RAM and abort the broker. `0` =
+    /// unlimited (the cap is off); the default is non-zero (1024). The default stream is never
+    /// counted. A new named stream past the cap is rejected by the engine.
+    max_streams: usize,
     /// The idle window after which an idle, fully-caught-up, lease-free NAMED work-group is evicted
     /// from memory (refs #277, #240), in MILLISECONDS: the lifecycle reclaim that complements the
     /// `max_groups` cap. `0` = DISABLED (never evict), the default; a non-zero value opts in. The
@@ -4898,6 +4930,7 @@ impl ServeConfig {
             // Key compaction (#337) is OFF by default.
             compact: false,
             max_groups: DEFAULT_MAX_GROUPS,
+            max_streams: DEFAULT_MAX_STREAMS,
             group_idle_evict_ms: DEFAULT_GROUP_IDLE_EVICT_MS,
             ram_ceiling_bytes: DEFAULT_RAM_CEILING_BYTES,
             disk_full_policy: DiskFullPolicyArg::DropNew,
@@ -6142,6 +6175,7 @@ fn materialized_config_line(config: &ServeConfig, addr: &str, data_dir: Option<&
         "materialized-config profile={} profile_schema_version={} addr={addr} \
          data_dir={data_dir} max_connections={} max_segment_bytes={} max_total_bytes={} \
          consumer_credit={} consumer_credit_bytes={} max_in_flight={} max_groups={} \
+         max_streams={} \
          group_idle_evict_ms={} checkpoint_interval={} max_deliver={} \
          allow_unlimited_deliver={} disk_full_policy={policy} visibility_timeout_ms={} \
          max_retained_bytes={} max_age_ms={} max_messages={} health_liveness_window_ms={} \
@@ -6159,6 +6193,7 @@ fn materialized_config_line(config: &ServeConfig, addr: &str, data_dir: Option<&
         config.consumer_credit_bytes,
         config.max_in_flight,
         config.max_groups,
+        config.max_streams,
         config.group_idle_evict_ms,
         config.checkpoint_interval,
         config.max_deliver,
@@ -8762,6 +8797,7 @@ fn cmd_serve(
         // #288/#99 footgun).
         config.compact,
         config.max_groups,
+        config.max_streams,
         config.group_idle_evict_ms,
         // The #115 refuse-to-boot RAM ceiling is read only on the Unix serve path (it wires the
         // engine's ram_ceiling_bytes and drives the boot guard), so the non-Unix stub must consume it
@@ -9005,6 +9041,7 @@ fn open_engine_with<F: Filesystem + Clone>(
             // can name groups. `0` = unlimited (off); the default is non-zero (1024). A new named
             // group past the cap is rejected by the engine before it allocates.
             max_groups: config.max_groups,
+            max_streams: config.max_streams,
             // Idle named-group eviction (refs #277, #240): the lifecycle reclaim that completes the
             // #240 cap. `0` = disabled (off, the default), a non-zero value is the idle window in ms
             // after which a fully-caught-up, lease-free named group is reclaimed. Never deletes a
@@ -12652,6 +12689,7 @@ mod tests {
             // Key compaction (#337) is OFF by default.
             compact: false,
             max_groups: DEFAULT_MAX_GROUPS,
+            max_streams: DEFAULT_MAX_STREAMS,
             group_idle_evict_ms: DEFAULT_GROUP_IDLE_EVICT_MS,
             ram_ceiling_bytes: DEFAULT_RAM_CEILING_BYTES,
             disk_full_policy: DiskFullPolicyArg::DropNew,
@@ -13214,6 +13252,11 @@ mod tests {
         assert!(
             line.contains("data_dir=/var/lib/ironbus"),
             "the data dir: {line}"
+        );
+        // The edge-tiny LOWERED named-stream cap (#863) carried through: 64, not the default 1024.
+        assert!(
+            line.contains("max_streams=64"),
+            "the edge-tiny stream cap: {line}"
         );
         // One single line (no embedded newline), so it is one structured log record.
         assert!(!line.contains('\n'), "a single line: {line}");
@@ -14560,6 +14603,7 @@ mod tests {
                 max_age_ms: 0,
                 max_messages: 0,
                 max_groups: DEFAULT_MAX_GROUPS,
+                max_streams: DEFAULT_MAX_STREAMS,
                 group_idle_evict_ms: 0,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,
@@ -15506,6 +15550,7 @@ mod tests {
                 max_age_ms: 0,
                 max_messages: 0,
                 max_groups: DEFAULT_MAX_GROUPS,
+                max_streams: DEFAULT_MAX_STREAMS,
                 group_idle_evict_ms: 0,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,
@@ -15590,6 +15635,7 @@ mod tests {
                 max_age_ms: 0,
                 max_messages: 0,
                 max_groups: DEFAULT_MAX_GROUPS,
+                max_streams: DEFAULT_MAX_STREAMS,
                 group_idle_evict_ms: 0,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,
@@ -16070,6 +16116,7 @@ mod tests {
             // Key compaction (#337) is OFF by default.
             compact: false,
             max_groups: DEFAULT_MAX_GROUPS,
+            max_streams: DEFAULT_MAX_STREAMS,
             group_idle_evict_ms: DEFAULT_GROUP_IDLE_EVICT_MS,
             ram_ceiling_bytes: DEFAULT_RAM_CEILING_BYTES,
             disk_full_policy: DiskFullPolicyArg::DropNew,
@@ -16167,6 +16214,7 @@ mod tests {
             consumer_credit: 8,
             consumer_credit_bytes: 256 * 1024,
             max_groups: 64,
+            max_streams: 64,
             max_in_flight: 256,
             ram_ceiling_bytes: EDGE_TINY_RAM_CEILING,
             // The edge-tiny preset lowers these (#878); with the shipped 4096 * 100_000 defaults the
@@ -16191,6 +16239,7 @@ mod tests {
             consumer_credit: 8,
             consumer_credit_bytes: 256 * 1024,
             max_groups: 64,
+            max_streams: 64,
             max_in_flight: 256,
             ram_ceiling_bytes: EDGE_TINY_RAM_CEILING,
             ..validation_config()
@@ -16239,6 +16288,7 @@ mod tests {
             consumer_credit: 8,
             consumer_credit_bytes: 256 * 1024,
             max_groups: 64,
+            max_streams: 64,
             max_in_flight: 256,
             ram_ceiling_bytes: EDGE_TINY_RAM_CEILING,
             // The edge-tiny preset LOWERS the dedup caps (#878) so the charged dedup term (~11 MiB)
@@ -17532,6 +17582,79 @@ mod tests {
         assert!(
             USAGE.contains("--max-groups"),
             "USAGE must document --max-groups"
+        );
+    }
+
+    #[test]
+    fn serve_rejects_a_non_numeric_max_streams() {
+        let mut buf = Vec::new();
+        let e = run(
+            &[
+                "serve".to_string(),
+                "--max-streams".to_string(),
+                "many".to_string(),
+            ],
+            &mut buf,
+        )
+        .unwrap_err();
+        assert_eq!(e.exit_code(), EXIT_USAGE);
+        match e {
+            CliError::Usage(m) => assert!(m.contains("--max-streams"), "{m}"),
+            other => panic!("expected Usage, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn serve_accepts_a_zero_max_streams_meaning_unlimited() {
+        // `0` = unlimited (the cap is off), matching the `0` = off convention of the other bounds.
+        // An explicit 0 must parse the same as the default, so the only failure is the unrelated
+        // bind path, never EXIT_USAGE.
+        let mut buf = Vec::new();
+        let e = run(
+            &[
+                "serve".to_string(),
+                "--data-dir".to_string(),
+                "/tmp/ironbus-cli-ms0-never-served".to_string(),
+                "--max-streams".to_string(),
+                "0".to_string(),
+                "--addr".to_string(),
+                "127.0.0.1:1".to_string(),
+            ],
+            &mut buf,
+        )
+        .unwrap_err();
+        assert_ne!(
+            e.exit_code(),
+            EXIT_USAGE,
+            "an explicit --max-streams 0 (unlimited) parses and validates: {e}"
+        );
+        let _ = std::fs::remove_dir_all("/tmp/ironbus-cli-ms0-never-served");
+    }
+
+    #[test]
+    fn max_streams_resolves_flag_over_preset_over_default() {
+        // The resolution precedence (#863, flag > preset > default): the flag wins; absent the flag
+        // the edge-tiny preset's LOWERED 64 flows through; absent any profile the balanced default.
+        let c = parse_serve_flags(&serve_args(&["--max-streams", "7"]))
+            .unwrap()
+            .config;
+        assert_eq!(c.max_streams, 7, "the flag value wins");
+        let c = parse_serve_flags(&serve_args(&["--profile", "edge-tiny"]))
+            .unwrap()
+            .config;
+        assert_eq!(c.max_streams, 64, "edge-tiny lowers the stream cap");
+        let c = parse_serve_flags(&serve_args(&[])).unwrap().config;
+        assert_eq!(
+            c.max_streams, DEFAULT_MAX_STREAMS,
+            "the balanced default (1024)"
+        );
+    }
+
+    #[test]
+    fn usage_lists_the_max_streams_flag() {
+        assert!(
+            USAGE.contains("--max-streams"),
+            "USAGE must document --max-streams"
         );
     }
 
@@ -19088,6 +19211,7 @@ mod tests {
                 max_age_ms: 0,
                 max_messages: 0,
                 max_groups: DEFAULT_MAX_GROUPS,
+                max_streams: DEFAULT_MAX_STREAMS,
                 group_idle_evict_ms: 0,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,
@@ -19171,6 +19295,7 @@ mod tests {
                 max_age_ms: 0,
                 max_messages: 0,
                 max_groups: DEFAULT_MAX_GROUPS,
+                max_streams: DEFAULT_MAX_STREAMS,
                 group_idle_evict_ms: 0,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,

--- a/crates/ironbus-client-async/tests/roundtrip.rs
+++ b/crates/ironbus-client-async/tests/roundtrip.rs
@@ -45,6 +45,8 @@ fn start_server() -> (SocketAddr, Arc<AtomicBool>, JoinHandle<()>) {
             max_age_ms: 0,
             max_messages: 0,
             max_groups: DEFAULT_MAX_GROUPS,
+            // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
+            max_streams: 0,
             group_idle_evict_ms: DEFAULT_GROUP_IDLE_EVICT_MS,
             ram_ceiling_bytes: 0,
             disk_full_policy: DiskFullPolicy::DropNew,

--- a/crates/ironbus-client/src/lib.rs
+++ b/crates/ironbus-client/src/lib.rs
@@ -3479,6 +3479,8 @@ mod tests {
                 max_age_ms: 0,
                 max_messages: 0,
                 max_groups: DEFAULT_MAX_GROUPS,
+                // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
+                max_streams: 0,
                 group_idle_evict_ms: DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,
@@ -3538,6 +3540,8 @@ mod tests {
                 max_age_ms: 0,
                 max_messages: 0,
                 max_groups: DEFAULT_MAX_GROUPS,
+                // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
+                max_streams: 0,
                 group_idle_evict_ms: DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,
@@ -6602,6 +6606,8 @@ mod tests {
                 max_age_ms: 0,
                 max_messages: 0,
                 max_groups: DEFAULT_MAX_GROUPS,
+                // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
+                max_streams: 0,
                 group_idle_evict_ms: DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,
@@ -6920,6 +6926,8 @@ mod tests {
             max_age_ms: 0,
             max_messages: 0,
             max_groups: DEFAULT_MAX_GROUPS,
+            // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
+            max_streams: 0,
             group_idle_evict_ms: DEFAULT_GROUP_IDLE_EVICT_MS,
             ram_ceiling_bytes: 0,
             disk_full_policy: DiskFullPolicy::DropNew,

--- a/crates/ironbus-server/src/actor.rs
+++ b/crates/ironbus-server/src/actor.rs
@@ -1743,6 +1743,8 @@ mod tests {
             max_age_ms: 0,
             max_messages: 0,
             max_groups: DEFAULT_MAX_GROUPS,
+            // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
+            max_streams: 0,
             group_idle_evict_ms: DEFAULT_GROUP_IDLE_EVICT_MS,
             ram_ceiling_bytes: 0,
             disk_full_policy: DiskFullPolicy::DropNew,

--- a/crates/ironbus-server/src/codes.rs
+++ b/crates/ironbus-server/src/codes.rs
@@ -105,6 +105,10 @@ impl ErrorCode {
     /// [`EngineError::TooManyGroups`].
     pub const ERR_TOO_MANY_GROUPS: ErrorCode = ErrorCode("ERR_TOO_MANY_GROUPS");
 
+    /// A new named stream exceeded the per-engine resident-stream cap (#863). Maps
+    /// [`EngineError::TooManyStreams`].
+    pub const ERR_TOO_MANY_STREAMS: ErrorCode = ErrorCode("ERR_TOO_MANY_STREAMS");
+
     /// A work-group name was empty, too long, or non-graphic ASCII (#240). Maps
     /// [`EngineError::InvalidGroupName`].
     pub const ERR_INVALID_GROUP_NAME: ErrorCode = ErrorCode("ERR_INVALID_GROUP_NAME");
@@ -193,6 +197,7 @@ impl ErrorCode {
             EngineError::BroadcastGroupBusy { .. } => Self::ERR_BROADCAST_GROUP_BUSY,
             EngineError::BroadcastGroupNotNamed { .. } => Self::ERR_BROADCAST_GROUP_NOT_NAMED,
             EngineError::TooManyGroups { .. } => Self::ERR_TOO_MANY_GROUPS,
+            EngineError::TooManyStreams { .. } => Self::ERR_TOO_MANY_STREAMS,
             EngineError::InvalidGroupName => Self::ERR_INVALID_GROUP_NAME,
             EngineError::InvalidStreamName { .. } => Self::ERR_INVALID_STREAM_NAME,
             EngineError::MirrorReadOnly { .. } => Self::ERR_MIRROR_READ_ONLY,

--- a/crates/ironbus-server/src/engine.rs
+++ b/crates/ironbus-server/src/engine.rs
@@ -376,6 +376,15 @@ pub struct EngineConfig {
     /// `AckCursor`/`LeaseTable` pairs is a few hundred KiB of state, so the cap is generous for
     /// real use yet still closes the denial-of-service vector.
     pub max_groups: usize,
+    /// The cap on the number of resident NAMED streams (#863): declare-on-first-produce / declare-on-bind
+    /// materializes a permanently-resident `Log` (an fd + `streams/<hex>/` dir + RAM) per distinct stream
+    /// name, with no eviction. Without this cap one client naming N distinct well-formed streams pins N
+    /// fds/inodes/`Log`s until fds (EMFILE), inodes/flash, or RAM are exhausted and the broker aborts
+    /// under `panic=abort`. A NEW named stream past this cap is rejected with
+    /// [`EngineError::TooManyStreams`] BEFORE its `Log` is opened; an already-resident stream and the
+    /// default stream are always allowed (the default does not count). `0` means UNLIMITED, matching the
+    /// other `0` = off bounds; the default is [`DEFAULT_MAX_STREAMS`] (1024), an edge profile lowers it.
+    pub max_streams: usize,
     /// How long a NAMED, NON-default work-group may sit IDLE before it is EVICTED (reclaimed from
     /// memory), in MILLISECONDS (refs #277, #240, #9): the deferred lifecycle half of #240. The cap
     /// (`max_groups`) BOUNDS the number of live groups; this RECLAIMS the idle ones, so a long-lived
@@ -564,6 +573,13 @@ pub enum EngineError {
         /// The cap that was reached.
         max: usize,
     },
+    /// A new NAMED stream could not be materialized: the per-engine resident-stream cap is reached
+    /// (#863). Rejected BEFORE any `Log` is opened, so one client cannot exhaust fds/inodes/RAM by
+    /// naming unbounded distinct streams.
+    TooManyStreams {
+        /// The cap that was reached.
+        max: usize,
+    },
     /// A work-group name was empty, too long, or held a non-graphic-ASCII byte (#240).
     InvalidGroupName,
     /// A cumulative ack (ack-all-up-to-offset) was requested on a competing work-group (#63).
@@ -702,6 +718,9 @@ impl core::fmt::Display for EngineError {
             }
             EngineError::TooManyGroups { max } => {
                 write!(f, "work-group limit {max} reached")
+            }
+            EngineError::TooManyStreams { max } => {
+                write!(f, "named-stream limit {max} reached")
             }
             EngineError::InvalidGroupName => {
                 write!(
@@ -1601,6 +1620,13 @@ pub struct EngineConfigSnapshot {
     pub max_deliver: u32,
     /// The cap on the number of live work-groups, the default included (`0` = unlimited).
     pub max_groups: usize,
+    /// The cap on the number of resident NAMED streams (#863, `0` = unlimited). Declare-on-first-produce
+    /// / declare-on-bind materializes a permanently-resident `Log` (an fd + dir + RAM) per distinct
+    /// stream name; without this cap one client naming N streams exhausts fds/inodes/RAM and aborts the
+    /// broker under `panic=abort`. A NEW named stream past the cap is rejected with
+    /// [`EngineError::TooManyStreams`] BEFORE any `Log` is opened; an already-resident stream and the
+    /// default stream are always allowed. The default stream does not count toward the cap.
+    pub max_streams: usize,
     /// The idle-eviction window for a named group in NANOSECONDS (`0` = disabled).
     pub group_idle_evict_nanos: u64,
     /// The lease visibility timeout in nanoseconds.
@@ -1846,6 +1872,13 @@ pub const DEFAULT_CONSUMER_CREDIT_BYTES: u64 = 8 * 1024 * 1024;
 /// of distinct consumer groups, and 1024 `AckCursor`/`LeaseTable` pairs is a modest, bounded amount
 /// of state. See [`EngineConfig::max_groups`] (where `0` = unlimited).
 pub const DEFAULT_MAX_GROUPS: usize = 1024;
+
+/// The default cap on the number of resident NAMED streams (#863). Like [`DEFAULT_MAX_GROUPS`] this is
+/// a generous-but-FINITE backstop (a server names few streams; the unbounded growth this bounds is the
+/// attack, not the steady state): one client naming unbounded distinct stream names would otherwise pin
+/// an fd + dir + `Log` per name until fds/inodes/RAM are exhausted. `0` = unlimited; an edge profile
+/// lowers it. See [`EngineConfig::max_streams`].
+pub const DEFAULT_MAX_STREAMS: usize = 1024;
 
 /// The default idle window after which a fully-caught-up, lease-free NAMED work-group is evicted
 /// from memory (refs #277, #240), in MILLISECONDS. `0` means DISABLED (never evict), the default:
@@ -2534,6 +2567,10 @@ pub struct Engine<F: Filesystem, C: Clock> {
     /// a new NAMED group past this is rejected with [`EngineError::TooManyGroups`] before it is
     /// allocated. `0` means unlimited. See [`EngineConfig::max_groups`].
     max_groups: usize,
+    /// The cap on the number of resident NAMED streams (#863): a new named stream past this is rejected
+    /// with [`EngineError::TooManyStreams`] before its `Log` is opened, bounding the fds/inodes/RAM one
+    /// client can pin. `0` means unlimited. See [`EngineConfig::max_streams`].
+    max_streams: usize,
     /// The idle window in NANOSECONDS after which a fully-caught-up, lease-free NAMED group is
     /// evicted from memory (#277): the configured `group_idle_evict_ms` converted to nanoseconds at
     /// open (the clock seam is in nanoseconds). `0` means DISABLED (never evict). The sweep
@@ -2997,6 +3034,7 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
             },
             disk_full_policy: config.disk_full_policy,
             max_groups: config.max_groups,
+            max_streams: config.max_streams,
             // The idle-eviction window (#277), converted from milliseconds to the clock seam's
             // nanoseconds and saturated rather than overflowed. `0` (disabled) stays 0, so the
             // sweep is a no-op unless an operator opts in.
@@ -3984,6 +4022,8 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
             });
         }
         let id = StreamId::named(stream)?;
+        // #863: cap the resident-stream COUNT before opening a new stream's log (fd/inode/RAM bound).
+        self.check_stream_cap(&id)?;
         // Declare-on-first-produce: open the named stream's independent log under `streams/<hex>/`
         // (idempotent — a no-op if already open) and mirror it in the per-stream consumer state.
         self.streams.declare(&id).map_err(EngineError::Storage)?;
@@ -4684,6 +4724,8 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
             return Ok(false);
         }
         let id = StreamId::named(stream)?;
+        // #863: cap the resident-stream COUNT before opening a new stream's log (fd/inode/RAM bound).
+        self.check_stream_cap(&id)?;
         let created = self.streams.declare(&id).map_err(EngineError::Storage)?;
         // Mirror the per-stream consumer state so a subsequent consume resolves the same way a
         // produce-declared stream does (idempotent: an existing entry is left untouched).
@@ -4929,6 +4971,33 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         self.streams.len().saturating_sub(1)
     }
 
+    /// Refuses materializing a NEW named stream once the resident-stream count has reached `max_streams`
+    /// (#863). Called on EVERY declare-on-first-produce / declare-on-bind / explicit declare path BEFORE
+    /// [`StreamSet::declare`] opens the stream's `Log`, so a flood of distinct stream names cannot pin
+    /// unbounded fds/inodes/RAM and abort the broker. An ALREADY-resident stream is always allowed (no
+    /// new resource); `max_streams == 0` disables the cap. The caller passes the NAMED stream id (the
+    /// default stream is materialized at open and never routed through here).
+    ///
+    /// Residency is tested against `self.streams` (the authoritative open-stream map that
+    /// [`named_stream_count`](Self::named_stream_count) also counts), NOT the lazily-populated
+    /// `self.named_streams` consumer-state cache: a stream RECOVERED at open lives in `self.streams`
+    /// but is absent from `named_streams` until first touched. Reading `named_streams` here would count
+    /// a recovered stream against the cap yet treat a produce TO it as "new", so an operator who
+    /// restarted with `max_streams`-or-more on-disk streams could never produce to them again (the
+    /// produce is rejected BEFORE the `or_insert` that would register it — a permanent wedge). Reading
+    /// the same map the count comes from keeps the exemption and the count consistent.
+    fn check_stream_cap(&self, id: &StreamId) -> Result<(), EngineError> {
+        if self.max_streams != 0
+            && self.streams.get(id).is_none()
+            && self.named_stream_count() >= self.max_streams
+        {
+            return Err(EngineError::TooManyStreams {
+                max: self.max_streams,
+            });
+        }
+        Ok(())
+    }
+
     // ===================================================================================
     // SUBJECT->STREAM BINDING + FAIL-CLOSED SINGLE-HOME RESOLUTION (#585, V2-M2-I9).
     //
@@ -4966,6 +5035,8 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
             StreamId::default_stream()
         } else {
             let id = StreamId::named(stream)?;
+            // #863: cap the resident-stream COUNT before opening a new stream's log (fd/inode/RAM bound).
+            self.check_stream_cap(&id)?;
             // Declare-on-bind: the stream must have a log to receive a subject-addressed publish later,
             // exactly as declare-on-first-produce gives the id-routed path one (idempotent).
             self.streams.declare(&id).map_err(EngineError::Storage)?;
@@ -8257,6 +8328,7 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
             consumer_credit_bytes: self.consumer_credit_bytes,
             max_deliver: self.delivery.max_deliver(),
             max_groups: self.max_groups,
+            max_streams: self.max_streams,
             group_idle_evict_nanos: self.group_idle_evict_nanos,
             visibility_nanos: self.lease_config.visibility_nanos,
             hard_cap_nanos: self.lease_config.hard_cap_nanos,
@@ -8299,6 +8371,7 @@ mod tests {
             max_messages: 0,
             disk_full_policy: DiskFullPolicy::DropNew,
             max_groups: DEFAULT_MAX_GROUPS,
+            max_streams: DEFAULT_MAX_STREAMS,
             // Eviction OFF by default in the shared test config (#277); the eviction tests build a
             // config with a non-zero window explicitly so the golden-path tests stay unaffected.
             group_idle_evict_ms: DEFAULT_GROUP_IDLE_EVICT_MS,
@@ -16156,6 +16229,169 @@ mod tests {
             e.poll_in_stream("orders", "g", 0).unwrap(),
             Poll::Idle
         ));
+    }
+
+    // A config with an explicit named-stream cap (#863), so a test exercises the bound without
+    // having to allocate `DEFAULT_MAX_STREAMS` streams.
+    fn config_with_max_streams(max_streams: usize) -> EngineConfig {
+        EngineConfig {
+            max_streams,
+            ..config(10, 5)
+        }
+    }
+
+    #[test]
+    fn a_new_named_stream_past_the_cap_is_rejected_across_every_declare_path() {
+        // The named-stream cap bounds fds/inodes/RAM once a client can name streams (#863). The
+        // default stream is exempt and never counted, so with `max_streams == 2` two NAMED streams
+        // fit; a third is rejected with the typed error and materializes NOTHING — on EVERY path that
+        // opens a stream: declare-on-first-produce, explicit declare, and declare-on-bind.
+        let mut e = open(config_with_max_streams(2));
+        // Fill the cap two different ways: one via first-produce, one via explicit declare.
+        produce_to(&mut e, "s0", b"a");
+        assert!(e.declare_stream("s1").unwrap(), "s1 is newly declared");
+        assert_eq!(e.named_stream_count(), 2, "two named streams fill the cap");
+
+        // Path 1 — produce to a THIRD distinct name is rejected at the cap (produce_to unwraps, so
+        // call the fallible entry point directly).
+        let err = e
+            .produce_in_stream(
+                "s2",
+                &Append {
+                    timestamp_ms: 0,
+                    flags: RecordFlags::EMPTY,
+                    key: b"",
+                    headers: b"",
+                    payload: b"x",
+                },
+            )
+            .unwrap_err();
+        assert!(
+            matches!(err, EngineError::TooManyStreams { max: 2 }),
+            "produce past the cap is rejected, got {err}"
+        );
+        // Path 2 — explicit declare of a third name is rejected.
+        assert!(matches!(
+            e.declare_stream("s3").unwrap_err(),
+            EngineError::TooManyStreams { max: 2 }
+        ));
+        // Path 3 — declare-on-bind of a third name is rejected (and installs no binding).
+        assert!(matches!(
+            e.bind_subject("s4", "sub.>").unwrap_err(),
+            EngineError::TooManyStreams { max: 2 }
+        ));
+
+        // None of the three rejected names materialized: the count did not grow and none exist.
+        assert_eq!(
+            e.named_stream_count(),
+            2,
+            "no rejected stream was allocated"
+        );
+        assert!(
+            !e.stream_exists("s2") && !e.stream_exists("s3") && !e.stream_exists("s4"),
+            "a rejected name must not be opened"
+        );
+
+        // An ALREADY-resident stream is always produceable at the cap (no new resource).
+        assert_eq!(
+            produce_to(&mut e, "s0", b"b"),
+            Offset::new(1),
+            "an existing stream is exempt from the cap"
+        );
+        // The default stream is exempt and works at the cap.
+        assert_eq!(produce_to(&mut e, "", b"d"), Offset::new(0));
+    }
+
+    #[test]
+    fn a_zero_stream_cap_means_unlimited_named_streams() {
+        // `0` = unlimited, matching the `0` = off convention of the other bounds: the `!= 0` guard
+        // short-circuits. Far more than the cap-of-2 sibling test may be created without rejection.
+        let mut e = open(config_with_max_streams(0));
+        for i in 0..16 {
+            produce_to(&mut e, &format!("s{i}"), b"a");
+        }
+        assert_eq!(e.named_stream_count(), 16, "no cap with `0`");
+    }
+
+    #[test]
+    fn lowering_the_stream_cap_still_lets_recovered_streams_be_produced() {
+        // Recovery loads EVERY durable named stream into `self.streams`; the cap gates only NEW stream
+        // creation, never a produce to a stream already on disk. An operator who LOWERS --max-streams
+        // below the on-disk stream count must still produce to the recovered streams: the cap COUNTS
+        // them, so testing residency against the lazily-filled `named_streams` consumer cache (empty
+        // right after recovery) would treat a produce to an existing stream as "new" and wedge it
+        // permanently. This pins that the residency exemption reads the same map as the count.
+        let mut e = open(config_with_max_streams(100));
+        for i in 0..3 {
+            produce_to(&mut e, &format!("s{i}"), b"a");
+        }
+        assert_eq!(e.named_stream_count(), 3);
+        let fs = e.into_filesystem();
+
+        // Reopen under a cap of 2 (BELOW the three recovered streams).
+        let mut e = Engine::open(fs, ManualClock::new(), config_with_max_streams(2)).unwrap();
+        assert_eq!(
+            e.named_stream_count(),
+            3,
+            "all three streams recovered despite the cap of 2"
+        );
+        // Each EXISTING recovered stream is still produceable (not a new resource), even over the cap.
+        for i in 0..3 {
+            assert_eq!(
+                produce_to(&mut e, &format!("s{i}"), b"b"),
+                Offset::new(1),
+                "recovered stream s{i} must stay produceable under a lowered cap"
+            );
+        }
+        // A genuinely NEW stream is still rejected at the lowered cap.
+        assert!(matches!(
+            e.declare_stream("brand-new").unwrap_err(),
+            EngineError::TooManyStreams { max: 2 }
+        ));
+    }
+
+    #[test]
+    fn the_stream_cap_rejects_before_the_filesystem_open_that_would_exhaust_fds() {
+        use ironbus_storage::fault::FaultFs;
+        // The #863 point: the cap must fire BEFORE `StreamSet::declare` opens a `Log` — that open is
+        // exactly the fd/inode-pinning step a flood of stream names abuses to crash the broker. We
+        // prove it by priming a filesystem fault that makes a NEW stream's `Log::open` fail (the
+        // EMFILE / fd-exhaustion analogue) and showing the cap short-circuits before it is reached.
+
+        // PART A — WITH the cap, the (cap+1)th declare returns the typed `TooManyStreams` and NEVER
+        // attempts the fault-primed open, so the broker stays up.
+        let (faultfs, control) = FaultFs::new(InMemoryFs::new());
+        let mut e = Engine::open(faultfs, ManualClock::new(), config_with_max_streams(1)).unwrap();
+        assert!(
+            e.declare_stream("s0").unwrap(),
+            "the first stream opens cleanly under the cap"
+        );
+        // Arm the faults that a fresh stream's `Log::open` would trip (the new segment write and the
+        // directory-publish fsync), modelling the resource exhaustion that an unbounded open hits.
+        control.set_fail_write(true);
+        control.set_fail_sync_dir(true);
+        let err = e.declare_stream("s1").unwrap_err();
+        assert!(
+            matches!(err, EngineError::TooManyStreams { max: 1 }),
+            "the cap must reject the (cap+1)th stream BEFORE any Log::open, got {err:?}"
+        );
+
+        // PART B — discrimination: WITHOUT the cap (`0` = unlimited), the SAME primed fault DOES fire
+        // on the next stream's `Log::open`, surfacing a `Storage` error. This proves the fault is real
+        // and that the cap in Part A is precisely what kept the fd-exhausting open from being tried.
+        let (faultfs, control) = FaultFs::new(InMemoryFs::new());
+        let mut e = Engine::open(faultfs, ManualClock::new(), config_with_max_streams(0)).unwrap();
+        assert!(
+            e.declare_stream("s0").unwrap(),
+            "the first stream opens cleanly with the cap off"
+        );
+        control.set_fail_write(true);
+        control.set_fail_sync_dir(true);
+        let err = e.declare_stream("s1").unwrap_err();
+        assert!(
+            matches!(err, EngineError::Storage(_)),
+            "with the cap off the next Log::open is attempted and the primed fault fires, got {err:?}"
+        );
     }
 
     #[test]

--- a/crates/ironbus-server/src/health.rs
+++ b/crates/ironbus-server/src/health.rs
@@ -2343,6 +2343,8 @@ mod tests {
             max_age_ms: 0,
             max_messages: 0,
             max_groups: crate::engine::DEFAULT_MAX_GROUPS,
+            // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
+            max_streams: 0,
             group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
             ram_ceiling_bytes: 0,
             disk_full_policy: DiskFullPolicy::DropNew,
@@ -2559,6 +2561,8 @@ mod tests {
                 max_age_ms: 0,
                 max_messages: 0,
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
+                // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
+                max_streams: 0,
                 group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,
@@ -3092,6 +3096,8 @@ mod tests {
                 max_age_ms: 0,
                 max_messages: 0,
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
+                // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
+                max_streams: 0,
                 group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,
@@ -3236,6 +3242,8 @@ mod tests {
                 max_age_ms: 0,
                 max_messages: 0,
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
+                // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
+                max_streams: 0,
                 group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes,
                 disk_full_policy: DiskFullPolicy::DropNew,
@@ -3313,6 +3321,8 @@ mod tests {
                 max_age_ms: 0,
                 max_messages: 0,
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
+                // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
+                max_streams: 0,
                 group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,
@@ -3587,6 +3597,8 @@ mod tests {
                     max_age_ms: 0,
                     max_messages: 0,
                     max_groups: crate::engine::DEFAULT_MAX_GROUPS,
+                    // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
+                    max_streams: 0,
                     group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                     ram_ceiling_bytes: 0,
                     disk_full_policy: DiskFullPolicy::DropNew,
@@ -3642,6 +3654,8 @@ mod tests {
                 max_age_ms: 0,
                 max_messages: 0,
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
+                // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
+                max_streams: 0,
                 group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,
@@ -3800,6 +3814,8 @@ mod tests {
                 max_age_ms: 0,
                 max_messages: 0,
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
+                // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
+                max_streams: 0,
                 group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,
@@ -3938,6 +3954,8 @@ mod tests {
                 max_age_ms: 0,
                 max_messages,
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
+                // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
+                max_streams: 0,
                 group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,
@@ -4153,6 +4171,8 @@ mod tests {
                 max_age_ms: 0,
                 max_messages: 0,
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
+                // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
+                max_streams: 0,
                 group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropOldest,
@@ -5187,6 +5207,8 @@ mod tests {
                 max_age_ms: 99,
                 max_messages: 33,
                 max_groups: 100,
+                // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
+                max_streams: 0,
                 group_idle_evict_ms: 0,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropOldest,
@@ -5397,6 +5419,8 @@ mod tests {
                 max_age_ms: 0,
                 max_messages: 0,
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
+                // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
+                max_streams: 0,
                 group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,
@@ -5613,6 +5637,8 @@ mod tests {
                 max_age_ms: 0,
                 max_messages: 0,
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
+                // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
+                max_streams: 0,
                 group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,
@@ -5925,6 +5951,8 @@ mod tests {
                 max_age_ms: 99,
                 max_messages: 33,
                 max_groups: 100,
+                // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
+                max_streams: 0,
                 group_idle_evict_ms: 0,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropOldest,
@@ -6219,6 +6247,8 @@ mod tests {
                 consumer_credit_bytes: 4096,
                 max_deliver: 7,
                 max_groups: 100,
+                // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
+                max_streams: 0,
                 group_idle_evict_nanos: 0,
                 visibility_nanos: 1234,
                 hard_cap_nanos: 5678,

--- a/crates/ironbus-server/src/server.rs
+++ b/crates/ironbus-server/src/server.rs
@@ -591,6 +591,8 @@ mod tests {
             max_age_ms: 0,
             max_messages: 0,
             max_groups: crate::engine::DEFAULT_MAX_GROUPS,
+            // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
+            max_streams: 0,
             group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
             ram_ceiling_bytes: 0,
             disk_full_policy: DiskFullPolicy::DropNew,

--- a/crates/ironbus-server/src/session.rs
+++ b/crates/ironbus-server/src/session.rs
@@ -4434,6 +4434,8 @@ mod tests {
             max_age_ms: 0,
             max_messages: 0,
             max_groups: crate::engine::DEFAULT_MAX_GROUPS,
+            // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
+            max_streams: 0,
             group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
             ram_ceiling_bytes: 0,
             disk_full_policy: DiskFullPolicy::DropNew,
@@ -4535,6 +4537,8 @@ mod tests {
                 max_age_ms: 0,
                 max_messages: 0,
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
+                // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
+                max_streams: 0,
                 group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,
@@ -4592,6 +4596,8 @@ mod tests {
                 max_age_ms: 0,
                 max_messages: 0,
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
+                // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
+                max_streams: 0,
                 group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropOldest,
@@ -4906,6 +4912,8 @@ mod tests {
                 max_age_ms: 0,
                 max_messages: 0,
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
+                // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
+                max_streams: 0,
                 group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,
@@ -6840,6 +6848,8 @@ mod tests {
                 max_age_ms: 0,
                 max_messages: 0,
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
+                // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
+                max_streams: 0,
                 group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,
@@ -7723,6 +7733,8 @@ mod tests {
                     max_age_ms: 0,
                     max_messages: 0,
                     max_groups: crate::engine::DEFAULT_MAX_GROUPS,
+                    // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
+                    max_streams: 0,
                     group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                     ram_ceiling_bytes: 0,
                     disk_full_policy: DiskFullPolicy::DropNew,
@@ -8109,6 +8121,8 @@ mod tests {
                 max_age_ms: 0,
                 max_messages: 0,
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
+                // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
+                max_streams: 0,
                 group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,
@@ -8165,6 +8179,8 @@ mod tests {
                 max_age_ms: 0,
                 max_messages: 0,
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
+                // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
+                max_streams: 0,
                 group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,
@@ -8374,6 +8390,8 @@ mod tests {
                 max_age_ms: 0,
                 max_messages: 0,
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
+                // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
+                max_streams: 0,
                 group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,
@@ -9266,6 +9284,8 @@ mod tests {
                 max_age_ms: 0,
                 max_messages: 0,
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
+                // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
+                max_streams: 0,
                 group_idle_evict_ms: 10, // eviction ON; the explicit-Unsub path ignores the window
                 disk_full_policy: DiskFullPolicy::DropNew,
                 ram_ceiling_bytes: 0,

--- a/crates/ironbus-server/tests/conformance_vectors.rs
+++ b/crates/ironbus-server/tests/conformance_vectors.rs
@@ -654,6 +654,9 @@ fn build_config(setup: &Setup) -> EngineConfig {
         max_messages: 0,
         disk_full_policy: policy,
         max_groups: 1024,
+        // Named-stream cap OFF (#863, `0` = unlimited): the conformance vectors assume the
+        // historical unbounded behavior, so the golden bytes are unchanged by the cap.
+        max_streams: 0,
         group_idle_evict_ms: 0,
         ram_ceiling_bytes: 0,
         dedup: DedupConfig {

--- a/crates/ironbus-server/tests/determinism.rs
+++ b/crates/ironbus-server/tests/determinism.rs
@@ -35,6 +35,8 @@ fn config() -> EngineConfig {
         max_messages: 0,
         // The default work-group cap (#240): the determinism image is unchanged by this field.
         max_groups: DEFAULT_MAX_GROUPS,
+        // Named-stream cap OFF (#863, `0` = unlimited): the determinism image is unchanged by the cap.
+        max_streams: 0,
         // Idle named-group eviction OFF (#277), the default: the determinism image is unchanged.
         group_idle_evict_ms: DEFAULT_GROUP_IDLE_EVICT_MS,
         ram_ceiling_bytes: 0,


### PR DESCRIPTION
## What

Closes #863. Adds a configurable `max_streams` ceiling on the number of resident **named streams**, mirroring the existing `max_groups` cap (`0` = unlimited). Without it, any client naming N distinct well-formed streams opens N resident `Log`s (each pinning an active-segment fd), creates N `streams/<hex>/` dirs (inodes / flash wear), and grows both engine maps unbounded — fd exhaustion (EMFILE), inode exhaustion, or RAM exhaustion then aborts the whole broker under `panic=abort`. One unauthenticated client can crash the process.

## How

- **Engine:** a single `check_stream_cap` helper runs BEFORE `StreamSet::declare` opens the `Log`, on **all three** declare paths — `produce_in_stream`, `declare_stream`, `bind_subject`. A new named stream past the cap is rejected with a typed `EngineError::TooManyStreams { max }` (wired through `codes.rs` as `ERR_TOO_MANY_STREAMS`) and materializes nothing. The default stream and any already-resident stream are exempt.
- **Recovery-safety:** residency is tested against `self.streams` (the authoritative open-stream map the count also reads), **not** the lazily-populated `named_streams` consumer cache. A stream recovered at open lives in `self.streams` but is absent from `named_streams` until first touched; reading `named_streams` would count a recovered stream against the cap yet treat a produce *to* it as "new", permanently wedging an operator who restarted with `max_streams`-or-more on-disk streams (the produce is rejected before the `or_insert` that would register it). Reading one map keeps the exemption and the count consistent.
- **CLI:** `--max-streams` (env `IRONBUS_MAX_STREAMS`), flag > preset > default resolution, threaded `ServeConfig` → `EngineConfig` (consumed by the non-Unix serve stub too, so the Windows `-D warnings` build stays clean), surfaced on the materialized-config startup line and in `USAGE`. Presets: edge-tiny **lowers** it to 64, balanced = `DEFAULT_MAX_STREAMS` (1024), throughput = 4096.

## Tests

- The cap fires at the limit across all three declare paths and allocates nothing past it.
- `0` = unlimited.
- Recovered streams stay produceable under a *lowered* cap while a genuinely new stream is rejected (pins the recovery-safety fix).
- A `FaultFs` **EMFILE pairing**: with the cap, the `(cap+1)`th declare returns `TooManyStreams` and never attempts the fault-primed `Log::open`; with the cap off the same primed fault fires (`Storage` error) — proving the cap short-circuits *before* the fd-exhausting open, with discrimination.
- 4 CLI tests (reject non-numeric, `0` = unlimited, flag>preset>default resolution, USAGE) + a materialized-config assertion for edge-tiny's lowered cap.
- The determinism and conformance-vector golden suites set `max_streams: 0`, so their bytes are unchanged.

Full `ironbus-server` (916 lib + integration) and `ironbus-cli` suites pass; `clippy -D warnings -W clippy::pedantic` clean.

## Follow-up (not in scope)

The refuse-to-boot RAM guard (`rss::RamFootprintConfig`) does not yet charge per-stream buffer RAM — this PR only bounds the **count**, which strictly reduces the prior unbounded worst case. Modeling per-stream buffers in the boot guard is a separate hardening; filing as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
