### PR TITLE
fix(server): detect a hung-fsync append-actor wedge and flip /healthz and /readyz to 503 (Closes #862)

### DIFF
--- a/crates/ironbus-cli/src/main.rs
+++ b/crates/ironbus-cli/src/main.rs
@@ -766,6 +766,15 @@ const DEFAULT_VISIBILITY_MS: u64 = 30_000;
 /// DISABLES the watchdog (`/healthz` is then a static 200 while up). 10 s matches the #95 spec.
 const DEFAULT_HEALTH_LIVENESS_WINDOW_MS: u64 = 10_000;
 
+/// The default APPEND-ACTOR WEDGE-WATCHDOG bound for `serve` (#862), in milliseconds: a durability
+/// `fdatasync` that hangs (a failing eMMC, a stalled overlay/networked FS, brownout-stuck flash) blocks
+/// the single append actor forever, and the accept-loop liveness beacon is decoupled (#95) so `/healthz`
+/// would stay green while the whole produce path is wedged and `/readyz` would hang behind the stuck
+/// fsync. Once an in-flight batch overruns this bound, `/healthz` AND `/readyz` flip to 503 so an
+/// orchestrator restarts the node. `0` DISABLES the watchdog. 30 s is far above any legitimate
+/// slow-but-progressing fsync, so it never false-trips a merely slow disk.
+const DEFAULT_ACTOR_WATCHDOG_BOUND_MS: u64 = 30_000;
+
 /// The default graceful-shutdown DRAIN TIMEOUT for `serve` (#637), in milliseconds: on a SIGTERM the
 /// broker flips `/readyz` to 503, then drains in-flight work (flush + checkpoint), and force-exits if
 /// the drain has not finished within this window — so an orchestrated stop (k8s `terminationGracePeriod`)
@@ -2254,6 +2263,8 @@ struct ServeFlags {
     health_addr: Option<String>,
     /// The `/healthz` liveness hysteresis window in ms (#95); `None` falls back to the default.
     health_liveness_window_ms: Option<u64>,
+    /// The append-actor wedge-watchdog bound in ms (#862); `None` falls back to the default. `0` disables.
+    actor_watchdog_bound_ms: Option<u64>,
     /// The fail-closed acknowledgement for a NON-LOOPBACK `--health-addr` (#95): the metrics/health
     /// surface is unauthenticated and unencrypted (TLS/#107 and auth/#106 are not wired), so a
     /// non-loopback bind refuses to start unless the operator sets this. A bare boolean flag.
@@ -2679,6 +2690,10 @@ fn collect_serve_flags(args: &[String]) -> Result<ServeFlags, CliError> {
                 f.health_liveness_window_ms =
                     Some(take_number("--health-liveness-window-ms", args, &mut i)?);
             }
+            "--actor-watchdog-bound-ms" => {
+                f.actor_watchdog_bound_ms =
+                    Some(take_number("--actor-watchdog-bound-ms", args, &mut i)?);
+            }
             // A bare boolean flag (no value): advance ONE token, not two, or the loop spins.
             "--health-allow-public" => {
                 f.health_allow_public = true;
@@ -3040,6 +3055,12 @@ fn parse_serve_flags_with_env_and_reader(
                 f.health_liveness_window_ms,
                 env,
                 DEFAULT_HEALTH_LIVENESS_WINDOW_MS,
+            )?,
+            actor_watchdog_bound_ms: resolve_number(
+                "--actor-watchdog-bound-ms",
+                f.actor_watchdog_bound_ms,
+                env,
+                DEFAULT_ACTOR_WATCHDOG_BOUND_MS,
             )?,
             health_allow_public: resolve_bool("--health-allow-public", f.health_allow_public, env)?,
             // #878: the dedup caps take their default from the PROFILE PRESET (edge-tiny lowers them so
@@ -4760,6 +4781,11 @@ struct ServeConfig {
     /// healthy idle loop stays 200. `0` = the watchdog is DISABLED (a static-200 `/healthz` while up).
     /// Default 10 s (`DEFAULT_HEALTH_LIVENESS_WINDOW_MS`).
     health_liveness_window_ms: u64,
+    /// The append-actor wedge-watchdog bound in MILLISECONDS (#862): a durability `fdatasync` that hangs
+    /// longer than this wedges the single append actor, and the broker flips `/healthz` AND `/readyz` to
+    /// 503 (so an orchestrator restarts it) instead of leaving liveness green and hanging `/readyz`. `0`
+    /// = DISABLED. Default 30 s (`DEFAULT_ACTOR_WATCHDOG_BOUND_MS`), far above any legitimate slow fsync.
+    actor_watchdog_bound_ms: u64,
     /// Acknowledge a NON-LOOPBACK `--health-addr` bind (#95), fail-closed default. The health surface
     /// (`/metrics`, `/healthz`, `/readyz`, optional `/admin`) is UNAUTHENTICATED and UNENCRYPTED: TLS
     /// (#107) and an auth identity (#106) are specified but NOT yet wired, so per the #107 bind
@@ -4939,6 +4965,7 @@ impl ServeConfig {
             enable_otlp_export: false,
             otlp_endpoint: None,
             health_liveness_window_ms: DEFAULT_HEALTH_LIVENESS_WINDOW_MS,
+            actor_watchdog_bound_ms: DEFAULT_ACTOR_WATCHDOG_BOUND_MS,
             health_allow_public: false,
             dedup_max_ids: DEFAULT_DEDUP_MAX_IDS,
             dedup_window_ms: DEFAULT_DEDUP_WINDOW_MS,
@@ -6179,6 +6206,7 @@ fn materialized_config_line(config: &ServeConfig, addr: &str, data_dir: Option<&
          group_idle_evict_ms={} checkpoint_interval={} max_deliver={} \
          allow_unlimited_deliver={} disk_full_policy={policy} visibility_timeout_ms={} \
          max_retained_bytes={} max_age_ms={} max_messages={} health_liveness_window_ms={} \
+         actor_watchdog_bound_ms={} \
          enable_admin={} ram_ceiling_bytes={} dedup_max_ids={} dedup_max_producers={} \
          durability_level={durability_level} \
          power_loss_safe={power_loss_safe} compression={compression} flush_interval_ms={} \
@@ -6203,6 +6231,7 @@ fn materialized_config_line(config: &ServeConfig, addr: &str, data_dir: Option<&
         config.max_age_ms,
         config.max_messages,
         config.health_liveness_window_ms,
+        config.actor_watchdog_bound_ms,
         config.enable_admin,
         config.ram_ceiling_bytes,
         config.dedup_max_ids,
@@ -7790,6 +7819,11 @@ fn run_broker<F: Filesystem + Clone + 'static>(
         Some(slot) => shared.with_client_ack_slot(slot),
         None => shared,
     };
+    // Arm the append-actor wedge watchdog (#862) BEFORE any produce can run: a durability fsync that
+    // hangs longer than this bound flips `/healthz` and `/readyz` to 503 (instead of leaving liveness
+    // green and hanging readyz), so an orchestrator restarts a node whose disk has stalled. `0` disables
+    // it. The bound is generous (default 30 s) so a slow-but-progressing fsync never false-trips.
+    shared.set_actor_watchdog_bound(config.actor_watchdog_bound_ms.saturating_mul(1_000_000));
     let listener = TcpListener::bind(addr)
         .map_err(|e| CliError::Internal(format!("cannot bind {addr}: {e}")))?;
     let local = listener
@@ -8815,6 +8849,7 @@ fn cmd_serve(
         // consume them too or the Windows `-D warnings` build trips field-never-read, invisible to a
         // macOS reviewer (the recurring #288/#99 footgun).
         config.health_liveness_window_ms,
+        config.actor_watchdog_bound_ms,
         config.health_allow_public,
         config.visibility_ms,
         // The #33 dedup knobs are read only on the Unix serve path (they size the engine's dedup
@@ -12698,6 +12733,7 @@ mod tests {
             enable_otlp_export: false,
             otlp_endpoint: None,
             health_liveness_window_ms: DEFAULT_HEALTH_LIVENESS_WINDOW_MS,
+            actor_watchdog_bound_ms: DEFAULT_ACTOR_WATCHDOG_BOUND_MS,
             health_allow_public: false,
             dedup_max_ids: DEFAULT_DEDUP_MAX_IDS,
             dedup_window_ms: DEFAULT_DEDUP_WINDOW_MS,
@@ -16125,6 +16161,7 @@ mod tests {
             enable_otlp_export: false,
             otlp_endpoint: None,
             health_liveness_window_ms: DEFAULT_HEALTH_LIVENESS_WINDOW_MS,
+            actor_watchdog_bound_ms: DEFAULT_ACTOR_WATCHDOG_BOUND_MS,
             health_allow_public: false,
             dedup_max_ids: DEFAULT_DEDUP_MAX_IDS,
             dedup_window_ms: DEFAULT_DEDUP_WINDOW_MS,
@@ -18865,6 +18902,28 @@ mod tests {
         assert_eq!(
             set.config.max_in_flight, 8,
             "the trailing flag still parses"
+        );
+    }
+
+    #[test]
+    fn serve_parses_the_actor_watchdog_bound_flag() {
+        // #862: the append-actor wedge-watchdog bound (ms) parses into the ServeConfig with the 30 s
+        // default absent the flag; an explicit value (incl. 0 = disabled) wins.
+        let def = parse_serve_flags(&["--data-dir".to_string(), "/tmp/x".to_string()]).unwrap();
+        assert_eq!(
+            def.config.actor_watchdog_bound_ms, DEFAULT_ACTOR_WATCHDOG_BOUND_MS,
+            "the actor-watchdog bound defaults to 30 s"
+        );
+        let set = parse_serve_flags(&[
+            "--data-dir".to_string(),
+            "/tmp/x".to_string(),
+            "--actor-watchdog-bound-ms".to_string(),
+            "0".to_string(),
+        ])
+        .unwrap();
+        assert_eq!(
+            set.config.actor_watchdog_bound_ms, 0,
+            "0 disables the actor-wedge watchdog"
         );
     }
 

--- a/crates/ironbus-server/src/actor.rs
+++ b/crates/ironbus-server/src/actor.rs
@@ -32,6 +32,7 @@
 //!   [`ActorGone`], never a panic, so neither side hangs forever if the other dies.
 
 use crate::engine::{DiskFullPolicy, Engine, EngineError};
+use crate::liveness::ActorWatchdog;
 use crate::produce_gate::ProduceCapGate;
 use bytes::Bytes;
 use ironbus_core::clock::Clock;
@@ -408,6 +409,13 @@ pub struct EngineHandle<F: Filesystem, C: Clock> {
     /// `cap_gate`): every connection reads the one slot the bootstrap fills. Until it is filled (the
     /// brief bootstrap window) the produce path acks immediately exactly as the non-cluster path does.
     client_ack: Option<ClientAckSlot<F, C>>,
+    /// The actor-progress watchdog (#862): the SAME `Arc` the actor thread stamps `busy`/`idle` on
+    /// around each command batch (including its covering fsync). The health server reads it (via
+    /// [`EngineAccess::actor_watchdog_overran`]) WITHOUT going through the actor, so a HUNG fsync that
+    /// blocks the actor forever flips `/healthz` and `/readyz` to 503 instead of leaving liveness green.
+    /// Shared on clone (like `cap_gate`): one watchdog per actor. Disabled (`bound == 0`) until the
+    /// serve path sets the bound via [`set_actor_watchdog_bound`](Self::set_actor_watchdog_bound).
+    actor_watchdog: Arc<ActorWatchdog>,
 }
 
 /// The shared, set-once slot holding the clustered [`ClientAckGate`] (#719). Created empty at serve
@@ -433,6 +441,8 @@ impl<F: Filesystem, C: Clock + Clone> Clone for EngineHandle<F, C> {
             // The SAME shared cluster produce-ack slot (#719): every connection reads the one slot the
             // data-plane bootstrap fills, so the `Arc<OnceLock>` is shared on clone. `None` off-cluster.
             client_ack: self.client_ack.clone(),
+            // The SAME shared actor-progress watchdog (#862): one per actor, read by the health server.
+            actor_watchdog: Arc::clone(&self.actor_watchdog),
         }
     }
 }
@@ -448,6 +458,15 @@ impl<F: Filesystem + 'static, C: Clock + 'static> EngineHandle<F, C> {
     pub fn with_client_ack_slot(mut self, slot: ClientAckSlot<F, C>) -> Self {
         self.client_ack = Some(slot);
         self
+    }
+
+    /// Arm the append-actor wedge watchdog (#862) with an overrun bound in NANOSECONDS; `0` DISABLES it
+    /// (the default). Called ONCE at serve start from the configured bound, BEFORE any produce can wedge,
+    /// so a hung durability fsync that blocks the actor longer than `bound_nanos` flips `/healthz` and
+    /// `/readyz` to 503 (via [`EngineAccess::actor_watchdog_overran`]) instead of leaving liveness green.
+    /// The bound is shared across every connection's handle clone (one watchdog per actor).
+    pub fn set_actor_watchdog_bound(&self, bound_nanos: u64) {
+        self.actor_watchdog.set_bound_nanos(bound_nanos);
     }
 
     /// The shared cluster produce-ack gate (#719), once the data-plane bootstrap has filled the slot;
@@ -791,6 +810,18 @@ pub trait EngineAccess<F: Filesystem, C: Clock> {
         false
     }
 
+    /// Whether the append actor's IN-FLIGHT command batch has overrun the watchdog bound at
+    /// `now_monotonic_nanos` — i.e. a HUNG durability fsync has wedged the actor thread (#862). A cheap
+    /// LOCAL, non-blocking atomic read (it does NOT go through the actor, so it answers even while the
+    /// actor is wedged). The DEFAULT impl returns `false` (no actor / no watchdog — every non-handle
+    /// `EngineAccess`, e.g. an in-process test fixture, is never "wedged"). [`EngineHandle`] overrides it
+    /// to consult its shared [`ActorWatchdog`]. The health server uses this to flip `/healthz` and
+    /// `/readyz` to 503 on a wedge instead of leaving liveness green or hanging `/readyz` behind the
+    /// wedged fsync.
+    fn actor_watchdog_overran(&self, _now_monotonic_nanos: u64) -> bool {
+        false
+    }
+
     /// The CLUSTER produce-ack decision (#719) for one durable produce on connection `member`: called
     /// AFTER the local group-commit fsync returned `Appended(offset)`, with the `offset`, and the EXACT
     /// wire-`PubAck` frame bytes the session would otherwise write now.
@@ -920,6 +951,13 @@ impl<F: Filesystem + Clone + 'static, C: Clock + Clone + 'static> EngineAccess<F
     fn has_client_ack_gate(&self) -> bool {
         // A cheap local read: the slot exists AND is filled (a clustered serve past bootstrap).
         self.client_ack_gate().is_some()
+    }
+
+    fn actor_watchdog_overran(&self, now_monotonic_nanos: u64) -> bool {
+        // A non-blocking atomic read of the shared watchdog (#862): does NOT go through the actor, so
+        // it answers even while the actor is wedged on a hung fsync. `false` until the serve path arms
+        // the bound (`bound == 0` is disabled), so single-node and unconfigured brokers are unaffected.
+        self.actor_watchdog.overran(now_monotonic_nanos)
     }
 
     fn client_ack_disposition(
@@ -1239,9 +1277,25 @@ where
         _ => cap_gate.disengage(),
     }
     let actor_gate = Arc::clone(&cap_gate);
+    // The actor-progress watchdog (#862), shared between the actor thread (which stamps busy/idle) and
+    // every EngineHandle clone (the health server reads it). Created DISABLED (bound 0); the serve path
+    // arms it via `EngineHandle::set_actor_watchdog_bound`, so existing callers/tests are inert by
+    // default. The actor's clock is read for the stamp; the health server reads the SAME clock seam.
+    let actor_watchdog = Arc::new(ActorWatchdog::new(0));
+    let actor_watchdog_thread = Arc::clone(&actor_watchdog);
+    let actor_clock = clock.clone();
     let join = std::thread::Builder::new()
         .name("ironbus-append-actor".to_string())
-        .spawn(move || run_actor(engine, &rx, gather_micros, &actor_gate))
+        .spawn(move || {
+            run_actor(
+                engine,
+                &rx,
+                gather_micros,
+                &actor_gate,
+                &actor_watchdog_thread,
+                &actor_clock,
+            )
+        })
         // A thread-spawn failure at startup is unrecoverable for the server, but the no-panic bar is
         // for the LIBRARY hot paths; spawning the single actor at boot is a startup step. Surface it
         // by propagating the panic only here (boot), never on a request path.
@@ -1261,6 +1315,8 @@ where
             // [`EngineHandle::with_client_ack_slot`] right after this returns, BEFORE any connection's
             // handle is cloned, so every connection sees it.
             client_ack: None,
+            // The shared actor-progress watchdog (#862), disabled until the serve path arms its bound.
+            actor_watchdog,
         },
         join,
     )
@@ -1359,11 +1415,17 @@ fn gather_commands<F, C>(
 /// appended (no sync) and their replies parked; a non-produce job or the end of the drain triggers
 /// the ONE `commit_batch` that covers the parked produces, after which their replies are released.
 /// Returns the engine on exit so a caller can recover it.
+// The drain/group-commit loop is one cohesive unit (recv → drain → per-command append/run/shutdown →
+// one covering fsync → publish); splitting it would scatter the single-writer ordering it enforces. The
+// #862 watchdog stamps push it one line over the pedantic 100-line bound.
+#[allow(clippy::too_many_lines)]
 fn run_actor<F, C>(
     mut engine: Engine<F, C>,
     rx: &Receiver<Command<F, C>>,
     gather_micros: u64,
     cap_gate: &ProduceCapGate,
+    watchdog: &ActorWatchdog,
+    clock: &C,
 ) -> Engine<F, C>
 where
     F: Filesystem,
@@ -1374,11 +1436,19 @@ where
     let mut pending: Vec<PendingProduce> = Vec::new();
     loop {
         // Block for the next command; a disconnect (the last handle dropped) ends the loop after a
-        // final drain so no acked-but-not-durable record is lost.
+        // final drain so no acked-but-not-durable record is lost. While blocked here the actor is IDLE
+        // (the watchdog was cleared at the end of the previous pass), so a quiet broker never trips it.
         let Ok(first) = rx.recv() else {
+            // Shutdown drain: mark BUSY across it so a wedged final fsync is still detectable, then exit.
+            watchdog.mark_busy(clock.now_monotonic_nanos());
             flush_pending(&mut engine, &mut pending);
             return engine;
         };
+        // A command arrived: the actor is now BUSY processing this batch — the append AND the covering
+        // durability fsync. The watchdog stamps the start instant (one relaxed store per BATCH); if the
+        // fsync HANGS, this stamp stays put while the clock advances and the health server's
+        // `actor_watchdog_overran` trips once the bound is exceeded (#862).
+        watchdog.mark_busy(clock.now_monotonic_nanos());
         let mut commands = vec![first];
         // Drain everything immediately available so a concurrent burst of produces forms one group.
         while let Ok(cmd) = rx.try_recv() {
@@ -1465,6 +1535,9 @@ where
         // disabled (the default), so the steady-state loop is unchanged for a broker that has not
         // opted in.
         engine.codel_queue_empty();
+        // The batch committed (its fsync returned) and the queue drained: the actor returns to IDLE
+        // (it blocks in `rx.recv()` next), so clear the watchdog — an idle actor is never wedged (#862).
+        watchdog.mark_idle();
     }
 }
 
@@ -1928,6 +2001,58 @@ mod tests {
             }
         }
         accepted
+    }
+
+    #[test]
+    fn a_hung_fsync_wedges_the_actor_and_the_watchdog_detects_it() {
+        // #862: a HUNG durability fsync blocks the single append actor FOREVER. The accept-loop liveness
+        // beacon is deliberately decoupled and stays green, and `/readyz` (which queues a job through the
+        // actor) would HANG behind the wedged fsync — a silent total stall with liveness reporting
+        // healthy. The actor-progress watchdog detects it: the actor stamps `busy` BEFORE the fsync, and
+        // the health server's NON-BLOCKING `actor_watchdog_overran` (which never goes through the actor)
+        // trips once the in-flight batch overruns the bound, so `/healthz` and `/readyz` flip to 503.
+        const BOUND: u64 = 1_000;
+        let (handle, actor, control) = rig();
+        handle.set_actor_watchdog_bound(BOUND);
+        let t0 = handle.now_monotonic_nanos();
+
+        // IDLE: with no in-flight batch the actor is never reported wedged, no matter how much time
+        // passes — only an overrunning in-flight batch trips it (a quiet broker never false-503s).
+        assert!(
+            !handle.actor_watchdog_overran(t0 + BOUND + 2),
+            "an idle actor is never reported wedged"
+        );
+
+        // Arm a HUNG fsync: the next produce's covering fdatasync PARKS on the closed gate forever.
+        control.close_sync_gate();
+        let produce = {
+            let h = handle.clone();
+            // This BLOCKS in the wedged fsync; it returns only once the gate is opened at teardown.
+            std::thread::spawn(move || {
+                let _ = h.produce(append(b"wedge"));
+            })
+        };
+        // Deterministically wait until the actor is parked mid-fsync (so `mark_busy` has already run).
+        control.wait_for_sync_gate_entered(1);
+
+        // The actor is now BUSY (stamped at ~t0) and wedged in the fsync. Within the bound it is still
+        // healthy; PAST the bound the watchdog trips — detected WITHOUT going through the wedged actor.
+        assert!(
+            !handle.actor_watchdog_overran(t0 + BOUND),
+            "within the bound the in-flight batch is not yet wedged (strict >)"
+        );
+        assert!(
+            handle.actor_watchdog_overran(t0 + BOUND + 2),
+            "past the bound the hung-fsync wedge is DETECTED — /healthz and /readyz flip to 503 (#862)"
+        );
+
+        // Recover: open the gate so the parked fsync completes, the produce returns, and the actor joins
+        // cleanly — proving the watchdog detection did not itself disturb the actor.
+        control.open_sync_gate();
+        produce.join().unwrap();
+        let _ = handle.shutdown();
+        drop(handle);
+        let _ = actor.join();
     }
 
     #[test]

--- a/crates/ironbus-server/src/actor.rs
+++ b/crates/ironbus-server/src/actor.rs
@@ -1571,6 +1571,9 @@ where
         watchdog.publish_writer_healthy(engine.is_healthy());
         // The batch committed (its fsync returned) and the queue drained: the actor returns to IDLE
         // (it blocks in `rx.recv()` next), so clear the watchdog — an idle actor is never wedged (#862).
+        // ORDER IS LOAD-BEARING: `mark_idle` is a RELEASE store that publishes the `publish_writer_healthy`
+        // store just above it, so a `/readyz` reader that sees the cleared wedge (Acquire) also sees the
+        // frozen flag — never a transient stale-healthy 200 on a weakly-ordered arch. Do not reorder.
         watchdog.mark_idle();
     }
 }

--- a/crates/ironbus-server/src/actor.rs
+++ b/crates/ironbus-server/src/actor.rs
@@ -822,6 +822,17 @@ pub trait EngineAccess<F: Filesystem, C: Clock> {
         false
     }
 
+    /// Whether the durable-log writer APPEARS healthy (not frozen), read from a PUBLISHED flag WITHOUT
+    /// going through the actor (#862), so `/readyz` can answer on a hung writer instead of queuing a job
+    /// behind the wedged fsync and HANGING. The DEFAULT returns `true` (no actor / an in-process test
+    /// fixture is assumed live); [`EngineHandle`] overrides it to read the actor's last-published
+    /// `is_healthy()`. This is an ADVISORY read: it reflects the state as of the last completed batch, so
+    /// a freeze becomes visible after the batch that froze the writer commits — exactly when the old
+    /// `engine.with(|e| e.is_healthy())` would have observed it, but without the blocking round-trip.
+    fn writer_appears_healthy(&self) -> bool {
+        true
+    }
+
     /// The CLUSTER produce-ack decision (#719) for one durable produce on connection `member`: called
     /// AFTER the local group-commit fsync returned `Appended(offset)`, with the `offset`, and the EXACT
     /// wire-`PubAck` frame bytes the session would otherwise write now.
@@ -958,6 +969,13 @@ impl<F: Filesystem + Clone + 'static, C: Clock + Clone + 'static> EngineAccess<F
         // it answers even while the actor is wedged on a hung fsync. `false` until the serve path arms
         // the bound (`bound == 0` is disabled), so single-node and unconfigured brokers are unaffected.
         self.actor_watchdog.overran(now_monotonic_nanos)
+    }
+
+    fn writer_appears_healthy(&self) -> bool {
+        // A non-blocking atomic read of the writer-frozen flag the actor publishes after each batch
+        // (#862): `/readyz` reads this instead of `engine.with(|e| e.is_healthy())`, so a hung writer
+        // can never block the health server. `true` for a fresh broker that has run no batch yet.
+        self.actor_watchdog.writer_healthy()
     }
 
     fn client_ack_disposition(
@@ -1111,6 +1129,17 @@ impl<F: Filesystem, C: Clock + Clone> EngineAccess<F, C> for SharedEngine<F, C> 
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         (e.consumer_credit(), e.consumer_credit_bytes())
+    }
+
+    fn writer_appears_healthy(&self) -> bool {
+        // The shared-engine test fixture (a `Mutex<Engine>`, no separate actor): read the REAL writer
+        // state under the lock, so a frozen engine reports unhealthy to `/readyz` exactly as the old
+        // `engine.with(|e| e.is_healthy())` did. The lock is uncontended in a health test (no real
+        // actor holds it across an fsync), so this never blocks — unlike the production `EngineHandle`,
+        // whose override reads the actor's PUBLISHED flag so a HUNG actor can never block the read.
+        self.lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .is_healthy()
     }
 }
 
@@ -1535,6 +1564,11 @@ where
         // disabled (the default), so the steady-state loop is unchanged for a broker that has not
         // opted in.
         engine.codel_queue_empty();
+        // Publish the writer's live/frozen state for `/readyz` to read non-blockingly (#862): the
+        // covering commit just ran, so `is_healthy()` now reflects a frozen writer (a fsync that RETURNED
+        // an error) — and a `/readyz` probe reads this flag instead of round-tripping through the actor,
+        // so it can never hang behind the writer. A cheap local read + one relaxed store, per batch.
+        watchdog.publish_writer_healthy(engine.is_healthy());
         // The batch committed (its fsync returned) and the queue drained: the actor returns to IDLE
         // (it blocks in `rx.recv()` next), so clear the watchdog — an idle actor is never wedged (#862).
         watchdog.mark_idle();
@@ -2050,6 +2084,51 @@ mod tests {
         // cleanly — proving the watchdog detection did not itself disturb the actor.
         control.open_sync_gate();
         produce.join().unwrap();
+        let _ = handle.shutdown();
+        drop(handle);
+        let _ = actor.join();
+    }
+
+    #[test]
+    fn the_actor_publishes_a_frozen_writer_and_readyz_reads_it_without_a_round_trip() {
+        // #862 PRODUCTION PUBLISH→READ PATH: after a covering fsync RETURNS an error and freezes the
+        // writer, `run_actor` publishes `engine.is_healthy()` to the watchdog, and
+        // `EngineAccess::writer_appears_healthy` (what `/readyz` reads) returns that PUBLISHED flag
+        // WITHOUT queuing a job through the actor. `admin_resilience` proves the `/readyz` 503 over a
+        // `SharedEngine` (a direct-lock fixture); this proves the REAL actor wiring — that the running
+        // append actor actually publishes the frozen state the non-blocking read reports.
+        let (handle, actor, control) = rig();
+
+        // A clean produce keeps the writer live; force the batch's post-commit publish to complete (a
+        // follow-up `Run` job is processed in a LATER actor iteration, so the produce batch's publish
+        // has run by the time `with` returns) and confirm the published flag reads HEALTHY.
+        handle.produce(append(b"live")).expect("a clean produce");
+        let _ = handle.with(|_| ());
+        assert!(
+            handle.writer_appears_healthy(),
+            "a live writer publishes healthy"
+        );
+
+        // Arm a FATAL fsync (one that RETURNS an error, not the hang above): the next produce's covering
+        // fdatasync fails and freezes the writer one-way. The produce comes back `Fatal`, and — unlike a
+        // hang — the actor keeps serving (a frozen writer answers reads, refuses writes).
+        control.set_fail_sync(true);
+        let outcome = handle.produce(append(b"freeze"));
+        assert!(
+            matches!(outcome, Ok(ProduceOutcome::Fatal(_))),
+            "the covering fsync error freezes the writer: {outcome:?}"
+        );
+
+        // Force the FROZEN batch's publish to complete, then assert the NON-BLOCKING read reports the
+        // writer unhealthy — exactly the signal `/readyz` sheds 503 on, observed WITHOUT a hung actor.
+        let _ = handle.with(|_| ());
+        assert!(
+            !handle.writer_appears_healthy(),
+            "the actor published the frozen writer; /readyz reads it without a round-trip (#862)"
+        );
+
+        // Clear the armed fault so teardown's drain does not re-trip it, then join cleanly.
+        control.set_fail_sync(false);
         let _ = handle.shutdown();
         drop(handle);
         let _ = actor.join();

--- a/crates/ironbus-server/src/health.rs
+++ b/crates/ironbus-server/src/health.rs
@@ -336,28 +336,28 @@ where
             // an orchestrator stops routing new work to it BEFORE the drain begins — the "stop
             // accepting before stop serving" ordering. The engine is still healthy at this instant
             // (the drain has not started), so the 503 must come from the gate, not the engine check.
+            // FULLY NON-BLOCKING readiness (#862): three atomic reads, NO actor round-trip, so a HUNG
+            // fsync can never block this handler and — on the single-threaded health server — wedge the
+            // whole health surface (the bug the old `engine.with(|e| e.is_healthy())` had: it queued a
+            // job behind the wedged fsync and hung FOREVER, so even the watchdog's own 503 was never
+            // served). Checked in priority order: a SIGTERM drain (#637, stop routing before stop
+            // serving), then a WEDGED actor (a hung fsync past the watchdog bound, #862), then a FROZEN
+            // writer (a fsync that RETURNED an error, read from the actor's published flag). Otherwise
+            // ready. The writer-frozen flag reflects the state as of the last completed batch — exactly
+            // when the old blocking read would have observed it.
             if draining.load(Ordering::Acquire) {
                 respond(&mut stream, 503, "Service Unavailable", "draining")
             } else if engine.actor_watchdog_overran(clock.now_monotonic_nanos()) {
-                // The append actor is WEDGED on a hung fsync (#862): answer 503 DIRECTLY via the
-                // non-blocking watchdog atomic, BEFORE `engine.with` — which would queue a job behind the
-                // wedged fsync and HANG `/readyz` forever (detection would then depend solely on the
-                // prober's own timeout, and on a single-node edge box with no orchestrator nothing would
-                // detect it). Checked here so a wedge is reported, not hung on.
                 respond(
                     &mut stream,
                     503,
                     "Service Unavailable",
                     "append actor wedged",
                 )
+            } else if engine.writer_appears_healthy() {
+                respond(&mut stream, 200, "OK", "ready")
             } else {
-                // Read the writer-health flag through the actor (the single owner). If the actor is
-                // gone (a shutdown drain), the broker is not ready: surface 503 rather than hang.
-                match engine.with(|e| e.is_healthy()) {
-                    Ok(true) => respond(&mut stream, 200, "OK", "ready"),
-                    Ok(false) => respond(&mut stream, 503, "Service Unavailable", "writer frozen"),
-                    Err(_) => respond(&mut stream, 503, "Service Unavailable", "shutting down"),
-                }
+                respond(&mut stream, 503, "Service Unavailable", "writer frozen")
             }
         }
         "/metrics" => match metrics_snapshot(engine, connz, data_dir) {
@@ -2563,6 +2563,8 @@ mod tests {
     struct WedgeableEngine {
         inner: SharedEngine<InMemoryFs, Arc<ironbus_core::clock::ManualClock>>,
         wedged: Arc<AtomicBool>,
+        /// The published writer live/frozen flag /readyz reads non-blockingly (#862); `true` = live.
+        writer_healthy: Arc<AtomicBool>,
     }
 
     impl EngineAccess<InMemoryFs, Arc<ironbus_core::clock::ManualClock>> for WedgeableEngine {
@@ -2590,6 +2592,9 @@ mod tests {
         fn actor_watchdog_overran(&self, _now_monotonic_nanos: u64) -> bool {
             self.wedged.load(Ordering::Relaxed)
         }
+        fn writer_appears_healthy(&self) -> bool {
+            self.writer_healthy.load(Ordering::Relaxed)
+        }
     }
 
     /// Runs `serve_health` over a `ManualClock` with the given liveness `window_nanos` and a beacon
@@ -2606,6 +2611,7 @@ mod tests {
         std::thread::JoinHandle<()>,
         Arc<ironbus_core::clock::ManualClock>,
         Arc<LivenessBeacon>,
+        Arc<AtomicBool>,
         Arc<AtomicBool>,
     ) {
         use ironbus_core::clock::ManualClock;
@@ -2658,9 +2664,13 @@ mod tests {
         // The actor-watchdog "wedged" flag (#862), default false so the liveness tests behave exactly as
         // before; the actor-wedge test flips it to drive /healthz and /readyz to 503.
         let wedged = Arc::new(AtomicBool::new(false));
+        // The published writer live/frozen flag (#862), default true (a fresh broker's writer is live);
+        // the frozen-writer test flips it to drive /readyz to 503 via the non-blocking path.
+        let writer_healthy = Arc::new(AtomicBool::new(true));
         let engine_access = WedgeableEngine {
             inner,
             wedged: Arc::clone(&wedged),
+            writer_healthy: Arc::clone(&writer_healthy),
         };
         // The beacon starts at the clock's origin (0), exactly as the broker seeds it from its start
         // instant, so it is fresh at t=0 and only goes stale once the clock advances past the window
@@ -2686,7 +2696,15 @@ mod tests {
                 .unwrap();
             }
         });
-        (addr, shutdown, handle, clock, beacon, wedged)
+        (
+            addr,
+            shutdown,
+            handle,
+            clock,
+            beacon,
+            wedged,
+            writer_healthy,
+        )
     }
 
     #[test]
@@ -2694,7 +2712,8 @@ mod tests {
         // With a 30 ms window: a beacon tick at the current instant keeps /healthz 200 even after the
         // clock advances a little (under the window), so a slow-but-progressing loop never sheds.
         let window = 30_000_000; // 30 ms in nanos
-        let (addr, shutdown, handle, clock, beacon, _wedged) = start_watchdog(window);
+        let (addr, shutdown, handle, clock, beacon, _wedged, _writer_healthy) =
+            start_watchdog(window);
 
         // Fresh at t=0.
         let h = request(addr, "GET /healthz HTTP/1.1\r\n\r\n");
@@ -2716,7 +2735,8 @@ mod tests {
         // clock has advanced past the window /healthz sheds 503. This is the only thing that makes
         // the guard real: remove the watchdog (revert to a static 200) and this fails.
         let window = 30_000_000; // 30 ms
-        let (addr, shutdown, handle, clock, beacon, _wedged) = start_watchdog(window);
+        let (addr, shutdown, handle, clock, beacon, _wedged, _writer_healthy) =
+            start_watchdog(window);
 
         // Tick once at t=0, then let the loop wedge: no more ticks.
         beacon.mark_progress(clock.now_monotonic_nanos());
@@ -2752,7 +2772,8 @@ mod tests {
         // with no client work, so even across MANY window-lengths of pure idle /healthz never sheds.
         // This pins "idle is progress" so the watchdog cannot crash-loop an idle edge node.
         let window = 30_000_000; // 30 ms
-        let (addr, shutdown, handle, clock, beacon, _wedged) = start_watchdog(window);
+        let (addr, shutdown, handle, clock, beacon, _wedged, _writer_healthy) =
+            start_watchdog(window);
 
         // Model a long idle run: a 5 ms idle poll tick repeated past several windows.
         for _ in 0..50 {
@@ -2774,8 +2795,13 @@ mod tests {
         // `a_hung_fsync_wedges...` test proves the real-wedge detection; this proves the health surface
         // surfaces it. The accept-loop beacon is kept FRESH throughout so the actor-watchdog is the SOLE
         // reason for any 503, never the liveness window.
+        //
+        // The writer stays LIVE throughout (`_writer_healthy` default true), so the /readyz 503 below is
+        // purely the wedge watchdog, never the frozen-writer branch — a wedge is a HANG, not a
+        // returned-error freeze.
         let window = 30_000_000; // 30 ms
-        let (addr, shutdown, handle, clock, beacon, wedged) = start_watchdog(window);
+        let (addr, shutdown, handle, clock, beacon, wedged, _writer_healthy) =
+            start_watchdog(window);
         beacon.mark_progress(clock.now_monotonic_nanos());
 
         // Not wedged: both routes are healthy.
@@ -2821,10 +2847,47 @@ mod tests {
     }
 
     #[test]
+    fn readyz_flips_to_503_on_a_frozen_writer_without_blocking_on_the_actor() {
+        // #862: /readyz reads the writer-frozen state from a PUBLISHED atomic, NOT through the actor
+        // (engine.with), so a frozen writer sheds 503 promptly AND — crucially — the read can never block
+        // behind a hung writer and wedge the single-threaded health server. /healthz is UNAFFECTED by a
+        // frozen writer (a frozen-but-running process is still alive — that is liveness, not readiness).
+        let window = 30_000_000; // 30 ms
+        let (addr, shutdown, handle, clock, beacon, _wedged, writer_healthy) =
+            start_watchdog(window);
+        beacon.mark_progress(clock.now_monotonic_nanos());
+
+        // Live writer: ready.
+        let r = request(addr, "GET /readyz HTTP/1.1\r\n\r\n");
+        assert!(
+            r.starts_with("HTTP/1.1 200 OK"),
+            "ready while the writer is live: {r}"
+        );
+
+        // The writer FREEZES (a covering fsync RETURNED an error): /readyz sheds 503 "writer frozen",
+        // read non-blockingly; /healthz stays 200 (the process is still live).
+        writer_healthy.store(false, Ordering::Release);
+        let r2 = request(addr, "GET /readyz HTTP/1.1\r\n\r\n");
+        assert!(
+            r2.starts_with("HTTP/1.1 503 Service Unavailable"),
+            "readyz flips to 503 on a frozen writer: {r2}"
+        );
+        assert!(r2.ends_with("writer frozen"), "{r2}");
+        let h = request(addr, "GET /healthz HTTP/1.1\r\n\r\n");
+        assert!(
+            h.starts_with("HTTP/1.1 200 OK"),
+            "a frozen-but-live broker is still alive (liveness != readiness): {h}"
+        );
+
+        shutdown.store(true, Ordering::Release);
+        handle.join().unwrap();
+    }
+
+    #[test]
     fn a_zero_window_disables_the_healthz_watchdog() {
         // window 0 = the watchdog is off: /healthz is the legacy static 200 no matter how stale the
         // beacon, the opt-out path (and the contract the existing metrics/admin helpers rely on).
-        let (addr, shutdown, handle, clock, _beacon, _wedged) = start_watchdog(0);
+        let (addr, shutdown, handle, clock, _beacon, _wedged, _writer_healthy) = start_watchdog(0);
         // Advance far past any window with NO beacon tick: still 200, because the watchdog is off.
         clock.advance_monotonic_nanos(10_000_000_000);
         let h = request(addr, "GET /healthz HTTP/1.1\r\n\r\n");

--- a/crates/ironbus-server/src/health.rs
+++ b/crates/ironbus-server/src/health.rs
@@ -238,7 +238,9 @@ where
     Ok(())
 }
 
-#[allow(clippy::too_many_arguments)]
+// The route dispatcher is one cohesive match over the fixed health routes (/metrics, /healthz,
+// /readyz, /admin, 404); the #862 actor-watchdog 503 branches push it one line over the pedantic bound.
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 fn handle<F, C, E>(
     mut stream: TcpStream,
     engine: &E,
@@ -304,12 +306,25 @@ where
         // A slow-but-progressing broker keeps ticking and stays 200; a frozen writer (a readyz 503)
         // is still live here. A zero window disables the watchdog (always 200 while up).
         "/healthz" => {
-            if progress.stuck_for_window(clock.now_monotonic_nanos(), liveness_window_nanos) {
+            let now = clock.now_monotonic_nanos();
+            // 503 if EITHER the ACCEPT loop wedged (#95) OR the APPEND ACTOR wedged on a hung fsync
+            // (#862). The actor-watchdog read is a non-blocking atomic that answers even while the actor
+            // is wedged, so a hung writer no longer leaves liveness GREEN (the silent total-stall bug) —
+            // an orchestrator now sees 503 and restarts the node. Disabled (always healthy here) until
+            // the serve path arms the bound, so an unconfigured/single-node broker is unchanged.
+            if progress.stuck_for_window(now, liveness_window_nanos) {
                 respond(
                     &mut stream,
                     503,
                     "Service Unavailable",
                     "no event-loop progress",
+                )
+            } else if engine.actor_watchdog_overran(now) {
+                respond(
+                    &mut stream,
+                    503,
+                    "Service Unavailable",
+                    "append actor wedged",
                 )
             } else {
                 respond(&mut stream, 200, "OK", "ok")
@@ -323,6 +338,18 @@ where
             // (the drain has not started), so the 503 must come from the gate, not the engine check.
             if draining.load(Ordering::Acquire) {
                 respond(&mut stream, 503, "Service Unavailable", "draining")
+            } else if engine.actor_watchdog_overran(clock.now_monotonic_nanos()) {
+                // The append actor is WEDGED on a hung fsync (#862): answer 503 DIRECTLY via the
+                // non-blocking watchdog atomic, BEFORE `engine.with` — which would queue a job behind the
+                // wedged fsync and HANG `/readyz` forever (detection would then depend solely on the
+                // prober's own timeout, and on a single-node edge box with no orchestrator nothing would
+                // detect it). Checked here so a wedge is reported, not hung on.
+                respond(
+                    &mut stream,
+                    503,
+                    "Service Unavailable",
+                    "append actor wedged",
+                )
             } else {
                 // Read the writer-health flag through the actor (the single owner). If the actor is
                 // gone (a shutdown drain), the broker is not ready: surface 503 rather than hang.
@@ -2529,10 +2556,47 @@ mod tests {
         handle.join().unwrap();
     }
 
+    /// A test `EngineAccess` that reports the append-actor wedge watchdog (#862) as overrun on demand,
+    /// delegating every real call to a shared engine. It lets a test drive the HTTP health server and
+    /// assert `/healthz` and `/readyz` flip to 503 the moment the watchdog trips — WITHOUT staging a real
+    /// hung fsync (the actor-level `a_hung_fsync_wedges...` test already proves the real-wedge detection).
+    struct WedgeableEngine {
+        inner: SharedEngine<InMemoryFs, Arc<ironbus_core::clock::ManualClock>>,
+        wedged: Arc<AtomicBool>,
+    }
+
+    impl EngineAccess<InMemoryFs, Arc<ironbus_core::clock::ManualClock>> for WedgeableEngine {
+        fn produce(
+            &self,
+            append: crate::actor::OwnedAppend,
+        ) -> Result<crate::actor::ProduceOutcome, crate::actor::ActorGone> {
+            self.inner.produce(append)
+        }
+        fn with<R, J>(&self, job: J) -> Result<R, crate::actor::ActorGone>
+        where
+            R: Send + 'static,
+            J: FnOnce(&mut Engine<InMemoryFs, Arc<ironbus_core::clock::ManualClock>>) -> R
+                + Send
+                + 'static,
+        {
+            self.inner.with(job)
+        }
+        fn now_monotonic_nanos(&self) -> u64 {
+            self.inner.now_monotonic_nanos()
+        }
+        fn consumer_credit_caps(&self) -> (u32, u64) {
+            self.inner.consumer_credit_caps()
+        }
+        fn actor_watchdog_overran(&self, _now_monotonic_nanos: u64) -> bool {
+            self.wedged.load(Ordering::Relaxed)
+        }
+    }
+
     /// Runs `serve_health` over a `ManualClock` with the given liveness `window_nanos` and a beacon
     /// the caller drives, so the #95 hysteresis watchdog can be exercised deterministically: the test
     /// advances the clock and ticks (or withholds) the beacon, then probes `/healthz`. Returns the
-    /// bound address, the shutdown flag, the join handle, the shared clock, and the shared beacon.
+    /// bound address, the shutdown flag, the join handle, the shared clock, the shared beacon, and the
+    /// shared actor-watchdog "wedged" flag (#862; default `false`, so liveness tests are unaffected).
     #[allow(clippy::type_complexity)]
     fn start_watchdog(
         window_nanos: u64,
@@ -2542,6 +2606,7 @@ mod tests {
         std::thread::JoinHandle<()>,
         Arc<ironbus_core::clock::ManualClock>,
         Arc<LivenessBeacon>,
+        Arc<AtomicBool>,
     ) {
         use ironbus_core::clock::ManualClock;
         let clock = Arc::new(ManualClock::new());
@@ -2589,7 +2654,14 @@ mod tests {
             },
         )
         .unwrap();
-        let shared: SharedEngine<InMemoryFs, Arc<ManualClock>> = Arc::new(Mutex::new(engine));
+        let inner: SharedEngine<InMemoryFs, Arc<ManualClock>> = Arc::new(Mutex::new(engine));
+        // The actor-watchdog "wedged" flag (#862), default false so the liveness tests behave exactly as
+        // before; the actor-wedge test flips it to drive /healthz and /readyz to 503.
+        let wedged = Arc::new(AtomicBool::new(false));
+        let engine_access = WedgeableEngine {
+            inner,
+            wedged: Arc::clone(&wedged),
+        };
         // The beacon starts at the clock's origin (0), exactly as the broker seeds it from its start
         // instant, so it is fresh at t=0 and only goes stale once the clock advances past the window
         // with no tick.
@@ -2604,7 +2676,7 @@ mod tests {
             move || {
                 serve_health(
                     &listener,
-                    &shared,
+                    &engine_access,
                     &shutdown,
                     false,
                     &beacon,
@@ -2614,7 +2686,7 @@ mod tests {
                 .unwrap();
             }
         });
-        (addr, shutdown, handle, clock, beacon)
+        (addr, shutdown, handle, clock, beacon, wedged)
     }
 
     #[test]
@@ -2622,7 +2694,7 @@ mod tests {
         // With a 30 ms window: a beacon tick at the current instant keeps /healthz 200 even after the
         // clock advances a little (under the window), so a slow-but-progressing loop never sheds.
         let window = 30_000_000; // 30 ms in nanos
-        let (addr, shutdown, handle, clock, beacon) = start_watchdog(window);
+        let (addr, shutdown, handle, clock, beacon, _wedged) = start_watchdog(window);
 
         // Fresh at t=0.
         let h = request(addr, "GET /healthz HTTP/1.1\r\n\r\n");
@@ -2644,7 +2716,7 @@ mod tests {
         // clock has advanced past the window /healthz sheds 503. This is the only thing that makes
         // the guard real: remove the watchdog (revert to a static 200) and this fails.
         let window = 30_000_000; // 30 ms
-        let (addr, shutdown, handle, clock, beacon) = start_watchdog(window);
+        let (addr, shutdown, handle, clock, beacon, _wedged) = start_watchdog(window);
 
         // Tick once at t=0, then let the loop wedge: no more ticks.
         beacon.mark_progress(clock.now_monotonic_nanos());
@@ -2680,7 +2752,7 @@ mod tests {
         // with no client work, so even across MANY window-lengths of pure idle /healthz never sheds.
         // This pins "idle is progress" so the watchdog cannot crash-loop an idle edge node.
         let window = 30_000_000; // 30 ms
-        let (addr, shutdown, handle, clock, beacon) = start_watchdog(window);
+        let (addr, shutdown, handle, clock, beacon, _wedged) = start_watchdog(window);
 
         // Model a long idle run: a 5 ms idle poll tick repeated past several windows.
         for _ in 0..50 {
@@ -2695,10 +2767,64 @@ mod tests {
     }
 
     #[test]
+    fn healthz_and_readyz_flip_to_503_when_the_append_actor_is_wedged() {
+        // #862 end-to-end at the HTTP layer: when the append actor is wedged on a hung fsync, /healthz
+        // AND /readyz both flip to 503 — instead of /healthz staying GREEN (the accept-loop beacon is
+        // decoupled, #95) and /readyz HANGING behind the wedged fsync. The actor-level
+        // `a_hung_fsync_wedges...` test proves the real-wedge detection; this proves the health surface
+        // surfaces it. The accept-loop beacon is kept FRESH throughout so the actor-watchdog is the SOLE
+        // reason for any 503, never the liveness window.
+        let window = 30_000_000; // 30 ms
+        let (addr, shutdown, handle, clock, beacon, wedged) = start_watchdog(window);
+        beacon.mark_progress(clock.now_monotonic_nanos());
+
+        // Not wedged: both routes are healthy.
+        let h = request(addr, "GET /healthz HTTP/1.1\r\n\r\n");
+        assert!(
+            h.starts_with("HTTP/1.1 200 OK"),
+            "healthy before the wedge: {h}"
+        );
+        let r = request(addr, "GET /readyz HTTP/1.1\r\n\r\n");
+        assert!(
+            r.starts_with("HTTP/1.1 200 OK"),
+            "ready before the wedge: {r}"
+        );
+
+        // The append actor wedges (a hung fsync overran the bound): /healthz AND /readyz flip to 503,
+        // and /readyz answers PROMPTLY (the non-blocking watchdog read, never the wedged actor).
+        wedged.store(true, Ordering::Release);
+        beacon.mark_progress(clock.now_monotonic_nanos());
+        let h2 = request(addr, "GET /healthz HTTP/1.1\r\n\r\n");
+        assert!(
+            h2.starts_with("HTTP/1.1 503 Service Unavailable"),
+            "healthz flips to 503 on an actor wedge: {h2}"
+        );
+        assert!(h2.ends_with("append actor wedged"), "{h2}");
+        let r2 = request(addr, "GET /readyz HTTP/1.1\r\n\r\n");
+        assert!(
+            r2.starts_with("HTTP/1.1 503 Service Unavailable"),
+            "readyz flips to 503 (and does NOT hang) on an actor wedge: {r2}"
+        );
+        assert!(r2.ends_with("append actor wedged"), "{r2}");
+
+        // Recovery (the fsync completed and the actor un-wedged): both return to healthy — not a latch.
+        wedged.store(false, Ordering::Release);
+        beacon.mark_progress(clock.now_monotonic_nanos());
+        let h3 = request(addr, "GET /healthz HTTP/1.1\r\n\r\n");
+        assert!(
+            h3.starts_with("HTTP/1.1 200 OK"),
+            "healthz recovers after the wedge clears: {h3}"
+        );
+
+        shutdown.store(true, Ordering::Release);
+        handle.join().unwrap();
+    }
+
+    #[test]
     fn a_zero_window_disables_the_healthz_watchdog() {
         // window 0 = the watchdog is off: /healthz is the legacy static 200 no matter how stale the
         // beacon, the opt-out path (and the contract the existing metrics/admin helpers rely on).
-        let (addr, shutdown, handle, clock, _beacon) = start_watchdog(0);
+        let (addr, shutdown, handle, clock, _beacon, _wedged) = start_watchdog(0);
         // Advance far past any window with NO beacon tick: still 200, because the watchdog is off.
         clock.advance_monotonic_nanos(10_000_000_000);
         let h = request(addr, "GET /healthz HTTP/1.1\r\n\r\n");

--- a/crates/ironbus-server/src/liveness.rs
+++ b/crates/ironbus-server/src/liveness.rs
@@ -136,20 +136,36 @@ impl ActorWatchdog {
 
     /// Records that the actor FINISHED a batch and is returning to idle (awaiting the next command).
     /// Clears the in-flight stamp so the watchdog cannot trip on an idle actor.
+    ///
+    /// This is a RELEASE store, and it is the publication point for the wedge→frozen handoff (#862): the
+    /// actor calls [`publish_writer_healthy`] (the writer's live/frozen state) and THEN `mark_idle`, so a
+    /// health reader whose [`overran`] ACQUIRE-loads this cleared stamp is guaranteed to also observe that
+    /// prior `writer_healthy` store. Without it, a weakly-ordered arch (e.g. aarch64) could let `/readyz`
+    /// observe the cleared wedge but a stale-healthy flag for one probe, transiently reporting 200 on a
+    /// writer that just froze. Release/Acquire closes that window; on x86 (TSO) it is a no-op anyway.
+    ///
+    /// [`publish_writer_healthy`]: ActorWatchdog::publish_writer_healthy
+    /// [`overran`]: ActorWatchdog::overran
     pub fn mark_idle(&self) {
-        self.processing_since.store(0, Ordering::Relaxed);
+        self.processing_since.store(0, Ordering::Release);
     }
 
     /// Whether the actor's current batch has been in flight longer than the configured bound — a hung
     /// fsync. `false` when idle (`processing_since == 0`), when no bound is configured (`bound == 0`),
     /// or within the bound. The comparison is strict `>` so the exact-bound boundary is still healthy.
+    ///
+    /// The `processing_since` load is ACQUIRE so that reading the idle stamp (`0`) synchronizes-with the
+    /// actor's [`mark_idle`] RELEASE store and transitively publishes the writer-frozen flag the actor set
+    /// just before it — see [`mark_idle`] for why `/readyz`'s wedge-then-frozen check needs this.
+    ///
+    /// [`mark_idle`]: ActorWatchdog::mark_idle
     #[must_use]
     pub fn overran(&self, now_monotonic_nanos: u64) -> bool {
         let bound = self.bound_nanos.load(Ordering::Relaxed);
         if bound == 0 {
             return false;
         }
-        let since = self.processing_since.load(Ordering::Relaxed);
+        let since = self.processing_since.load(Ordering::Acquire);
         since != 0 && now_monotonic_nanos.saturating_sub(since) > bound
     }
 

--- a/crates/ironbus-server/src/liveness.rs
+++ b/crates/ironbus-server/src/liveness.rs
@@ -70,6 +70,77 @@ impl LivenessBeacon {
     }
 }
 
+/// A shared actor-progress watchdog (#862): the append actor stamps the monotonic instant it BEGINS
+/// processing a command batch — which includes the covering durability `fdatasync` — and clears it
+/// when the batch completes and it returns to idle. The health server reads it WITHOUT going through
+/// the actor, so a HUNG fsync (a failing eMMC doing long internal retries, a stalled networked/overlay
+/// FS, brownout-stuck flash on the edge target) that blocks the actor thread FOREVER is DETECTED:
+/// `processing_since` stays put while the monotonic clock advances, and once the gap exceeds the
+/// configured bound the broker reports UNHEALTHY (flipping `/healthz` AND `/readyz` to 503) so an
+/// orchestrator restarts it — instead of liveness staying green while the whole produce path is wedged.
+///
+/// This is DISTINCT from [`LivenessBeacon`]: that watches the ACCEPT loop, which is deliberately
+/// decoupled from the writer (#95) and keeps ticking even while the actor is wedged, so it cannot see a
+/// hung writer. This watches the actor itself. Unlike the accept loop, the actor does NOT tick while
+/// idle (it blocks awaiting a command), so a stale-since-last-tick model would false-trip on a quiet
+/// broker; instead a `processing_since` of `0` means IDLE (never wedged), and a non-zero stamp older
+/// than the bound means the in-flight batch has overrun — a genuine wedge, not idleness. Cheap to
+/// share: two `AtomicU64`, relaxed ordering (advisory heartbeat, not a synchronization point).
+#[derive(Debug)]
+pub struct ActorWatchdog {
+    /// The monotonic nanos the actor began the current batch, or `0` when idle (blocked awaiting a
+    /// command). Stored as `max(1)` so a `now` of `0` (a fresh manual clock) is never mistaken for idle.
+    processing_since: AtomicU64,
+    /// The overrun bound in nanos: an in-flight batch older than this is WEDGED. `0` = the watchdog is
+    /// DISABLED (it never trips), the default until a serve configures it via [`set_bound_nanos`].
+    ///
+    /// [`set_bound_nanos`]: ActorWatchdog::set_bound_nanos
+    bound_nanos: AtomicU64,
+}
+
+impl ActorWatchdog {
+    /// A fresh watchdog (idle) with the given overrun `bound_nanos` (`0` = disabled).
+    #[must_use]
+    pub fn new(bound_nanos: u64) -> ActorWatchdog {
+        ActorWatchdog {
+            processing_since: AtomicU64::new(0),
+            bound_nanos: AtomicU64::new(bound_nanos),
+        }
+    }
+
+    /// Sets the overrun bound in nanos; `0` disables the watchdog. Called once at serve start from the
+    /// configured value, before any produce can wedge.
+    pub fn set_bound_nanos(&self, bound_nanos: u64) {
+        self.bound_nanos.store(bound_nanos, Ordering::Relaxed);
+    }
+
+    /// Records that the actor BEGAN a command batch at `now_monotonic_nanos` (it is about to append and
+    /// run the covering fsync). One relaxed store on the actor's per-BATCH boundary, never per message.
+    pub fn mark_busy(&self, now_monotonic_nanos: u64) {
+        self.processing_since
+            .store(now_monotonic_nanos.max(1), Ordering::Relaxed);
+    }
+
+    /// Records that the actor FINISHED a batch and is returning to idle (awaiting the next command).
+    /// Clears the in-flight stamp so the watchdog cannot trip on an idle actor.
+    pub fn mark_idle(&self) {
+        self.processing_since.store(0, Ordering::Relaxed);
+    }
+
+    /// Whether the actor's current batch has been in flight longer than the configured bound — a hung
+    /// fsync. `false` when idle (`processing_since == 0`), when no bound is configured (`bound == 0`),
+    /// or within the bound. The comparison is strict `>` so the exact-bound boundary is still healthy.
+    #[must_use]
+    pub fn overran(&self, now_monotonic_nanos: u64) -> bool {
+        let bound = self.bound_nanos.load(Ordering::Relaxed);
+        if bound == 0 {
+            return false;
+        }
+        let since = self.processing_since.load(Ordering::Relaxed);
+        since != 0 && now_monotonic_nanos.saturating_sub(since) > bound
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -131,5 +202,59 @@ mod tests {
         }
         // Now the loop wedges: no further tick. After a full window it sheds.
         assert!(b.stuck_for_window(now + window + 1, window));
+    }
+
+    #[test]
+    fn an_idle_actor_watchdog_never_overruns() {
+        // #862: a `processing_since` of 0 means the actor is idle (blocked awaiting a command), so the
+        // watchdog must NOT trip no matter how much time passes — only an in-flight batch can wedge.
+        let w = ActorWatchdog::new(30);
+        assert!(!w.overran(0));
+        assert!(!w.overran(u64::MAX), "an idle actor is never wedged");
+        // A finished batch (mark_busy then mark_idle) returns to idle: never wedged afterward.
+        w.mark_busy(100);
+        w.mark_idle();
+        assert!(!w.overran(100 + 1_000_000));
+    }
+
+    #[test]
+    fn a_busy_actor_watchdog_overruns_only_past_the_bound() {
+        // The actor begins a batch at t=100; within the bound it is healthy, at exactly the bound it is
+        // still healthy (strict >), and past the bound the in-flight batch is WEDGED (a hung fsync).
+        let w = ActorWatchdog::new(30);
+        w.mark_busy(100);
+        assert!(!w.overran(100 + 10));
+        assert!(!w.overran(100 + 30));
+        assert!(w.overran(100 + 31), "the in-flight batch overran the bound");
+        // The actor completing the batch clears the wedge (no flapping latch): idle again.
+        w.mark_idle();
+        assert!(!w.overran(100 + 1_000));
+    }
+
+    #[test]
+    fn a_zero_bound_disables_the_actor_watchdog() {
+        // bound 0 = disabled: even a very old in-flight stamp never trips (the default until a serve
+        // configures a bound). Setting a bound then engages it.
+        let w = ActorWatchdog::new(0);
+        w.mark_busy(1);
+        assert!(!w.overran(u64::MAX));
+        w.set_bound_nanos(30);
+        assert!(w.overran(1 + 31));
+        w.set_bound_nanos(0);
+        assert!(!w.overran(u64::MAX), "re-disabling stops the watchdog");
+    }
+
+    #[test]
+    fn a_busy_stamp_of_zero_is_not_mistaken_for_idle() {
+        // A fresh manual clock can read `now == 0`; `mark_busy` stores `max(1)`, so a batch that began
+        // at logical time 0 is still seen as busy (not idle) and can overrun.
+        let w = ActorWatchdog::new(30);
+        w.mark_busy(0);
+        assert!(!w.overran(0));
+        // The stamp is clamped to 1, so the overrun is at now > 1 + bound (= 31), not idle-forever.
+        assert!(
+            w.overran(32),
+            "a batch begun at t=0 still overruns the bound"
+        );
     }
 }

--- a/crates/ironbus-server/src/liveness.rs
+++ b/crates/ironbus-server/src/liveness.rs
@@ -14,7 +14,7 @@
 //! ([`ironbus_core::clock::Clock::now_monotonic_nanos`]), never the wall clock, so an NTP step never
 //! drives liveness.
 
-use core::sync::atomic::{AtomicU64, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 /// A shared monotonic "last made progress" timestamp the broker's main loop ticks and `/healthz`
 /// reads, the heart of the liveness hysteresis watchdog (#95).
@@ -84,8 +84,15 @@ impl LivenessBeacon {
 /// hung writer. This watches the actor itself. Unlike the accept loop, the actor does NOT tick while
 /// idle (it blocks awaiting a command), so a stale-since-last-tick model would false-trip on a quiet
 /// broker; instead a `processing_since` of `0` means IDLE (never wedged), and a non-zero stamp older
-/// than the bound means the in-flight batch has overrun — a genuine wedge, not idleness. Cheap to
-/// share: two `AtomicU64`, relaxed ordering (advisory heartbeat, not a synchronization point).
+/// than the bound means the in-flight batch has overrun — a genuine wedge, not idleness.
+///
+/// It also carries the writer's FROZEN state (#862) as a published flag, so the health server can answer
+/// `/readyz` WITHOUT going through the actor at all. Previously `/readyz` read the frozen state via
+/// `engine.with(|e| e.is_healthy())`, which queues a job behind the actor — and on a HUNG fsync that job
+/// blocks FOREVER, wedging the single-threaded health server so even the watchdog's own 503 is never
+/// served. Publishing the frozen flag here lets `/readyz` shed on `draining` / a wedge / a frozen writer
+/// with three non-blocking atomic reads and NO actor round-trip, so it can never hang. Cheap to share:
+/// two `AtomicU64` + one `AtomicBool`, relaxed ordering (advisory heartbeat, not a synchronization point).
 #[derive(Debug)]
 pub struct ActorWatchdog {
     /// The monotonic nanos the actor began the current batch, or `0` when idle (blocked awaiting a
@@ -96,15 +103,21 @@ pub struct ActorWatchdog {
     ///
     /// [`set_bound_nanos`]: ActorWatchdog::set_bound_nanos
     bound_nanos: AtomicU64,
+    /// The writer's live/frozen state, PUBLISHED by the actor after each batch (`engine.is_healthy()`),
+    /// so `/readyz` can read it non-blockingly instead of through the actor (#862). `true` = live (the
+    /// default for a fresh broker that has run no batch yet); `false` once a covering fsync RETURNED an
+    /// error and froze the writer.
+    writer_healthy: AtomicBool,
 }
 
 impl ActorWatchdog {
-    /// A fresh watchdog (idle) with the given overrun `bound_nanos` (`0` = disabled).
+    /// A fresh watchdog (idle, writer live) with the given overrun `bound_nanos` (`0` = disabled).
     #[must_use]
     pub fn new(bound_nanos: u64) -> ActorWatchdog {
         ActorWatchdog {
             processing_since: AtomicU64::new(0),
             bound_nanos: AtomicU64::new(bound_nanos),
+            writer_healthy: AtomicBool::new(true),
         }
     }
 
@@ -138,6 +151,19 @@ impl ActorWatchdog {
         }
         let since = self.processing_since.load(Ordering::Relaxed);
         since != 0 && now_monotonic_nanos.saturating_sub(since) > bound
+    }
+
+    /// Publishes the writer's live/frozen state (`engine.is_healthy()`), called by the actor after each
+    /// batch's covering commit (#862). One relaxed store on the per-batch boundary.
+    pub fn publish_writer_healthy(&self, healthy: bool) {
+        self.writer_healthy.store(healthy, Ordering::Relaxed);
+    }
+
+    /// The last-published writer live/frozen state, read non-blockingly by `/readyz` (#862) so it never
+    /// has to round-trip through the actor (which a hung fsync would block forever). `true` = live.
+    #[must_use]
+    pub fn writer_healthy(&self) -> bool {
+        self.writer_healthy.load(Ordering::Relaxed)
     }
 }
 
@@ -255,6 +281,27 @@ mod tests {
         assert!(
             w.overran(32),
             "a batch begun at t=0 still overruns the bound"
+        );
+    }
+
+    #[test]
+    fn the_watchdog_publishes_and_reads_the_writer_frozen_state() {
+        // #862: /readyz reads the writer live/frozen state from this published flag (non-blocking), NOT
+        // through the actor — so a frozen (or hung) writer can never block the readiness check.
+        let w = ActorWatchdog::new(0);
+        assert!(
+            w.writer_healthy(),
+            "a fresh watchdog reports the writer live"
+        );
+        w.publish_writer_healthy(false);
+        assert!(
+            !w.writer_healthy(),
+            "a frozen writer is published and read back"
+        );
+        w.publish_writer_healthy(true);
+        assert!(
+            w.writer_healthy(),
+            "a live writer reads back live again (not a one-way latch here)"
         );
     }
 }


### PR DESCRIPTION
## What

Closes #862. The durability barrier runs as a blocking syscall **inline on the single append-actor thread**, with no deadline or watchdog. A permanently-hung fsync (failing eMMC, stalled overlay/networked FS, brownout-stuck flash) wedges that thread forever. The #95 liveness beacon is ticked only by the accept loop and is **deliberately decoupled** from the writer, so `/healthz` stays **200**. `/readyz` queues a `Command::Run` behind the wedged fsync and **hangs**. The frozen-writer fail-closed path only triggers when fsync *returns* an error, never on a hang — so a single-node edge box silently stalls with liveness green and nothing restarts it.

## How (the issue's "at minimum" — an actor-progress watchdog distinct from the accept-loop beacon)

- **`ActorWatchdog`** (in `liveness.rs`, alongside `LivenessBeacon`): the append actor stamps it **busy** at the start of each command batch (which includes the covering `fdatasync`) and **idle** when the batch completes and it returns to blocking on `recv`. A `processing_since` of `0` = IDLE (a quiet broker never false-trips); a non-zero stamp older than the bound = the in-flight batch overran — a genuine wedge.
- The health server reads it via the new **`EngineAccess::actor_watchdog_overran`** — a **non-blocking atomic** that never goes through the actor, so it answers even while the actor is wedged. `/healthz` → 503 on *either* the accept-loop window *or* an actor overrun; `/readyz` checks the watchdog **first**, before `engine.with`, so it answers 503 **promptly** instead of hanging.
- Shared on every `EngineHandle` clone (one per actor); **disabled** (bound 0) until the serve path arms it, so single-node/unconfigured brokers and existing tests are unchanged.

## CLI

`--actor-watchdog-bound-ms` (env `IRONBUS_ACTOR_WATCHDOG_BOUND_MS`), flag > env > default, threaded into `ServeConfig` and the materialized-config line. Default **30 s** (far above any legitimate slow fsync), `0` disables.

## Tests

- `ActorWatchdog` unit tests (idle never trips; overruns only past the bound, strict `>`; `0` disables; a `t=0` stamp is not idle).
- `a_hung_fsync_wedges_the_actor_and_the_watchdog_detects_it`: a **real hung fsync** via the `FaultFs` sync gate proves the watchdog trips through the **live `EngineHandle`** (the production path) without disturbing the actor — which recovers cleanly on un-wedge.
- `healthz_and_readyz_flip_to_503_when_the_append_actor_is_wedged`: an **HTTP end-to-end** test proves `/healthz` *and* `/readyz` flip to 503 (and `/readyz` does not hang) on a wedge, and recover.
- CLI flag parse/resolve test.

`clippy --workspace --all-targets --all-features -D warnings -W clippy::pedantic` clean.

## Follow-up (not in scope, will file)

Run the durability barrier on a **dedicated IO worker** so the actor stays responsive (the issue's fuller hardening). This PR adds the **detection + fail-closed liveness flip**, which is the reported defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
