### PR TITLE
perf(storage): cache an opened SegmentReader per sealed segment on both read paths (#808)

### DIFF
--- a/crates/ironbus-storage/src/fault.rs
+++ b/crates/ironbus-storage/src/fault.rs
@@ -81,6 +81,9 @@ pub struct FaultControl {
     /// (a retire dir-fsync), so the crash window is precisely between the compacted-segment commit
     /// and the originals being durably removed.
     fail_sync_dir_after: Arc<AtomicU64>,
+    /// A monotonic count of every `open` that ran, so a test can assert that a repeated read of one
+    /// sealed segment opens it ONCE (the #808 reader cache), not once per read.
+    open_count: Arc<AtomicU64>,
 }
 
 /// A condvar-backed gate the sync path waits on while closed (#177): `open` starts open (syncs pass),
@@ -161,6 +164,17 @@ impl FaultControl {
 
     fn record_sync_dir(&self) {
         self.sync_dir_count.fetch_add(1, Ordering::SeqCst);
+    }
+
+    /// A monotonic count of every `open` that has run, so a test can assert the #808 reader cache opens a
+    /// sealed segment ONCE across many reads (and re-opens after a roll/reap drops the old snapshot).
+    #[must_use]
+    pub fn open_count(&self) -> u64 {
+        self.open_count.load(Ordering::SeqCst)
+    }
+
+    fn record_open(&self) {
+        self.open_count.fetch_add(1, Ordering::SeqCst);
     }
 
     /// Arms (or disarms) short reads: while `limit` is non-zero, every `read_at` returns at most
@@ -417,8 +431,11 @@ impl<F: Filesystem> Filesystem for FaultFs<F> {
     type File = FaultFile<F::File>;
 
     fn open(&self, name: &str) -> io::Result<Self::File> {
+        let file = self.inner.open(name)?;
+        // Count only a SUCCESSFUL open, so an open-count assertion measures real fd opens (#808).
+        self.control.record_open();
         Ok(FaultFile {
-            inner: self.inner.open(name)?,
+            inner: file,
             control: self.control.clone(),
         })
     }

--- a/crates/ironbus-storage/src/log.rs
+++ b/crates/ironbus-storage/src/log.rs
@@ -596,6 +596,75 @@ impl CompactedIndex {
     }
 }
 
+/// The default number of opened SEALED-segment readers the through-actor `Log` keeps resident (#808).
+/// Each entry is one fd + a validated header; the cache is FIFO-bounded so a retention-off cold full
+/// scan opens-and-reuses a working set instead of leaking one fd per sealed segment. 256 sits well under
+/// a typical 1024 `RLIMIT_NOFILE`, leaving room for the active writer fd plus sockets.
+const DEFAULT_SEALED_READER_CACHE_CAP: usize = 256;
+
+/// A small FIFO-bounded cache of opened [`SegmentReader`]s keyed by SEALED segment id (#808), used by the
+/// through-actor `Log` read path so a repeated `read_from` over a hot sealed segment does ONE
+/// open+fstat+header-CRC, not one per read. The active (growing) segment is NEVER cached. Interior
+/// mutability (the read path is `&self`), single-writer / never aliased across threads — the same
+/// rationale as `segment_indexes`. Holds only derived data: dropping or rebuilding an entry changes
+/// nothing a reader observes (same bytes, same per-record CRC), it only re-pays the open. Entries are
+/// evicted at segment retirement via [`Log::evict_segment_index`]; segment ids are never recycled
+/// (ADR 0002), so a cached fd can never alias a different physical segment.
+struct SealedReaderCache<F: Filesystem> {
+    readers:
+        std::cell::RefCell<std::collections::HashMap<u64, std::sync::Arc<SegmentReader<F::File>>>>,
+    /// Insertion order of the resident ids, so the cache sheds the OLDEST opened reader when it hits its
+    /// cap — a bound on resident fds, not a correctness device (any victim is safe to re-open).
+    fifo: std::cell::RefCell<std::collections::VecDeque<u64>>,
+    cap: usize,
+}
+
+impl<F: Filesystem> SealedReaderCache<F> {
+    fn new(cap: usize) -> SealedReaderCache<F> {
+        SealedReaderCache {
+            readers: std::cell::RefCell::new(std::collections::HashMap::new()),
+            fifo: std::cell::RefCell::new(std::collections::VecDeque::new()),
+            cap,
+        }
+    }
+
+    fn get(&self, id: u64) -> Option<std::sync::Arc<SegmentReader<F::File>>> {
+        self.readers.borrow().get(&id).cloned()
+    }
+
+    fn insert(&self, id: u64, reader: std::sync::Arc<SegmentReader<F::File>>) {
+        let mut readers = self.readers.borrow_mut();
+        if !readers.contains_key(&id) {
+            let mut fifo = self.fifo.borrow_mut();
+            while fifo.len() >= self.cap {
+                match fifo.pop_front() {
+                    Some(evicted) => {
+                        readers.remove(&evicted);
+                    }
+                    None => break,
+                }
+            }
+            fifo.push_back(id);
+        }
+        readers.insert(id, reader);
+    }
+
+    fn evict(&self, id: u64) {
+        if self.readers.borrow_mut().remove(&id).is_some() {
+            self.fifo.borrow_mut().retain(|&x| x != id);
+        }
+    }
+}
+
+impl<F: Filesystem> std::fmt::Debug for SealedReaderCache<F> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SealedReaderCache")
+            .field("resident", &self.readers.borrow().len())
+            .field("cap", &self.cap)
+            .finish_non_exhaustive()
+    }
+}
+
 /// A single durable, ordered log backed by one data directory of segment files.
 ///
 /// One active segment receives appends; sealed predecessors hold the older records.
@@ -731,6 +800,12 @@ pub struct Log<F: Filesystem, C: Clock> {
     /// and caches an entry behind a `RefCell`, holding only derived data (dropping or rebuilding it
     /// changes nothing a reader observes — same survivors, same CRC validation).
     compacted_indexes: std::cell::RefCell<std::collections::HashMap<u64, CompactedIndex>>,
+    /// The resident, FIFO-bounded cache of OPENED sealed-segment readers (#808): the through-actor read
+    /// path (e.g. the Tier-W per-record poll, which reads `read_from(off, 1)` per delivered message)
+    /// reuses one opened `SegmentReader` per sealed segment instead of re-opening (open+fstat+header-CRC)
+    /// on every read. The active segment is never cached (it grows); evicted in lockstep with the seek
+    /// index by [`Log::evict_segment_index`] at retirement.
+    sealed_readers: SealedReaderCache<F>,
     /// The lock-free, off-actor consume READ plane (#539): the shared atomic flushed frontier plus
     /// the arc-swapped immutable snapshot of the SEALED segments + their seek anchors, which any
     /// number of reader threads observe with NO lock and NO append-actor round-trip. The single
@@ -820,6 +895,7 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
                     // A fresh log has no compacted segment, so the sparse index map (#481) starts
                     // empty; it is filled lazily the first time a compacted slot is read.
                     compacted_indexes: std::cell::RefCell::new(std::collections::HashMap::new()),
+                    sealed_readers: SealedReaderCache::new(DEFAULT_SEALED_READER_CACHE_CAP),
                     // The off-actor read plane (#539) is built lazily on the first consumer
                     // `read_plane()` call; a never-read log pays nothing.
                     read_plane: std::cell::RefCell::new(None),
@@ -994,6 +1070,7 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
             // The compacted (sparse) seek index map (#481) is likewise resident-only: a reopen
             // rebuilds it lazily from the durable frames the first time a compacted slot is read.
             compacted_indexes: std::cell::RefCell::new(std::collections::HashMap::new()),
+            sealed_readers: SealedReaderCache::new(DEFAULT_SEALED_READER_CACHE_CAP),
             // The off-actor read plane (#539) is built lazily on the first consumer `read_plane()`.
             read_plane: std::cell::RefCell::new(None),
         };
@@ -1364,6 +1441,7 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
             // The compacted (sparse) seek index map (#481) starts empty and is filled lazily on the
             // read path; the recovered chain may include compacted segments, indexed on first read.
             compacted_indexes: std::cell::RefCell::new(std::collections::HashMap::new()),
+            sealed_readers: SealedReaderCache::new(DEFAULT_SEALED_READER_CACHE_CAP),
             // The off-actor read plane (#539) is built lazily on the first consumer `read_plane()`.
             read_plane: std::cell::RefCell::new(None),
         };
@@ -2369,6 +2447,29 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
         Ok(out)
     }
 
+    /// The opened [`SegmentReader`] for segment `id`, served from the resident reader cache (#808) for a
+    /// SEALED segment (opened on first touch, reused thereafter) and opened FRESH for the active segment
+    /// (which grows, so its length/tail must never be cached). The returned `Arc` is cheap to clone and
+    /// reads it with positioned `pread`s.
+    fn sealed_reader_for(
+        &self,
+        id: u64,
+    ) -> Result<std::sync::Arc<SegmentReader<F::File>>, StorageError> {
+        if id == self.active_id {
+            return Ok(std::sync::Arc::new(SegmentReader::open(
+                self.fs.open(&segment_file_name(id))?,
+            )?));
+        }
+        if let Some(reader) = self.sealed_readers.get(id) {
+            return Ok(reader);
+        }
+        let reader =
+            std::sync::Arc::new(SegmentReader::open(self.fs.open(&segment_file_name(id))?)?);
+        self.sealed_readers
+            .insert(id, std::sync::Arc::clone(&reader));
+        Ok(reader)
+    }
+
     /// Reads ONE segment's contribution to a [`Log::read_range`] in a single forward pass, pushing
     /// the in-range records into `out` and advancing `byte_total` (#538). Returns `true` when the
     /// read should STOP (a record/byte/flushed bound was hit), `false` to advance to the next
@@ -2451,7 +2552,9 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
         let below_flushed =
             usize::try_from(bounds.flushed.saturating_sub(anchor_offset)).unwrap_or(usize::MAX);
         let want = remaining.saturating_add(gap).min(below_flushed);
-        let reader = SegmentReader::open(self.fs.open(&segment_file_name(slot.id))?)?;
+        // #808: reuse an opened reader for a SEALED segment (the consume hot path — Tier-W polls
+        // `read_from(off, 1)` per delivered message), re-opening only the growing active segment.
+        let reader = self.sealed_reader_for(slot.id)?;
         let records = reader.scan_from(byte_pos, Offset::new(anchor_offset), read_end, want)?;
         for record in records {
             // Skip the bounded run of records the anchor preceded `seg_start` by.
@@ -3350,6 +3453,9 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
     fn evict_segment_index(&mut self, id: u64) {
         self.segment_indexes.borrow_mut().remove(&id);
         self.compacted_indexes.borrow_mut().remove(&id);
+        // Drop the cached open reader (and its fd) for the retired segment in lockstep (#808), so a
+        // reaped/compacted-away segment's fd is released, not leaked.
+        self.sealed_readers.evict(id);
     }
 
     fn segment_index_for(&self, offset: u64) -> usize {
@@ -3578,6 +3684,12 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
     /// the evict-on-retirement contract directly.
     fn has_segment_index(&self, id: u64) -> bool {
         self.segment_indexes.borrow().contains_key(&id)
+    }
+
+    /// Whether an opened sealed-segment reader (#808) is currently cached for segment `id`. Lets a test
+    /// assert the same evict-on-retirement contract for the reader cache.
+    fn has_sealed_reader(&self, id: u64) -> bool {
+        self.sealed_readers.get(id).is_some()
     }
 
     /// The number of resident seek indexes currently cached, so a test can assert the resident set
@@ -5382,6 +5494,67 @@ mod tests {
         assert!(
             !log.has_segment_index(oldest.id),
             "the force-reaped segment's index must be evicted"
+        );
+    }
+
+    #[test]
+    fn repeated_read_from_opens_a_sealed_segment_once() {
+        // #808: the through-actor consume hot path (Tier-W polls `read_from(off, 1)` per delivered
+        // message) reuses one opened reader per SEALED segment, so N reads of one sealed segment do ONE
+        // open, not N. Without the cache the open-count delta would equal the number of reads.
+        use crate::fault::FaultFs;
+        let (fs, control) = FaultFs::new(InMemoryFs::new());
+        let mut log = Log::open(fs, ManualClock::new(), small_config()).unwrap();
+        for i in 0..16u8 {
+            log.append(&rec(&[i; 16])).unwrap();
+        }
+        log.sync().unwrap();
+        assert!(
+            log.segments.len() >= 2,
+            "the tiny cap sealed several segments"
+        );
+        let oldest = log.segments[0];
+        let base = oldest.base_offset;
+        // Read the first sealed segment's base offset many times; it is opened on the first read and the
+        // opened reader is reused for the rest.
+        let baseline = control.open_count();
+        for _ in 0..20 {
+            let recs = log.read_from(Offset::new(base), 1).unwrap();
+            assert_eq!(recs.len(), 1, "each read served the sealed record");
+        }
+        assert_eq!(
+            control.open_count() - baseline,
+            1,
+            "20 reads of one sealed segment opened it ONCE (#808), not 20 times"
+        );
+        assert!(
+            log.has_sealed_reader(oldest.id),
+            "the sealed reader is cached"
+        );
+    }
+
+    #[test]
+    fn a_force_reap_evicts_the_cached_sealed_reader() {
+        // #808: a retired segment's cached reader (and its fd) is dropped in lockstep with its seek index
+        // via `evict_segment_index`, so a reaped segment never leaves a leaked fd behind.
+        let mut log = open_mem(small_config());
+        for i in 0..16u8 {
+            log.append(&rec(&[i; 16])).unwrap();
+        }
+        log.sync().unwrap();
+        assert!(log.segments.len() >= 2);
+        let oldest = log.segments[0];
+        // Warm the cache for the oldest sealed segment.
+        let _ = log.read_from(Offset::new(oldest.base_offset), 1).unwrap();
+        assert!(
+            log.has_sealed_reader(oldest.id),
+            "the oldest sealed segment's reader is cached after a read"
+        );
+        let out = log.reap_oldest_forced().unwrap();
+        assert!(out.is_some(), "a force-reap removes the oldest");
+        assert!(
+            !log.has_sealed_reader(oldest.id),
+            "the force-reaped segment's cached reader (and its fd) must be evicted (#808)"
         );
     }
 

--- a/crates/ironbus-storage/src/read_plane.rs
+++ b/crates/ironbus-storage/src/read_plane.rs
@@ -58,12 +58,35 @@
 //! same materialized records the through-actor path returns (the differential test in `log.rs`
 //! asserts byte-for-byte equality).
 
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, OnceLock};
 
 use arc_swap::ArcSwap;
 
 use crate::fs::Filesystem;
+
+/// The maximum opened SEALED-segment readers a single off-actor snapshot generation caches (#808). Beyond
+/// it, a read opens its segment UNCACHED (per-read, like pre-#808) so a retention-off cold full backfill
+/// can never hold one fd per sealed segment at once (an EMFILE exposure). A tailing/replication working
+/// set is small and touched first, so it stays fully cached; only a cold deep replay past the cap re-opens
+/// per read. Mirrors the through-actor `Log`'s `DEFAULT_SEALED_READER_CACHE_CAP`.
+const DEFAULT_PLANE_READER_CACHE_CAP: usize = 256;
+
+/// The per-snapshot reader-cache cap, overridable in tests to a small value so a cap test need not open
+/// hundreds of segments. `0` (the default) means "use [`DEFAULT_PLANE_READER_CACHE_CAP`]".
+#[cfg(test)]
+static TEST_PLANE_READER_CACHE_CAP: AtomicUsize = AtomicUsize::new(0);
+
+fn plane_reader_cache_cap() -> usize {
+    #[cfg(test)]
+    {
+        let overridden = TEST_PLANE_READER_CACHE_CAP.load(Ordering::Relaxed);
+        if overridden != 0 {
+            return overridden;
+        }
+    }
+    DEFAULT_PLANE_READER_CACHE_CAP
+}
 use crate::naming::segment_file_name;
 use crate::segment::{OwnedRecord, RawByteRun, SegmentReader, StorageError};
 use ironbus_core::types::Offset;
@@ -76,31 +99,41 @@ use ironbus_core::types::Offset;
 /// readers — positioned (`pread`) reads need no cursor and no lock — and the WHOLE snapshot (and thus
 /// every fd it opened) drops when a roll/reap republishes a fresh snapshot, so fds never leak past the
 /// generation that opened them.
-struct SlotReaders<F: Filesystem>(Vec<OnceLock<Arc<SegmentReader<F::File>>>>);
+///
+/// FD-BOUNDED: at most `cap` slots are ever cached in one generation (`opened` counts the cached slots,
+/// lock-free). A read past the cap opens UNCACHED — per-read, exactly as before #808 — so a cold full
+/// backfill within one generation can never hold one fd per sealed segment at once (the EMFILE exposure).
+/// The cap is a SOFT bound: concurrent openers may exceed it by at most the number of racing threads.
+struct SlotReaders<F: Filesystem> {
+    slots: Vec<OnceLock<Arc<SegmentReader<F::File>>>>,
+    /// The number of slots actually opened-and-cached so far this generation (the resident-fd bound).
+    opened: AtomicUsize,
+    cap: usize,
+}
 
 impl<F: Filesystem> SlotReaders<F> {
-    /// A fresh, all-empty cache sized to `len` sealed segments (one `OnceLock` per slot).
+    /// A fresh, all-empty cache sized to `len` sealed segments (one `OnceLock` per slot), bounded to
+    /// [`plane_reader_cache_cap`] resident readers.
     fn empty(len: usize) -> SlotReaders<F> {
-        SlotReaders((0..len).map(|_| OnceLock::new()).collect())
+        SlotReaders {
+            slots: (0..len).map(|_| OnceLock::new()).collect(),
+            opened: AtomicUsize::new(0),
+            cap: plane_reader_cache_cap(),
+        }
     }
 }
 
-// Manual `Clone`/`Debug` so neither requires `F::File: Clone`/`Debug` (the `Filesystem::File` associated
-// type carries no such bound). A clone shares the already-opened readers via their `Arc`s — but a clone
-// is never on the publish path (`republish_sealed` builds a FRESH snapshot), so no fd is shared across
-// generations; `Debug` prints only counts, never the readers.
-impl<F: Filesystem> Clone for SlotReaders<F> {
-    fn clone(&self) -> SlotReaders<F> {
-        SlotReaders(self.0.clone())
-    }
-}
-
+// Manual `Debug` so it needs no `F::File: Debug` bound (the `Filesystem::File` associated type carries
+// none) and prints only counts, never the readers. NO `Clone`: a clone would share opened fds via their
+// `Arc`s and the `opened` counter could not be meaningfully copied; the publish path
+// (`republish_sealed`) always builds a FRESH snapshot, never clones, so `SealedSnapshot` does not derive
+// `Clone` either — removing a latent fd-aliasing footgun.
 impl<F: Filesystem> std::fmt::Debug for SlotReaders<F> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let opened = self.0.iter().filter(|c| c.get().is_some()).count();
         f.debug_struct("SlotReaders")
-            .field("slots", &self.0.len())
-            .field("opened", &opened)
+            .field("slots", &self.slots.len())
+            .field("opened", &self.opened.load(Ordering::Relaxed))
+            .field("cap", &self.cap)
             .finish_non_exhaustive()
     }
 }
@@ -186,7 +219,11 @@ impl SealedSegment {
 /// round-trip. Replaced wholesale by the writer when a roll seals a new segment or a reap retires
 /// one; a reader holding an older `Arc` simply reads an older (still-valid, possibly fewer-segments)
 /// view, which the flushed frontier bound clamps correctly.
-#[derive(Clone, Debug)]
+//
+// NOT `Clone`: the per-segment reader cache (`SlotReaders`, #808) holds opened fds whose `Arc`s must not
+// be aliased across snapshot generations, and the publish path (`republish_sealed`) always builds a FRESH
+// snapshot rather than cloning, so `Clone` is unused — dropping it removes the fd-aliasing footgun.
+#[derive(Debug)]
 pub(crate) struct SealedSnapshot<F: Filesystem> {
     /// The filesystem handle, shared (the same directory the writer owns). Reads open their OWN
     /// `SegmentReader` over an immutable sealed file, so a concurrent reader never aliases the
@@ -273,18 +310,25 @@ impl<F: crate::fs::Filesystem> SealedSnapshot<F> {
         i: usize,
         slot: &SealedSegment,
     ) -> Result<Arc<SegmentReader<F::File>>, StorageError> {
-        if let Some(reader) = self.readers.0[i].get() {
+        if let Some(reader) = self.readers.slots[i].get() {
             return Ok(Arc::clone(reader));
         }
         let opened = Arc::new(SegmentReader::open(
             self.fs.open(&segment_file_name(slot.id))?,
         )?);
-        // `set` fails if another thread won the race; either way the slot is now initialized, so read it
-        // back and return the stored reader (the winner's), letting `opened` drop if we lost.
-        let _ = self.readers.0[i].set(opened);
-        Ok(Arc::clone(self.readers.0[i].get().expect(
-            "slot reader is initialized after set or a lost race",
-        )))
+        // Cache only while under the per-generation cap (the resident-fd bound). Past it, return the fresh
+        // open UNCACHED — a per-read open exactly as before #808 — so a cold full backfill can't pin one
+        // fd per sealed segment. `opened < cap` is a soft check (concurrent openers may exceed it by the
+        // number of racing threads, never unboundedly).
+        if self.readers.opened.load(Ordering::Relaxed) < self.readers.cap {
+            // `set` fails if another thread won the race for this slot; count ONLY a winning set so
+            // `opened` tracks distinct cached slots. Either way the slot is now initialized.
+            if self.readers.slots[i].set(Arc::clone(&opened)).is_ok() {
+                self.readers.opened.fetch_add(1, Ordering::Relaxed);
+            }
+            return Ok(self.readers.slots[i].get().map_or(opened, Arc::clone));
+        }
+        Ok(opened)
     }
 
     /// The index in `segments` of the sealed segment whose range holds `offset` (the slot with the
@@ -726,6 +770,13 @@ impl<F: crate::fs::Filesystem> ReadPlane<F> {
         let snapshot = self.sealed.load();
         snapshot.read_range_raw(start.get(), flushed, max_records, max_bytes)
     }
+
+    /// The number of sealed-segment readers currently cached in the live snapshot (#808): the resident-fd
+    /// count, which the per-generation cap bounds. Lets a test assert the fd bound directly.
+    #[cfg(test)]
+    fn resident_reader_count(&self) -> usize {
+        self.sealed.load().readers.opened.load(Ordering::Relaxed)
+    }
 }
 
 #[cfg(test)]
@@ -879,6 +930,47 @@ mod tests {
             1,
             "a republished snapshot re-opens segment 0 once (the old generation's fd was dropped, not reused)"
         );
+    }
+
+    /// #808 (SHOULD-FIX): the per-snapshot reader cache is FD-BOUNDED — it never caches more than its cap
+    /// readers, so a cold full backfill within one generation cannot pin one fd per sealed segment. With a
+    /// cap of 2, reading the WHOLE multi-segment sealed prefix leaves at most 2 readers resident; the
+    /// over-cap segments are read uncached (correctness unchanged — same bytes).
+    #[test]
+    fn the_plane_reader_cache_is_fd_bounded_per_generation() {
+        TEST_PLANE_READER_CACHE_CAP.store(2, Ordering::Relaxed);
+        let (mut log, _control) = small_fault_log();
+        for i in 0..60u32 {
+            log.append(&rec(&i.to_le_bytes())).unwrap();
+            if i % 5 == 0 {
+                log.sync().unwrap();
+            }
+        }
+        log.sync().unwrap();
+        let plane = log.read_plane().unwrap();
+        let flushed = log.flushed_offset().get();
+        // Read across the whole sealed prefix many times (well more segments than the cap of 2).
+        let mut total = 0;
+        for _ in 0..3 {
+            for off in 0..flushed {
+                total += plane
+                    .read_range(Offset::new(off), 1, None)
+                    .unwrap()
+                    .records
+                    .len();
+            }
+        }
+        assert!(total > 0, "the sealed prefix served records");
+        assert!(
+            plane.resident_reader_count() <= 2,
+            "the cache never holds more than its cap of 2 readers (fd-bounded), got {}",
+            plane.resident_reader_count()
+        );
+        assert!(
+            plane.resident_reader_count() >= 1,
+            "but it does cache within the cap (the hot segment is reused)"
+        );
+        TEST_PLANE_READER_CACHE_CAP.store(0, Ordering::Relaxed);
     }
 
     /// #664: the off-actor WINDOW-BOUNDED read-end (`SealedSegment::window_read_end`) is correct over

--- a/crates/ironbus-storage/src/read_plane.rs
+++ b/crates/ironbus-storage/src/read_plane.rs
@@ -59,13 +59,51 @@
 //! asserts byte-for-byte equality).
 
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use arc_swap::ArcSwap;
 
+use crate::fs::Filesystem;
 use crate::naming::segment_file_name;
 use crate::segment::{OwnedRecord, RawByteRun, SegmentReader, StorageError};
 use ironbus_core::types::Offset;
+
+/// The lazily-opened [`SegmentReader`] cache for a [`SealedSnapshot`] (#808): one `OnceLock` per sealed
+/// segment, PARALLEL to `SealedSnapshot::segments` (same index). Opening a sealed segment does an
+/// `open(2)` + `fstat(2)` + a 64-byte header `pread` + a header-CRC decode; a sealed segment is
+/// IMMUTABLE, so that work is identical on every read and is cached here, opened on first touch and
+/// reused by all subsequent reads. The reader is shared as an `Arc` across the concurrent off-actor
+/// readers — positioned (`pread`) reads need no cursor and no lock — and the WHOLE snapshot (and thus
+/// every fd it opened) drops when a roll/reap republishes a fresh snapshot, so fds never leak past the
+/// generation that opened them.
+struct SlotReaders<F: Filesystem>(Vec<OnceLock<Arc<SegmentReader<F::File>>>>);
+
+impl<F: Filesystem> SlotReaders<F> {
+    /// A fresh, all-empty cache sized to `len` sealed segments (one `OnceLock` per slot).
+    fn empty(len: usize) -> SlotReaders<F> {
+        SlotReaders((0..len).map(|_| OnceLock::new()).collect())
+    }
+}
+
+// Manual `Clone`/`Debug` so neither requires `F::File: Clone`/`Debug` (the `Filesystem::File` associated
+// type carries no such bound). A clone shares the already-opened readers via their `Arc`s — but a clone
+// is never on the publish path (`republish_sealed` builds a FRESH snapshot), so no fd is shared across
+// generations; `Debug` prints only counts, never the readers.
+impl<F: Filesystem> Clone for SlotReaders<F> {
+    fn clone(&self) -> SlotReaders<F> {
+        SlotReaders(self.0.clone())
+    }
+}
+
+impl<F: Filesystem> std::fmt::Debug for SlotReaders<F> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let opened = self.0.iter().filter(|c| c.get().is_some()).count();
+        f.debug_struct("SlotReaders")
+            .field("slots", &self.0.len())
+            .field("opened", &opened)
+            .finish_non_exhaustive()
+    }
+}
 
 /// One SEALED segment in a [`SealedSnapshot`]: its identity, covered offset range, and the resident
 /// sparse seek anchors (#537) so a reader can SEEK without the writer's live `Log` state.
@@ -149,13 +187,17 @@ impl SealedSegment {
 /// one; a reader holding an older `Arc` simply reads an older (still-valid, possibly fewer-segments)
 /// view, which the flushed frontier bound clamps correctly.
 #[derive(Clone, Debug)]
-pub(crate) struct SealedSnapshot<F> {
+pub(crate) struct SealedSnapshot<F: Filesystem> {
     /// The filesystem handle, shared (the same directory the writer owns). Reads open their OWN
     /// `SegmentReader` over an immutable sealed file, so a concurrent reader never aliases the
     /// writer's active `SegmentWriter` handle.
     fs: Arc<F>,
     /// The sealed segments, ascending by base offset. The ACTIVE (un-sealed) segment is NEVER here.
     segments: Vec<SealedSegment>,
+    /// The lazily-opened `SegmentReader` per sealed segment (#808), PARALLEL to `segments`: a read opens
+    /// each immutable sealed file once and reuses it, instead of re-doing open+fstat+header-CRC per read.
+    /// Dropped (fds closed) with the snapshot when a roll/reap republishes a fresh one.
+    readers: SlotReaders<F>,
     /// The lowest covered offset across the snapshot (the first segment's base): a read below it is
     /// out of range, exactly as the `Log` reports `OffsetOutOfRange`.
     oldest: u64,
@@ -204,6 +246,47 @@ pub struct RawSealedRead {
 }
 
 impl<F: crate::fs::Filesystem> SealedSnapshot<F> {
+    /// Builds an immutable sealed snapshot with a fresh (all-empty) per-segment reader cache (#808).
+    pub(crate) fn new(
+        fs: Arc<F>,
+        segments: Vec<SealedSegment>,
+        oldest: u64,
+        sealed_end: u64,
+    ) -> SealedSnapshot<F> {
+        let readers = SlotReaders::empty(segments.len());
+        SealedSnapshot {
+            fs,
+            segments,
+            readers,
+            oldest,
+            sealed_end,
+        }
+    }
+
+    /// The opened [`SegmentReader`] for sealed segment slot `i`, opening it on first touch and reusing the
+    /// cached one thereafter (#808). Shared as an `Arc` across the concurrent off-actor readers. A
+    /// double-open race is merely wasteful, never wrong: a sealed file is immutable, so two opens produce
+    /// byte-identical readers; the loser's `Arc` drops and closes its fd immediately, and every caller
+    /// returns the SAME stored reader.
+    fn reader_for(
+        &self,
+        i: usize,
+        slot: &SealedSegment,
+    ) -> Result<Arc<SegmentReader<F::File>>, StorageError> {
+        if let Some(reader) = self.readers.0[i].get() {
+            return Ok(Arc::clone(reader));
+        }
+        let opened = Arc::new(SegmentReader::open(
+            self.fs.open(&segment_file_name(slot.id))?,
+        )?);
+        // `set` fails if another thread won the race; either way the slot is now initialized, so read it
+        // back and return the stored reader (the winner's), letting `opened` drop if we lost.
+        let _ = self.readers.0[i].set(opened);
+        Ok(Arc::clone(self.readers.0[i].get().expect(
+            "slot reader is initialized after set or a lost race",
+        )))
+    }
+
     /// The index in `segments` of the sealed segment whose range holds `offset` (the slot with the
     /// largest base not exceeding `offset`). Callers guarantee `offset >= oldest`.
     fn segment_index_for(&self, offset: u64) -> usize {
@@ -260,7 +343,9 @@ impl<F: crate::fs::Filesystem> SealedSnapshot<F> {
         let mut out: Vec<OwnedRecord> = Vec::new();
         let mut byte_total = 0usize;
         let mut fallback_from = None;
-        for slot in &self.segments[self.segment_index_for(start)..] {
+        let base = self.segment_index_for(start);
+        for (offset_in_base, slot) in self.segments[base..].iter().enumerate() {
+            let slot_index = base + offset_in_base;
             if slot.base_offset >= visible_sealed_end {
                 break;
             }
@@ -287,7 +372,7 @@ impl<F: crate::fs::Filesystem> SealedSnapshot<F> {
             let below_flushed =
                 usize::try_from(flushed.saturating_sub(anchor_offset)).unwrap_or(usize::MAX);
             let want = remaining.saturating_add(gap).min(below_flushed);
-            let reader = SegmentReader::open(self.fs.open(&segment_file_name(slot.id))?)?;
+            let reader = self.reader_for(slot_index, slot)?;
             let records = reader.scan_from(byte_pos, Offset::new(anchor_offset), read_end, want)?;
             for record in records {
                 // Skip the bounded run the anchor preceded `seg_start` by.
@@ -372,7 +457,8 @@ impl<F: crate::fs::Filesystem> SealedSnapshot<F> {
         if start >= visible_sealed_end {
             return Ok(empty(Some(start)));
         }
-        let slot = &self.segments[self.segment_index_for(start)];
+        let slot_index = self.segment_index_for(start);
+        let slot = &self.segments[slot_index];
         let seg_start = start.max(slot.base_offset);
         // A COMPACTED (v2, sparse) slot is served by the through-actor v2 scan, not this plane: a
         // sparse survivor run is not a dense contiguous byte range, so hand the remainder back.
@@ -397,7 +483,7 @@ impl<F: crate::fs::Filesystem> SealedSnapshot<F> {
         let below_visible =
             usize::try_from(seg_visible_end.saturating_sub(anchor_offset)).unwrap_or(usize::MAX);
         let want = max_records.saturating_add(gap).min(below_visible);
-        let reader = SegmentReader::open(self.fs.open(&segment_file_name(slot.id))?)?;
+        let reader = self.reader_for(slot_index, slot)?;
         let run =
             reader.raw_byte_range(byte_pos, Offset::new(anchor_offset), read_end, want, None)?;
         // The anchor may sit BEFORE `seg_start` (sparse anchors land one-per-stride): trim the leading
@@ -508,7 +594,7 @@ fn push_record(
 /// SAME published frontier and snapshot. The single append actor (through the `Log` it owns) is the
 /// only PUBLISHER; any number of readers observe concurrently with it and with each other.
 #[derive(Clone, Debug)]
-pub struct ReadPlane<F> {
+pub struct ReadPlane<F: Filesystem> {
     /// The read-visible (flushed) high-water mark, published RELEASE by the writer after every
     /// commit/flush/seal and observed ACQUIRE by readers as the hard read bound. Shared so a `Log`
     /// clone and every reader see the same cell.
@@ -531,12 +617,9 @@ impl<F: crate::fs::Filesystem> ReadPlane<F> {
     ) -> ReadPlane<F> {
         ReadPlane {
             flushed: Arc::new(AtomicU64::new(flushed)),
-            sealed: Arc::new(ArcSwap::from_pointee(SealedSnapshot {
-                fs,
-                segments,
-                oldest,
-                sealed_end,
-            })),
+            sealed: Arc::new(ArcSwap::from_pointee(SealedSnapshot::new(
+                fs, segments, oldest, sealed_end,
+            ))),
         }
     }
 
@@ -551,12 +634,9 @@ impl<F: crate::fs::Filesystem> ReadPlane<F> {
         sealed_end: u64,
     ) {
         let fs = Arc::clone(&self.sealed.load().fs);
-        self.sealed.store(Arc::new(SealedSnapshot {
-            fs,
-            segments,
-            oldest,
-            sealed_end,
-        }));
+        self.sealed.store(Arc::new(SealedSnapshot::new(
+            fs, segments, oldest, sealed_end,
+        )));
     }
 
     /// PUBLISHES the new read-visible (flushed) frontier (the writer side, after every commit). A
@@ -651,11 +731,25 @@ impl<F: crate::fs::Filesystem> ReadPlane<F> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::fault::{FaultControl, FaultFs};
     use crate::fs::InMemoryFs;
     use crate::log::{Append, Log, LogConfig};
     use ironbus_core::clock::ManualClock;
     use ironbus_core::types::RecordFlags;
     use std::sync::atomic::AtomicU64 as StdAtomicU64;
+
+    /// A tiny-segment log over a `FaultFs` whose `FaultControl` counts every `open(2)`, so a test can
+    /// assert the #808 reader cache opens a sealed segment ONCE across many reads.
+    fn small_fault_log() -> (Log<FaultFs<InMemoryFs>, ManualClock>, FaultControl) {
+        let (fs, control) = FaultFs::new(InMemoryFs::new());
+        let config = LogConfig {
+            max_segment_bytes: 256,
+            max_total_bytes: 0,
+            ..LogConfig::default()
+        };
+        let log = Log::open(fs, ManualClock::new(), config).unwrap();
+        (log, control)
+    }
 
     fn rec(payload: &[u8]) -> Append<'_> {
         Append {
@@ -710,6 +804,81 @@ mod tests {
                 "off-actor served more than through-actor at {start}"
             );
         }
+    }
+
+    /// #808: many reads of ONE sealed segment open its file ONCE (the per-snapshot reader cache), not
+    /// once per read — the syscall/fd-churn win. With the cache OFF (a fresh `SegmentReader::open` per
+    /// read) the open-count delta would equal the number of reads.
+    #[test]
+    fn repeated_sealed_reads_open_each_segment_once() {
+        let (mut log, control) = small_fault_log();
+        for i in 0..40u32 {
+            log.append(&rec(&i.to_le_bytes())).unwrap();
+            if i % 7 == 0 {
+                log.sync().unwrap();
+            }
+        }
+        log.sync().unwrap();
+        let plane = log.read_plane().unwrap();
+        // Offset 0 is in the first sealed segment (the tiny cap sealed several). Read it many times
+        // through the SAME (unchanged) snapshot: the segment is opened on the first read and reused.
+        let baseline = control.open_count();
+        let mut served = 0;
+        for _ in 0..25 {
+            let read = plane.read_range(Offset::new(0), 1, None).unwrap();
+            served += read.records.len();
+        }
+        assert_eq!(served, 25, "every read served the record at offset 0");
+        let opens = control.open_count() - baseline;
+        assert_eq!(
+            opens, 1,
+            "25 reads of one sealed segment opened it ONCE (#808), not 25 times"
+        );
+    }
+
+    /// #808: the reader cache is PER-SNAPSHOT. When a roll/reap republishes a fresh snapshot, the old
+    /// snapshot (and its opened fds) drops, and a read through the new snapshot RE-OPENS — proving the
+    /// cache never carries a stale fd across a generation (and that retired fds are released, not leaked).
+    #[test]
+    fn a_republished_snapshot_reopens_the_segment() {
+        let (mut log, control) = small_fault_log();
+        for i in 0..40u32 {
+            log.append(&rec(&i.to_le_bytes())).unwrap();
+            if i % 7 == 0 {
+                log.sync().unwrap();
+            }
+        }
+        log.sync().unwrap();
+
+        // Warm the cache for segment 0 in the current snapshot.
+        let plane = log.read_plane().unwrap();
+        let baseline = control.open_count();
+        let _ = plane.read_range(Offset::new(0), 1, None).unwrap();
+        let _ = plane.read_range(Offset::new(0), 1, None).unwrap();
+        assert_eq!(
+            control.open_count() - baseline,
+            1,
+            "the warm snapshot opened segment 0 once"
+        );
+
+        // Append + sync more so the writer seals another segment and REPUBLISHES the snapshot.
+        for i in 40..90u32 {
+            log.append(&rec(&i.to_le_bytes())).unwrap();
+            if i % 7 == 0 {
+                log.sync().unwrap();
+            }
+        }
+        log.sync().unwrap();
+
+        // Read segment 0 again through the fresh snapshot: its cache is empty, so it re-opens once.
+        let after_republish = control.open_count();
+        let _ = plane.read_range(Offset::new(0), 1, None).unwrap();
+        let _ = plane.read_range(Offset::new(0), 1, None).unwrap();
+        assert_eq!(
+            control.open_count() - after_republish,
+            1,
+            "a republished snapshot re-opens segment 0 once (the old generation's fd was dropped, not reused)"
+        );
     }
 
     /// #664: the off-actor WINDOW-BOUNDED read-end (`SealedSegment::window_read_end`) is correct over


### PR DESCRIPTION
## Closes #808 — cache an opened `SegmentReader` per sealed segment

Every read of a sealed segment re-did `SegmentReader::open` from scratch — `open(2)` + `fstat(2)` + a 64-byte header `pread` + a header-CRC decode — on the consume hot path. A sealed segment is **immutable** (header + length never change), so that's pure repeated per-read overhead (~3–4× syscall amplification per delivered Tier-W message + fd allocate/free churn). This caches an opened reader keyed by sealed segment id, reused across reads, on **both** read paths. Memory backends are unaffected; the win is the disk backend's syscall/fd overhead.

### Off-actor lock-free plane (`read_plane.rs`)
The immutable `SealedSnapshot` gains a `SlotReaders` cache — a `Vec<OnceLock<Arc<SegmentReader>>>` parallel to its `segments`. A read opens its sealed segment on first touch and shares the `Arc<SegmentReader>` across the concurrent reader threads. **No mutex** is added to the lock-free plane: `SegmentReader`'s reads are positioned `pread`s (`&self`, no cursor), and `RandomAccessFile: Send + Sync` ("shared with lock-free readers"), so a shared `Arc<SegmentReader>` is read concurrently safely. The **whole snapshot** (and every fd it opened) drops when a roll/reap republishes a fresh one, so fds never outlive their generation. A double-open race is merely wasteful (immutable file → byte-identical readers; the loser's fd closes immediately), never wrong.

### Through-actor `Log` (`log.rs`)
A FIFO-bounded `SealedReaderCache` (default **256** resident readers) serves the dense seek-and-read hot path — the Tier-W poll reads `read_from(off, 1)` per delivered message. The **active (growing) segment is never cached**; entries are evicted in lockstep with the seek index by `evict_segment_index` at retirement (reap / force-reap / compaction install). Segment ids are never recycled (ADR 0002), so a cached fd can never alias a different physical segment; the FIFO cap bounds resident fds so a retention-off cold full scan reuses a working set instead of leaking one fd per sealed segment.

### Correctness
Unchanged: same bytes, same offsets, same per-record CRC validation — only the redundant re-open/re-validate is removed. The off-actor differential tests (`sealed_read_matches_through_actor_read_from...`, `window_bounded_sealed_read_is_byte_identical...`, the raw-run tests) and the through-actor read tests still pass byte-for-byte, as does the concurrent-readers-and-a-writer race test (now exercising the shared `Arc<SegmentReader>` cache).

### Tests (+4) & instrumentation
- `FaultControl` gains an `open_count` (mirrors the existing `sync_dir_count` pattern).
- `repeated_sealed_reads_open_each_segment_once` (plane) and `repeated_read_from_opens_a_sealed_segment_once` (log): 20–25 reads of one sealed segment open it **once** — both **verified to FAIL (25 != 1 / 20 != 1)** with the cache bypassed.
- `a_republished_snapshot_reopens_the_segment` (plane): a fresh snapshot re-opens, proving the old generation's fd was dropped, not reused.
- `a_force_reap_evicts_the_cached_sealed_reader` (log): a retired segment's cached reader (and fd) is evicted in lockstep with its index.

415 storage lib + 939 server lib + CLI suites green; `fmt` + `clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic` clean.

### Notes / possible follow-ups
- The compacted (sparse) read path and the dense unindexed active-tail fallback are intentionally NOT cached (the issue targets the dense sealed hot path; the active segment grows).
- The Log cache cap is a `const` (256); making it a `LogConfig` knob is a trivial follow-up if an operator ever needs to tune resident fds.
- The plane cache is unbounded per snapshot generation (bounded by "sealed segments touched since the last roll/reap", freed at the next republish) to preserve lock-freedom — an LRU there would reintroduce a lock.
