### PR TITLE
fix(storage): defer a roll on a transient create fault instead of permanently freezing the writer (#867)

### DIFF
--- a/crates/ironbus-storage/src/fault.rs
+++ b/crates/ironbus-storage/src/fault.rs
@@ -88,6 +88,12 @@ pub struct FaultControl {
     /// Lets a test park a fetch-serve mid-read (in a positioned `read_at`) and then prove the server lock
     /// is NOT held during the serve (off-lock fetch-serve), without a wall-clock sleep.
     read_gate: Arc<SyncGate>,
+    /// While non-zero, the next this-many `create_new` calls fail with a TRANSIENT injected IO error
+    /// (decrementing on each, so a count of 1 fails exactly the next call), modelling an EMFILE/short
+    /// ENOSPC at a segment-roll boundary. Lets a test prove a transient create fault DEFERS the roll
+    /// rather than permanently freezing the writer (#867): arm 1, drive a roll, then assert a later
+    /// append succeeds once the fault has cleared. `0` disables it.
+    fail_create_new: Arc<AtomicU64>,
 }
 
 /// A condvar-backed gate the sync path waits on while closed (#177): `open` starts open (syncs pass),
@@ -164,6 +170,32 @@ impl FaultControl {
         }
         let threshold = self.fail_sync_dir_after.load(Ordering::SeqCst);
         threshold != 0 && self.sync_dir_count.load(Ordering::SeqCst) >= threshold
+    }
+
+    /// Arms a TRANSIENT `create_new` failure (#867): the next `count` calls to `create_new` fail with
+    /// an injected IO error, then it self-clears. Models a momentary EMFILE / short ENOSPC at a
+    /// segment-roll boundary so a test can prove the roll DEFERS (the writer stays resumable) instead
+    /// of permanently freezing. `0` disables it.
+    pub fn fail_create_new(&self, count: u64) {
+        self.fail_create_new.store(count, Ordering::SeqCst);
+    }
+
+    /// `true` (consuming one armed failure) if this `create_new` should fail. A no-op returning
+    /// `false` once the armed count is exhausted.
+    fn create_new_should_fail(&self) -> bool {
+        loop {
+            let n = self.fail_create_new.load(Ordering::SeqCst);
+            if n == 0 {
+                return false;
+            }
+            if self
+                .fail_create_new
+                .compare_exchange(n, n - 1, Ordering::SeqCst, Ordering::SeqCst)
+                .is_ok()
+            {
+                return true;
+            }
+        }
     }
 
     fn record_sync_dir(&self) {
@@ -435,6 +467,7 @@ impl FaultControl {
         self.set_fail_read(false);
         self.set_short_read(0);
         self.set_fail_sync_dir(false);
+        self.fail_create_new(0);
         // Consume any still-armed one-shot torn write so it cannot fire on a later op.
         let _ = self.take_torn_write();
     }
@@ -509,6 +542,13 @@ impl<F: Filesystem> Filesystem for FaultFs<F> {
     }
 
     fn create_new(&self, name: &str) -> io::Result<Self::File> {
+        // A transient create fault (#867): fail BEFORE delegating, so no partial file is left behind,
+        // modelling EMFILE/short-ENOSPC where the inode is never created.
+        if self.control.create_new_should_fail() {
+            return Err(io::Error::other(
+                "injected transient create_new fault (#867)",
+            ));
+        }
         Ok(FaultFile {
             inner: self.inner.create_new(name)?,
             control: self.control.clone(),

--- a/crates/ironbus-storage/src/log.rs
+++ b/crates/ironbus-storage/src/log.rs
@@ -821,6 +821,27 @@ pub struct Log<F: Filesystem, C: Clock> {
     /// nothing. The cell holds only derived state: the snapshot is rebuilt from `self.segments`, so
     /// dropping or rebuilding it changes nothing a reader observes.
     read_plane: std::cell::RefCell<Option<ReadPlane<F>>>,
+    /// A roll that SEALED the predecessor but could not yet CREATE the next active segment, because
+    /// `start_segment` hit a transient resource fault (EMFILE from fd exhaustion, a short ENOSPC a
+    /// reap will clear, EINTR) at the roll boundary (#867). The seal is durable, so no data is lost;
+    /// the next write retries the deferred creation via [`ensure_writable`](Log::ensure_writable), so
+    /// a recoverable fault no longer permanently freezes the writer. `None` in steady state: the only
+    /// thing that sets it is a failed `start_segment` during a roll, and the next successful create
+    /// clears it. While it is `Some`, `active` is `None` but the writer is RESUMABLE, not frozen.
+    pending_roll: Option<PendingRoll>,
+}
+
+/// A deferred active-segment creation: a [`Log::roll`] sealed the old segment but a transient fault
+/// stopped it from creating the next one, so the create is retried on the next write (#867). The
+/// fields are exactly the arguments [`Log::start_segment`] needs to finish the roll.
+#[derive(Clone, Copy, Debug)]
+struct PendingRoll {
+    /// The id of the not-yet-created next active segment.
+    id: u64,
+    /// Its base sequence (continues the sealed predecessor's run).
+    base_seq: Seq,
+    /// Its base offset (continues the sealed predecessor's run).
+    base_offset: Offset,
 }
 
 /// The bounds of a single [`Log::read_range`] pass, threaded to the per-segment read helpers so
@@ -908,6 +929,7 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
                     // The off-actor read plane (#539) is built lazily on the first consumer
                     // `read_plane()` call; a never-read log pays nothing.
                     read_plane: std::cell::RefCell::new(None),
+                    pending_roll: None,
                 };
                 log.start_segment(FIRST_SEGMENT_ID, Seq::new(0), Offset::ZERO)?;
                 log
@@ -1178,6 +1200,7 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
             sealed_readers: SealedReaderCache::new(DEFAULT_SEALED_READER_CACHE_CAP),
             // The off-actor read plane (#539) is built lazily on the first consumer `read_plane()`.
             read_plane: std::cell::RefCell::new(None),
+            pending_roll: None,
         };
 
         if scan.footer.is_some() {
@@ -1549,6 +1572,7 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
             sealed_readers: SealedReaderCache::new(DEFAULT_SEALED_READER_CACHE_CAP),
             // The off-actor read plane (#539) is built lazily on the first consumer `read_plane()`.
             read_plane: std::cell::RefCell::new(None),
+            pending_roll: None,
         };
 
         match active {
@@ -1653,13 +1677,28 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
         // grow-on-append and surfaces at the append/sync as it does today (the doc's ENOSPC-to-
         // `AtCapacity` routing is a forward refinement, not required for correctness).
         let _ = file.preallocate(self.config.max_segment_bytes);
-        let writer = SegmentWriter::create(file, header)?;
-        let mut writer = writer;
+        let mut writer = SegmentWriter::create(file, header)?;
         writer.sync()?; // the header is durable...
         self.fs.sync_dir()?; // ...and so is its directory entry.
-                             // The segment header is physical write volume an SSD/eMMC wear model charges (#118): the
-                             // 64-byte header is on disk now (the `sync` above made it durable). Counted here, after the
-                             // create succeeded, so a failed create never inflates the physical-bytes total.
+        self.install_started_segment(writer, id, base_offset);
+        Ok(())
+    }
+
+    /// Installs a freshly created + durably-headered active segment into the in-memory log state: the
+    /// active writer, its id, its (empty) retention slot, and its empty resident seek index, and
+    /// charges the header's physical write volume. The IO half (create + preallocate + header/dir
+    /// fsync) is done by the caller ([`start_segment`](Log::start_segment) or
+    /// [`create_or_defer_segment`](Log::create_or_defer_segment)); this is the infallible commit that
+    /// makes the new segment the active one once it is durable.
+    fn install_started_segment(
+        &mut self,
+        writer: SegmentWriter<F::File>,
+        id: u64,
+        base_offset: Offset,
+    ) {
+        // The segment header is physical write volume an SSD/eMMC wear model charges (#118): the
+        // 64-byte header is on disk now (the `sync` above made it durable). Counted here, after the
+        // create succeeded, so a failed create never inflates the physical-bytes total.
         self.charge_physical(SEGMENT_HEADER_LEN as u64);
         self.active = Some(writer);
         self.active_id = id;
@@ -1692,7 +1731,6 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
                 flushed_end: SEGMENT_HEADER_LEN as u64,
             },
         );
-        Ok(())
     }
 
     /// The next FRESH segment id, strictly greater than any id ever used: `max(active_id, the
@@ -1750,12 +1788,12 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
         // segment's header were charged on append and `start_segment`).
         self.charge_physical(SEGMENT_FOOTER_LEN as u64);
         self.sealed_record_bytes = self.sealed_record_bytes.saturating_add(old_record_bytes);
-        self.start_segment(next_id, self.next_seq, self.next_offset)
-            .map_err(|_| StorageError::WriterFrozen)?;
         // Sealing fsynced every record in the old segment, so both the visible and the DURABLE
         // head advance to the start of the new segment even without an explicit sync. Advancing
         // `synced_offset` here is what bounds a relaxed level's loss to the open segment's unsynced
-        // tail: a roll is a real durability barrier, so every record up to it is durable (#341).
+        // tail: a roll is a real durability barrier, so every record up to it is durable (#341). These
+        // reflect the SEAL (already durable), so they hold even if the create below is deferred by a
+        // transient fault (#867): the durable head is `next_offset` the moment the predecessor sealed.
         self.flushed_offset = self.next_offset;
         self.synced_offset = self.next_offset;
         // The seal made every previously-unsynced record durable and the new active segment is empty,
@@ -1768,6 +1806,82 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
         // active-tail fallback served those same records, so consume behavior is identical across the
         // seal. A no-op if no consumer has built the plane.
         self.republish_read_plane();
+        // Create the next active segment. The predecessor is already durably sealed, so a failure
+        // here loses NO data and must not permanently freeze the writer on a TRANSIENT resource fault
+        // (EMFILE / a short ENOSPC at the roll boundary, #867): `create_or_defer_segment` records a
+        // pending roll and surfaces the raw, NON-FATAL error, and the next write retries the create.
+        self.create_or_defer_segment(next_id, self.next_seq, self.next_offset)
+    }
+
+    /// Creates the next active segment for a roll, distinguishing a TRANSIENT create fault (defer and
+    /// retry) from a genuine DURABILITY-BARRIER fault (freeze), so a recoverable resource fault no
+    /// longer permanently freezes the writer (#867).
+    ///
+    /// The predecessor was already sealed and fsynced before this is reached, so NOTHING here can lose
+    /// durable data, and reads keep serving off the sealed plane regardless of the outcome:
+    /// - **Create phase** (`create_new` + `SegmentWriter::create`): a failure is a transient resource
+    ///   fault (EMFILE from fd exhaustion, a short ENOSPC a reap will clear, EINTR). Record a
+    ///   [`PendingRoll`] and return the RAW error, which is NOT [`StorageError::WriterFrozen`], so
+    ///   [`EngineError::is_fatal`] is false and the writer stays RESUMABLE: the next write retries via
+    ///   [`ensure_writable`](Log::ensure_writable), so the writer resumes once the fault clears.
+    /// - **Durability-barrier phase** (the header / dir fsync): a failure means the disk cannot make
+    ///   even the 64-byte header durable — a genuine durability fault — so FREEZE
+    ///   ([`StorageError::WriterFrozen`]), exactly as a failed sync on the append path does, so a dead
+    ///   disk is surfaced fail-stop to health rather than retried forever.
+    ///
+    /// Any partial orphan from a prior failed attempt is removed first so the retry's `create_new`
+    /// cannot collide on the id; the orphan holds nothing durable (the predecessor is already sealed),
+    /// so the remove is safe and best-effort.
+    fn create_or_defer_segment(
+        &mut self,
+        id: u64,
+        base_seq: Seq,
+        base_offset: Offset,
+    ) -> Result<(), StorageError> {
+        let _ = self.fs.remove(&segment_file_name(id));
+        let header = SegmentHeader {
+            segment_id: id,
+            base_seq,
+            base_offset,
+            created_unix_ms: self.clock.now_unix_millis(),
+            flags: 0,
+        };
+        // Create phase — a failure is transient: DEFER (the predecessor is durably sealed, no loss).
+        let defer = |this: &mut Self, e: StorageError| -> StorageError {
+            let _ = this.fs.remove(&segment_file_name(id));
+            this.pending_roll = Some(PendingRoll {
+                id,
+                base_seq,
+                base_offset,
+            });
+            e
+        };
+        let file = match self.fs.create_new(&segment_file_name(id)) {
+            Ok(f) => f,
+            Err(e) => return Err(defer(self, StorageError::Io(e))),
+        };
+        let _ = file.preallocate(self.config.max_segment_bytes);
+        let mut writer = match SegmentWriter::create(file, header) {
+            Ok(w) => w,
+            Err(e) => return Err(defer(self, e)),
+        };
+        // Durability-barrier phase — a failure is a genuine durability fault: FREEZE.
+        writer.sync().map_err(|_| StorageError::WriterFrozen)?;
+        self.fs.sync_dir().map_err(|_| StorageError::WriterFrozen)?;
+        // Durable: install the new active segment and clear the pending roll.
+        self.install_started_segment(writer, id, base_offset);
+        self.pending_roll = None;
+        Ok(())
+    }
+
+    /// Completes a roll whose active-segment creation was deferred by a transient fault (#867), so
+    /// the writer resumes once the fault clears. A no-op when no roll is pending (the steady state).
+    /// Called at the top of every write entry point: if the deferred create still fails it returns
+    /// the raw (non-fatal) error and stays pending, so the write is refused without freezing.
+    fn ensure_writable(&mut self) -> Result<(), StorageError> {
+        if let Some(p) = self.pending_roll {
+            self.create_or_defer_segment(p.id, p.base_seq, p.base_offset)?;
+        }
         Ok(())
     }
 
@@ -2000,6 +2114,9 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
     /// # Errors
     /// [`StorageError::WriterFrozen`] if the writer is frozen, or an IO error from the seal's fsync.
     pub fn seal_active_segment(&mut self) -> Result<(), StorageError> {
+        // Finish any roll a transient fault deferred first (#867): a pending roll already sealed the
+        // predecessor, so once its empty successor is created there is nothing more to seal.
+        self.ensure_writable()?;
         if self.active()?.record_count() == 0 {
             return Ok(());
         }
@@ -2014,6 +2131,12 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
     /// # Errors
     /// [`StorageError::WriterFrozen`] if the writer is frozen.
     pub fn active_segment_at_or_over_cap(&self) -> Result<bool, StorageError> {
+        // A roll deferred by a transient fault (#867) has already sealed the predecessor; its
+        // not-yet-created successor will be EMPTY, so it is not at cap. Answer without a frozen error
+        // (this is a `&self` query, so it cannot itself complete the deferred create).
+        if self.pending_roll.is_some() {
+            return Ok(false);
+        }
         let active = self.active()?;
         Ok(active.write_pos() >= self.config.max_segment_bytes && active.record_count() > 0)
     }
@@ -2065,6 +2188,11 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
             }
         }
 
+        // Complete any roll a transient fault deferred (#867) before touching the writer, so a
+        // momentary EMFILE/ENOSPC at a previous roll boundary resolves on this write instead of having
+        // permanently frozen the stream. If the deferred create still fails, this returns the raw
+        // (non-fatal) error and the produce is refused without freezing.
+        self.ensure_writable()?;
         // Soft size cap: roll before appending if the active segment has reached the cap,
         // but never roll an empty one (so an oversized record still gets written). `allow_roll` is
         // false ONLY on the `append_without_roll` path (#906), where the caller manages segment
@@ -2180,6 +2308,9 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
         // and a health check sees the degraded state. Reads keep serving the durable prefix.
         // The sync needs the writer mutably (#452: it flushes the pending buffered records to
         // the file before its fdatasync, so durable keeps its meaning).
+        // Finish any transient-fault-deferred roll first (#867); the predecessor it sealed is already
+        // durable, so once the empty successor exists there is nothing pending to sync.
+        self.ensure_writable()?;
         self.active()?;
         let frozen = match self.active.as_mut() {
             Some(w) => w.sync().is_err(),
@@ -2226,6 +2357,9 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
     /// # Errors
     /// Returns [`StorageError::WriterFrozen`] if a prior fatal fsync already froze the writer.
     pub fn flush_no_sync(&mut self) -> Result<(), StorageError> {
+        // Finish any transient-fault-deferred roll first (#867) so a momentary roll-boundary fault
+        // does not leave the visible head stuck.
+        self.ensure_writable()?;
         // A frozen writer has no active segment: surface the fatal state rather than silently
         // advancing the visible head over records the writer can no longer own.
         self.active()?;
@@ -3073,6 +3207,9 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
     ///   surgery or the re-derivation. The unlink-then-truncate order keeps the chain
     ///   valid-prefix-recoverable at every step, so a crash mid-surgery is reconciled by [`Log::open`].
     pub fn truncate_to(&mut self, target: Offset) -> Result<TruncateOutcome, StorageError> {
+        // Finish any transient-fault-deferred roll first (#867) so the truncation acts on a fully
+        // installed active segment, not a momentarily-deferred one.
+        self.ensure_writable()?;
         // Fail closed if the writer is already dead: we never truncate against a frozen log.
         self.active()?;
         let next = self.next_offset.get();
@@ -3252,6 +3389,9 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
         if !config.enabled {
             return Ok(crate::compaction::CompactionOutcome::default());
         }
+        // Finish any transient-fault-deferred roll first (#867) so compaction sees a fully installed
+        // active segment.
+        self.ensure_writable()?;
         // Never compact on a frozen writer (it has no active segment to protect against, but the
         // log is degraded; do no extra IO).
         self.active()?;
@@ -5048,22 +5188,76 @@ mod tests {
     }
 
     #[test]
-    fn a_failed_roll_freezes_the_writer() {
-        let mut log = open_mem(small_config());
-        // Pre-create the file the next roll targets, so its create_new fails mid-roll.
-        log.filesystem().create_new(&segment_file_name(1)).unwrap();
-        let mut roll_err = None;
-        for i in 0..20u8 {
-            if let Err(e) = log.append(&rec(&[i; 20])) {
-                roll_err = Some(e);
-                break;
-            }
+    fn a_transient_create_fault_at_a_roll_defers_and_resumes_the_writer() {
+        use crate::fault::FaultFs;
+        // #867: a momentary EMFILE / short ENOSPC failing `create_new` at a roll boundary must NOT
+        // permanently freeze the writer. The roll's predecessor is already durably sealed, so the
+        // create is DEFERRED (a non-fatal error) and retried on the next write, which succeeds once
+        // the fault clears — instead of the old behaviour that killed write availability until restart.
+        let (fs, control) = FaultFs::new(InMemoryFs::new());
+        let mut log = Log::open(fs, ManualClock::new(), small_config()).unwrap();
+
+        // Fill the first segment (syncing each record) until the next append would roll it.
+        let mut durable = 0u64;
+        while !log.active_segment_at_or_over_cap().unwrap() {
+            assert_eq!(log.append(&rec(&[7u8; 20])).unwrap(), Offset::new(durable));
+            log.sync().unwrap();
+            durable += 1;
+        }
+
+        // Arm a one-shot transient create fault; the next append triggers a roll whose `create_new`
+        // fails. The roll seals the predecessor (durable) and then DEFERS the create.
+        control.fail_create_new(1);
+        let err = log.append(&rec(&[8u8; 20])).unwrap_err();
+        assert!(
+            !matches!(err, StorageError::WriterFrozen),
+            "a transient create fault must NOT freeze the writer: {err:?}"
+        );
+        assert!(matches!(err, StorageError::Io(_)), "got {err:?}");
+        // The predecessor was durably sealed by the roll, so its records survive; the failed produce
+        // consumed no offset (the reservation happens after the roll).
+        assert_eq!(log.flushed_offset(), Offset::new(durable));
+
+        // The fault has cleared: the NEXT append completes the deferred roll and succeeds, proving the
+        // writer resumed rather than freezing until restart. The resumed produce takes the offset the
+        // deferred one did not consume.
+        assert_eq!(log.append(&rec(&[9u8; 20])).unwrap(), Offset::new(durable));
+        log.sync().unwrap();
+        assert_eq!(
+            log.active_segment_id(),
+            1,
+            "the deferred roll completed to segment 1"
+        );
+
+        // Everything is durable across a reopen: the predecessor's records plus the resumed one.
+        let fs = log.into_filesystem();
+        let reopened = Log::open(fs, ManualClock::new(), small_config()).unwrap();
+        assert_eq!(reopened.next_offset(), Offset::new(durable + 1));
+    }
+
+    #[test]
+    fn a_durability_barrier_fault_at_a_roll_freezes_the_writer() {
+        use crate::fault::FaultFs;
+        // #867: a TRANSIENT create fault defers, but a genuine DURABILITY-BARRIER fault — the new
+        // segment's directory-publish fsync — is a real durability failure and must still FREEZE the
+        // writer fail-stop, so a dead disk surfaces to health instead of being retried forever.
+        let (fs, control) = FaultFs::new(InMemoryFs::new());
+        let mut log = Log::open(fs, ManualClock::new(), small_config()).unwrap();
+        while !log.active_segment_at_or_over_cap().unwrap() {
+            log.append(&rec(&[7u8; 20])).unwrap();
             log.sync().unwrap();
         }
-        // The roll's create_new hit AlreadyExists, which froze the writer: the freezing
-        // append surfaces the fatal `WriterFrozen`, not a soft IO error.
-        assert!(matches!(roll_err, Some(StorageError::WriterFrozen)));
-        // The writer is frozen: further writes refuse, getters stay sane (no panic).
+        // Fail the new segment's directory-publish fsync during the roll (the seal of the predecessor
+        // fsyncs the FILE, not the directory, so it still succeeds — only the create's barrier fails).
+        control.set_fail_sync_dir(true);
+        let err = log.append(&rec(&[8u8; 20])).unwrap_err();
+        assert!(
+            matches!(err, StorageError::WriterFrozen),
+            "a durability-barrier fault at a roll must freeze: {err:?}"
+        );
+        // The freeze is permanent even after the fault clears: further writes refuse, getters stay
+        // sane (no panic).
+        control.set_fail_sync_dir(false);
         assert!(matches!(
             log.append(&rec(b"x")),
             Err(StorageError::WriterFrozen)
@@ -6289,18 +6483,17 @@ mod tests {
 
     #[test]
     fn reads_serve_the_durable_prefix_from_a_frozen_writer() {
-        let mut log = open_mem(small_config());
-        // Pre-create the file the first roll targets, so that roll fails and freezes.
-        log.filesystem().create_new(&segment_file_name(1)).unwrap();
-        let mut froze = false;
-        for i in 0..30u8 {
-            if log.append(&rec(&[i; 20])).is_err() {
-                froze = true;
-                break;
-            }
+        use crate::fault::FaultFs;
+        let (fs, control) = FaultFs::new(InMemoryFs::new());
+        let mut log = Log::open(fs, ManualClock::new(), small_config()).unwrap();
+        let mut durable = 0u64;
+        while !log.active_segment_at_or_over_cap().unwrap() {
+            log.append(&rec(&[7u8; 20])).unwrap();
             log.sync().unwrap();
+            durable += 1;
         }
-        assert!(froze, "a roll should have been attempted and failed");
+        // Freeze the writer with a durability-barrier fault at the roll (the new segment's dir fsync).
+        control.set_fail_sync_dir(true);
         assert!(matches!(
             log.append(&rec(b"x")),
             Err(StorageError::WriterFrozen)
@@ -6308,6 +6501,7 @@ mod tests {
         // Reads ignore the writer and still serve the flushed prefix.
         let records = log.read_from(Offset::ZERO, 100).unwrap();
         assert!(!records.is_empty());
+        assert_eq!(records.len() as u64, durable);
         assert_eq!(records.len() as u64, log.flushed_offset().get());
     }
 

--- a/crates/ironbus-storage/src/log.rs
+++ b/crates/ironbus-storage/src/log.rs
@@ -1800,17 +1800,21 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
         // so the at-risk exposure resets to zero: this is what bounds the relaxed levels' loss to at
         // most one open segment's worth of records (#341, #379).
         self.unsynced_record_bytes = 0;
-        // A roll SEALED a segment: the sealed set changed, so REPUBLISH the whole off-actor read
-        // plane (#539) — the new immutable sealed snapshot FIRST (Release), then the new frontier
-        // (Release). After this the just-sealed segment is served lock-free off-actor; before it the
-        // active-tail fallback served those same records, so consume behavior is identical across the
-        // seal. A no-op if no consumer has built the plane.
-        self.republish_read_plane();
         // Create the next active segment. The predecessor is already durably sealed, so a failure
         // here loses NO data and must not permanently freeze the writer on a TRANSIENT resource fault
         // (EMFILE / a short ENOSPC at the roll boundary, #867): `create_or_defer_segment` records a
         // pending roll and surfaces the raw, NON-FATAL error, and the next write retries the create.
-        self.create_or_defer_segment(next_id, self.next_seq, self.next_offset)
+        let result = self.create_or_defer_segment(next_id, self.next_seq, self.next_offset);
+        // A roll SEALED a segment: the sealed set changed, so REPUBLISH the whole off-actor read
+        // plane (#539) — the new immutable sealed snapshot FIRST (Release), then the new frontier
+        // (Release). After this the just-sealed segment is served lock-free off-actor; before it the
+        // active-tail fallback served those same records, so consume behavior is identical across the
+        // seal. A no-op if no consumer has built the plane. Done AFTER the create so the new active
+        // slot is installed first (so `build_sealed_descriptor` includes the just-sealed predecessor
+        // in the sealed prefix); on a DEFERRED roll there is no active slot and the predecessor is
+        // served as a fully-sealed prefix (#867).
+        self.republish_read_plane();
+        result
     }
 
     /// Creates the next active segment for a roll, distinguishing a TRANSIENT create fault (defer and
@@ -1865,9 +1869,14 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
             Ok(w) => w,
             Err(e) => return Err(defer(self, e)),
         };
-        // Durability-barrier phase — a failure is a genuine durability fault: FREEZE.
-        writer.sync().map_err(|_| StorageError::WriterFrozen)?;
-        self.fs.sync_dir().map_err(|_| StorageError::WriterFrozen)?;
+        // Durability-barrier phase — a failure is a genuine durability fault: FREEZE. Clear any
+        // pending roll so the freeze is TERMINAL even when this is a retry of a previously-deferred
+        // roll, matching `WriterFrozen`'s "fatal, never-retried" contract (a later write must not
+        // resume it via `ensure_writable`). The orphan new segment is recovered at boot (#868).
+        if writer.sync().is_err() || self.fs.sync_dir().is_err() {
+            self.pending_roll = None;
+            return Err(StorageError::WriterFrozen);
+        }
         // Durable: install the new active segment and clear the pending roll.
         self.install_started_segment(writer, id, base_offset);
         self.pending_roll = None;
@@ -2419,6 +2428,9 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
     /// Returns [`StorageError::WriterFrozen`] if the writer is already frozen, or if this fdatasync
     /// fails its durability barrier (which freezes the writer read-only).
     pub(crate) fn sync_data_only(&mut self) -> Result<(), StorageError> {
+        // Complete any transient-fault-deferred roll first (#867), so this barrier runs against a
+        // fully installed active segment rather than a momentarily-deferred one.
+        self.ensure_writable()?;
         self.active()?;
         let frozen = match self.active.as_mut() {
             Some(w) => w.sync_data_only().is_err(),
@@ -2579,13 +2591,17 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
         self.clock.clone()
     }
 
-    /// Whether the writer is still live (an active segment is open). The writer freezes
-    /// (`active` becomes `None`) when a fatal `fdatasync` fails (see [`Log::sync`]) or a segment
-    /// roll fails; this reports that degraded state without a failing write, so a health check
-    /// can surface it. Reads keep serving the durable prefix from a frozen writer.
+    /// Whether the writer is still live (NOT permanently frozen). The writer freezes when a fatal
+    /// `fdatasync` fails (see [`Log::sync`]) or a roll hits a genuine durability-barrier fault; this
+    /// reports that degraded state without a failing write, so a health check can surface it. Reads
+    /// keep serving the durable prefix from a frozen writer.
+    ///
+    /// A roll a TRANSIENT fault merely DEFERRED (#867) has `active == None` but is RESUMABLE — the
+    /// next write completes the deferred create — so it reports `true`, NOT a freeze: a momentary
+    /// EMFILE/ENOSPC at a roll boundary must not flap a node out of `/readyz`.
     #[must_use]
     pub fn is_writable(&self) -> bool {
-        self.active.is_some()
+        self.active.is_some() || self.pending_roll.is_some()
     }
 
     /// Reads up to `max` records starting at log offset `start`, crossing segment
@@ -3743,12 +3759,27 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
         // base is the first offset NOT in the sealed prefix (the sealed end). With no sealed
         // predecessor (only the active segment, or none) the sealed prefix is empty and ends at the
         // oldest offset.
-        let sealed_count = self.segments.len().saturating_sub(1);
+        //
+        // When there is NO active segment — a frozen writer, or a roll a transient fault deferred
+        // (#867), where the last slot is the just-sealed predecessor, not an active tail — EVERY slot
+        // is sealed and the sealed prefix runs to the durable head. Treating the predecessor as active
+        // here would drop the hottest just-sealed segment from the off-actor plane (it would fall back
+        // through the actor) until the next republish.
+        let active_present = self.active.is_some();
+        let sealed_count = if active_present {
+            self.segments.len().saturating_sub(1)
+        } else {
+            self.segments.len()
+        };
         let sealed_slots = &self.segments[..sealed_count];
-        let sealed_end = self
-            .segments
-            .last()
-            .map_or(oldest, SegmentSlot::covered_base_offset);
+        let sealed_end = if active_present {
+            self.segments
+                .last()
+                .map_or(oldest, SegmentSlot::covered_base_offset)
+        } else {
+            // No active tail: the durable head is the end of the (fully sealed) prefix.
+            self.next_offset.get()
+        };
         let mut sealed = Vec::with_capacity(sealed_count);
         for slot in sealed_slots {
             if slot.compacted_covered.is_some() {
@@ -5266,6 +5297,97 @@ mod tests {
         let _ = log.next_offset();
         let _ = log.next_seq();
         let _ = log.active_segment_id();
+    }
+
+    #[test]
+    fn a_roll_republishes_the_just_sealed_segment_to_the_off_actor_read_plane() {
+        // #867 review finding 1: the roll must republish the #539 read plane AFTER installing the new
+        // active segment, so the just-sealed predecessor is served lock-free off-actor rather than
+        // forced through the actor. Build the plane FIRST (so the roll republishes it), roll, then
+        // read a predecessor offset and assert it completes off-plane (no fallback).
+        let mut log = open_mem(small_config());
+        let _ = log.read_plane().unwrap(); // cache the plane so the next roll REPUBLISHES it
+        let mut durable = 0u64;
+        while log.active_segment_id() == 0 {
+            log.append(&rec(&[7u8; 20])).unwrap();
+            log.sync().unwrap();
+            durable += 1;
+        }
+        assert!(log.active_segment_id() >= 1, "a roll happened");
+        let plane = log.read_plane().unwrap();
+        let read = plane.read_one(Offset::ZERO).unwrap();
+        assert_eq!(
+            read.records.len(),
+            1,
+            "the just-sealed predecessor's record is served"
+        );
+        assert!(
+            read.fallback_from.is_none(),
+            "the just-sealed segment is served off-actor, not via the through-actor fallback"
+        );
+        let _ = durable;
+    }
+
+    #[test]
+    fn a_persistent_transient_create_fault_keeps_deferring_then_resumes() {
+        use crate::fault::FaultFs;
+        // #867 review finding 5: a transient create fault that persists across several writes must
+        // keep DEFERRING (each write non-fatal, the writer never frozen and reported writable) and
+        // then resume cleanly once the fault clears — no data lost, no offset skipped.
+        let (fs, control) = FaultFs::new(InMemoryFs::new());
+        let mut log = Log::open(fs, ManualClock::new(), small_config()).unwrap();
+        let mut durable = 0u64;
+        while !log.active_segment_at_or_over_cap().unwrap() {
+            assert_eq!(log.append(&rec(&[7u8; 20])).unwrap(), Offset::new(durable));
+            log.sync().unwrap();
+            durable += 1;
+        }
+        // The next 3 create_new calls fail: the roll defers, and the next two writes RE-defer.
+        control.fail_create_new(3);
+        for attempt in 0..3 {
+            let err = log.append(&rec(&[8u8; 20])).unwrap_err();
+            assert!(
+                !matches!(err, StorageError::WriterFrozen),
+                "attempt {attempt} must not freeze: {err:?}"
+            );
+            assert!(
+                log.is_writable(),
+                "attempt {attempt}: a deferred roll is resumable, reported writable (#867 finding 2)"
+            );
+            assert_eq!(
+                log.flushed_offset(),
+                Offset::new(durable),
+                "attempt {attempt}: no durable data lost while deferring"
+            );
+        }
+        // The fault has cleared: the next write completes the roll at the un-consumed offset.
+        assert_eq!(log.append(&rec(&[9u8; 20])).unwrap(), Offset::new(durable));
+        log.sync().unwrap();
+        let fs = log.into_filesystem();
+        let reopened = Log::open(fs, ManualClock::new(), small_config()).unwrap();
+        assert_eq!(reopened.next_offset(), Offset::new(durable + 1));
+    }
+
+    #[test]
+    fn a_deferred_roll_is_completed_by_a_later_sync() {
+        use crate::fault::FaultFs;
+        // #867 review finding 5: a deferred roll is completed by ANY write entry point, not just
+        // append — here a `sync` finishes it via `ensure_writable`.
+        let (fs, control) = FaultFs::new(InMemoryFs::new());
+        let mut log = Log::open(fs, ManualClock::new(), small_config()).unwrap();
+        let mut durable = 0u64;
+        while !log.active_segment_at_or_over_cap().unwrap() {
+            log.append(&rec(&[7u8; 20])).unwrap();
+            log.sync().unwrap();
+            durable += 1;
+        }
+        control.fail_create_new(1);
+        let err = log.append(&rec(&[8u8; 20])).unwrap_err();
+        assert!(!matches!(err, StorageError::WriterFrozen), "got {err:?}");
+        // A `sync` (not an append) completes the deferred roll; the fault has already cleared.
+        log.sync().unwrap();
+        assert!(log.is_writable(), "the roll completed, the writer is live");
+        assert_eq!(log.append(&rec(&[9u8; 20])).unwrap(), Offset::new(durable));
     }
 
     #[test]


### PR DESCRIPTION
## The bug (#867)

`Log::roll` seals the active segment, then calls `start_segment` for the next one and maps **any** error to the fatal, never-retried `WriterFrozen`. So a momentary, recoverable fault at a roll boundary — `create_new` returning **EMFILE** (fd table exhausted by a consume/connection flood, since sealed-slot reads open fresh fds) or a short **ENOSPC** a retention reap would clear — permanently kills write availability for that stream until the broker restarts. The sealed data is durable and reads keep working; only the writer dies. The asymmetry is self-inflicted: the append path already routes capacity exhaustion to the non-fatal, retryable `AtCapacity`.

## The fix

Split the roll's create into two phases with the correct failure semantics:

| Phase | Fault | Behaviour |
|---|---|---|
| **Create** (`create_new` + `SegmentWriter::create`) | transient (EMFILE / short ENOSPC / EINTR) | record a `PendingRoll`, return the **raw** error (NOT `WriterFrozen` ⇒ `is_fatal()` false ⇒ writer **resumable**); next write retries via `ensure_writable` |
| **Durability barrier** (new segment header / dir fsync) | genuine durability fault | still **freeze** (`WriterFrozen`) — a dead disk surfaces fail-stop to health |

The predecessor is durably sealed before either phase, so a deferred (or never-completed) create loses no data and reads keep serving off the sealed plane.

### Why defer instead of reorder

Creating the successor *before* sealing the predecessor would be crash-unsafe: a crash in that window leaves an **unsealed non-final** segment beside a valid successor, which `scan_recover_chain` rejects as `UnsealedPredecessor` (unbootable). So the seal stays first and the create is deferred.

### Plumbing

- `ensure_writable` completes a pending roll (or re-defers, non-fatally) at the top of every write entry point: `append`, `sync`, `flush_no_sync`, `seal_active_segment`, `truncate_to`, `maybe_compact`.
- `active_segment_at_or_over_cap` reports a pending roll's (empty) successor as not-at-cap.
- A partial orphan from a failed attempt is removed before each retry so `create_new` can't collide on the id (the orphan holds nothing durable — the predecessor is already sealed).
- `is_fatal()` was already `WriterFrozen`-only, so a deferred roll's raw error is non-fatal with no server-side change.

## Tests
- `FaultControl::fail_create_new(n)` — new one-shot transient `create_new` fault injector.
- `a_transient_create_fault_at_a_roll_defers_and_resumes_the_writer` — the roll defers (non-fatal `Io`, not `WriterFrozen`), the next append resumes the writer, and everything is durable across a reopen.
- `a_durability_barrier_fault_at_a_roll_freezes_the_writer` — a dir-fsync fault at the roll still freezes (and stays frozen after the fault clears).
- `reads_serve_the_durable_prefix_from_a_frozen_writer` — repointed to freeze via a durability-barrier fault.

## Verification
- `cargo test -p ironbus-storage` — 419 lib + all integration green
- `cargo test --workspace --all-features` — green
- `cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic` + `cargo fmt --all --check` — clean

Closes #867
