### PR TITLE
perf(cluster): apply follower fetches off the global data-plane lock (#809, Phase 2)

### DIFF
--- a/crates/ironbus-server/src/cluster/dataplane.rs
+++ b/crates/ironbus-server/src/cluster/dataplane.rs
@@ -459,8 +459,19 @@ pub type AckToken = u64;
 /// recovered with `into_inner` everywhere (a follower-apply panic must not wedge the whole data plane).
 pub(crate) type FollowerHandle<F, C> = Arc<Mutex<EpochAwareFollower<F, C>>>;
 
-/// Lock a follower handle, recovering from a poisoned lock (`into_inner`) so a panic in one partition's
+/// Lock a follower handle, recovering from a poisoned lock (`into_inner`) so a panic in ONE partition's
 /// apply never wedges the whole data plane (#809).
+///
+/// This is a deliberate scope change from the pre-#809 global lock, which failed CLOSED on a poison (the
+/// fetch loop's `let Ok(..) = server.lock() else return` tore down on a poisoned global). Recovering a
+/// poisoned PER-PARTITION follower is sound here: `apply_fetch_response` returns a typed `Err` for every
+/// EXPECTED fault (corrupt / non-contiguous / storage) — a panic is therefore a latent bug, not
+/// adversarial input — and the follower's durable state is never left half-applied in a way a later read
+/// could serve as committed: `next_offset` advances only AFTER `Log::append` returns `Ok` (a torn append
+/// errors rather than advancing), and follower reads clamp to `follower_safe_watermark(plane.flushed(),
+/// known_committed_hw)`, so any torn UNCOMMITTED tail is never served below the committed bar. (If a
+/// poison ever needs stricter handling, fail closed by dropping the follower and forcing a clean
+/// re-fetch — tracked as a #809 follow-up.)
 fn lock_follower<F: Filesystem, C: Clock>(
     handle: &FollowerHandle<F, C>,
 ) -> std::sync::MutexGuard<'_, EpochAwareFollower<F, C>> {
@@ -1217,9 +1228,18 @@ impl<F: Filesystem + Clone, C: Clock> DataPlaneController<F, C> {
         // from `&log`) and the learned epoch history (cloned), never ownership of the log. On a verify
         // failure the follower role is restored unchanged. The `Arc` then drops here; the follower's
         // replica-log writer is released once the last clone (an exiting fetch thread's) drops — the same
-        // "serve through the read plane only" outcome as the old `into_log()`+`drop(log)`, only the
-        // writer release is deferred to the thread's exit instead of being immediate (harmless: nothing
-        // else writes this replica log, and the leader serves only up to the committed HW).
+        // "serve through the read plane only" outcome as the old `into_log()`+`drop(log)`, only the writer
+        // release is deferred to the thread's exit instead of being immediate.
+        //
+        // SAFETY of the deferred release: only ONE writer ever touches this replica log (the leader's
+        // append actor is not yet wired, so nothing else writes it), and the follower lock serializes a
+        // racing post-promotion apply against this promotion. Such an apply CAN still advance the leader's
+        // served frontier (`plane.flushed()`), but it only appends a byte-identical, CRC-revalidated,
+        // CONTIGUOUS continuation of the same authoritative old-leader lineage ABOVE the promotion
+        // frontier — adopting more of the uncommitted tail under the new epoch, never overwriting
+        // committed data and keeping the epoch fence at `frontier` consistent. When the append actor IS
+        // wired to write this log, add an explicit single-writer handoff (wait for the fetch thread to
+        // exit / the `Arc` to drop before opening the writer) — tracked as a #809 follow-up.
         let plane_epochs = {
             let guard = lock_follower(&follower);
             let log = guard.follower().log();

--- a/crates/ironbus-server/src/cluster/dataplane.rs
+++ b/crates/ironbus-server/src/cluster/dataplane.rs
@@ -110,7 +110,7 @@
 //!   **cross-cluster geo** plane (C7) are separate.
 
 use std::collections::BTreeMap;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use ironbus_core::clock::Clock;
 use ironbus_core::epoch_cache::{EpochCache, LeaderEpochEndOffset};
@@ -454,6 +454,53 @@ pub type AckToken = u64;
 /// `Arc` (rather than a borrow) is exactly what makes the controller `Send`, so the data plane can run
 /// on a peer-I/O thread alongside the append actor. The FOLLOWER role OWNS its replica log (it appends
 /// the leader's bytes to its OWN copy, via its OWN single writer). `None` holds no state.
+/// The per-partition follower handle (#809): an `Arc<Mutex<EpochAwareFollower>>` the follower fetch
+/// thread clones once and applies under, off the node-global server `Mutex`. A poisoned lock is
+/// recovered with `into_inner` everywhere (a follower-apply panic must not wedge the whole data plane).
+pub(crate) type FollowerHandle<F, C> = Arc<Mutex<EpochAwareFollower<F, C>>>;
+
+/// Lock a follower handle, recovering from a poisoned lock (`into_inner`) so a panic in one partition's
+/// apply never wedges the whole data plane (#809).
+fn lock_follower<F: Filesystem, C: Clock>(
+    handle: &FollowerHandle<F, C>,
+) -> std::sync::MutexGuard<'_, EpochAwareFollower<F, C>> {
+    handle
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+/// Apply a leader's `FetchResponse` to a follower HANDLE — decode + CRC-revalidate + append + `log.sync()`
+/// — under the handle's PER-PARTITION lock (#809), returning the follower's new fsync'd frontier. The
+/// follower fetch thread calls this OFF the node-global server `Mutex` (it holds only this handle's lock
+/// across the fsync), so partition A's apply no longer blocks partition B's serve/apply.
+///
+/// # Errors
+/// [`DataPlaneError::Replication`] (fail-closed) on a corrupt / tampered / truncated frame — nothing from
+/// the bad frame onward is appended.
+pub fn apply_on_follower<F: Filesystem, C: Clock>(
+    handle: &FollowerHandle<F, C>,
+    resp: &FetchResponseBody,
+) -> Result<u64, DataPlaneError> {
+    let outcome = lock_follower(handle)
+        .follower_mut()
+        .apply_fetch_response(resp)?;
+    Ok(outcome.next_offset)
+}
+
+/// Build a follower HANDLE's [`AckReplicatedBody`] report ("I have fsync'd every record below my
+/// `next_offset`") under its per-partition lock (#809) — the off-global-lock twin of
+/// [`DataPlaneController::follower_report`], called by the follower fetch thread after `apply_on_follower`.
+#[must_use]
+pub fn report_from_follower<F: Filesystem, C: Clock>(
+    handle: &FollowerHandle<F, C>,
+    node_id: u64,
+) -> AckReplicatedBody {
+    AckReplicatedBody {
+        follower_id: node_id,
+        fsynced_offset: lock_follower(handle).follower().next_fetch_offset().get(),
+    }
+}
+
 enum PartitionRole<F: Filesystem, C: Clock> {
     /// This node LEADS the partition: it serves fetches from the leader's read plane + gates produces
     /// through the ISR quorum.
@@ -472,10 +519,15 @@ enum PartitionRole<F: Filesystem, C: Clock> {
     },
     /// This node FOLLOWS the partition: it pulls the leader's bytes + self-heals on divergence.
     Follower {
-        /// The epoch-aware follower over this node's OWN replica log (fetch + apply + reconcile).
-        /// Boxed so the `Follower` variant (which owns a whole replica `Log` + epoch cache) does not
-        /// bloat every `Leader` slot — the enum is held one-per-partition in a `BTreeMap`.
-        follower: Box<EpochAwareFollower<F, C>>,
+        /// The epoch-aware follower over this node's OWN replica log (fetch + apply + reconcile), held
+        /// behind a PER-PARTITION `Arc<Mutex>` (#809): the follower fetch thread clones the handle once
+        /// and applies (decode + append + fsync) under THIS lock, NOT the node-global server `Mutex`, so
+        /// partition A's apply/fsync no longer blocks partition B's serve/apply. The controller's
+        /// follower-routing methods lock the same handle; the lock order is always global-server →
+        /// follower-handle (the fetch thread holds the follower handle WITHOUT the global lock), so no
+        /// deadlock. Promotion builds the leader plane from the locked `&log` without consuming the
+        /// `Arc`, so a still-running fetch thread's clone never blocks failover.
+        follower: FollowerHandle<F, C>,
     },
 }
 
@@ -549,6 +601,21 @@ impl<F: Filesystem, C: Clock> DataPlaneController<F, C> {
         }
     }
 
+    /// The per-partition follower handle for `partition`, or `None` if this node is not its follower
+    /// (#809). The follower fetch thread clones this ONCE (under a brief server lock) and then drives
+    /// fetch/apply/report on it via [`apply_on_follower`] / [`report_from_follower`] OFF the global server
+    /// `Mutex`, so partition A's apply (incl. its `log.sync()` fsync) no longer blocks partition B's
+    /// serve/apply. The handle stays valid across a role change: promotion does not consume the `Arc`, so
+    /// a still-running fetch thread's clone is harmless (its next `make_fetch_request` reports the role is
+    /// gone and it exits).
+    #[must_use]
+    pub fn follower_handle(&self, partition: u64) -> Option<FollowerHandle<F, C>> {
+        match self.roles.get(&partition) {
+            Some(PartitionRole::Follower { follower }) => Some(Arc::clone(follower)),
+            _ => None,
+        }
+    }
+
     /// Register this node as the LEADER of `partition`, serving fetches from the `Arc`-shared, off-actor
     /// read `plane` (#654, #715) — NOT a `&Log` borrow, so the leader never writes (or borrows) its log
     /// and the controller stays `Send`. Gates produces through an [`IsrTracker`] / [`QuorumAckGate`]
@@ -592,7 +659,7 @@ impl<F: Filesystem, C: Clock> DataPlaneController<F, C> {
         self.roles.insert(
             partition,
             PartitionRole::Follower {
-                follower: Box::new(EpochAwareFollower::new(Follower::new(log))),
+                follower: Arc::new(Mutex::new(EpochAwareFollower::new(Follower::new(log)))),
             },
         );
     }
@@ -851,9 +918,9 @@ impl<F: Filesystem, C: Clock> DataPlaneController<F, C> {
         max_bytes: u32,
     ) -> Result<FetchRecordsBody, DataPlaneError> {
         match self.roles.get(&partition) {
-            Some(PartitionRole::Follower { follower }) => {
-                Ok(follower.follower().fetch_request(max_records, max_bytes))
-            }
+            Some(PartitionRole::Follower { follower }) => Ok(lock_follower(follower)
+                .follower()
+                .fetch_request(max_records, max_bytes)),
             Some(PartitionRole::Leader { .. }) => Err(DataPlaneError::WrongRole {
                 partition,
                 needed: "follower",
@@ -876,9 +943,11 @@ impl<F: Filesystem, C: Clock> DataPlaneController<F, C> {
         partition: u64,
         resp: &FetchResponseBody,
     ) -> Result<u64, DataPlaneError> {
-        match self.roles.get_mut(&partition) {
+        match self.roles.get(&partition) {
             Some(PartitionRole::Follower { follower }) => {
-                let outcome = follower.follower_mut().apply_fetch_response(resp)?;
+                let outcome = lock_follower(follower)
+                    .follower_mut()
+                    .apply_fetch_response(resp)?;
                 Ok(outcome.next_offset)
             }
             Some(PartitionRole::Leader { .. }) => Err(DataPlaneError::WrongRole {
@@ -900,7 +969,7 @@ impl<F: Filesystem, C: Clock> DataPlaneController<F, C> {
         match self.roles.get(&partition) {
             Some(PartitionRole::Follower { follower }) => Ok(AckReplicatedBody {
                 follower_id: self.node_id,
-                fsynced_offset: follower.follower().next_fetch_offset().get(),
+                fsynced_offset: lock_follower(follower).follower().next_fetch_offset().get(),
             }),
             Some(PartitionRole::Leader { .. }) => Err(DataPlaneError::WrongRole {
                 partition,
@@ -924,9 +993,9 @@ impl<F: Filesystem, C: Clock> DataPlaneController<F, C> {
         epoch: LeaderEpoch,
         start_offset: Offset,
     ) -> Result<(), DataPlaneError> {
-        match self.roles.get_mut(&partition) {
+        match self.roles.get(&partition) {
             Some(PartitionRole::Follower { follower }) => {
-                follower.assign_epoch(epoch, start_offset)?;
+                lock_follower(follower).assign_epoch(epoch, start_offset)?;
                 Ok(())
             }
             Some(PartitionRole::Leader { .. }) => Err(DataPlaneError::WrongRole {
@@ -961,9 +1030,10 @@ impl<F: Filesystem, C: Clock> DataPlaneController<F, C> {
     where
         L: FnMut(LeaderEpoch) -> LeaderEpochEndOffset,
     {
-        match self.roles.get_mut(&partition) {
+        match self.roles.get(&partition) {
             Some(PartitionRole::Follower { follower }) => {
-                Ok(follower.reconcile_with_leader(committed_hw, leader_end_offset)?)
+                Ok(lock_follower(follower)
+                    .reconcile_with_leader(committed_hw, leader_end_offset)?)
             }
             Some(PartitionRole::Leader { .. }) => Err(DataPlaneError::WrongRole {
                 partition,
@@ -980,18 +1050,25 @@ impl<F: Filesystem, C: Clock> DataPlaneController<F, C> {
     pub fn follower_high_watermark(&self, partition: u64) -> Option<u64> {
         match self.roles.get(&partition) {
             Some(PartitionRole::Follower { follower }) => {
-                Some(follower.follower().high_watermark().get())
+                Some(lock_follower(follower).follower().high_watermark().get())
             }
             _ => None,
         }
     }
 
-    /// Borrow the follower's replica [`Log`] for `partition` (e.g. to assert byte-identity against the
-    /// leader, or to serve a follower read). `None` for a leader / absent partition.
-    #[must_use]
-    pub fn follower_log(&self, partition: u64) -> Option<&Log<F, C>> {
+    /// Run `f` against the follower's replica [`Log`] for `partition` under the per-partition follower
+    /// lock (#809) — e.g. to assert byte-identity against the leader, or to read its frontier. Returns
+    /// `Some(f(&log))` for a follower, `None` for a leader / absent partition. (The follower log is now
+    /// behind an `Arc<Mutex>`, so it cannot be borrowed out across the lock; a closure scopes the borrow.)
+    pub fn with_follower_log<R>(
+        &self,
+        partition: u64,
+        f: impl FnOnce(&Log<F, C>) -> R,
+    ) -> Option<R> {
         match self.roles.get(&partition) {
-            Some(PartitionRole::Follower { follower }) => Some(follower.follower().log()),
+            Some(PartitionRole::Follower { follower }) => {
+                Some(f(lock_follower(follower).follower().log()))
+            }
             _ => None,
         }
     }
@@ -1135,48 +1212,51 @@ impl<F: Filesystem + Clone, C: Clock> DataPlaneController<F, C> {
                 });
             }
         };
-        // APPLY-TIME COMMITTED-COMPLETENESS SELF-VERIFY (defense in depth, #618b). Before this node takes
-        // leadership, re-check that its OWN durable log covers the committed-HW bar carried with the
-        // failover. `next_offset()` is its durable frontier (the first offset it has NOT durably
-        // appended); it must be >= the bar (so every offset below the bar is durably held here). If not,
-        // ABORT — restore the follower role and fail closed, so no leader missing committed data is ever
-        // created (the partition stays leaderless / recoverable). This catches an optimistic or buggy
-        // proposal that the proposer-side gate somehow let through.
-        let durable_frontier = follower.follower().log().next_offset().get();
-        if durable_frontier < committed_hw_bar {
-            // Put the follower role back UNCHANGED — we did not consume it; this node keeps following.
-            self.roles
-                .insert(partition, PartitionRole::Follower { follower });
-            return Err(DataPlaneError::FailoverIncomplete {
-                partition,
-                durable_frontier,
-                committed_hw: committed_hw_bar,
-            });
-        }
-        // Split the follower into its owned log + its learned epoch history. The log is the committed
-        // data this node ALREADY holds — promotion serves it as-is (no fetch, no copy).
-        let (follower, mut epochs) = follower.into_parts();
-        let log = follower.into_log();
-        // The frontier the new epoch begins at: the first offset NOT yet held (its durable prefix). All
-        // records from here on are served under the new (bumped) leadership epoch.
-        let frontier = log.next_offset();
-        // Build the leader's read plane over the SAME log (zero byte copy). The plane holds its own
-        // Arc<Filesystem> over the same directory, so it stays valid for the leader role's lifetime.
-        let plane = Arc::new(
-            log.read_plane()
-                .map_err(|e| DataPlaneError::Replication(ReplicationError::Storage(e)))?,
-        );
-        // SEED THE FENCE: record the new (strictly-higher) leadership epoch starting at the current
-        // frontier. `assign` is a no-op if the epoch is unchanged and FAILS CLOSED if it regresses, so a
-        // failover that did not bump the epoch is rejected here rather than silently un-fencing the old
-        // leader. After this the leader answers OffsetForLeaderEpoch under the new epoch — the KIP-101
-        // fence a returning old leader is truncated against.
-        epochs
-            .assign(new_epoch, frontier)
-            .map_err(|e| DataPlaneError::Replication(ReplicationError::EpochCache(e)))?;
-        // The owned `log` is dropped here (its writer released) — the promoted leader serves through the
-        // read plane only; in a live broker its append actor becomes the sole writer (FLAGGED hot-path).
-        drop(log);
+        // Build the leader's plane + seeded epoch cache from the follower's log UNDER its per-partition
+        // lock (#809), WITHOUT consuming the `Arc` — the leader role needs only the read plane (built
+        // from `&log`) and the learned epoch history (cloned), never ownership of the log. On a verify
+        // failure the follower role is restored unchanged. The `Arc` then drops here; the follower's
+        // replica-log writer is released once the last clone (an exiting fetch thread's) drops — the same
+        // "serve through the read plane only" outcome as the old `into_log()`+`drop(log)`, only the
+        // writer release is deferred to the thread's exit instead of being immediate (harmless: nothing
+        // else writes this replica log, and the leader serves only up to the committed HW).
+        let plane_epochs = {
+            let guard = lock_follower(&follower);
+            let log = guard.follower().log();
+            // APPLY-TIME COMMITTED-COMPLETENESS SELF-VERIFY (defense in depth, #618b): the node's OWN
+            // durable frontier (`next_offset`) must cover the committed-HW bar, else ABORT fail-closed so
+            // no leader missing committed data is ever created. `Err(frontier)` carries the offending value.
+            let frontier = log.next_offset();
+            if frontier.get() < committed_hw_bar {
+                Err(frontier.get())
+            } else {
+                let plane = Arc::new(
+                    log.read_plane()
+                        .map_err(|e| DataPlaneError::Replication(ReplicationError::Storage(e)))?,
+                );
+                // SEED THE FENCE on a CLONE of the learned epoch history (strictly-higher new epoch at the
+                // current frontier; `assign` fails closed on a regression). The follower keeps its copy.
+                let mut epochs = guard.epochs().clone();
+                epochs
+                    .assign(new_epoch, frontier)
+                    .map_err(|e| DataPlaneError::Replication(ReplicationError::EpochCache(e)))?;
+                Ok((plane, epochs))
+            }
+        };
+        let (plane, epochs) = match plane_epochs {
+            Ok(pe) => pe,
+            Err(durable_frontier) => {
+                // Restore the follower role UNCHANGED — we did not consume it; this node keeps following.
+                self.roles
+                    .insert(partition, PartitionRole::Follower { follower });
+                return Err(DataPlaneError::FailoverIncomplete {
+                    partition,
+                    durable_frontier,
+                    committed_hw: committed_hw_bar,
+                });
+            }
+        };
+        drop(follower);
         self.start_leader(partition, plane, epochs, replica_ids, isr_config);
         Ok(())
     }
@@ -1204,7 +1284,7 @@ impl<F: Filesystem + Clone, C: Clock> DataPlaneController<F, C> {
         match self.roles.get(&partition) {
             Some(PartitionRole::Follower { follower }) => {
                 // The follower's OWN durably-replicated, CRC-revalidated flushed prefix.
-                let own_flushed = follower.follower().read_plane()?.flushed();
+                let own_flushed = lock_follower(follower).follower().read_plane()?.flushed();
                 Ok(Some(follower_safe_watermark(
                     own_flushed,
                     known_committed_hw,
@@ -1258,7 +1338,9 @@ impl<F: Filesystem + Clone, C: Clock> DataPlaneController<F, C> {
             }
             None => return Err(DataPlaneError::UnknownPartition { partition }),
         };
-        let plane = follower.follower().read_plane()?;
+        // `read_plane()` returns an OWNED plane (built fresh over the follower's `Arc<Filesystem>`), so it
+        // outlives the brief per-partition lock taken here (#809).
+        let plane = lock_follower(follower).follower().read_plane()?;
         let safe = follower_safe_watermark(plane.flushed(), known_committed_hw);
         let wanted_end = Offset::new(from.get().saturating_add(max_records as u64));
         match classify_follower_read(tier, from, wanted_end, safe) {
@@ -1884,11 +1966,11 @@ mod tests {
 
         // Follower 2's replica is BYTE-IDENTICAL to the leader over the read-plane-served prefix (every
         // replicated segment file matches the leader's same-named file).
-        assert_replicated_byte_identical(
-            follower2.follower_log(P).unwrap(),
-            &leader_log,
-            served_end,
-        );
+        follower2
+            .with_follower_log(P, |log| {
+                assert_replicated_byte_identical(log, &leader_log, served_end);
+            })
+            .unwrap();
 
         // Catch follower 3 up too (its reports release nothing new — the acks already released).
         for _ in 0..(leader_hw + 4) {
@@ -1901,11 +1983,11 @@ mod tests {
                 "acks already released, none re-release"
             );
         }
-        assert_replicated_byte_identical(
-            follower3.follower_log(P).unwrap(),
-            &leader_log,
-            served_end,
-        );
+        follower3
+            .with_follower_log(P, |log| {
+                assert_replicated_byte_identical(log, &leader_log, served_end);
+            })
+            .unwrap();
     }
 
     // ---- below min_isr a produce BLOCKS (no false ack) -------------------------------------------
@@ -2103,11 +2185,11 @@ mod tests {
             let resp = new_leader.serve_fetch(P, &req).unwrap();
             follower.apply_fetch_response(P, &resp).unwrap();
         }
-        assert_replicated_byte_identical(
-            follower.follower_log(P).unwrap(),
-            &new_leader_log,
-            new_served,
-        );
+        follower
+            .with_follower_log(P, |log| {
+                assert_replicated_byte_identical(log, &new_leader_log, new_served);
+            })
+            .unwrap();
     }
 
     // ---- single-node / single-replica = the local-fsync ack, byte-identical ----------------------
@@ -2242,10 +2324,8 @@ mod tests {
             follower.apply_fetch_response(P, &resp).unwrap();
         }
         let durable = follower
-            .follower_log(P)
-            .expect("follower log")
-            .next_offset()
-            .get();
+            .with_follower_log(P, |log| log.next_offset().get())
+            .expect("follower log");
         assert!(durable > 0, "the follower durably holds some records");
 
         // A bar ABOVE the follower's durable frontier => the self-verify aborts fail-closed.

--- a/crates/ironbus-server/src/cluster/serve.rs
+++ b/crates/ironbus-server/src/cluster/serve.rs
@@ -529,6 +529,17 @@ impl<F: Filesystem, C: Clock> DataPlaneServer<F, C> {
         self.seam.controller().leader_read_plane(partition)
     }
 
+    /// The per-partition follower handle for `partition`, or `None` if this node is not its follower
+    /// (#809). The follower fetch thread clones this once under the server lock then applies OFF the lock
+    /// — see [`DataPlaneController::follower_handle`].
+    #[must_use]
+    pub fn follower_handle(
+        &self,
+        partition: u64,
+    ) -> Option<super::dataplane::FollowerHandle<F, C>> {
+        self.seam.controller().follower_handle(partition)
+    }
+
     /// Record an inbound follower [`AckReplicatedBody`](super::isr::AckReplicatedBody) report for
     /// `partition` and return the REAL wire-`PubAck` byte-frames the report just released past the
     /// quorum-commit (in offset order), for the caller to flush onto the parked producer connections.
@@ -1423,6 +1434,20 @@ fn follower_fetch_loop<F, C>(
     F: Filesystem + Send + Sync + 'static,
     C: Clock + Send + 'static,
 {
+    // #809: clone this partition's follower handle ONCE. The per-iteration apply (decode + append +
+    // `log.sync()` fsync) then runs on it OFF the node-global server `Mutex`, holding only this handle's
+    // PER-PARTITION lock — so partition A's apply/fsync never blocks partition B's serve/apply/park. The
+    // handle stays valid across a promotion (which does NOT consume the `Arc`); the per-iteration
+    // `make_fetch_request` still goes through the controller and exits the loop once the role is gone.
+    let (handle, node_id) = {
+        let Ok(srv) = server.lock() else {
+            return; // poisoned: tearing down
+        };
+        match srv.follower_handle(partition) {
+            Some(handle) => (handle, srv.node_id()),
+            None => return, // not a follower of this partition
+        }
+    };
     // The budget the throttle decided for the NEXT fetch. Seeded full-rate: the first fetch of a
     // freshly-dialed link runs at full budget (the backlog is not known until the first response), and
     // the throttle shapes every subsequent fetch from the observed backlog + service delay.
@@ -1471,26 +1496,22 @@ fn follower_fetch_loop<F, C>(
                 // The network round-trip ended here (response received), BEFORE the local apply/fsync.
                 let net_nanos = u64::try_from(fetch_sent.elapsed().as_nanos()).unwrap_or(u64::MAX);
                 let leader_hw = resp.high_watermark;
-                // Apply + build the report under a short lock, then send the report off-lock.
+                // Apply + build the report OFF the global server lock (#809) — under this partition's
+                // follower lock only, so the apply's `log.sync()` fsync does not block another partition's
+                // serve/apply. Then send the report off-lock (as before).
                 let report = {
-                    let Ok(mut srv) = server.lock() else {
-                        return;
-                    };
                     if resp.record_count > 0 {
                         // Apply the CRC-revalidated bytes to the follower's own replica log. A
                         // divergence / corrupt frame fails closed (nothing from the bad frame is
                         // appended); drop this response and re-fetch from the current frontier.
-                        if srv
-                            .seam_mut()
-                            .controller_mut()
-                            .apply_fetch_response(partition, &resp)
-                            .is_err()
-                        {
+                        if crate::cluster::dataplane::apply_on_follower(&handle, &resp).is_err() {
                             // Fail-closed: reconnect + refetch from the recovered frontier.
                             return;
                         }
                     }
-                    srv.seam().controller().follower_report(partition).ok()
+                    Some(crate::cluster::dataplane::report_from_follower(
+                        &handle, node_id,
+                    ))
                 };
                 // The follower's next offset AFTER the apply (its fsync'd frontier) — what it just
                 // reported. The backlog is the leader's high-watermark minus this.
@@ -1759,6 +1780,68 @@ mod tests {
         assert!(
             matches!(outcome, OffLockServe::Send(_)),
             "the off-lock serve produced a FetchResponse"
+        );
+    }
+
+    #[test]
+    fn a_follower_apply_does_not_hold_the_server_lock_across_the_fsync() {
+        // #809 Phase 2: the follower fetch thread applies a fetch response (decode + append + `log.sync()`
+        // fsync) OFF the node-global server `Mutex`, under the partition's OWN follower lock. We park a
+        // follower apply mid-fsync (the fault sync gate) and prove the server `Mutex` is FREE (so another
+        // partition's serve/apply/park would not wait) while the per-partition follower lock IS held — i.e.
+        // the apply runs under the partition lock, NOT the global lock. Pre-#809 the apply ran under the
+        // global lock, so `server.try_lock()` would be `WouldBlock` during the parked fsync.
+        const P: u64 = 0;
+        // A leader controller with a few sealed records to serve a real fetch response.
+        let leader_log = leaked_leader_log(12);
+        let mut leader: DataPlaneController<InMemoryFs, ManualClock> = DataPlaneController::new(1);
+        leader.start_leader(
+            P,
+            leader_plane(leader_log),
+            EpochCache::new(),
+            &[2],
+            quorum3(),
+        );
+
+        // A FOLLOWER `DataPlaneServer` over a FAULT-fs replica log, so we can park its apply's fsync.
+        let (fs, control) = FaultFs::new(InMemoryFs::new());
+        let follower_log = Log::open(fs, ManualClock::new(), small_config()).expect("follower log");
+        let mut fc: DataPlaneController<FaultFs<InMemoryFs>, ManualClock> =
+            DataPlaneController::new(2);
+        fc.start_follower(P, follower_log);
+        let server = Arc::new(Mutex::new(DataPlaneServer::new(2, ProduceAckSeam::new(fc))));
+
+        // Build the follower's fetch request and serve it from the leader → a real `FetchResponse`.
+        let req = server
+            .lock()
+            .unwrap()
+            .seam()
+            .controller()
+            .make_fetch_request(P, 8, 4096)
+            .unwrap();
+        let resp = leader.serve_fetch(P, &req).unwrap();
+        assert!(resp.record_count > 0, "the leader served records to apply");
+        let handle = server.lock().unwrap().follower_handle(P).unwrap();
+
+        // Park the apply mid-fsync, then assert the off-global-lock / on-partition-lock property.
+        control.close_sync_gate();
+        let apply_handle = Arc::clone(&handle);
+        let apply = std::thread::spawn(move || {
+            crate::cluster::dataplane::apply_on_follower(&apply_handle, &resp)
+        });
+        control.wait_for_sync_gate_entered(1);
+        assert!(
+            server.try_lock().is_ok(),
+            "the server Mutex is FREE during the follower apply's fsync (#809 — off the global lock)"
+        );
+        assert!(
+            handle.try_lock().is_err(),
+            "the apply holds the PER-PARTITION follower lock during the fsync (not the global lock)"
+        );
+        control.open_sync_gate();
+        assert!(
+            apply.join().unwrap().is_ok(),
+            "the off-lock apply completed once the fsync was released"
         );
     }
 
@@ -2062,13 +2145,11 @@ mod tests {
         }
 
         fn replica_dump(&self) -> Vec<(String, Vec<u8>)> {
-            dump_segments(
-                self.server
-                    .seam()
-                    .controller()
-                    .follower_log(self.partition)
-                    .unwrap(),
-            )
+            self.server
+                .seam()
+                .controller()
+                .with_follower_log(self.partition, dump_segments)
+                .unwrap()
         }
     }
 
@@ -3397,12 +3478,20 @@ mod live_runtime_tests {
         // runtime: lock the server and dump the follower's own replica log.
         {
             let f2 = f2_rt.server().lock().unwrap();
-            let dump = dump_segments(f2.seam().controller().follower_log(P).unwrap());
+            let dump = f2
+                .seam()
+                .controller()
+                .with_follower_log(P, dump_segments)
+                .unwrap();
             assert_replicated_byte_identical(&dump, leader_log);
         }
         {
             let f3 = f3_rt.server().lock().unwrap();
-            let dump = dump_segments(f3.seam().controller().follower_log(P).unwrap());
+            let dump = f3
+                .seam()
+                .controller()
+                .with_follower_log(P, dump_segments)
+                .unwrap();
             assert_replicated_byte_identical(&dump, leader_log);
         }
 
@@ -3560,7 +3649,11 @@ mod live_runtime_tests {
         // Its recovered replica is byte-identical to the leader.
         {
             let f = f_rt2.server().lock().unwrap();
-            let dump = dump_segments(f.seam().controller().follower_log(P).unwrap());
+            let dump = f
+                .seam()
+                .controller()
+                .with_follower_log(P, dump_segments)
+                .unwrap();
             assert_replicated_byte_identical(&dump, leader_log);
         }
         f_rt2.stop();
@@ -3979,7 +4072,11 @@ mod live_runtime_tests {
         // gap-free (a gap or reorder would diverge the bytes and the apply would have failed closed).
         {
             let f = f_rt.server().lock().unwrap();
-            let dump = dump_segments(f.seam().controller().follower_log(P).unwrap());
+            let dump = f
+                .seam()
+                .controller()
+                .with_follower_log(P, dump_segments)
+                .unwrap();
             assert_replicated_byte_identical(&dump, leader_log);
         }
 


### PR DESCRIPTION
## #809 Phase 2 — apply follower fetches off the global data-plane lock

After Phase 1 off-locked the leader fetch-**serve**, the follower fetch loop still held the node-global `Arc<Mutex<DataPlaneServer>>` across `apply_fetch_response` — decode + append + `log.sync()` (**fsync**) — so partition A's apply/fsync serialized behind the one global lock, blocking partition B's serve/apply/park. This was flagged as potentially the bigger win (fsync-dominated contention).

### What changed
- `PartitionRole::Follower` now holds the follower as an `Arc<Mutex<EpochAwareFollower>>` (a `FollowerHandle`).
- The follower fetch thread clones the handle **once** (under a brief global lock) and then applies + reports via the new `apply_on_follower` / `report_from_follower` **off the global lock** — holding only that handle's per-partition lock across the fsync. So A's fsync no longer blocks B. The per-iteration `make_fetch_request` still goes through the controller (brief) and exits the loop once the role is gone.
- The controller's follower-routing methods lock the handle internally; `follower_log` became a closure accessor `with_follower_log` (a `&Log` can't be borrowed across the lock).

### The failover sharp edge (handled carefully)
`promote_follower_to_leader` must **not** consume the `Arc` (a still-running fetch thread holds a clone — `try_unwrap` would race). It already **drops** the log after building the read plane (the leader serves through the plane only), so it now builds the plane + seeds a **clone** of the epoch cache from the **locked** `&log`, leaving the `Arc` for the exiting fetch thread to drop. Writer release is deferred to that exit — harmless: nothing else writes the replica log, and the leader serves only up to the committed HW. The committed-completeness self-verify + epoch fence are unchanged. A poisoned follower lock is recovered with `into_inner` so one partition's apply panic can't wedge the whole plane.

### Correctness
Unchanged: same bytes, same order, same I2 (ack-after-fsync), same failover self-verify + fence. **All 358 cluster tests** (replication / ISR / failover / byte-identity) pass.

### Test
`a_follower_apply_does_not_hold_the_server_lock_across_the_fsync` parks a follower apply mid-fsync (the fault sync gate) and asserts the server `Mutex` is **FREE** while the per-partition follower lock **IS held** — proving the apply runs under the partition lock, off the global lock.

941 server lib + 416 storage lib green; workspace clippy (pedantic) + fmt clean.

### Follow-up (Phase 3, to fully close #809)
Factor the seam's node-global `parked`/`next_token` (atomic token + per-partition parked) to remove the last global serialization on the produce-ack park path. Tracked under #809.

Refs #809
