### PR TITLE
fix(cluster): cap the per-partition parked-ack backlog to stop an ISR-down OOM (Closes #864)

### DIFF
--- a/crates/ironbus-server/src/cluster/ack_level.rs
+++ b/crates/ironbus-server/src/cluster/ack_level.rs
@@ -599,7 +599,7 @@ mod gate_wiring_tests {
         // still holds; the CLUSTER gate withholds the wire PubAck until a quorum has FSYNC'd).
         isr.observe_leader_fsync(5);
         for off in 0..5u64 {
-            gate.park(off, off);
+            let _ = gate.park(off, off);
         }
 
         // Only the leader has fsync'd ⇒ quorum-commit (2nd-largest fsync'd frontier of [5,0,0]) = 0 ⇒
@@ -665,7 +665,7 @@ mod gate_wiring_tests {
         fsync_isr.observe_leader_fsync(3);
         pagecache_isr.observe_leader_fsync(3);
         for off in 0..3u64 {
-            gate.park(off, off);
+            let _ = gate.park(off, off);
         }
         // A follower has the records in PAGE CACHE (received frontier 3) but has NOT fsync'd them
         // (fsync'd frontier 0). The fsync gate sees no quorum-fsync; the page-cache gate sees a quorum
@@ -725,7 +725,7 @@ mod gate_wiring_tests {
         );
         let mut gate: QuorumAckGate<u64> = QuorumAckGate::new();
         for off in 0..4u64 {
-            gate.park(off, off);
+            let _ = gate.park(off, off);
         }
         // Before the local fsync nothing is durable ⇒ quorum-commit 0 ⇒ no release.
         assert_eq!(isr.quorum_commit(), Some(0));

--- a/crates/ironbus-server/src/cluster/dataplane.rs
+++ b/crates/ironbus-server/src/cluster/dataplane.rs
@@ -248,6 +248,18 @@ pub enum DataPlaneFrame {
     CommittedHwResponse(CommittedHwResponseBody),
 }
 
+/// The per-partition cap on parked (quorum-withheld) `C2-fsync` produce acks (#864). A `C2-fsync`
+/// produce to a led partition whose ISR is below `min_isr` (a follower down) cannot be quorum-committed,
+/// so its `PubAck` is withheld; below `min_isr` NOTHING drains. Without a cap a pipelining producer that
+/// does not wait for acks grows the gate's `pending` list AND the seam's `parked` reply-bytes map without
+/// bound — driving a bounded-RAM node to OOM (and, under `panic = "abort"`, an allocation failure aborts
+/// the whole broker). At the cap the produce is FAILED with an explicit not-enough-replicas error (the
+/// honest unavailable-over-unsafe signal the producer can back off on) rather than buffered unboundedly.
+/// `8192` per partition bounds the worst-case parked footprint to a few hundred KiB per led partition
+/// while tolerating a transient follower blip (the backlog drains the moment the quorum advances). A
+/// configurable cap is a tracked follow-up.
+const MAX_PARKED_ACKS_PER_PARTITION: usize = 8192;
+
 /// The `kind` discriminant byte leading a [`FrameType::CommittedHwQuery`] body (#739), so the request
 /// and the response (which SHARE the wire tag 43, like `OffsetForLeaderEpoch`) are never confused.
 const HW_KIND_REQUEST: u8 = 0;
@@ -549,7 +561,12 @@ impl<F: Filesystem, C: Clock> DataPlaneController<F, C> {
                 plane,
                 epochs,
                 isr,
-                gate: QuorumAckGate::new(),
+                // The per-partition parked-ack backlog cap (#864): under an unsatisfiable ISR (a follower
+                // down, below `min_isr`) nothing drains, so without a cap a pipelining producer grows the
+                // gate's `pending` + the seam's `parked` map without bound — OOM/abort on a bounded-RAM
+                // node. At the cap the gate refuses and the produce is failed with an explicit
+                // not-enough-replicas error rather than buffered unboundedly.
+                gate: QuorumAckGate::with_cap(MAX_PARKED_ACKS_PER_PARTITION),
             },
         );
     }
@@ -712,6 +729,11 @@ impl<F: Filesystem, C: Clock> DataPlaneController<F, C> {
     /// real serve). Leader-only. The leader has ALREADY locally fsync'd (the I2 ack-after-its-own-fsync
     /// holds); this gate adds the cluster condition.
     ///
+    /// Returns `Ok(true)` if the ack was parked, or `Ok(false)` if the partition's gate is at its
+    /// backlog cap (#864) — an unsatisfiable ISR is withholding the cap's worth of acks and nothing is
+    /// draining. On `Ok(false)` the caller MUST NOT treat the produce as parked: it fails the produce
+    /// with an explicit not-enough-replicas error rather than buffering the reply unboundedly.
+    ///
     /// # Errors
     /// As [`serve_fetch`](Self::serve_fetch) (a produce only lands on a leader partition).
     pub fn park_produce_ack(
@@ -719,12 +741,9 @@ impl<F: Filesystem, C: Clock> DataPlaneController<F, C> {
         partition: u64,
         offset: u64,
         token: AckToken,
-    ) -> Result<(), DataPlaneError> {
+    ) -> Result<bool, DataPlaneError> {
         match self.roles.get_mut(&partition) {
-            Some(PartitionRole::Leader { gate, .. }) => {
-                gate.park(offset, token);
-                Ok(())
-            }
+            Some(PartitionRole::Leader { gate, .. }) => Ok(gate.park(offset, token)),
             Some(PartitionRole::Follower { .. }) => Err(DataPlaneError::WrongRole {
                 partition,
                 needed: "leader",
@@ -1311,6 +1330,13 @@ pub enum AckDisposition {
     /// nothing goes on the wire until [`ProduceAckSeam::on_follower_report`] releases it on quorum
     /// fsync. Below `min_isr` it stays parked — no false ack on the wire (#593).
     Parked,
+    /// The produce was REFUSED because the partition's parked-ack backlog is at its cap (#864): an
+    /// unsatisfiable ISR (below `min_isr`) is already withholding [`MAX_PARKED_ACKS_PER_PARTITION`] acks
+    /// and nothing is draining, so parking another would grow memory unboundedly toward OOM. The caller
+    /// writes an explicit not-enough-replicas error to the producer (the honest unavailable-over-unsafe
+    /// signal it can back off on) — NOT a `PubAck` (the record is durable on the leader but is not
+    /// quorum-fsync'd, so it must not be acked) and NOT a silent withhold.
+    Rejected,
 }
 
 /// The produce-ack SEAM: the one hot-path hookup that threads a REAL produce's wire `PubAck` through
@@ -1457,13 +1483,19 @@ impl<F: Filesystem, C: Clock> ProduceAckSeam<F, C> {
         if !ack_level.ack_implies_quorum_fsync() || !self.controller.is_leader(partition) {
             return Ok(AckDisposition::WriteNow(reply_bytes));
         }
-        // Park the REAL wire bytes keyed by a fresh token (tagged with the owner), then thread that token
-        // through the controller's gate at the appended offset. The leader has ALREADY locally fsync'd
-        // (the I2 ack-after-its-own-fsync); the gate adds the quorum-fsync condition.
+        // Thread a fresh token through the controller's gate at the appended offset FIRST (it is
+        // cap-checked), THEN — only on a successful park — store the REAL wire bytes keyed by that token.
+        // The leader has ALREADY locally fsync'd (the I2 ack-after-its-own-fsync); the gate adds the
+        // quorum-fsync condition. On a FULL backlog (#864) the gate refuses (`Ok(false)`): REJECT this
+        // produce so the caller writes an explicit not-enough-replicas error, and store NOTHING — never
+        // buffer the reply bytes unboundedly while the ISR is below `min_isr`. The `?` still propagates
+        // the (unreachable for a led partition) `WrongRole` / `UnknownPartition` errors unchanged.
         let token = self.next_token;
+        if !self.controller.park_produce_ack(partition, offset, token)? {
+            return Ok(AckDisposition::Rejected);
+        }
         self.next_token = self.next_token.wrapping_add(1);
         self.parked.insert(token, (owner, reply_bytes));
-        self.controller.park_produce_ack(partition, offset, token)?;
         // Re-check the CURRENT quorum-commit: a follower may already have reported past this offset
         // (its report arrived before this produce's local fsync completed), in which case the ack is
         // immediately quorum-committed and we hand the real bytes straight back to write now. Below
@@ -2310,6 +2342,53 @@ mod tests {
             })
             .collect();
         (ProduceAckSeam::new(leader), followers, served_end)
+    }
+
+    #[test]
+    fn a_clustered_c2_fsync_produce_is_rejected_when_the_parked_backlog_hits_the_cap() {
+        // #864: under an unsatisfiable ISR (a follower down, below `min_isr`) NOTHING drains, so a
+        // pipelining producer's parked acks accumulate. The gate caps the per-partition backlog at
+        // `MAX_PARKED_ACKS_PER_PARTITION`; past it the produce is REJECTED (an explicit
+        // not-enough-replicas signal) instead of buffered unboundedly toward OOM. Lead P over {1,2,3}
+        // (min_isr=2) with NO follower reports — the ISR is {leader} < min_isr, so every park stays
+        // withheld and the backlog only grows.
+        const P: u64 = 0;
+        let (mut seam, _followers, _served_end) = led_cluster(P, 1, &[1, 2, 3], quorum3(), 4);
+        assert!(seam.controller().is_leader(P));
+
+        // Park exactly the cap's worth of C2-fsync produces: each is withheld (no quorum to release it).
+        for off in 0..MAX_PARKED_ACKS_PER_PARTITION as u64 {
+            let disposition = seam
+                .on_local_fsynced_ack(ClusterAckLevel::C2Fsync, P, off, wire_pub_ack(off))
+                .unwrap();
+            assert_eq!(
+                disposition,
+                AckDisposition::Parked,
+                "below the cap a clustered C2-fsync produce parks"
+            );
+        }
+        assert_eq!(
+            seam.parked_len(),
+            MAX_PARKED_ACKS_PER_PARTITION,
+            "the backlog filled to exactly the cap"
+        );
+
+        // The NEXT produce overflows the cap: REJECTED, not parked, and it buffers NOTHING — so a
+        // sustained unsatisfiable-ISR flood is bounded at the cap, never unbounded toward OOM.
+        let over = MAX_PARKED_ACKS_PER_PARTITION as u64;
+        let disposition = seam
+            .on_local_fsynced_ack(ClusterAckLevel::C2Fsync, P, over, wire_pub_ack(over))
+            .unwrap();
+        assert_eq!(
+            disposition,
+            AckDisposition::Rejected,
+            "past the cap the produce is rejected (not-enough-replicas), never buffered"
+        );
+        assert_eq!(
+            seam.parked_len(),
+            MAX_PARKED_ACKS_PER_PARTITION,
+            "the rejected produce buffered NOTHING — the backlog stays bounded at the cap"
+        );
     }
 
     #[test]

--- a/crates/ironbus-server/src/cluster/isr.rs
+++ b/crates/ironbus-server/src/cluster/isr.rs
@@ -452,6 +452,12 @@ pub struct QuorumAckGate<T> {
     /// releases nothing twice. Starts at 0 (no offset released yet; offset 0's ack releases when
     /// `quorum_commit >= 1`).
     released_through: u64,
+    /// The cap on `pending.len()` (#864): the most acks this gate may withhold before [`park`](Self::park)
+    /// REFUSES a new one. `0` = unlimited (the single-node-shaped / test default). Under an unsatisfiable
+    /// ISR (a follower down, below `min_isr`) nothing drains, so without a cap a pipelining producer grows
+    /// `pending` without bound — OOM/abort. At the cap `park` returns `false` so the caller fails the
+    /// produce with an explicit not-enough-replicas error rather than buffering unboundedly.
+    cap: usize,
 }
 
 impl<T> Default for QuorumAckGate<T> {
@@ -461,23 +467,42 @@ impl<T> Default for QuorumAckGate<T> {
 }
 
 impl<T> QuorumAckGate<T> {
-    /// A fresh gate with no pending acks.
+    /// A fresh gate with no pending acks and NO backlog cap (`0` = unlimited). Used by the
+    /// single-node-shaped path and the gate's own tests; the clustered leader uses
+    /// [`with_cap`](Self::with_cap) to bound the parked backlog (#864).
     #[must_use]
     pub fn new() -> Self {
+        Self::with_cap(0)
+    }
+
+    /// A fresh gate that withholds at most `cap` acks before [`park`](Self::park) refuses (#864); `0` =
+    /// unlimited. The clustered leader sets this so an unsatisfiable ISR cannot grow the parked backlog
+    /// without bound.
+    #[must_use]
+    pub fn with_cap(cap: usize) -> Self {
         Self {
             pending: Vec::new(),
             released_through: 0,
+            cap,
         }
     }
 
-    /// Park a produce's `C2-fsync` ack to be released once its offset is quorum-committed. The leader
-    /// calls this AFTER its own local-fsync (the I2 ack-after-its-own-fsync still holds); the cluster
-    /// gate withholds the wire `PubAck` until the quorum has also fsync'd.
+    /// Park a produce's `C2-fsync` ack to be released once its offset is quorum-committed, returning
+    /// `true` if it was parked and `false` if the gate is at its backlog cap (#864). The leader calls
+    /// this AFTER its own local-fsync (the I2 ack-after-its-own-fsync still holds); the cluster gate
+    /// withholds the wire `PubAck` until the quorum has also fsync'd. On a `false` return the caller MUST
+    /// NOT treat the produce as parked — it fails the produce with an explicit not-enough-replicas error
+    /// rather than buffer the reply unboundedly while the ISR is below `min_isr`.
     ///
     /// Offsets must be parked in non-decreasing order (the produce path assigns offsets monotonically);
     /// this is the produce path's natural order.
-    pub fn park(&mut self, offset: u64, token: T) {
+    #[must_use]
+    pub fn park(&mut self, offset: u64, token: T) -> bool {
+        if self.cap != 0 && self.pending.len() >= self.cap {
+            return false;
+        }
         self.pending.push(PendingAck { offset, token });
+        true
     }
 
     /// The number of acks currently withheld (awaiting quorum-fsync). Zero means every produced ack has
@@ -738,9 +763,9 @@ mod tests {
     fn the_gate_releases_an_ack_only_once_its_offset_is_quorum_committed() {
         let mut gate: QuorumAckGate<u64> = QuorumAckGate::new();
         // Three produces parked at offsets 0, 1, 2 (the token here is just the offset for the test).
-        gate.park(0, 0);
-        gate.park(1, 1);
-        gate.park(2, 2);
+        let _ = gate.park(0, 0);
+        let _ = gate.park(1, 1);
+        let _ = gate.park(2, 2);
         assert_eq!(gate.pending_len(), 3);
 
         // Quorum-commit = 1 → offsets < 1 release → just offset 0.
@@ -760,8 +785,8 @@ mod tests {
     #[test]
     fn the_gate_releases_nothing_when_there_is_no_quorum() {
         let mut gate: QuorumAckGate<u64> = QuorumAckGate::new();
-        gate.park(0, 0);
-        gate.park(1, 1);
+        let _ = gate.park(0, 0);
+        let _ = gate.park(1, 1);
         // No quorum (ISR below min_isr) → quorum_commit is None → NOTHING releases (no-false-ack).
         assert!(gate.release_up_to(None).is_empty());
         assert_eq!(
@@ -769,6 +794,41 @@ mod tests {
             2,
             "the acks stay withheld, never falsely fired"
         );
+    }
+
+    #[test]
+    fn a_capped_gate_refuses_a_park_past_its_backlog_cap() {
+        // #864: a capped gate withholds at most `cap` acks; past it, `park` REFUSES (returns false) so the
+        // caller fails the produce rather than buffering unboundedly while the ISR is below min_isr.
+        let mut gate: QuorumAckGate<u64> = QuorumAckGate::with_cap(2);
+        assert!(gate.park(0, 0), "first park fits under the cap");
+        assert!(gate.park(1, 1), "second park fills the cap");
+        assert!(!gate.park(2, 2), "a third park is REFUSED at the cap");
+        assert_eq!(
+            gate.pending_len(),
+            2,
+            "the refused park allocated nothing past the cap"
+        );
+
+        // Draining below the cap re-admits parks (the backlog recovered when the quorum advanced).
+        assert_eq!(gate.release_up_to(Some(1)), vec![0]);
+        assert_eq!(gate.pending_len(), 1);
+        assert!(
+            gate.park(2, 2),
+            "with a slot freed, a park is admitted again"
+        );
+        assert_eq!(gate.pending_len(), 2);
+    }
+
+    #[test]
+    fn an_uncapped_gate_parks_without_bound() {
+        // `new()` / `with_cap(0)` = unlimited (the single-node-shaped / test default): the cap only
+        // engages for the clustered leader gate built with a non-zero cap.
+        let mut gate: QuorumAckGate<u64> = QuorumAckGate::new();
+        for i in 0..1000u64 {
+            assert!(gate.park(i, i), "an uncapped gate never refuses");
+        }
+        assert_eq!(gate.pending_len(), 1000);
     }
 }
 
@@ -861,7 +921,7 @@ mod cluster_quorum_tests {
         // Park each produce's C2-fsync ack (the leader has fsync'd locally; the CLUSTER gate still
         // withholds the wire PubAck until a quorum has fsync'd).
         for off in 0..5u64 {
-            gate.park(off, off);
+            let _ = gate.park(off, off);
         }
 
         // ---- ONLY the leader has the records: ISR = {leader} (followers at 0, lag 5 < 1024 so they
@@ -947,7 +1007,7 @@ mod cluster_quorum_tests {
         leader_log.sync().unwrap();
         isr.observe_leader_fsync(leader_log.flushed_offset().get());
         for off in 0..10u64 {
-            gate.park(off, off);
+            let _ = gate.park(off, off);
         }
 
         // Both followers are far behind (fsync'd only offset 1, lag 9 >> 3) → BOTH evicted → ISR = 1.

--- a/crates/ironbus-server/src/session.rs
+++ b/crates/ironbus-server/src/session.rs
@@ -4288,6 +4288,15 @@ fn write_pub_reply_gated<
             // plane releases it onto this connection's outbox on quorum-fsync; the session drains it on a
             // later pass. No false ack below min_isr (the gate releases nothing).
             Some(crate::cluster::dataplane::AckDisposition::Parked) => {}
+            // The partition's parked-ack backlog is at its cap (#864): an unsatisfiable ISR is already
+            // withholding the cap's worth of acks and nothing is draining, so the data plane refused to
+            // park another rather than grow memory toward OOM. Reply with an explicit, typed error (the
+            // honest unavailable-over-unsafe signal) so the producer backs off — NEVER a PubAck (the
+            // record is durable on the leader but is NOT quorum-fsync'd, so acking it would be a lie).
+            // The connection stays open; the producer can retry once the ISR recovers.
+            Some(crate::cluster::dataplane::AckDisposition::Rejected) => {
+                reply_err(out, "not enough in-sync replicas to quorum-commit; retry");
+            }
         }
         return Ok(());
     }


### PR DESCRIPTION
## What

Closes #864. When a follower dies/partitions and the ISR drops below `min_isr`, `C2-fsync` produces to a led partition can't be quorum-committed, so each wire `PubAck` is **withheld** — and below `min_isr` **nothing drains**. The park path had no cap and no backpressure: `QuorumAckGate::park` pushed onto an unbounded `pending` Vec, `ProduceAckSeam` stored the full PubAck frame in an unbounded `parked` map, and the session's cluster `Parked` arm is a no-op. A pipelining producer (which frees its `max_in_flight` slot the moment the local fsync returns `Appended`) grows both structures without bound → **OOM during any follower outage** (and, under `panic = "abort"`, an allocation failure aborts the whole broker).

## How

- **Cap** the parked backlog **per partition** at `MAX_PARKED_ACKS_PER_PARTITION` (8192 — a few hundred KiB per led partition, draining the moment the quorum advances). `QuorumAckGate` gains a `cap` (`0` = unlimited, the single-node-shaped default); `park` returns `false` at the cap.
- `park_produce_ack` surfaces that as `Ok(false)`; `on_local_fsynced_ack_owned` then returns the new **`AckDisposition::Rejected`**, reserving the gate slot **before** the reply bytes so a rejection **buffers nothing**.
- The session writes an explicit typed **not-enough-replicas error** (`reply_err`) for `Rejected` — the honest unavailable-over-unsafe signal the producer backs off on — **never a `PubAck`** (the record is durable on the leader but not quorum-fsync'd, so acking it would be a lie). The connection stays open.

The rejection is `Ok(Rejected)`, **not** an `Err` — an `Err` is mapped to an immediate ack by the client-ack fallback (`client_ack.rs:342`), which would be a **false ack**.

**Single-node / no-cluster is byte-identical**: the seam is never constructed off-cluster, and an uncapped gate (`0`) preserves the historical behavior for the existing in-process layer tests.

## Tests

- `a_capped_gate_refuses_a_park_past_its_backlog_cap` / `an_uncapped_gate_parks_without_bound` (gate unit).
- `a_clustered_c2_fsync_produce_is_rejected_when_the_parked_backlog_hits_the_cap`: leads a partition at `C2-fsync` with an unsatisfiable ISR, parks exactly the cap, asserts the next produce is `Rejected` and **buffers nothing** (the backlog stays bounded at the cap, not 1:1 with offered produces).

The `Rejected` arm has the same test depth as the existing `Parked` arm (both covered at the seam/gate layer). Full `ironbus-server` suite green; `clippy --workspace --all-targets --all-features -D warnings -W clippy::pedantic` clean.

## Follow-up (not in scope, will file)

Make the cap configurable, and emit a parked-depth metric/alarm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
