### PR TITLE
fix(cli): add context create --token-file so the bearer token is not on argv (#885)

### DIFF
--- a/crates/ironbus-cli/src/context.rs
+++ b/crates/ironbus-cli/src/context.rs
@@ -294,7 +294,11 @@ pub(crate) fn run_context(args: &[String], out: &mut impl Write) -> Result<(), C
     }
 }
 
-/// `context create <name> [--addr a] [--token t] [--tls-ca p] [--tls-server-name n] [--data-dir d] [--use]`.
+/// `context create <name> [--addr a] [--token-file p | --token t] [--tls-ca p] [--tls-server-name n] [--data-dir d] [--use]`.
+///
+/// The bearer token is a SECRET: prefer `--token-file <path>` (StrictModes-checked owner-only on unix)
+/// or `--token-file -` (stdin) so it never lands on the process argv table; `--token <t>` is kept for
+/// back-compat but warns about argv exposure (#885).
 fn context_create(path: &Path, args: &[String], out: &mut impl Write) -> Result<(), CliError> {
     let mut name: Option<String> = None;
     let mut ctx = Context::default();
@@ -303,7 +307,21 @@ fn context_create(path: &Path, args: &[String], out: &mut impl Write) -> Result<
     while i < args.len() {
         match args[i].as_str() {
             "--addr" => ctx.addr = Some(crate::take_value("--addr", args, &mut i)?),
-            "--token" => ctx.token = Some(crate::take_value("--token", args, &mut i)?),
+            "--token" => {
+                let token = crate::take_value("--token", args, &mut i)?;
+                // #885: a bearer token is a secret; on argv it is visible to any local user via `ps` /
+                // `/proc/<pid>/cmdline` for the lifetime of the invocation and lingers in shell history.
+                // Warn (to stderr, never stdout) and steer to the off-argv path, mirroring `passwd`.
+                eprintln!(
+                    "warning: --token exposes the bearer token in the process table and shell history; \
+                     prefer `--token-file <path>` (or `--token-file -` to read from stdin)"
+                );
+                ctx.token = Some(token);
+            }
+            "--token-file" => {
+                let path = crate::take_value("--token-file", args, &mut i)?;
+                ctx.token = Some(read_token_from_file_or_stdin(&path)?);
+            }
             "--tls-ca" => ctx.tls_ca = Some(crate::take_value("--tls-ca", args, &mut i)?),
             "--tls-server-name" => {
                 ctx.tls_server_name = Some(crate::take_value("--tls-server-name", args, &mut i)?);
@@ -340,6 +358,38 @@ fn context_create(path: &Path, args: &[String], out: &mut impl Write) -> Result<
     let verb = if existed { "updated" } else { "created" };
     writeln!(out, "{verb} context `{name}`")?;
     Ok(())
+}
+
+/// Read a bearer token from a file (or from stdin when `path` is `-`), so the secret never appears on
+/// the process argv table (#885) — mirroring `passwd`'s `--password-file` discipline. On unix the file
+/// is StrictModes-checked fail-closed (owner-only) BEFORE it is read, exactly like the auth-config /
+/// TLS-key / password file. One trailing newline (and an accompanying CR) is trimmed, the shape a
+/// `printf` / `echo` / heredoc produces, so the stored token is the intended value, not `token\n`. The
+/// token must be valid UTF-8 (it is sent as a UTF-8 wire credential).
+fn read_token_from_file_or_stdin(path: &str) -> Result<String, CliError> {
+    use std::io::Read as _;
+    let mut bytes = if path == "-" {
+        let mut buf = Vec::new();
+        std::io::stdin()
+            .read_to_end(&mut buf)
+            .map_err(|e| CliError::Usage(format!("cannot read --token-file from stdin: {e}")))?;
+        buf
+    } else {
+        // The token file is a secret reference: fail-closed owner-only check on unix (no-op elsewhere,
+        // where POSIX mode bits do not apply), then read.
+        #[cfg(unix)]
+        crate::strict_mode_check_secret_file(path)?;
+        std::fs::read(path)
+            .map_err(|e| CliError::Usage(format!("cannot read --token-file `{path}`: {e}")))?
+    };
+    if bytes.last() == Some(&b'\n') {
+        bytes.pop();
+        if bytes.last() == Some(&b'\r') {
+            bytes.pop();
+        }
+    }
+    String::from_utf8(bytes)
+        .map_err(|_| CliError::Usage("the token in --token-file is not valid UTF-8".to_string()))
 }
 
 /// `context use <name>` — point `current` at an existing context.
@@ -553,6 +603,60 @@ mod tests {
         std::fs::write(&path, "this is = = not toml").unwrap();
         let e = load(&path).unwrap_err();
         assert_eq!(e.exit_code(), crate::EXIT_USAGE);
+    }
+
+    #[test]
+    fn create_reads_the_token_from_a_file_not_argv() {
+        // #885: `--token-file` reads the bearer token from a file (off the argv table), trimming one
+        // trailing newline, and on unix StrictModes-checks the file owner-only fail-closed first.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("contexts.toml");
+        let tok = dir.path().join("token.secret");
+        std::fs::write(&tok, "s3cr3t-bearer\n").unwrap(); // a trailing newline, the printf/echo shape
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            std::fs::set_permissions(&tok, std::fs::Permissions::from_mode(0o600)).unwrap();
+        }
+        let args = |v: &[&str]| v.iter().map(|s| (*s).to_string()).collect::<Vec<_>>();
+        let mut buf = Vec::new();
+        context_create(
+            &path,
+            &args(&[
+                "prod",
+                "--addr",
+                "example.com:7000",
+                "--token-file",
+                tok.to_str().unwrap(),
+            ]),
+            &mut buf,
+        )
+        .unwrap();
+        let cfg = load(&path).unwrap();
+        assert_eq!(
+            cfg.contexts.get("prod").and_then(|c| c.token.as_deref()),
+            Some("s3cr3t-bearer"),
+            "the token is read from the file with the trailing newline trimmed"
+        );
+
+        // On unix, a group/world-readable token file is refused fail-closed (StrictModes).
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            std::fs::set_permissions(&tok, std::fs::Permissions::from_mode(0o644)).unwrap();
+            let mut buf2 = Vec::new();
+            let e = context_create(
+                &path,
+                &args(&["staging", "--token-file", tok.to_str().unwrap()]),
+                &mut buf2,
+            )
+            .unwrap_err();
+            assert_eq!(
+                e.exit_code(),
+                crate::EXIT_USAGE,
+                "a group/world-readable token file is refused"
+            );
+        }
     }
 
     #[test]

--- a/crates/ironbus-cli/src/main.rs
+++ b/crates/ironbus-cli/src/main.rs
@@ -887,8 +887,10 @@ USAGE:
                   [--min-samples <n>] [--json]            (opt-in: build --features zstd)
     ironbus dict install --data-dir <dir> --dict <path> [--json]   (opt-in: --features zstd)
     ironbus dict ls --data-dir <dir> [--json]                      (opt-in: --features zstd)
-    ironbus context create <name> [--addr <host:port>] [--token <t>] [--tls-ca <path>]
-                  [--tls-server-name <name>] [--data-dir <dir>] [--use]
+    ironbus context create <name> [--addr <host:port>] [--token-file <path> | --token <t>]
+                  [--tls-ca <path>] [--tls-server-name <name>] [--data-dir <dir>] [--use]
+                  (token is a secret: prefer --token-file <path>, or --token-file - for stdin;
+                   --token <t> is visible in the process table)
     ironbus context (use <name> | list | show [<name>] | rm <name> | current)
     ironbus completion <bash|zsh|fish>
     ironbus cheat


### PR DESCRIPTION
## The bug (#885)

`context create` read the connection auth token straight from argv:

```rust
"--token" => ctx.token = Some(crate::take_value("--token", args, &mut i)?),
```

So the plaintext token was exposed in the process argv table (readable by any local user via `ps` / `/proc/<pid>/cmdline`) and lingered in shell history. The token is explicitly a secret per the module's own docs, and the careful `0600` on-disk storage was undermined by exposing the same secret on argv at creation time. This contradicts `passwd`, which reads its password only via `--password-file` or stdin and never places it on the command line.

## The fix

Mirror `passwd`'s discipline:
- Add **`--token-file <path>`** (and **`--token-file -`** to read from stdin), reading the token off argv. On unix the file is **StrictModes-checked** fail-closed (owner-only) before it is read, exactly like the auth-config / TLS-key / password file; a trailing newline (+CR) is trimmed; the token must be valid UTF-8.
- Keep `--token <t>` for back-compat but **warn** (to stderr, never stdout) that the value is visible in the process table, steering to `--token-file`.
- Help text + the `context create` rustdoc document the secure path.

## Test

`create_reads_the_token_from_a_file_not_argv`: `--token-file` reads the token from a file with the trailing newline trimmed; on unix a group/world-readable token file is refused fail-closed (the StrictModes wiring).

## Verification
- `cargo test -p ironbus-cli` — green
- `cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic` + `cargo fmt --all --check` — clean

Closes #885
