### PR TITLE
fix(cluster): purge a disconnected producer's parked C2-fsync acks on drop_connection (#871, #869)

### DIFF
--- a/crates/ironbus-server/src/cluster/client_ack.rs
+++ b/crates/ironbus-server/src/cluster/client_ack.rs
@@ -392,22 +392,29 @@ impl<F: Filesystem, C: Clock> ClientAckGate<F, C> {
     /// in offset order, for that connection to flush on its own pass. Below `min_isr` releases NOTHING
     /// (the no-false-ack property, on the real client wire). Returns the number of replies released.
     ///
-    /// Locks the shared server, then the outbox — both briefly, NEVER across a socket write (the
-    /// release just moves bytes into the outbox; the owning connection's thread does the actual write).
+    /// Locks the shared server, THEN the outbox, holding BOTH across the release + deposit — both
+    /// briefly, NEVER across a socket write (the release just moves bytes into the outbox; the owning
+    /// connection's thread does the actual write). Holding both (the same server→outbox order
+    /// [`drop_connection`](Self::drop_connection) uses, so no deadlock) makes the gate/seam drain and
+    /// the outbox deposit ATOMIC w.r.t. a concurrent disconnect: `drop_connection` cannot interleave
+    /// between them, so a just-released ack is never deposited into an already-cleared dead-owner
+    /// outbox that nobody drains (#871). Either the report fully deposits and then `drop_connection`
+    /// clears it, or `drop_connection` purges the still-parked ack first and the report releases
+    /// nothing for it.
     pub fn on_follower_report(&self, partition: u64, report: &AckReplicatedBody) -> usize {
-        let released = {
-            let Ok(mut srv) = self.server.lock() else {
-                return 0;
-            };
-            match srv.seam_mut().on_follower_report_owned(partition, report) {
-                Ok(r) => r,
-                Err(_) => return 0,
-            }
+        // A poisoned server lock means the runtime is tearing down; do nothing (as before).
+        let Ok(mut srv) = self.server.lock() else {
+            return 0;
+        };
+        let Ok(released) = srv.seam_mut().on_follower_report_owned(partition, report) else {
+            return 0;
         };
         if released.is_empty() {
             return 0;
         }
         let count = released.len();
+        // Acquire the outbox WHILE still holding the server lock (see the method doc): this is what
+        // closes the deposit race against a concurrent `drop_connection`.
         let mut outbox = self
             .outbox
             .lock()
@@ -444,9 +451,12 @@ impl<F: Filesystem, C: Clock> ClientAckGate<F, C> {
     /// outbox between the two clears. A poisoned server lock recovers in place (the cleanup must still
     /// run) rather than skipping the purge.
     pub fn drop_connection(&self, member: MemberId) {
-        // Hold the server lock THEN the outbox lock (the same order the runtime's `on_follower_report`
-        // acquires them, so no deadlock) across BOTH purges, so a concurrent report cannot release this
-        // owner's acks into the outbox between the two clears.
+        // Hold the server lock THEN the outbox lock across BOTH purges — the SAME order
+        // `on_follower_report` holds them (it now keeps the server lock through its outbox deposit), so
+        // the two operations serialize on the server lock: a concurrent report either fully releases +
+        // deposits this owner's acks BEFORE this runs (then the outbox clear below drops them) or finds
+        // them already purged from the seam/gate and releases nothing. No deadlock (consistent
+        // server→outbox order). A poisoned lock recovers in place — the cleanup must still run.
         let mut srv = self
             .server
             .lock()

--- a/crates/ironbus-server/src/cluster/client_ack.rs
+++ b/crates/ironbus-server/src/cluster/client_ack.rs
@@ -431,11 +431,27 @@ impl<F: Filesystem, C: Clock> ClientAckGate<F, C> {
         outbox.remove(&member.get()).unwrap_or_default()
     }
 
-    /// Drop any released-but-undrained acks for a producer connection that DISCONNECTED (#719): nobody
-    /// is left to flush them, so the outbox entry is removed rather than leaked. Called from the
-    /// connection-cleanup path, like the #497 `drop_l2_confirms`. (A still-PARKED ack — withheld inside
-    /// the seam, not yet released — is left to the seam's bounded gate; this only clears the outbox.)
+    /// Drop every still-withheld ack for a producer connection that DISCONNECTED (#719, #869, #871):
+    /// nobody is left to flush them, so leaving them parked leaks reply bytes + gate-cap slots that an
+    /// unsatisfiable quorum (a follower partitioned below `min_isr`) may never drain. Called from the
+    /// connection-cleanup path, like the #497 `drop_l2_confirms`.
+    ///
+    /// Purges in TWO places: the seam's still-PARKED acks + their quorum-ack-gate `pending` slots (via
+    /// [`ProduceAckSeam::purge_owner`], so a later follower report can never release — or re-deposit —
+    /// them), then the per-connection released-but-undrained outbox. The seam purge is done FIRST and
+    /// the outbox purge under the SAME contiguous critical section ordering the runtime uses (server
+    /// lock, then outbox), so a concurrent `on_follower_report` cannot release the owner's acks into the
+    /// outbox between the two clears. A poisoned server lock recovers in place (the cleanup must still
+    /// run) rather than skipping the purge.
     pub fn drop_connection(&self, member: MemberId) {
+        // Hold the server lock THEN the outbox lock (the same order the runtime's `on_follower_report`
+        // acquires them, so no deadlock) across BOTH purges, so a concurrent report cannot release this
+        // owner's acks into the outbox between the two clears.
+        let mut srv = self
+            .server
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        srv.seam_mut().purge_owner(member.get());
         let mut outbox = self
             .outbox
             .lock()
@@ -705,6 +721,51 @@ mod tests {
         );
         // A second drain is empty (the outbox entry was removed).
         assert!(gate.drain_released(member).is_empty());
+    }
+
+    #[test]
+    fn drop_connection_purges_a_disconnected_producers_still_parked_ack() {
+        // #871: a producer that parks a C2-fsync ack below min_isr then DISCONNECTS must have its
+        // STILL-PARKED ack purged from the seam AND the quorum-gate by `drop_connection` — not leaked
+        // until the partition heals. (Before this fix it cleared only the released-but-undrained outbox,
+        // leaving the parked ack — and its gate-cap slot — to leak.)
+        let gate = leader_gate(8); // leader fsync'd through 8; no follower reported → below min_isr
+        let member = MemberId::new(7);
+        let offset = 3;
+        let disposition = gate.on_local_fsynced_ack(member, P, offset, wire_ack(offset));
+        assert_eq!(disposition, AckDisposition::Parked);
+        assert_eq!(
+            gate.server.lock().unwrap().seam().parked_len(),
+            1,
+            "the wire PubAck is withheld in the seam"
+        );
+        assert_eq!(
+            gate.server
+                .lock()
+                .unwrap()
+                .seam()
+                .controller()
+                .pending_ack_count(P),
+            1
+        );
+
+        // The producer disconnects: drop_connection purges its parked ack from BOTH the seam and gate.
+        gate.drop_connection(member);
+        assert_eq!(
+            gate.server.lock().unwrap().seam().parked_len(),
+            0,
+            "the disconnected producer's parked ack was purged (not leaked)"
+        );
+        assert_eq!(
+            gate.server
+                .lock()
+                .unwrap()
+                .seam()
+                .controller()
+                .pending_ack_count(P),
+            0,
+            "and its quorum-gate cap slot was freed"
+        );
     }
 
     #[test]

--- a/crates/ironbus-server/src/cluster/dataplane.rs
+++ b/crates/ironbus-server/src/cluster/dataplane.rs
@@ -109,7 +109,7 @@
 //! * **Snapshot / compaction** (#660), **multi-partition fan-out optimization**, and the
 //!   **cross-cluster geo** plane (C7) are separate.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::{Arc, Mutex};
 
 use ironbus_core::clock::Clock;
@@ -842,6 +842,24 @@ impl<F: Filesystem, C: Clock> DataPlaneController<F, C> {
             }),
             None => Err(DataPlaneError::UnknownPartition { partition }),
         }
+    }
+
+    /// Remove `tokens` from EVERY led partition's quorum-ack gate (#869, #871): a disconnected
+    /// producer's still-parked acks are dropped from the gate `pending` so their backlog-cap slots are
+    /// freed and they never release. Returns the total removed across all partitions. A token is parked
+    /// in exactly one gate, so the cross-partition sweep removes each at most once; an empty `tokens` is
+    /// a cheap no-op (the common disconnect, which parked nothing).
+    pub fn purge_parked_tokens(&mut self, tokens: &BTreeSet<AckToken>) -> usize {
+        if tokens.is_empty() {
+            return 0;
+        }
+        let mut removed = 0;
+        for role in self.roles.values_mut() {
+            if let PartitionRole::Leader { gate, .. } = role {
+                removed += gate.purge_where(|t| tokens.contains(t));
+            }
+        }
+        removed
     }
 
     /// Record a follower's [`AckReplicatedBody`] report for `partition` and RELEASE any produce acks
@@ -1685,6 +1703,32 @@ impl<F: Filesystem, C: Clock> ProduceAckSeam<F, C> {
             .iter()
             .filter_map(|t| self.parked.remove(t))
             .collect()
+    }
+
+    /// Purge every still-PARKED ack owned by `owner` from BOTH the seam's reply side-table AND the
+    /// controller's quorum-ack gates (#869, #871). Called when a producer connection disconnects: its
+    /// withheld `C2-fsync` acks can never be delivered (no connection is left to write them), so leaving
+    /// them parked leaks the reply bytes + the gate's backlog-cap slots an unsatisfiable quorum (a
+    /// follower partitioned below `min_isr`) may never drain. Returns the number of parked acks dropped.
+    ///
+    /// Because the entries are removed from the seam here, a LATER follower report can never release
+    /// them — so it can never re-deposit them into the dead owner's outbox either (#871's second leak).
+    pub fn purge_owner(&mut self, owner: u64) -> usize {
+        let dead: BTreeSet<AckToken> = self
+            .parked
+            .iter()
+            .filter(|(_, (o, _))| *o == owner)
+            .map(|(t, _)| *t)
+            .collect();
+        if dead.is_empty() {
+            return 0;
+        }
+        for t in &dead {
+            self.parked.remove(t);
+        }
+        // Free the gate-cap slots too, so the cap is not permanently consumed by dead-owner entries.
+        self.controller.purge_parked_tokens(&dead);
+        dead.len()
     }
 }
 
@@ -2618,6 +2662,107 @@ mod tests {
         );
         // Silence the unused-mut on `followers` if the loop above ever changes.
         let _ = &mut followers;
+    }
+
+    #[test]
+    fn purge_owner_drops_a_disconnected_producers_parked_acks_and_frees_gate_slots() {
+        // #869/#871: a producer that parks C2-fsync acks below min_isr (no quorum, never released) then
+        // DISCONNECTS must have its parked acks purged from BOTH the seam side-table AND the gate's
+        // backlog, so its reply bytes and (#864) cap slots are not leaked until the partition heals. The
+        // purge is owner-selective: a still-connected producer's acks survive.
+        const P: u64 = 0;
+        const M: u64 = 7; // the disconnecting producer
+        const N: u64 = 9; // a different, still-connected producer
+        let (mut seam, _followers, served_end) = led_cluster(P, 1, &[1, 2, 3], quorum3(), 10);
+        assert!(
+            served_end >= 4,
+            "need at least 4 served offsets for this fixture"
+        );
+
+        // Park (below min_isr → all stay parked) in monotone offset order: M owns 0,1,2; N owns 3.
+        for (owner, off) in [(M, 0u64), (M, 1), (M, 2), (N, 3)] {
+            let d = seam
+                .on_local_fsynced_ack_owned(
+                    owner,
+                    ClusterAckLevel::C2Fsync,
+                    P,
+                    off,
+                    wire_pub_ack(off),
+                )
+                .unwrap();
+            assert_eq!(d, AckDisposition::Parked, "owner {owner} offset {off}");
+        }
+        assert_eq!(seam.parked_len(), 4);
+        assert_eq!(seam.controller().pending_ack_count(P), 4);
+
+        // M disconnects: purge drops its 3 parked acks from the seam AND frees its 3 gate-cap slots.
+        assert_eq!(seam.purge_owner(M), 3, "M's three parked acks were dropped");
+        assert_eq!(seam.parked_len(), 1, "only N's ack remains in the seam");
+        assert_eq!(
+            seam.controller().pending_ack_count(P),
+            1,
+            "M's gate-cap slots were freed too (not just the seam side-table)"
+        );
+
+        // Purging an owner that parked nothing is a cheap no-op.
+        assert_eq!(seam.purge_owner(12345), 0);
+        assert_eq!(seam.parked_len(), 1);
+    }
+
+    #[test]
+    fn a_quorum_report_after_purge_releases_nothing_for_a_dead_owner() {
+        // #871 second leak: once a disconnected owner's acks are purged, a LATER follower report that
+        // reaches quorum must release NOTHING for it — so its bytes can never be re-deposited into a
+        // dead-owner outbox nobody drains.
+        const P: u64 = 0;
+        const M: u64 = 7;
+        let (mut seam, mut followers, served_end) = led_cluster(P, 1, &[1, 2, 3], quorum3(), 25);
+        let offset = served_end - 1;
+        let d = seam
+            .on_local_fsynced_ack_owned(
+                M,
+                ClusterAckLevel::C2Fsync,
+                P,
+                offset,
+                wire_pub_ack(offset),
+            )
+            .unwrap();
+        assert_eq!(d, AckDisposition::Parked);
+        assert_eq!(seam.parked_len(), 1);
+
+        // M disconnects BEFORE quorum catches up.
+        assert_eq!(seam.purge_owner(M), 1);
+        assert_eq!(seam.parked_len(), 0);
+
+        // Drive the 2nd replica to quorum-fsync past `offset`. With M's ack purged, the report releases
+        // nothing — so nothing is ever re-deposited for the dead owner.
+        let mut released: Vec<Vec<u8>> = Vec::new();
+        for _ in 0..40 {
+            if seam.controller().is_leader(P) {
+                let req = followers[0].make_fetch_request(P, 8, 4096).unwrap();
+                let action = seam
+                    .controller_mut()
+                    .handle_frame(P, DataPlaneFrame::FetchRequest(req))
+                    .unwrap();
+                let resp = match action {
+                    DataPlaneAction::SendFetchResponse { response, .. } => response,
+                    other => panic!("expected a fetch response, got {other:?}"),
+                };
+                followers[0]
+                    .handle_frame(P, DataPlaneFrame::FetchResponse(resp))
+                    .unwrap();
+                let report = followers[0].follower_report(P).unwrap();
+                released.extend(seam.on_follower_report(P, &report).unwrap());
+            }
+            if followers[0].follower_high_watermark(P).unwrap() >= served_end {
+                break;
+            }
+        }
+        assert!(
+            released.is_empty(),
+            "a purged owner's ack is never released, so it is never re-deposited"
+        );
+        assert_eq!(seam.parked_len(), 0);
     }
 
     #[test]

--- a/crates/ironbus-server/src/cluster/isr.rs
+++ b/crates/ironbus-server/src/cluster/isr.rs
@@ -512,6 +512,17 @@ impl<T> QuorumAckGate<T> {
         self.pending.len()
     }
 
+    /// Drop every pending ack whose token satisfies `is_dead` — e.g. a disconnected producer's tokens
+    /// (#871) — returning the count removed. The survivors keep their order (offsets stay
+    /// non-decreasing), and `released_through` is untouched: a purged token simply never releases, so
+    /// release semantics are unchanged. This frees the dropped acks' backlog-cap slots (#864/#869) so a
+    /// new produce is no longer refused by dead-owner entries an unsatisfiable quorum will never drain.
+    pub fn purge_where(&mut self, mut is_dead: impl FnMut(&T) -> bool) -> usize {
+        let before = self.pending.len();
+        self.pending.retain(|p| !is_dead(&p.token));
+        before - self.pending.len()
+    }
+
     /// Whether an ack for `offset` is still being withheld.
     #[must_use]
     pub fn is_pending(&self, offset: u64) -> bool {


### PR DESCRIPTION
## The bug (#871, #869)

On a clustered leader, a `C2-fsync` produce to a led partition parks its wire `PubAck` in the seam until quorum-fsync. Below `min_isr` (a follower partitioned/dead) **nothing drains**, and `ClientAckGate::drop_connection` removed **only** the released-but-undrained outbox. The still-**PARKED** ack — its reply bytes in `ProduceAckSeam::parked` AND its slot in the partition's `QuorumAckGate::pending` — **survived the producer disconnect**:

- A connect / produce-1-C2 / disconnect loop under a sustained sub-`min_isr` outage leaked an entry per disconnect (reconnecting producers take fresh member ids).
- A quorum that later advanced **re-deposited** a disconnected owner's bytes into a dead-member outbox nobody drains (#871's second leak).
- The #864 per-partition cap bounds total RAM, but dead-owner entries **fill the cap** and start fast-rejecting live producers.

> Note: #869's "grows without bound / no cap" premise is partly stale — the per-partition cap landed in **#864** (`QuorumAckGate::with_cap(MAX_PARKED_ACKS_PER_PARTITION)`). The real remaining leak is disconnect-survival, fixed here.

## The fix

`drop_connection` now purges the disconnecting owner **everywhere**, holding the server lock then the outbox lock (the runtime's `on_follower_report` order, so no deadlock and no release can interleave between the two clears):

1. `ProduceAckSeam::purge_owner(owner)` — drop every `parked` entry tagged with that owner from the seam side-table;
2. `DataPlaneController::purge_parked_tokens` — remove those tokens from **every** led partition's `QuorumAckGate::pending` (new `QuorumAckGate::purge_where`), freeing the #864 cap slots so they aren't held by entries an unsatisfiable quorum will never drain.

Because the entries are gone from the seam, a later follower report can never release — and therefore never re-deposit — them, closing the second leak with no separate liveness check on the deposit path.

## Tests
- `purge_owner_drops_a_disconnected_producers_parked_acks_and_frees_gate_slots` — drops the owner's parked acks AND frees the gate slots; owner-selective (a still-connected producer survives).
- `a_quorum_report_after_purge_releases_nothing_for_a_dead_owner` — after a purge, driving the follower to quorum releases nothing (no re-deposit).
- `drop_connection_purges_a_disconnected_producers_still_parked_ack` — the end-to-end `ClientAckGate` path.

## Verification
- `cargo test --workspace --all-features` — green
- `cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic` + `cargo fmt --all --check` — clean

Closes #871. Substantially closes #869 (its unboundedness is capped by #864; this removes the disconnect-survival leak). The optional #869 refinements — tying produce *admission* to ISR health, and timing out very old parks — are not implemented here.
