### PR TITLE
perf(cluster): serve FetchRecords off the global data-plane lock (#809, Phase 1)

### DIFF
--- a/crates/ironbus-server/src/cluster/dataplane.rs
+++ b/crates/ironbus-server/src/cluster/dataplane.rs
@@ -535,6 +535,20 @@ impl<F: Filesystem, C: Clock> DataPlaneController<F, C> {
         )
     }
 
+    /// The leader's `Arc`-shared read plane for `partition`, or `None` if this node is not its leader
+    /// (#809). The reader thread clones this under the server lock and then serves the `FetchRecords`
+    /// OFF the lock: `ReadPlaneLeader::serve_fetch` is a pure read (`&self`) over the wait-free
+    /// [`ReadPlane`] (its own `ArcSwap`/Acquire ordering, independent of the server `Mutex`), so K
+    /// followers' fetch-serves to different partitions run in PARALLEL instead of serializing on the one
+    /// global lock across each `read_range_raw`.
+    #[must_use]
+    pub fn leader_read_plane(&self, partition: u64) -> Option<Arc<ReadPlane<F>>> {
+        match self.roles.get(&partition) {
+            Some(PartitionRole::Leader { plane, .. }) => Some(Arc::clone(plane)),
+            _ => None,
+        }
+    }
+
     /// Register this node as the LEADER of `partition`, serving fetches from the `Arc`-shared, off-actor
     /// read `plane` (#654, #715) — NOT a `&Log` borrow, so the leader never writes (or borrows) its log
     /// and the controller stays `Send`. Gates produces through an [`IsrTracker`] / [`QuorumAckGate`]

--- a/crates/ironbus-server/src/cluster/serve.rs
+++ b/crates/ironbus-server/src/cluster/serve.rs
@@ -119,6 +119,7 @@ use super::dataplane::{
     DataPlaneError, DataPlaneFrame, PlacementRole, ProduceAckSeam,
 };
 use super::isr::IsrConfig;
+use super::replication::{FetchRecordsBody, FetchResponseBody};
 use super::rereplication::{
     FetchBudget, ReReplicationThrottle, FULL_CATCHUP_BYTES, FULL_CATCHUP_RECORDS,
 };
@@ -518,6 +519,14 @@ impl<F: Filesystem, C: Clock> DataPlaneServer<F, C> {
         frame: DataPlaneFrame,
     ) -> Result<DataPlaneAction, DataPlaneError> {
         self.seam.controller_mut().handle_frame(partition, frame)
+    }
+
+    /// The leader's `Arc`-shared read plane for `partition`, or `None` if this node is not its leader
+    /// (#809). The reader thread clones this under the server lock then serves `FetchRecords` OFF the
+    /// lock — see [`DataPlaneController::leader_read_plane`].
+    #[must_use]
+    pub fn leader_read_plane(&self, partition: u64) -> Option<Arc<ReadPlane<F>>> {
+        self.seam.controller().leader_read_plane(partition)
     }
 
     /// Record an inbound follower [`AckReplicatedBody`](super::isr::AckReplicatedBody) report for
@@ -1168,6 +1177,48 @@ fn run_dataplane_listener<F, C>(
 ///
 /// Every bound in [`DataPlaneLink::recv`] is applied: a hostile / oversized / corrupt frame is a typed
 /// error that drops the link, never a panic or an over-allocation (the fail-closed bounded codec).
+/// The outcome of [`serve_fetch_off_lock`]: what the reader thread does with a served `FetchRecords`.
+enum OffLockServe {
+    /// The server `Mutex` was poisoned (a holder panicked) — the reader thread tears down.
+    Poisoned,
+    /// Serve produced a response frame to send to the follower.
+    Send(FetchResponseBody),
+    /// Nothing to send: this node is not the partition's leader, or the serve faulted — drop the frame
+    /// (exactly what the old through-`handle_frame` path did with a `WrongRole`/`UnknownPartition` error).
+    Drop,
+}
+
+/// Serve a follower's `FetchRecords` for `partition` OFF the global server lock (#809): take the lock
+/// ONLY to clone the leader's `Arc<ReadPlane>` (a refcount bump), DROP it, then run the seek/scan +
+/// `Bytes`-slice serve with NO lock held. `ReadPlaneLeader::serve_fetch` is a pure read over the
+/// wait-free read plane (its own `ArcSwap`/Acquire ordering governs freshness, never this `Mutex`), so K
+/// followers' fetch-serves to different partitions run in parallel instead of serializing on the one lock
+/// across each `read_range_raw`. Factored out (rather than inlined in the reader loop) so a test can drive
+/// the EXACT lock/serve sequence and prove the lock is released during the serve.
+fn serve_fetch_off_lock<F, C>(
+    server: &Arc<Mutex<DataPlaneServer<F, C>>>,
+    partition: u64,
+    req: &FetchRecordsBody,
+) -> OffLockServe
+where
+    F: Filesystem + Send + Sync + 'static,
+    C: Clock + Send + 'static,
+{
+    // The ONLY work under the lock: clone the partition's read-plane `Arc`. The lock is dropped at the
+    // end of this block, BEFORE the serve below.
+    let plane = match server.lock() {
+        Ok(srv) => srv.leader_read_plane(partition),
+        Err(_) => return OffLockServe::Poisoned,
+    };
+    let Some(plane) = plane else {
+        return OffLockServe::Drop; // not this node's leader role for the partition
+    };
+    match crate::cluster::replication::ReadPlaneLeader::new(&plane).serve_fetch(req) {
+        Ok(response) => OffLockServe::Send(response),
+        Err(_) => OffLockServe::Drop, // a serve fault: drop, matching the old `.ok()`-swallow behavior
+    }
+}
+
 fn run_dataplane_reader<F, C>(
     mut link: DataPlaneLink<TcpStream>,
     server: &Arc<Mutex<DataPlaneServer<F, C>>>,
@@ -1197,6 +1248,29 @@ fn run_dataplane_reader<F, C>(
                         };
                         let _ = srv.on_follower_report_bytes(partition, &report);
                     }
+                }
+            }
+            // #809: serve a `FetchRecords` OFF the global server lock. Take the lock ONLY to clone the
+            // partition's `Arc<ReadPlane>` (a refcount bump), drop it, then run the seek/scan +
+            // `Bytes`-slice serve with NO lock held — so K followers' fetch-serves to DIFFERENT partitions
+            // run in parallel instead of serializing on the one global lock across each `read_range_raw`.
+            // `serve_fetch` is a pure read (`&self`) over the wait-free read plane, whose freshness comes
+            // from its own `ArcSwap`/Acquire ordering (never from this `Mutex`), so off-lock serve sees an
+            // identical-or-fresher snapshot. A non-leader (`None`) drops the frame, exactly as the old
+            // through-`handle_frame` path did (it returned a `WrongRole`/`UnknownPartition` error the
+            // generic arm swallowed with `.ok()`).
+            Ok(Some((partition, DataPlaneFrame::FetchRequest(req)))) => {
+                match serve_fetch_off_lock(server, partition, &req) {
+                    OffLockServe::Poisoned => return, // the runtime is tearing down
+                    OffLockServe::Send(response) => {
+                        if link
+                            .send(partition, &DataPlaneFrame::FetchResponse(response))
+                            .is_err()
+                        {
+                            return;
+                        }
+                    }
+                    OffLockServe::Drop => {} // not this node's leader role, or a serve fault: drop it
                 }
             }
             Ok(Some((partition, frame))) => {
@@ -1502,6 +1576,7 @@ mod tests {
     use ironbus_core::types::RecordFlags;
     use ironbus_proto::frame::encode_frame as proto_encode_frame;
     use ironbus_proto::message::{decode_pub_ack, encode_pub_ack, PubAckBody};
+    use ironbus_storage::fault::{FaultControl, FaultFs};
     use ironbus_storage::fs::InMemoryFs;
     use ironbus_storage::io::RandomAccessFile;
     use ironbus_storage::log::{Append, Log, LogConfig};
@@ -1618,6 +1693,73 @@ mod tests {
     /// role serves fetches from (NO `&Log` borrow). This is what makes the `DataPlaneServer` `Send`.
     fn leader_plane(log: &Log<InMemoryFs, ManualClock>) -> Arc<ReadPlane<InMemoryFs>> {
         Arc::new(log.read_plane().expect("read plane builds"))
+    }
+
+    /// A leaked leader log over a FAULT fs (so reads pass through the read gate), its `Arc`-shared read
+    /// plane, and the fault control — used to PARK a fetch-serve mid-read and prove the server lock is free
+    /// during the serve (#809).
+    fn fault_leader_plane(n: u32) -> (Arc<ReadPlane<FaultFs<InMemoryFs>>>, FaultControl) {
+        let (fs, control) = FaultFs::new(InMemoryFs::new());
+        let mut log = Log::open(fs, ManualClock::new(), small_config()).expect("log opens");
+        for i in 0..n {
+            log.append(&rec(format!("rep-{i:02}").as_bytes())).unwrap();
+        }
+        log.sync().unwrap();
+        let plane = Arc::new(log.read_plane().expect("read plane builds"));
+        Box::leak(Box::new(log));
+        (plane, control)
+    }
+
+    #[test]
+    fn a_fetch_serve_does_not_hold_the_server_lock_across_the_read() {
+        // #809: the reader thread serves a `FetchRecords` OFF the global server lock. We park a fetch-serve
+        // mid-read (the fault read gate) and prove the server `Mutex` is FREE during the serve — so a
+        // second partition's fetch-serve would NOT wait behind it. Pre-#809 the serve ran UNDER the lock
+        // (through `handle_frame`), so the lock would be HELD across the parked read and this `try_lock`
+        // would be `WouldBlock`.
+        const P: u64 = 0;
+        let (plane, control) = fault_leader_plane(25);
+        let mut controller: DataPlaneController<FaultFs<InMemoryFs>, ManualClock> =
+            DataPlaneController::new(1);
+        controller.start_leader(P, plane, EpochCache::new(), &[2, 3], quorum3());
+        let server = Arc::new(Mutex::new(DataPlaneServer::new(
+            1,
+            ProduceAckSeam::new(controller),
+        )));
+
+        // Close the read gate so the next positioned read parks; spawn the off-lock fetch-serve.
+        control.close_read_gate();
+        let server_t = Arc::clone(&server);
+        let serve = std::thread::spawn(move || {
+            serve_fetch_off_lock(
+                &server_t,
+                P,
+                &FetchRecordsBody {
+                    from_offset: 0,
+                    max_records: 10,
+                    max_bytes: 0,
+                },
+            )
+        });
+
+        // Wait until the serve is parked mid-read (deterministic, condvar — no wall-clock sleep).
+        control.wait_for_read_gate_entered(1);
+
+        // THE DISCRIMINATING ASSERTION: the server `Mutex` is FREE while the serve is parked in the read,
+        // because the serve clones the read plane under the lock and then serves OFF the lock. Pre-#809
+        // (serve under the lock) this would be `WouldBlock`. The guard drops immediately.
+        assert!(
+            server.try_lock().is_ok(),
+            "the server Mutex must NOT be held during the fetch-serve read (#809 off-lock serve)"
+        );
+
+        // Release the parked read; the off-lock serve completes and produces a response.
+        control.open_read_gate();
+        let outcome = serve.join().expect("serve thread joins");
+        assert!(
+            matches!(outcome, OffLockServe::Send(_)),
+            "the off-lock serve produced a FetchResponse"
+        );
     }
 
     /// The first offset the leader's read plane does NOT serve off-actor (its sealed-served end): chain

--- a/crates/ironbus-storage/src/fault.rs
+++ b/crates/ironbus-storage/src/fault.rs
@@ -84,6 +84,10 @@ pub struct FaultControl {
     /// A monotonic count of every `open` that ran, so a test can assert that a repeated read of one
     /// sealed segment opens it ONCE (the #808 reader cache), not once per read.
     open_count: Arc<AtomicU64>,
+    /// A condvar gate the READ path waits on while closed — the read analogue of `sync_gate` (#809).
+    /// Lets a test park a fetch-serve mid-read (in a positioned `read_at`) and then prove the server lock
+    /// is NOT held during the serve (off-lock fetch-serve), without a wall-clock sleep.
+    read_gate: Arc<SyncGate>,
 }
 
 /// A condvar-backed gate the sync path waits on while closed (#177): `open` starts open (syncs pass),
@@ -289,6 +293,70 @@ impl FaultControl {
     /// parks, so [`wait_for_sync_gate_entered`] can observe the stall. No wall-clock sleep.
     ///
     /// [`wait_for_sync_gate_entered`]: FaultControl::wait_for_sync_gate_entered
+    /// Closes the READ gate (#809): the NEXT positioned `read_at` blocks until [`open_read_gate`], so a
+    /// test can park a fetch-serve mid-read. Already-passed reads are unaffected.
+    ///
+    /// [`open_read_gate`]: FaultControl::open_read_gate
+    pub fn close_read_gate(&self) {
+        let mut state = self
+            .read_gate
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        state.0 = false;
+    }
+
+    /// Opens the READ gate, releasing any parked read and letting later reads pass straight through.
+    pub fn open_read_gate(&self) {
+        let mut state = self
+            .read_gate
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        state.0 = true;
+        self.read_gate.cv.notify_all();
+    }
+
+    /// Blocks (on the condvar, no wall-clock sleep) until at least `n` reads have ENTERED the closed read
+    /// gate, so a test can deterministically wait for a fetch-serve to be parked mid-read.
+    pub fn wait_for_read_gate_entered(&self, n: u64) {
+        let mut state = self
+            .read_gate
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        while state.1 < n {
+            state = self
+                .read_gate
+                .cv
+                .wait(state)
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+        }
+    }
+
+    /// Parks the calling read on the condvar if the read gate is closed, bumping the entered-count (and
+    /// notifying waiters) so [`wait_for_read_gate_entered`] can observe the stall. No wall-clock sleep.
+    ///
+    /// [`wait_for_read_gate_entered`]: FaultControl::wait_for_read_gate_entered
+    fn enter_read_gate(&self) {
+        let mut state = self
+            .read_gate
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if !state.0 {
+            state.1 = state.1.saturating_add(1);
+            self.read_gate.cv.notify_all();
+            while !state.0 {
+                state = self
+                    .read_gate
+                    .cv
+                    .wait(state)
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+            }
+        }
+    }
+
     fn enter_sync_gate(&self) {
         self.sync_count.fetch_add(1, Ordering::SeqCst);
         let mut state = self
@@ -518,6 +586,8 @@ fn injected_read_error() -> io::Error {
 
 impl<F: RandomAccessFile> RandomAccessFile for FaultFile<F> {
     fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<usize> {
+        // Park here if the read gate is closed (#809) — a test stalls a fetch-serve mid-read this way.
+        self.control.enter_read_gate();
         if self.control.read_should_fail() {
             return Err(injected_read_error());
         }

--- a/crates/ironbus-storage/src/fault.rs
+++ b/crates/ironbus-storage/src/fault.rs
@@ -288,11 +288,6 @@ impl FaultControl {
         self.sync_count.load(Ordering::SeqCst)
     }
 
-    /// Records that a sync ran and, if the gate is closed, parks the calling thread on the condvar
-    /// until the gate is opened. The entered-count is bumped (and waiters notified) when a sync
-    /// parks, so [`wait_for_sync_gate_entered`] can observe the stall. No wall-clock sleep.
-    ///
-    /// [`wait_for_sync_gate_entered`]: FaultControl::wait_for_sync_gate_entered
     /// Closes the READ gate (#809): the NEXT positioned `read_at` blocks until [`open_read_gate`], so a
     /// test can park a fetch-serve mid-read. Already-passed reads are unaffected.
     ///
@@ -357,6 +352,11 @@ impl FaultControl {
         }
     }
 
+    /// Records that a sync ran and, if the gate is closed, parks the calling thread on the condvar
+    /// until the gate is opened. The entered-count is bumped (and waiters notified) when a sync
+    /// parks, so [`wait_for_sync_gate_entered`] can observe the stall. No wall-clock sleep.
+    ///
+    /// [`wait_for_sync_gate_entered`]: FaultControl::wait_for_sync_gate_entered
     fn enter_sync_gate(&self) {
         self.sync_count.fetch_add(1, Ordering::SeqCst);
         let mut state = self


### PR DESCRIPTION
## #809 Phase 1 — serve `FetchRecords` off the global data-plane lock

The node-local data plane funneled through one `Arc<Mutex<DataPlaneServer>>` whose roles map spans **every partition and both leader+follower roles**. The leader fetch-serve ran **under** that lock — across the read-plane seek/scan — so K followers' fetch-serves to different partitions **serialized** on the one lock instead of running in parallel, discarding the read plane's wait-free design.

This is **Phase 1** of the design's recommended decomposition: the contained, high-value, low-risk read-side win.

### What changed
The reader thread takes the lock **only to clone the partition's `Arc<ReadPlane>`** (a refcount bump), drops it, then runs the seek/scan + `Bytes`-slice serve with **no lock held**. `ReadPlaneLeader::serve_fetch` is a pure read (`&self`) over the wait-free read plane, whose freshness comes from its own `ArcSwap`/Acquire ordering — **never from this `Mutex`** — so off-lock serve sees an identical-or-fresher snapshot and the responses are byte-identical. A non-leader drops the frame exactly as the old through-`handle_frame` path did.

- `dataplane.rs`: `DataPlaneController::leader_read_plane(partition)` clones the leader role's plane `Arc` (or `None`).
- `serve.rs`: `DataPlaneServer::leader_read_plane` delegation; the `FetchRequest` arm in `run_dataplane_reader` calls `serve_fetch_off_lock` (factored out so a test can drive the exact lock/serve sequence). The controller's `serve_fetch`/`handle_frame` path is **untouched** for its other callers (tests).
- `fault.rs`: a **read gate** (the read analogue of the existing sync gate) so a test can park a fetch-serve mid-read with no wall-clock sleep.

### Note on the premise (the issue text is partly stale)
Two commits already landed since #809 was filed: **#810** made `frame_bytes` a `bytes::Bytes` refcount clone (not a `to_vec` memcpy), and **#808** cached sealed-segment readers. So the residual under-lock work was already not a multi-MiB copy; the real cost this fixes is the **global lock spanning every partition + being held across the read**, so partitions now serve in parallel.

### Test
`a_fetch_serve_does_not_hold_the_server_lock_across_the_read` parks a fetch-serve mid-read (the read gate) and asserts `server.try_lock()` **succeeds** while it is parked — proving the serve is off-lock. **Verified to FAIL** (the `Mutex` is held) when the serve is reverted to run under the lock. 358 cluster + 416 storage lib tests green; workspace clippy (pedantic) + fmt clean — wire frames unchanged, so the replication/dataplane/client_ack suites pass byte-for-byte.

### Follow-ups (Phases 2–3, to fully close #809)
- **Phase 2** — shard the roles map (`RwLock<HashMap<u64, Arc<Mutex<PartitionRole>>>>`) so partition A's follower fsync no longer blocks partition B's serve/apply, and drop the lock before `log.sync()` on the follower apply path (the design flags this may be the bigger win if contention is fsync-dominated).
- **Phase 3** — factor the seam's node-global `parked`/`next_token` out (atomic token + per-partition parked) to remove the last global serialization, preserving the gate↔parked consistency invariant.

These remain open under #809; this PR is the read-side fan-out step.
