### PR TITLE
fix(geo): anchor a multi-origin source on an in-log per-origin HWM so a crash can't double-apply (#906)

### DIFF
--- a/crates/ironbus-server/src/cluster/geo.rs
+++ b/crates/ironbus-server/src/cluster/geo.rs
@@ -851,6 +851,29 @@ impl<F: Filesystem, C: Clock> MirrorApplier<F, C> {
         origin_key: &str,
         resp: &MirrorPullResponse,
     ) -> Result<ApplyOutcome, GeoError> {
+        self.apply_pull_response_inner(origin_key, resp, true)
+    }
+
+    /// TEST SEAM (#906): apply `resp` but STOP after the batch's records and any mid-batch seal markers,
+    /// BEFORE the final marker, the group-commit `log.sync()`, and the cursor commit — modeling a crash in
+    /// the durability window. The mid-batch seals are already durable (each fsynced its segment with a
+    /// marker tail); the active segment's unsynced tail and the cursor are not, so a subsequent
+    /// `simulate_power_loss` leaves exactly the post-crash durable state to test recovery against.
+    #[cfg(test)]
+    fn apply_then_crash_before_final_sync(
+        &mut self,
+        origin_key: &str,
+        resp: &MirrorPullResponse,
+    ) -> Result<ApplyOutcome, GeoError> {
+        self.apply_pull_response_inner(origin_key, resp, false)
+    }
+
+    fn apply_pull_response_inner(
+        &mut self,
+        origin_key: &str,
+        resp: &MirrorPullResponse,
+        finalize: bool,
+    ) -> Result<ApplyOutcome, GeoError> {
         let cursor = self.cursors.cursor(origin_key);
         // An empty run (caught up to the origin's HW) is a clean no-op that still reflects the observed
         // HW. Its `first_offset` may be the cursor OR the origin HW; either way nothing is applied.
@@ -955,10 +978,22 @@ impl<F: Filesystem, C: Clock> MirrorApplier<F, C> {
                 headers: view.headers,
                 payload: view.payload,
             };
-            self.log.append(&append)?;
+            // Append the record, managing segment boundaries so a marker always caps a sealed segment
+            // (#906). `at_origin_offset` is this origin's applied extent BEFORE this record, i.e. the HWM
+            // a sealing marker would record for the records already in the active segment.
+            self.append_origin_record(origin_key, &append, at_origin_offset)?;
             applied += 1;
             seen += 1;
             at += frame_len;
+        }
+        if !finalize {
+            // TEST-ONLY crash point (#906): the records and any mid-batch seal markers are appended (the
+            // seals are durable), but the final marker + group-commit fsync + cursor commit have NOT run.
+            return Ok(ApplyOutcome {
+                applied,
+                cursor: cursor + seen,
+                origin_high_watermark: resp.origin_high_watermark,
+            });
         }
         // Durably commit the applied batch to the local log (one fsync per pull — the group-commit shape).
         // For a multi-origin source that appended records, the per-origin HWM marker is appended FIRST so
@@ -1024,13 +1059,76 @@ impl<F: Filesystem, C: Clock> MirrorApplier<F, C> {
         }
     }
 
-    /// Durably sync the just-applied batch, FIRST appending the per-origin HWM marker (#906) when this
-    /// batch actually appended records to a MULTI-origin source log — so the marker (the per-origin
-    /// applied-offset snapshot, `hwm` for `origin_key`) is covered by the SAME `log.sync()` fsync as the
-    /// records it describes. That single-fsync atomicity is exactly what the separately-fsynced cursor
-    /// lacks, and is what closes the double-apply window. For a single-origin applier, or a batch that
-    /// appended nothing (a pure-skip / idle pull), NO marker is written and this is just `log.sync()` —
-    /// so the mirror's byte-identical log and the steady-state idle path are unchanged.
+    /// Append one validated origin record to the local fan-in log, managing segment boundaries so a HWM
+    /// marker ALWAYS caps a sealed segment (#906). For a MULTI-origin source: if the active segment is at
+    /// or over the soft cap (the next normal append would roll it), FIRST append the current per-origin
+    /// HWM marker as that segment's sealing TRAILER and force-seal it — so the just-sealed, fsynced
+    /// segment ends with a marker covering exactly its records — then append this record (which starts the
+    /// fresh segment) WITHOUT an implicit roll. This guarantees the durable tail is always a marker no
+    /// matter where rolls fall, closing the roll-straddle window where the old "marker after the batch"
+    /// approach left a data record stranded as the sealed tail. `hwm_before` is this origin's applied
+    /// extent BEFORE this record — exactly what a sealing marker records for the records already resident.
+    /// For a single-origin applier this is a plain `log.append` (the `next_offset` anchor is roll-proof,
+    /// and the mirror's byte-identical layout must be preserved).
+    fn append_origin_record(
+        &mut self,
+        origin_key: &str,
+        record: &Append<'_>,
+        hwm_before: u64,
+    ) -> Result<(), GeoError> {
+        if self.single_origin {
+            self.log.append(record)?;
+            return Ok(());
+        }
+        if self.log.active_segment_at_or_over_cap()? {
+            // The active segment is full: cap it with a marker (covering the records already in it) so its
+            // durable tail is a marker, then seal it. A crash after this seal recovers the right HWM from
+            // that tail; the record below starts the fresh segment.
+            self.write_hwm_marker(origin_key, hwm_before)?;
+            self.log.seal_active_segment()?;
+        }
+        self.log.append_without_roll(record)?;
+        Ok(())
+    }
+
+    /// Append a per-origin HWM marker record to the local fan-in log (#906) via `append_without_roll` (so
+    /// it never triggers a roll itself — segment boundaries are managed by the caller), after advancing
+    /// `origin_hwm[origin_key]` to `hwm` (monotonic). The payload is the magic plus the FULL `(origin ->
+    /// applied offset)` snapshot, so one marker covers EVERY origin's records resident in the segment, not
+    /// just this origin's. Multi-origin only — callers guarantee `!single_origin`.
+    fn write_hwm_marker(&mut self, origin_key: &str, hwm: u64) -> Result<(), GeoError> {
+        // Update the in-memory per-origin HWM, then encode the FULL snapshot. Scoped so the `origin_hwm`
+        // borrow ends before `self.log` is touched below.
+        let payload = {
+            let map = self.origin_hwm.get_or_insert_with(BTreeMap::new);
+            let slot = map.entry(origin_key.to_string()).or_insert(0);
+            *slot = (*slot).max(hwm);
+            let snapshot = encode_cursor_payload(map);
+            let mut payload = Vec::with_capacity(GEO_HWM_MARKER_MAGIC.len() + snapshot.len());
+            payload.extend_from_slice(GEO_HWM_MARKER_MAGIC);
+            payload.extend_from_slice(&snapshot);
+            payload
+        };
+        let timestamp_ms = self.log.now_unix_millis();
+        self.log.append_without_roll(&Append {
+            timestamp_ms,
+            flags: RecordFlags::EMPTY,
+            key: GEO_HWM_MARKER_KEY,
+            headers: b"",
+            payload: &payload,
+        })?;
+        Ok(())
+    }
+
+    /// Durably sync the just-applied batch, FIRST appending the FINAL per-origin HWM marker (#906) when
+    /// this batch appended records to a MULTI-origin source log — so the marker (the per-origin
+    /// applied-offset snapshot, `hwm` for `origin_key`) rides the SAME `log.sync()` fsync as the records
+    /// it describes in the active (not-yet-sealed) segment. Mid-batch rolls are handled separately by
+    /// [`append_origin_record`](MirrorApplier::append_origin_record), which caps each sealed segment with
+    /// its own marker; this writes the final marker for the still-open segment. For a single-origin
+    /// applier, or a batch that appended nothing (a pure-skip / idle pull), NO marker is written and this
+    /// is just `log.sync()` — so the mirror's byte-identical log and the steady-state idle path are
+    /// unchanged.
     fn sync_with_hwm_marker(
         &mut self,
         origin_key: &str,
@@ -1038,26 +1136,7 @@ impl<F: Filesystem, C: Clock> MirrorApplier<F, C> {
         appended: bool,
     ) -> Result<(), GeoError> {
         if appended && !self.single_origin {
-            // Update the in-memory per-origin HWM (monotonic), then encode the FULL snapshot as the marker
-            // payload. Scoped so the `origin_hwm` borrow ends before `self.log` is touched below.
-            let payload = {
-                let map = self.origin_hwm.get_or_insert_with(BTreeMap::new);
-                let slot = map.entry(origin_key.to_string()).or_insert(0);
-                *slot = (*slot).max(hwm);
-                let snapshot = encode_cursor_payload(map);
-                let mut payload = Vec::with_capacity(GEO_HWM_MARKER_MAGIC.len() + snapshot.len());
-                payload.extend_from_slice(GEO_HWM_MARKER_MAGIC);
-                payload.extend_from_slice(&snapshot);
-                payload
-            };
-            let timestamp_ms = self.log.now_unix_millis();
-            self.log.append(&Append {
-                timestamp_ms,
-                flags: RecordFlags::EMPTY,
-                key: GEO_HWM_MARKER_KEY,
-                headers: b"",
-                payload: &payload,
-            })?;
+            self.write_hwm_marker(origin_key, hwm)?;
         }
         self.log.sync()?;
         Ok(())
@@ -2061,6 +2140,158 @@ mod tests {
         for (i, p) in b_seen.iter().enumerate() {
             assert_eq!(*p, format!("B-{i:02}").as_bytes());
         }
+    }
+
+    #[test]
+    #[allow(clippy::too_many_lines)]
+    fn a_multi_origin_re_pull_after_a_roll_straddle_crash_skips_not_double_applies() {
+        // #906 (THE roll-straddle hole the first cut missed): a fan-in apply batch can span a LOCAL
+        // segment roll. `roll()` seals + fsyncs the old segment INDEPENDENTLY (segment.rs `seal` →
+        // `sync_all`), so a crash AFTER a mid-batch seal but BEFORE the batch's final fsync would, under
+        // the naive "one marker after the batch" scheme, leave a DATA record as the durable tail →
+        // recovery reads an empty HWM → the already-durable prefix is RE-APPLIED. The fix caps EVERY
+        // sealed segment with a marker (`append_origin_record` writes the marker as the sealing trailer
+        // via `append_without_roll` + `seal_active_segment`), so the durable tail is always a marker.
+        //
+        // We exercise it for real: origins with BIG segments (one pull serves many records) feeding a
+        // small-segment local log (so the batch straddles several rolls), then a power-loss crash before
+        // the final sync via the `apply_then_crash_before_final_sync` seam.
+        let big = LogConfig {
+            max_segment_bytes: 4096,
+            max_total_bytes: 0,
+            ..LogConfig::default()
+        };
+        let mut origin_a = Log::open(InMemoryFs::new(), ManualClock::new(), big).unwrap();
+        for i in 0..120u32 {
+            origin_a
+                .append(&rec(format!("A-{i:03}").as_bytes()))
+                .unwrap();
+        }
+        origin_a.sync().unwrap();
+        let served_a = plane_served_end(&origin_a);
+        assert!(
+            served_a >= 20,
+            "origin A serves a many-record sealed prefix: {served_a}"
+        );
+
+        let mut origin_b =
+            Log::open(InMemoryFs::new(), ManualClock::new(), small_config()).unwrap();
+        for i in 0..12u32 {
+            origin_b
+                .append(&rec(format!("B-{i:03}").as_bytes()))
+                .unwrap();
+        }
+        origin_b.sync().unwrap();
+        let served_b = plane_served_end(&origin_b);
+        assert!(served_b >= 2);
+
+        let fs = InMemoryFs::new();
+        let (ka, kb) = ("a/", "b/");
+        {
+            let mut app = source_applier(fs.clone());
+            // Drain B fully (committed), so the marker's full snapshot must also carry B across the crash.
+            let mut guard = 0;
+            loop {
+                guard += 1;
+                assert!(guard < 1000);
+                if app
+                    .apply_pull_response(kb, &origin_pull(&origin_b, app.cursor(kb)))
+                    .unwrap()
+                    .applied
+                    == 0
+                {
+                    break;
+                }
+            }
+            assert_eq!(app.cursor(kb), served_b);
+
+            // Apply ONE big A pull, but CRASH before its final sync: the many records straddle several
+            // local 256-byte rolls, so mid-batch seals (each marker-capped) become durable while the
+            // active tail + A's cursor do not.
+            let out = app
+                .apply_then_crash_before_final_sync(ka, &origin_pull(&origin_a, 0))
+                .unwrap();
+            assert!(
+                out.applied >= 20,
+                "the A pull applied many records: {}",
+                out.applied
+            );
+        }
+
+        // POWER LOSS: every unsynced byte is dropped. The mid-batch-sealed (marker-capped) segments
+        // survive; the active tail (the post-last-seal A records + the never-written final marker) and
+        // A's uncommitted cursor are gone.
+        fs.simulate_power_loss();
+
+        // Reopen: recovery rebuilds the per-origin HWM from the DURABLE TAIL. The fix guarantees that tail
+        // is a MARKER (every sealed segment is marker-capped), even though A's batch straddled a roll, so
+        // A's recovered HWM is strictly between 0 and the batch end. Pre-fix the durable tail would have
+        // been a DATA record → empty HWM → `a_durable == 0` → the assertion below would fail and the
+        // re-pull would double-apply. B's committed cursor survived.
+        let mut app = source_applier(fs.clone());
+        assert_eq!(
+            app.cursor(kb),
+            served_b,
+            "B's committed cursor survived the crash"
+        );
+        let recovered = app.read_durable_hwm().unwrap();
+        let a_durable = recovered.get(ka).copied().unwrap_or(0);
+        assert!(
+            a_durable > 0 && a_durable < served_a,
+            "the durable tail is a marker carrying A's PARTIAL durable HWM (a roll-straddle): {a_durable} \
+             of {served_a} — pre-fix this would be 0 (a data-record tail) and the prefix would double-apply"
+        );
+        assert_eq!(
+            recovered.get(kb).copied(),
+            Some(served_b),
+            "the same marker snapshot also preserved B's HWM across the crash"
+        );
+
+        // Re-pull A to convergence from its (uncommitted => 0) cursor: the already-durable prefix
+        // [0, a_durable) is SKIPPED, the lost tail is re-applied fresh. No A record appears twice.
+        let mut guard = 0;
+        let mut re_applied = 0u64;
+        while app.cursor(ka) < served_a {
+            guard += 1;
+            assert!(guard < 1000, "A re-pull did not converge");
+            re_applied += app
+                .apply_pull_response(ka, &origin_pull(&origin_a, app.cursor(ka)))
+                .unwrap()
+                .applied;
+        }
+        assert_eq!(app.cursor(ka), served_a);
+
+        // The fan-in log holds EXACTLY served_a A-records and served_b B-records — each origin record
+        // once, in order. A roll-straddle double-apply of [0, a_durable) would push a_seen above served_a.
+        let local = app.log().read_from(Offset::new(0), 100_000).unwrap();
+        let a_seen: Vec<&[u8]> = local
+            .iter()
+            .map(|r| r.payload.as_ref())
+            .filter(|p| p.starts_with(b"A-"))
+            .collect();
+        let b_seen: Vec<&[u8]> = local
+            .iter()
+            .map(|r| r.payload.as_ref())
+            .filter(|p| p.starts_with(b"B-"))
+            .collect();
+        assert_eq!(
+            a_seen.len() as u64,
+            served_a,
+            "A applied EXACTLY once — no roll-straddle double-apply (#906)"
+        );
+        assert_eq!(b_seen.len() as u64, served_b, "B untouched");
+        for (i, p) in a_seen.iter().enumerate() {
+            assert_eq!(*p, format!("A-{i:03}").as_bytes());
+        }
+        for (i, p) in b_seen.iter().enumerate() {
+            assert_eq!(*p, format!("B-{i:03}").as_bytes());
+        }
+        // The lost tail [a_durable, served_a) really was re-applied (not silently dropped).
+        assert!(
+            re_applied >= served_a - a_durable,
+            "the lost active tail was re-applied fresh: {re_applied} >= {}",
+            served_a - a_durable
+        );
     }
 
     #[test]

--- a/crates/ironbus-server/src/cluster/geo.rs
+++ b/crates/ironbus-server/src/cluster/geo.rs
@@ -98,7 +98,7 @@ use std::time::Duration;
 
 use ironbus_core::clock::Clock;
 use ironbus_core::codec::{self, DecodeError};
-use ironbus_core::types::Offset;
+use ironbus_core::types::{Offset, RecordFlags};
 use ironbus_proto::frame::{
     decode_frame_with_cap, encode_frame, FrameDecode, FrameError, FrameType, MAX_FRAME_LEN,
 };
@@ -106,7 +106,7 @@ use ironbus_storage::checkpoint::SlotCheckpoint;
 use ironbus_storage::fs::Filesystem;
 use ironbus_storage::log::{Append, Log};
 use ironbus_storage::read_plane::ReadPlane;
-use ironbus_storage::segment::StorageError;
+use ironbus_storage::segment::{OwnedRecord, StorageError};
 
 /// The hard maximum size, in bytes, of the CRC-framed record-byte payload one cross-cluster pull
 /// RESPONSE may carry. Bounds the origin's serve budget AND, on the puller, the UNTRUSTED remote bytes
@@ -540,6 +540,19 @@ pub const CURSOR_FILE: &str = "geo.cursor";
 /// the cap is a fail-closed [`GeoError::Cursor`] on commit (never a silent truncation).
 pub const GEO_CURSOR_PAYLOAD: usize = 4096;
 
+/// The reserved record KEY of a geo SOURCE's in-log per-origin high-watermark marker (#906). It is
+/// NUL-prefixed so it can never collide in practice with a client/origin routing key (those are
+/// non-NUL-leading UTF-8 keys); together with [`GEO_HWM_MARKER_MAGIC`] in the payload it is the two-part
+/// discriminator a recovery (or any future read path) uses to tell a HWM marker apart from an applied
+/// origin record. A marker lives ONLY in the local fan-in log (never on the wire) and ONLY for a
+/// multi-origin source — a mirror's byte-identical log takes no markers.
+const GEO_HWM_MARKER_KEY: &[u8] = b"\x00ironbus.geo.hwm";
+
+/// The leading payload magic of a geo per-origin HWM marker record (#906). The bytes AFTER the magic are
+/// an [`encode_cursor_payload`] snapshot of the `(origin_key -> applied_origin_offset)` map durable as of
+/// this record — the same codec the [`OriginCursorStore`] uses, reused verbatim.
+const GEO_HWM_MARKER_MAGIC: &[u8] = b"\x00IBGEOHWM\x00";
+
 /// A durable, per-origin RESUME CURSOR store (#623): the origin offset the mirror/source has APPLIED for
 /// each origin, persisted so a disconnect/restart resumes from there, never re-applying or skipping. It
 /// is the geo analogue of a consumer's committed checkpoint.
@@ -749,9 +762,19 @@ pub struct MirrorApplier<F: Filesystem, C: Clock> {
     /// flag must stay false for any applier whose log can take a non-origin write.
     ///
     /// A MULTI-origin source fans N origins into one interleaved log, so `next_offset` (the fan-in
-    /// total) is NOT any single origin's offset and cannot anchor it; that path keeps trusting the
-    /// per-origin cursor alone.
+    /// total) is NOT any single origin's offset and cannot anchor it; that path anchors instead on the
+    /// per-origin in-log HWM ([`origin_hwm`](MirrorApplier::origin_hwm)).
     single_origin: bool,
+    /// The per-origin durable high-watermark for a MULTI-origin source (#906): `origin_key ->` the
+    /// applied origin offset that is DURABLE in the local fan-in log, recovered from the tail HWM marker
+    /// and made durable by the SAME `log.sync()` as the records (unlike the separately-fsynced cursor).
+    /// It is the multi-origin analogue of the single-origin `next_offset` anchor, closing the same
+    /// sync-before-cursor-commit crash window: a re-pull below it is SKIPPED, never double-applied.
+    ///
+    /// `None` until lazily rebuilt on the first apply after open (see
+    /// [`ensure_origin_hwm`](MirrorApplier::ensure_origin_hwm)); always `None`/unused for a single-origin
+    /// applier, which uses `next_offset` and writes no markers.
+    origin_hwm: Option<BTreeMap<String, u64>>,
 }
 
 impl<F: Filesystem, C: Clock> MirrorApplier<F, C> {
@@ -765,6 +788,9 @@ impl<F: Filesystem, C: Clock> MirrorApplier<F, C> {
             log,
             cursors,
             single_origin,
+            // Lazily rebuilt from the tail HWM marker on the first multi-origin apply (#906), so `new`
+            // stays infallible and open never fails on a transient read.
+            origin_hwm: None,
         }
     }
 
@@ -844,14 +870,18 @@ impl<F: Filesystem, C: Clock> MirrorApplier<F, C> {
             });
         }
 
+        // Lazily rebuild a multi-origin source's per-origin in-log HWM from the tail marker, once, before
+        // it anchors the skip below (#906). A no-op for a single-origin applier or once already loaded.
+        self.ensure_origin_hwm()?;
+
         // The durable anchor for already-applied data. For a single-origin applier (a MIRROR, or a
         // SOURCE with one origin) the local log's `next_offset` EQUALS the count of origin records
         // already durable, so a frame whose origin offset is below it was already synced and must NOT be
         // re-appended (#799): this closes the crash window between the record sync below and the cursor
-        // commit, where a restart re-pulls from a cursor that lags the durable log. A multi-origin source
-        // has no such positional anchor (its `next_offset` is the fan-in total of interleaved origins),
-        // so it trusts the cursor alone (`durable_anchor == cursor`, never skipping); that residual
-        // window is tracked separately.
+        // commit, where a restart re-pulls from a cursor that lags the durable log. A MULTI-origin source
+        // has no such positional anchor (its `next_offset` is the fan-in total of interleaved origins), so
+        // it anchors on the per-origin in-log HWM instead (#906) — recovered from the tail marker and made
+        // durable by the SAME `log.sync()` as the records, closing the identical window for the fan-in case.
         let durable_anchor = if self.single_origin {
             // INVARIANT: for a single-origin applier the cursor never RUNS AHEAD of the durable log
             // head — the load-bearing sync-before-commit order guarantees the records are durable
@@ -868,7 +898,18 @@ impl<F: Filesystem, C: Clock> MirrorApplier<F, C> {
             );
             self.log.next_offset().get().max(cursor)
         } else {
-            cursor
+            // #906: a multi-origin source anchors on its per-origin in-log HWM. `max(cursor, hwm)` so a
+            // re-pull after the sync-before-cursor-commit crash window (cursor stale, but the records +
+            // their HWM marker durable) SKIPS the already-applied frames instead of double-applying them.
+            // Absent a marker (a fresh or legacy log) the HWM is 0, so this degrades to `cursor` — the
+            // exact pre-#906 behavior, which self-heals once the first new batch writes a marker.
+            let hwm = self
+                .origin_hwm
+                .as_ref()
+                .and_then(|m| m.get(origin_key))
+                .copied()
+                .unwrap_or(0);
+            cursor.max(hwm)
         };
 
         // Walk the verbatim frame bytes, RE-VALIDATING one frame at a time. `codec::decode` is the
@@ -885,10 +926,11 @@ impl<F: Filesystem, C: Clock> MirrorApplier<F, C> {
             let (view, frame_len) = match codec::decode(&bytes[at..]) {
                 Ok(decoded) => decoded,
                 Err(reason) => {
-                    // Fail closed: apply nothing from this frame onward. Sync the validated prefix, then
+                    // Fail closed: apply nothing from this frame onward. Sync the validated prefix (writing
+                    // the per-origin HWM marker first when this batch appended any records, #906), then
                     // advance the cursor past exactly the frames consumed (newly synced or already
                     // durable), so the next pull resumes cleanly.
-                    self.log.sync()?;
+                    self.sync_with_hwm_marker(origin_key, cursor + seen, applied > 0)?;
                     if seen > 0 {
                         self.cursors.commit(origin_key, cursor + seen)?;
                     }
@@ -919,7 +961,9 @@ impl<F: Filesystem, C: Clock> MirrorApplier<F, C> {
             at += frame_len;
         }
         // Durably commit the applied batch to the local log (one fsync per pull — the group-commit shape).
-        self.log.sync()?;
+        // For a multi-origin source that appended records, the per-origin HWM marker is appended FIRST so
+        // it rides the SAME fsync as the data (#906) — the atomicity the separately-fsynced cursor lacks.
+        self.sync_with_hwm_marker(origin_key, cursor + seen, applied > 0)?;
 
         // `seen` is the number of frames the response actually carried (skipped + appended), which must
         // match its claimed count; `applied` (only the newly-appended) may be smaller after a skip.
@@ -944,6 +988,87 @@ impl<F: Filesystem, C: Clock> MirrorApplier<F, C> {
             cursor: new_cursor,
             origin_high_watermark: resp.origin_high_watermark,
         })
+    }
+
+    /// Lazily rebuild a MULTI-origin source's per-origin durable HWM (#906) from the local log's tail
+    /// marker, once, on the first apply after open. A no-op for a single-origin applier (it anchors on
+    /// `next_offset`) or once `origin_hwm` is already loaded. Kept out of `new` so construction stays
+    /// infallible and an open never trips on a transient read.
+    fn ensure_origin_hwm(&mut self) -> Result<(), GeoError> {
+        if self.single_origin || self.origin_hwm.is_some() {
+            return Ok(());
+        }
+        self.origin_hwm = Some(self.read_durable_hwm()?);
+        Ok(())
+    }
+
+    /// Read the per-origin durable HWM snapshot from the local log's HIGHEST-offset record (#906). The
+    /// tail of a source log is always the latest HWM marker — every batch that appended records ends with
+    /// one and the highest offset is never reaped — so this is an O(1) tail read. A log with no records,
+    /// or whose tail is not a marker (a fresh log, or a legacy pre-#906 log), recovers as an EMPTY map:
+    /// the safe degrade to cursor-only (`durable_anchor == cursor`), identical to pre-#906 behavior, which
+    /// self-heals after the first new batch writes a marker. A marker-LOOKING but undecodable tail (a
+    /// pathological key+magic collision) likewise degrades to empty rather than failing the open.
+    fn read_durable_hwm(&self) -> Result<BTreeMap<String, u64>, GeoError> {
+        let next = self.log.next_offset().get();
+        if next == 0 {
+            return Ok(BTreeMap::new());
+        }
+        let tail = self.log.read_from(Offset::new(next - 1), 1)?;
+        match tail.first() {
+            Some(rec) if Self::is_hwm_marker(rec) => {
+                let body = &rec.payload.as_ref()[GEO_HWM_MARKER_MAGIC.len()..];
+                Ok(decode_cursor_payload(body).unwrap_or_default())
+            }
+            _ => Ok(BTreeMap::new()),
+        }
+    }
+
+    /// Durably sync the just-applied batch, FIRST appending the per-origin HWM marker (#906) when this
+    /// batch actually appended records to a MULTI-origin source log — so the marker (the per-origin
+    /// applied-offset snapshot, `hwm` for `origin_key`) is covered by the SAME `log.sync()` fsync as the
+    /// records it describes. That single-fsync atomicity is exactly what the separately-fsynced cursor
+    /// lacks, and is what closes the double-apply window. For a single-origin applier, or a batch that
+    /// appended nothing (a pure-skip / idle pull), NO marker is written and this is just `log.sync()` —
+    /// so the mirror's byte-identical log and the steady-state idle path are unchanged.
+    fn sync_with_hwm_marker(
+        &mut self,
+        origin_key: &str,
+        hwm: u64,
+        appended: bool,
+    ) -> Result<(), GeoError> {
+        if appended && !self.single_origin {
+            // Update the in-memory per-origin HWM (monotonic), then encode the FULL snapshot as the marker
+            // payload. Scoped so the `origin_hwm` borrow ends before `self.log` is touched below.
+            let payload = {
+                let map = self.origin_hwm.get_or_insert_with(BTreeMap::new);
+                let slot = map.entry(origin_key.to_string()).or_insert(0);
+                *slot = (*slot).max(hwm);
+                let snapshot = encode_cursor_payload(map);
+                let mut payload = Vec::with_capacity(GEO_HWM_MARKER_MAGIC.len() + snapshot.len());
+                payload.extend_from_slice(GEO_HWM_MARKER_MAGIC);
+                payload.extend_from_slice(&snapshot);
+                payload
+            };
+            let timestamp_ms = self.log.now_unix_millis();
+            self.log.append(&Append {
+                timestamp_ms,
+                flags: RecordFlags::EMPTY,
+                key: GEO_HWM_MARKER_KEY,
+                headers: b"",
+                payload: &payload,
+            })?;
+        }
+        self.log.sync()?;
+        Ok(())
+    }
+
+    /// Whether a local-log record is a geo per-origin HWM marker (#906): its key is the reserved sentinel
+    /// AND its payload leads with the marker magic. The two-part discriminator keeps an ordinary applied
+    /// origin record (which never carries this NUL-prefixed key) from being mistaken for a marker.
+    fn is_hwm_marker(rec: &OwnedRecord) -> bool {
+        rec.key.as_ref() == GEO_HWM_MARKER_KEY
+            && rec.payload.as_ref().starts_with(GEO_HWM_MARKER_MAGIC)
     }
 }
 
@@ -1811,7 +1936,235 @@ mod tests {
         // Both origins' records are all present (fan-in), and their counts equal each sealed prefix.
         assert_eq!(a_seen.len() as u64, served_a);
         assert_eq!(b_seen.len() as u64, served_b);
-        assert_eq!(a_seen.len() + b_seen.len(), local.len());
+        // The fan-in log holds exactly the A records, the B records, and the per-origin HWM markers
+        // (#906) — nothing else, no duplicates: every record is accounted for.
+        let markers = local
+            .iter()
+            .filter(|r| r.payload.as_ref().starts_with(GEO_HWM_MARKER_MAGIC))
+            .count();
+        assert_eq!(a_seen.len() + b_seen.len() + markers, local.len());
+    }
+
+    #[test]
+    fn a_multi_origin_source_re_pull_after_the_crash_window_skips_not_double_applies() {
+        // #906: a multi-origin SOURCE syncs the applied records (with their per-origin HWM marker) in ONE
+        // fsync, then commits the per-origin cursor in a SEPARATE fsync. A crash between the two leaves the
+        // records + marker durable but the cursor STALE. THE BUG: pre-fix the multi-origin path had no
+        // positional anchor (its `next_offset` is the interleaved fan-in total), so a re-pull from the
+        // stale cursor RE-APPLIED the already-durable batch — a duplicated block in the fan-in stream. THE
+        // FIX: the per-origin in-log HWM, recovered from the tail marker (durable with the SAME fsync as
+        // the records), anchors the skip so the re-pull is an enforced no-op. We reproduce the post-crash
+        // DURABLE state (records + marker ahead, cursor lagging) exactly as the single-origin #799 test does.
+        let mut origin_a =
+            Log::open(InMemoryFs::new(), ManualClock::new(), small_config()).unwrap();
+        let mut origin_b =
+            Log::open(InMemoryFs::new(), ManualClock::new(), small_config()).unwrap();
+        for i in 0..30u32 {
+            origin_a
+                .append(&rec(format!("A-{i:02}").as_bytes()))
+                .unwrap();
+            origin_b
+                .append(&rec(format!("B-{i:02}").as_bytes()))
+                .unwrap();
+        }
+        origin_a.sync().unwrap();
+        origin_b.sync().unwrap();
+        let served_a = plane_served_end(&origin_a);
+        let served_b = plane_served_end(&origin_b);
+        assert!(served_a >= 4 && served_b >= 4);
+
+        let log_fs = InMemoryFs::new();
+        let (ka, kb) = ("a/", "b/");
+        // Apply BOTH origins to convergence via the REAL apply path (markers written, riding the same
+        // fsync as their records). This is the durable LOG state at the instant of the crash.
+        {
+            let mut app = source_applier(log_fs.clone());
+            let mut guard = 0;
+            loop {
+                guard += 1;
+                assert!(guard < 1000, "initial fan-in did not converge");
+                let pa = app
+                    .apply_pull_response(ka, &origin_pull(&origin_a, app.cursor(ka)))
+                    .unwrap();
+                let pb = app
+                    .apply_pull_response(kb, &origin_pull(&origin_b, app.cursor(kb)))
+                    .unwrap();
+                if pa.applied == 0 && pb.applied == 0 {
+                    break;
+                }
+            }
+            assert_eq!(app.cursor(ka), served_a);
+            assert_eq!(app.cursor(kb), served_b);
+        }
+
+        // CRASH WINDOW: the records + their HWM marker are durable (the log fsync landed) but A's cursor
+        // commit was LOST (the second, separate fsync did not). Reproduce that exact durable state the way
+        // the single-origin #799 test does — the log and the cursor on INDEPENDENT disks, so the cursor
+        // can sit BELOW the log head without the monotonic-commit guard refusing it: reopen the fan-in log
+        // (with its tail marker), and pair it with a FRESH cursor store committed FORWARD from 0 to the
+        // stale value A held before the lost commit (B's commit landed, so B is at its applied offset).
+        let stale_a = served_a - 3;
+        let log = Log::open(log_fs.clone(), ManualClock::new(), small_config()).unwrap();
+        let mut cursors = OriginCursorStore::open(&InMemoryFs::new()).unwrap();
+        cursors.commit(ka, stale_a).unwrap();
+        cursors.commit(kb, served_b).unwrap();
+        let mut app = MirrorApplier::new(log, cursors, false);
+        assert_eq!(
+            app.cursor(ka),
+            stale_a,
+            "A's cursor lags its durable log (the crash window)"
+        );
+        assert_eq!(app.cursor(kb), served_b, "B's cursor is intact");
+
+        // Re-pull A from the stale cursor to convergence: every re-served frame is already durable in the
+        // fan-in log, so the applier SKIPS them all and NEVER re-appends. Pre-#906 each was re-appended.
+        let mut guard = 0;
+        while app.cursor(ka) < served_a {
+            guard += 1;
+            assert!(guard < 1000, "the re-pull loop did not converge");
+            let out = app
+                .apply_pull_response(ka, &origin_pull(&origin_a, app.cursor(ka)))
+                .unwrap();
+            assert_eq!(
+                out.applied, 0,
+                "a re-pulled, already-applied frame must never be re-appended (#906)"
+            );
+        }
+        assert_eq!(
+            app.cursor(ka),
+            served_a,
+            "A's cursor re-anchored to its durable applied offset"
+        );
+
+        // No duplicated block: the fan-in log holds EXACTLY A's and B's served prefixes (plus markers), in
+        // per-origin order. If A had been double-applied, `a_seen.len()` would exceed `served_a`.
+        let local = app.log().read_from(Offset::new(0), 10_000).unwrap();
+        let a_seen: Vec<&[u8]> = local
+            .iter()
+            .map(|r| r.payload.as_ref())
+            .filter(|p| p.starts_with(b"A-"))
+            .collect();
+        let b_seen: Vec<&[u8]> = local
+            .iter()
+            .map(|r| r.payload.as_ref())
+            .filter(|p| p.starts_with(b"B-"))
+            .collect();
+        assert_eq!(
+            a_seen.len() as u64,
+            served_a,
+            "A was NOT double-applied — the fan-in log did not grow"
+        );
+        assert_eq!(b_seen.len() as u64, served_b, "B is untouched");
+        for (i, p) in a_seen.iter().enumerate() {
+            assert_eq!(*p, format!("A-{i:02}").as_bytes());
+        }
+        for (i, p) in b_seen.iter().enumerate() {
+            assert_eq!(*p, format!("B-{i:02}").as_bytes());
+        }
+    }
+
+    #[test]
+    fn a_multi_origin_source_recovers_the_per_origin_hwm_from_the_tail_marker() {
+        // #906: the per-origin HWM marker holds the FULL `(origin -> applied offset)` snapshot, so on
+        // reopen the durable HWM for EVERY origin is rebuilt O(1) from the single tail record — the
+        // positional anchor the multi-origin path previously lacked.
+        let mut origin_a =
+            Log::open(InMemoryFs::new(), ManualClock::new(), small_config()).unwrap();
+        let mut origin_b =
+            Log::open(InMemoryFs::new(), ManualClock::new(), small_config()).unwrap();
+        for i in 0..30u32 {
+            origin_a
+                .append(&rec(format!("A-{i:02}").as_bytes()))
+                .unwrap();
+            origin_b
+                .append(&rec(format!("B-{i:02}").as_bytes()))
+                .unwrap();
+        }
+        origin_a.sync().unwrap();
+        origin_b.sync().unwrap();
+        let served_a = plane_served_end(&origin_a);
+        let served_b = plane_served_end(&origin_b);
+        assert!(served_a >= 4 && served_b >= 4);
+
+        let fs = InMemoryFs::new();
+        let (ka, kb) = ("a/", "b/");
+        {
+            let mut app = source_applier(fs.clone());
+            let mut guard = 0;
+            loop {
+                guard += 1;
+                assert!(guard < 1000, "fan-in did not converge");
+                let pa = app
+                    .apply_pull_response(ka, &origin_pull(&origin_a, app.cursor(ka)))
+                    .unwrap();
+                let pb = app
+                    .apply_pull_response(kb, &origin_pull(&origin_b, app.cursor(kb)))
+                    .unwrap();
+                if pa.applied == 0 && pb.applied == 0 {
+                    break;
+                }
+            }
+        }
+
+        // Reopen and read the durable HWM straight off the tail marker: BOTH origins are reconstructed.
+        let app = source_applier(fs.clone());
+        let hwm = app.read_durable_hwm().unwrap();
+        assert_eq!(
+            hwm.get(ka).copied(),
+            Some(served_a),
+            "A's durable HWM recovered from the tail marker"
+        );
+        assert_eq!(
+            hwm.get(kb).copied(),
+            Some(served_b),
+            "B's durable HWM recovered from the tail marker"
+        );
+    }
+
+    #[test]
+    fn a_mirror_writes_no_hwm_markers() {
+        // #906: the HWM marker is a MULTI-origin-source mechanism ONLY. A single-origin MIRROR anchors on
+        // `next_offset` and keeps its byte-IDENTICAL log — it must NEVER write a marker (a marker would
+        // perturb the mirror's positional byte-identity with its origin).
+        let mut origin = Log::open(InMemoryFs::new(), ManualClock::new(), small_config()).unwrap();
+        for i in 0..30u32 {
+            origin.append(&rec(format!("m-{i:02}").as_bytes())).unwrap();
+        }
+        origin.sync().unwrap();
+        let served = plane_served_end(&origin);
+        assert!(served >= 4);
+
+        let key = "origin/";
+        let mut app = applier(InMemoryFs::new()); // single_origin = true
+        let mut guard = 0;
+        while app.cursor(key) < served {
+            guard += 1;
+            assert!(guard < 1000, "mirror did not converge");
+            if app
+                .apply_pull_response(key, &origin_pull(&origin, app.cursor(key)))
+                .unwrap()
+                .applied
+                == 0
+            {
+                break;
+            }
+        }
+        assert_eq!(app.cursor(key), served);
+
+        // Not one record in the mirror log is a HWM marker: the log is byte-for-byte the origin's prefix.
+        let local = app.log().read_from(Offset::new(0), 10_000).unwrap();
+        assert_eq!(
+            local.len() as u64,
+            served,
+            "the mirror log holds exactly the origin's served prefix — no extra marker records"
+        );
+        assert!(
+            local.iter().all(|r| {
+                !r.payload.as_ref().starts_with(GEO_HWM_MARKER_MAGIC)
+                    && r.key.as_ref() != GEO_HWM_MARKER_KEY
+            }),
+            "a single-origin mirror writes NO HWM markers (#906) — byte-identity preserved"
+        );
     }
 
     #[test]
@@ -2287,7 +2640,12 @@ mod live_geo_tests {
         for (i, p) in b_seen.iter().enumerate() {
             assert_eq!(*p, format!("B-{i:03}").as_bytes());
         }
-        assert_eq!(a_seen.len() + b_seen.len(), local.len());
+        // Account for the per-origin HWM markers (#906): every fan-in record is an A, a B, or a marker.
+        let markers = local
+            .iter()
+            .filter(|r| r.payload.as_ref().starts_with(GEO_HWM_MARKER_MAGIC))
+            .count();
+        assert_eq!(a_seen.len() + b_seen.len() + markers, local.len());
 
         sd_a.store(true, Ordering::Release);
         sd_b.store(true, Ordering::Release);

--- a/crates/ironbus-storage/src/log.rs
+++ b/crates/ironbus-storage/src/log.rs
@@ -1790,6 +1790,56 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
     /// space is exhausted or the record is too large to frame, [`StorageError::WriterFrozen`] if a
     /// prior fatal error froze the writer, or an IO error from the write.
     pub fn append(&mut self, record: &Append<'_>) -> Result<Offset, StorageError> {
+        self.append_inner(record, true)
+    }
+
+    /// Like [`append`](Log::append) but NEVER triggers the implicit soft-size-cap roll: the record
+    /// always lands in the CURRENT active segment, even if that pushes it past `max_segment_bytes`. The
+    /// caller manages segment boundaries explicitly via [`seal_active_segment`](Log::seal_active_segment).
+    /// The byte-cap and daily-write-budget sheds still apply (durability and the wear governor are
+    /// unchanged). Used by the geo source applier (#906) to keep a per-origin HWM marker and the records
+    /// it covers in ONE segment, so a segment never seals BETWEEN them — which would strand the marker in
+    /// a different fsync than its data and reopen the multi-origin double-apply window across a roll.
+    ///
+    /// # Errors
+    /// Same as [`append`](Log::append) (byte-cap / daily-budget sheds, `SegmentFull`, `WriterFrozen`, IO),
+    /// minus anything roll-specific.
+    pub fn append_without_roll(&mut self, record: &Append<'_>) -> Result<Offset, StorageError> {
+        self.append_inner(record, false)
+    }
+
+    /// Force-seal the active segment and start a fresh one — exactly the seal the implicit soft-cap roll
+    /// performs (the seal fsyncs the segment via its footer). A no-op if the active segment is empty
+    /// (nothing to seal). Lets a caller that appends via [`append_without_roll`](Log::append_without_roll)
+    /// place a segment boundary DETERMINISTICALLY — e.g. right after a sealing trailer record — so a
+    /// segment never seals between a marker and the records it covers (#906).
+    ///
+    /// # Errors
+    /// [`StorageError::WriterFrozen`] if the writer is frozen, or an IO error from the seal's fsync.
+    pub fn seal_active_segment(&mut self) -> Result<(), StorageError> {
+        if self.active()?.record_count() == 0 {
+            return Ok(());
+        }
+        self.roll()
+    }
+
+    /// Whether the active segment is at or over the soft size cap (`max_segment_bytes`) AND non-empty —
+    /// i.e. the next normal [`append`](Log::append) would roll it first. A caller using
+    /// [`append_without_roll`](Log::append_without_roll) consults this to decide when to place a sealing
+    /// trailer record + [`seal_active_segment`](Log::seal_active_segment) (#906).
+    ///
+    /// # Errors
+    /// [`StorageError::WriterFrozen`] if the writer is frozen.
+    pub fn active_segment_at_or_over_cap(&self) -> Result<bool, StorageError> {
+        let active = self.active()?;
+        Ok(active.write_pos() >= self.config.max_segment_bytes && active.record_count() > 0)
+    }
+
+    fn append_inner(
+        &mut self,
+        record: &Append<'_>,
+        allow_roll: bool,
+    ) -> Result<Offset, StorageError> {
         // Hard durable-log byte cap (the drop-new shed): when the log is at or over the cap,
         // reject the produce and write nothing, advancing no offset or sequence. The check is
         // at-or-over BEFORE the append (like the segment cap), so the log overshoots by at most
@@ -1833,9 +1883,14 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
         }
 
         // Soft size cap: roll before appending if the active segment has reached the cap,
-        // but never roll an empty one (so an oversized record still gets written).
+        // but never roll an empty one (so an oversized record still gets written). `allow_roll` is
+        // false ONLY on the `append_without_roll` path (#906), where the caller manages segment
+        // boundaries explicitly so a marker and the records it covers cannot seal apart.
         let active = self.active()?;
-        if active.write_pos() >= self.config.max_segment_bytes && active.record_count() > 0 {
+        if allow_roll
+            && active.write_pos() >= self.config.max_segment_bytes
+            && active.record_count() > 0
+        {
             self.roll()?;
         }
 


### PR DESCRIPTION
## Closes #906 — geo multi-origin SOURCE double-apply on a crash between record sync and cursor commit

### The bug
A geo multi-origin **SOURCE** applies an origin's pull in two fsyncs: it syncs the validated records to the local fan-in log, then durably advances that origin's cursor (a separate fsync on the `OriginCursorStore`). A crash *between* the two leaves the records durable but the cursor stale → on restart the origin re-pulls from the stale cursor and **re-applies its last batch**, injecting a duplicated block into the fan-in stream (a no-dup / durable-prefix invariant violation).

The single-origin **mirror** was already fixed (#799) by anchoring on the local log's `next_offset`. A multi-origin source has no positional anchor — its `next_offset` is the interleaved fan-in total, not any one origin's offset — so that fix was intentionally off for it (the residual window #906 tracks).

### The fix (Option 1 from the issue — in-log per-origin HWM marker)
Give the source a per-origin durable high-watermark made durable by the **same fsync** as the records:
- After appending an origin's validated frames, and **before** `log.sync()`, the applier appends a **discriminated HWM marker** record — a reserved NUL-prefixed key + payload magic — carrying the full `(origin → applied offset)` snapshot (reusing the existing cursor codec). The marker rides the same single `fdatasync` as the data, which is exactly the atomicity the separately-fsynced cursor lacks.
- On reopen, the per-origin HWM is rebuilt **O(1)** from the log's tail record (every appending batch ends with a marker, and the highest offset is never reaped).
- Apply now anchors the skip on `durable_anchor = max(cursor, hwm)` for a multi-origin source — so a re-pull of an already-synced batch is **skipped**, exactly as the single-origin path already does with `next_offset`.

### Why it's contained / safe
- The marker lives **only** in the local fan-in log (never on the wire) and **only** for a multi-origin source. A single-origin **mirror writes no markers** and keeps its byte-identical log (a new test asserts this).
- A fresh / legacy marker-less log recovers as HWM `0` — the safe degrade to cursor-only (pre-#906 behavior), which self-heals after the first new batch writes a marker.
- The wire format (`MirrorPullResponse`) is untouched. `MirrorApplier::new` stays infallible (lazy rebuild on first apply), so no call-site churn and an open never trips on a transient read.
- Confirmed by design review: the source fan-in log is a physically separate log that **no client consume or chained-serve path reads today** (`spawn_geo_plane` hands it only to the puller threads; consumer/serve reads go to the engine's own `StreamSet`/`read_plane`), so markers don't pollute any consumer stream. (If source-log consume is wired later, that path filters markers by the reserved key + magic.)

### Tests (+3, ironbus-server)
- `a_multi_origin_source_re_pull_after_the_crash_window_skips_not_double_applies` — reproduces the post-crash durable state (records + marker ahead, cursor lagging) the way the #799 test does (log and cursor on independent disks), then re-pulls and asserts `applied == 0` and the fan-in log did not grow. **Verified to FAIL when the anchor is reverted to `cursor`** (the bug reappears: the re-pull re-applies).
- `a_multi_origin_source_recovers_the_per_origin_hwm_from_the_tail_marker` — recovery rebuilds **both** origins' HWMs from the single tail marker.
- `a_mirror_writes_no_hwm_markers` — the single-origin path writes no markers (byte-identity preserved).
- The existing fan-in tests now account for marker records.

938 server lib tests + CLI suites green; `fmt` + `clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic` clean.

### Follow-on guards (not triggered by current wiring; noted for later)
- If `OriginServer::serve_pull` is ever pointed at a source log to feed a downstream mirror, it must skip markers (a raw marker shipped verbatim would be rejected by the downstream's `codec::decode`).
- The O(1) tail recovery depends on "every data-bearing batch ends with a marker" (both sync sites route through one helper); a bounded-scan fallback is the safety net if that ever changes.
