### PR TITLE
fix(server): route a dedup-hit C2-fsync produce through the quorum gate (#917)

### DIFF
--- a/crates/ironbus-server/src/cluster/isr.rs
+++ b/crates/ironbus-server/src/cluster/isr.rs
@@ -547,18 +547,28 @@ impl<T> QuorumAckGate<T> {
         };
         // Re-driving with a non-advancing commit must release nothing new.
         let commit = commit.max(self.released_through);
-        // The pending list is in offset order; split off the released prefix. An ack at `offset` is
-        // committed iff `offset < commit`.
-        let split = self
-            .pending
-            .iter()
-            .position(|p| p.offset >= commit)
-            .unwrap_or(self.pending.len());
-        let released: Vec<T> = self
-            .pending
-            .drain(..split)
-            .map(|p| p.token)
-            .collect::<Vec<_>>();
+        // Release EVERY pending ack whose record is now quorum-committed (`offset < commit`),
+        // preserving the pending (submission) order of BOTH the released and the retained acks.
+        //
+        // An all-fresh-produce gate is in non-decreasing offset order, so this releases exactly the
+        // same contiguous prefix a prefix-drain would. But a dedup-hit (#917) parks an OLD duplicate
+        // offset that can sit BELOW a higher already-parked offset, breaking the non-decreasing order.
+        // A plain prefix drain (`drain(..position(>= commit))`) would then STRAND that duplicate behind
+        // the higher entry until the HIGHER offset committed, not its own — so a duplicate whose record
+        // is already quorum-durable could be withheld through a partial-ISR stall. Scanning the whole
+        // list ties every ack's release to ITS OWN offset's quorum-commit, never a later one's, and can
+        // never release an offset `>= commit` (no false ack). This runs per follower-report (not the
+        // produce hot path) over a list bounded by the #864 cap, so the single O(n) pass is cheap.
+        let mut released = Vec::new();
+        let mut retained = Vec::with_capacity(self.pending.len());
+        for p in self.pending.drain(..) {
+            if p.offset < commit {
+                released.push(p.token);
+            } else {
+                retained.push(p);
+            }
+        }
+        self.pending = retained;
         self.released_through = commit;
         released
     }
@@ -790,6 +800,36 @@ mod tests {
         // Quorum advances to 3 → offsets 1 and 2 release, in order.
         let released = gate.release_up_to(Some(3));
         assert_eq!(released, vec![1, 2]);
+        assert_eq!(gate.pending_len(), 0);
+    }
+
+    #[test]
+    fn the_gate_releases_an_out_of_order_duplicate_park_by_its_own_offset() {
+        // #917: a dedup-hit parks an OLD duplicate offset that can sit BELOW a higher already-parked
+        // offset (a fresh produce pipelined between an original and its retry), so `pending` is no
+        // longer non-decreasing. The release must still tie each ack to ITS OWN offset's quorum-commit,
+        // never a later entry's — a plain prefix drain would strand the duplicate behind the higher
+        // offset until THAT offset committed.
+        let mut gate: QuorumAckGate<u64> = QuorumAckGate::new();
+        // Token 100 = original at offset 5; token 6 = a fresh produce at offset 6; token 200 = the
+        // dedup retry at offset 5, parked AFTER offset 6 (out of order).
+        let _ = gate.park(5, 100);
+        let _ = gate.park(6, 6);
+        let _ = gate.park(5, 200);
+        assert_eq!(gate.pending_len(), 3);
+
+        // Quorum-commit = 6 → offset 5 is committed, offset 6 is NOT. BOTH offset-5 acks (the original
+        // AND the out-of-order duplicate) release, in submission order; the offset-6 ack stays parked.
+        let released = gate.release_up_to(Some(6));
+        assert_eq!(
+            released,
+            vec![100, 200],
+            "both offset-5 acks release; the duplicate is not stranded behind offset 6"
+        );
+        assert_eq!(gate.pending_len(), 1, "only the offset-6 ack remains");
+
+        // When offset 6 commits (quorum 7), it releases. No double-release of the offset-5 acks.
+        assert_eq!(gate.release_up_to(Some(7)), vec![6]);
         assert_eq!(gate.pending_len(), 0);
     }
 

--- a/crates/ironbus-server/src/cluster/isr.rs
+++ b/crates/ironbus-server/src/cluster/isr.rs
@@ -547,28 +547,25 @@ impl<T> QuorumAckGate<T> {
         };
         // Re-driving with a non-advancing commit must release nothing new.
         let commit = commit.max(self.released_through);
-        // Release EVERY pending ack whose record is now quorum-committed (`offset < commit`),
-        // preserving the pending (submission) order of BOTH the released and the retained acks.
+        // Release the contiguous SUBMISSION-ORDER prefix of acks whose record is now quorum-committed
+        // (`offset < commit`). This is a strict prefix drain on purpose: each producer connection's acks
+        // are delivered in FIFO submission order (the client's `produce_window` correlates replies by
+        // ARRIVAL POSITION, not by offset — broker-assigned offsets are unknown until the ack arrives),
+        // so an ack may NEVER be released ahead of an earlier-submitted one on the same stream.
         //
-        // An all-fresh-produce gate is in non-decreasing offset order, so this releases exactly the
-        // same contiguous prefix a prefix-drain would. But a dedup-hit (#917) parks an OLD duplicate
-        // offset that can sit BELOW a higher already-parked offset, breaking the non-decreasing order.
-        // A plain prefix drain (`drain(..position(>= commit))`) would then STRAND that duplicate behind
-        // the higher entry until the HIGHER offset committed, not its own — so a duplicate whose record
-        // is already quorum-durable could be withheld through a partial-ISR stall. Scanning the whole
-        // list ties every ack's release to ITS OWN offset's quorum-commit, never a later one's, and can
-        // never release an offset `>= commit` (no false ack). This runs per follower-report (not the
-        // produce hot path) over a list bounded by the #864 cap, so the single O(n) pass is cheap.
-        let mut released = Vec::new();
-        let mut retained = Vec::with_capacity(self.pending.len());
-        for p in self.pending.drain(..) {
-            if p.offset < commit {
-                released.push(p.token);
-            } else {
-                retained.push(p);
-            }
-        }
-        self.pending = retained;
+        // A dedup-hit (#917) can park an OLD duplicate offset BELOW a higher already-parked offset, so
+        // `pending` is not always non-decreasing; the prefix drain correctly holds such a duplicate
+        // behind its FIFO-predecessor (releasing it would re-order that connection's ack stream and
+        // corrupt the client's position-indexed results) — it releases once the blocking earlier ack
+        // does, and a never-committing blocker withholds BOTH (the producer waits, unavailable over
+        // unsafe) until `purge_owner` reclaims them on disconnect. An ack at `offset >= commit` is
+        // committed iff `offset < commit`.
+        let split = self
+            .pending
+            .iter()
+            .position(|p| p.offset >= commit)
+            .unwrap_or(self.pending.len());
+        let released: Vec<T> = self.pending.drain(..split).map(|p| p.token).collect();
         self.released_through = commit;
         released
     }
@@ -804,12 +801,13 @@ mod tests {
     }
 
     #[test]
-    fn the_gate_releases_an_out_of_order_duplicate_park_by_its_own_offset() {
+    fn the_gate_holds_an_out_of_order_duplicate_behind_its_fifo_predecessor() {
         // #917: a dedup-hit parks an OLD duplicate offset that can sit BELOW a higher already-parked
         // offset (a fresh produce pipelined between an original and its retry), so `pending` is no
-        // longer non-decreasing. The release must still tie each ack to ITS OWN offset's quorum-commit,
-        // never a later entry's — a plain prefix drain would strand the duplicate behind the higher
-        // offset until THAT offset committed.
+        // longer non-decreasing. Each producer connection's acks are delivered in FIFO SUBMISSION
+        // order (the client correlates replies by ARRIVAL POSITION, not by offset), so the duplicate
+        // must be HELD behind the offset-6 ack submitted before it — releasing it early would re-order
+        // that connection's ack stream and corrupt the client's position-indexed results.
         let mut gate: QuorumAckGate<u64> = QuorumAckGate::new();
         // Token 100 = original at offset 5; token 6 = a fresh produce at offset 6; token 200 = the
         // dedup retry at offset 5, parked AFTER offset 6 (out of order).
@@ -818,18 +816,19 @@ mod tests {
         let _ = gate.park(5, 200);
         assert_eq!(gate.pending_len(), 3);
 
-        // Quorum-commit = 6 → offset 5 is committed, offset 6 is NOT. BOTH offset-5 acks (the original
-        // AND the out-of-order duplicate) release, in submission order; the offset-6 ack stays parked.
+        // Quorum-commit = 6 → only the contiguous FIFO prefix releases: just the original offset-5 ack.
+        // The out-of-order duplicate stays withheld behind the offset-6 ack (it cannot jump the queue).
         let released = gate.release_up_to(Some(6));
         assert_eq!(
             released,
-            vec![100, 200],
-            "both offset-5 acks release; the duplicate is not stranded behind offset 6"
+            vec![100],
+            "only the FIFO prefix releases; the duplicate waits behind its offset-6 predecessor"
         );
-        assert_eq!(gate.pending_len(), 1, "only the offset-6 ack remains");
+        assert_eq!(gate.pending_len(), 2);
 
-        // When offset 6 commits (quorum 7), it releases. No double-release of the offset-5 acks.
-        assert_eq!(gate.release_up_to(Some(7)), vec![6]);
+        // When offset 6 commits (quorum 7), the offset-6 ack AND the duplicate behind it release, in
+        // submission order — preserving the connection's FIFO ack stream. No double-release.
+        assert_eq!(gate.release_up_to(Some(7)), vec![6, 200]);
         assert_eq!(gate.pending_len(), 0);
     }
 

--- a/crates/ironbus-server/src/session.rs
+++ b/crates/ironbus-server/src/session.rs
@@ -4271,7 +4271,13 @@ fn write_pub_reply_gated<
     // outcome (it yields `FireAndForgetAppended`), so this never withholds a no-reply produce.
     let gated = match &outcome {
         ProduceOutcome::Appended(offset) => Some((*offset, FrameType::PubAck)),
-        ProduceOutcome::AppendedDuplicate(offset) => Some((*offset, FrameType::PubAckDuplicate)),
+        // A dedup hit on a FIRE-AND-FORGET produce sends NO frame (the QoS-0 no-frame contract): the
+        // actor's dedup path returns `AppendedDuplicate` even for a fire-and-forget produce (unlike the
+        // fresh-append path, which maps it to `FireAndForgetAppended`), so guard on the flag here so a
+        // QoS-0 duplicate is never quorum-gated or written. Only a REPLY-wanting duplicate is gated.
+        ProduceOutcome::AppendedDuplicate(offset) if !fire_and_forget => {
+            Some((*offset, FrameType::PubAckDuplicate))
+        }
         _ => None,
     };
     if let Some((offset, frame_type)) = gated {
@@ -4346,9 +4352,14 @@ fn write_pub_reply(
         // A BENIGN dedup hit (#33): the `msg_id` was already in the producer's window, so the
         // broker returns the ORIGINAL offset via the NEW PubAckDuplicate frame (the frozen PubAck
         // body is untouched). It is a SUCCESS (`rc = 0`, `duplicate = true`), never an error, so an
-        // idempotent retry over a lossy edge link does not loop.
+        // idempotent retry over a lossy edge link does not loop. A FIRE-AND-FORGET produce that
+        // dedup-hits sends NO frame (the QoS-0 no-frame contract): the actor's dedup path yields
+        // `AppendedDuplicate` regardless of the flag, so honor it here, exactly like every other
+        // outcome's fire-and-forget arm.
         ProduceOutcome::AppendedDuplicate(offset) => {
-            reply_pub_ack(out, FrameType::PubAckDuplicate, offset);
+            if !fire_and_forget {
+                reply_pub_ack(out, FrameType::PubAckDuplicate, offset);
+            }
             Ok(())
         }
         // A stale-epoch fence (#33): a zombie session reused an old `producer_id` with an epoch
@@ -7153,6 +7164,16 @@ mod tests {
             one_response(&out).0,
             FrameType::PubAckDuplicate,
             "a dedup hit at quorum writes the duplicate-ack"
+        );
+
+        // A FIRE-AND-FORGET produce that dedup-hits sends NO frame (the QoS-0 no-frame contract), even
+        // with a cluster gate present: the actor returns `AppendedDuplicate` regardless of the flag, so
+        // a QoS-0 duplicate must never be quorum-gated or written (it would desync the reply stream).
+        let mut s = Session::new();
+        let out = connect_and_pub_faf(&mut s, &DedupParkingEngine);
+        assert!(
+            out.is_empty(),
+            "a fire-and-forget dedup hit must send no frame: {out:?}"
         );
     }
 

--- a/crates/ironbus-server/src/session.rs
+++ b/crates/ironbus-server/src/session.rs
@@ -4262,25 +4262,37 @@ fn write_pub_reply_gated<
     fire_and_forget: bool,
     out: &mut Vec<u8>,
 ) -> Result<(), SessionError> {
-    if let ProduceOutcome::Appended(offset) = outcome {
+    // Both a fresh `Appended` and a dedup-hit `AppendedDuplicate` must clear the C2-fsync quorum gate
+    // before their ack is released: an idempotent RETRY of a C2-fsync produce whose original offset is
+    // NOT yet quorum-committed must NOT get an immediate `PubAckDuplicate` for a record that is durable
+    // only on the leader (#917). They differ ONLY in the reply FRAME TYPE (`PubAck` vs `PubAckDuplicate`)
+    // and the gate keys on the (original) offset, so a duplicate releases exactly when the original is
+    // quorum-fsync'd — immediately if it already is. A fire-and-forget produce never yields either
+    // outcome (it yields `FireAndForgetAppended`), so this never withholds a no-reply produce.
+    let gated = match &outcome {
+        ProduceOutcome::Appended(offset) => Some((*offset, FrameType::PubAck)),
+        ProduceOutcome::AppendedDuplicate(offset) => Some((*offset, FrameType::PubAckDuplicate)),
+        _ => None,
+    };
+    if let Some((offset, frame_type)) = gated {
         // SINGLE-NODE / no-cluster FAST PATH (zero added cost): with NO cluster gate the produce-ack is
         // written DIRECTLY into `out`, byte-for-byte today's path — no temp allocation, no lock, no extra
         // work. `has_client_ack_gate` is a cheap local bool (default `false`), so the non-cluster hot
         // path never even builds the bytes the gate would need.
         if !engine.has_client_ack_gate() {
-            reply_pub_ack(out, FrameType::PubAck, offset);
+            reply_pub_ack(out, frame_type, offset);
             return Ok(());
         }
-        // CLUSTERED path: build the EXACT wire PubAck bytes the immediate-ack path would write, then let
+        // CLUSTERED path: build the EXACT wire reply bytes the immediate-ack path would write, then let
         // the gate decide whether to write them now or withhold them for quorum-fsync.
         let mut reply_bytes = Vec::with_capacity(11);
-        reply_pub_ack(&mut reply_bytes, FrameType::PubAck, offset);
+        reply_pub_ack(&mut reply_bytes, frame_type, offset);
         match engine.client_ack_disposition(member_id, offset.get(), reply_bytes) {
             // The gate vanished between the bool check and here (a teardown race), or handed the bytes
             // back (non-C2-fsync level, or a partition this node does not lead): write them now,
             // byte-identical.
             None => {
-                reply_pub_ack(out, FrameType::PubAck, offset);
+                reply_pub_ack(out, frame_type, offset);
             }
             Some(crate::cluster::dataplane::AckDisposition::WriteNow(bytes)) => {
                 out.extend_from_slice(&bytes);
@@ -4292,7 +4304,7 @@ fn write_pub_reply_gated<
                     out.extend_from_slice(&f);
                 }
             }
-            // Clustered C2-fsync to a led partition, below/at quorum: WITHHOLD the wire PubAck. The data
+            // Clustered C2-fsync to a led partition, below/at quorum: WITHHOLD the wire reply. The data
             // plane releases it onto this connection's outbox on quorum-fsync; the session drains it on a
             // later pass. No false ack below min_isr (the gate releases nothing).
             Some(crate::cluster::dataplane::AckDisposition::Parked) => {}
@@ -7029,6 +7041,118 @@ mod tests {
         assert!(
             out.is_empty(),
             "a fence sent a frame to a QoS-0 pub: {out:?}"
+        );
+    }
+
+    /// A mock whose produce path always reports a dedup HIT (`AppendedDuplicate`), with a cluster ack
+    /// gate present that PARKS the ack (the original offset is below quorum). For #917.
+    struct DedupParkingEngine;
+    impl crate::actor::EngineAccess<InMemoryFs, ManualClock> for DedupParkingEngine {
+        fn produce(
+            &self,
+            _append: crate::actor::OwnedAppend,
+        ) -> Result<ProduceOutcome, crate::actor::ActorGone> {
+            Ok(ProduceOutcome::AppendedDuplicate(Offset::new(5)))
+        }
+        fn with<R, J>(&self, _job: J) -> Result<R, crate::actor::ActorGone>
+        where
+            R: Send + 'static,
+            J: FnOnce(&mut Engine<InMemoryFs, ManualClock>) -> R + Send + 'static,
+        {
+            Err(crate::actor::ActorGone)
+        }
+        fn now_monotonic_nanos(&self) -> u64 {
+            0
+        }
+        fn consumer_credit_caps(&self) -> (u32, u64) {
+            (64, 0)
+        }
+        fn has_client_ack_gate(&self) -> bool {
+            true
+        }
+        fn client_ack_disposition(
+            &self,
+            _member: MemberId,
+            _offset: u64,
+            _reply_bytes: Vec<u8>,
+        ) -> Option<crate::cluster::dataplane::AckDisposition> {
+            Some(crate::cluster::dataplane::AckDisposition::Parked)
+        }
+    }
+
+    /// Same dedup hit, but the gate RELEASES the duplicate-ack now (the original is already
+    /// quorum-committed): the `PubAckDuplicate` is written, byte-identical to the immediate path (#917).
+    struct DedupReleasingEngine;
+    impl crate::actor::EngineAccess<InMemoryFs, ManualClock> for DedupReleasingEngine {
+        fn produce(
+            &self,
+            _append: crate::actor::OwnedAppend,
+        ) -> Result<ProduceOutcome, crate::actor::ActorGone> {
+            Ok(ProduceOutcome::AppendedDuplicate(Offset::new(5)))
+        }
+        fn with<R, J>(&self, _job: J) -> Result<R, crate::actor::ActorGone>
+        where
+            R: Send + 'static,
+            J: FnOnce(&mut Engine<InMemoryFs, ManualClock>) -> R + Send + 'static,
+        {
+            Err(crate::actor::ActorGone)
+        }
+        fn now_monotonic_nanos(&self) -> u64 {
+            0
+        }
+        fn consumer_credit_caps(&self) -> (u32, u64) {
+            (64, 0)
+        }
+        fn has_client_ack_gate(&self) -> bool {
+            true
+        }
+        fn client_ack_disposition(
+            &self,
+            _member: MemberId,
+            _offset: u64,
+            reply_bytes: Vec<u8>,
+        ) -> Option<crate::cluster::dataplane::AckDisposition> {
+            Some(crate::cluster::dataplane::AckDisposition::WriteNow(
+                reply_bytes,
+            ))
+        }
+    }
+
+    #[test]
+    fn a_dedup_hit_c2_fsync_produce_routes_through_the_quorum_gate() {
+        // #917: a dedup-hit (AppendedDuplicate) on a clustered C2-fsync serve must clear the SAME quorum
+        // gate as a fresh Appended. Below quorum the duplicate-ack is WITHHELD (no immediate
+        // PubAckDuplicate for a record durable only on the leader); at quorum it is written.
+        let mut s = Session::new();
+        let mut out = Vec::new();
+        s.process(
+            &DedupParkingEngine,
+            &frame(FrameType::Connect, b""),
+            &mut out,
+        )
+        .unwrap();
+        out.clear();
+        connect_and_pub(&mut s, &DedupParkingEngine, &mut out);
+        assert!(
+            out.is_empty(),
+            "a dedup hit below quorum must withhold the PubAckDuplicate: {out:?}"
+        );
+
+        // When the gate releases (the original IS quorum-committed), the PubAckDuplicate IS written.
+        let mut s = Session::new();
+        let mut out = Vec::new();
+        s.process(
+            &DedupReleasingEngine,
+            &frame(FrameType::Connect, b""),
+            &mut out,
+        )
+        .unwrap();
+        out.clear();
+        connect_and_pub(&mut s, &DedupReleasingEngine, &mut out);
+        assert_eq!(
+            one_response(&out).0,
+            FrameType::PubAckDuplicate,
+            "a dedup hit at quorum writes the duplicate-ack"
         );
     }
 

--- a/crates/ironbus-server/src/session.rs
+++ b/crates/ironbus-server/src/session.rs
@@ -4271,10 +4271,12 @@ fn write_pub_reply_gated<
     // outcome (it yields `FireAndForgetAppended`), so this never withholds a no-reply produce.
     let gated = match &outcome {
         ProduceOutcome::Appended(offset) => Some((*offset, FrameType::PubAck)),
-        // A dedup hit on a FIRE-AND-FORGET produce sends NO frame (the QoS-0 no-frame contract): the
-        // actor's dedup path returns `AppendedDuplicate` even for a fire-and-forget produce (unlike the
-        // fresh-append path, which maps it to `FireAndForgetAppended`), so guard on the flag here so a
-        // QoS-0 duplicate is never quorum-gated or written. Only a REPLY-wanting duplicate is gated.
+        // Only a REPLY-wanting duplicate is gated. Today a fire-and-forget produce never reaches this
+        // reply path at all (a QoS-0 publish early-returns into the no-reply L0 batch before a
+        // `ParkedPub` is pushed, so `fire_and_forget` is always `false` here). Guard on the flag anyway
+        // as defense-in-depth: the actor's dedup path yields `AppendedDuplicate` regardless of the flag
+        // (unlike the fresh-append path, which maps a QoS-0 produce to `FireAndForgetAppended`), so a
+        // future routing change must not be able to quorum-gate or write a frame for a QoS-0 duplicate.
         ProduceOutcome::AppendedDuplicate(offset) if !fire_and_forget => {
             Some((*offset, FrameType::PubAckDuplicate))
         }
@@ -4352,10 +4354,10 @@ fn write_pub_reply(
         // A BENIGN dedup hit (#33): the `msg_id` was already in the producer's window, so the
         // broker returns the ORIGINAL offset via the NEW PubAckDuplicate frame (the frozen PubAck
         // body is untouched). It is a SUCCESS (`rc = 0`, `duplicate = true`), never an error, so an
-        // idempotent retry over a lossy edge link does not loop. A FIRE-AND-FORGET produce that
-        // dedup-hits sends NO frame (the QoS-0 no-frame contract): the actor's dedup path yields
-        // `AppendedDuplicate` regardless of the flag, so honor it here, exactly like every other
-        // outcome's fire-and-forget arm.
+        // idempotent retry over a lossy edge link does not loop. The fire-and-forget arm is
+        // defense-in-depth (a QoS-0 publish does not reach this reply path today): the actor's dedup
+        // path yields `AppendedDuplicate` regardless of the flag, so honor the QoS-0 no-frame contract
+        // here, exactly like every other outcome's fire-and-forget arm.
         ProduceOutcome::AppendedDuplicate(offset) => {
             if !fire_and_forget {
                 reply_pub_ack(out, FrameType::PubAckDuplicate, offset);


### PR DESCRIPTION
## The bug (#917)

A produce dedup hit returns `ProduceOutcome::AppendedDuplicate(offset)`, which is NOT `Appended`. `write_pub_reply_gated` only routed `Appended` through the cluster client-ack gate; `AppendedDuplicate` fell through to `write_pub_reply`, which wrote an immediate `PubAckDuplicate` **without** the quorum-fsync gate.

So a producer that idempotently RETRIES a `C2-fsync` produce whose original is still NOT quorum-committed (it timed out / got a not-enough-replicas error, #864) could receive an **immediate** duplicate-ack for a record durable only on the leader — a no-false-ack hole on the dedup path. (Flagged pre-existing during the #864 review.)

## The fix

Route `AppendedDuplicate` through the **same** gate as `Appended`. They differ only in the reply **frame type** (`PubAck` vs `PubAckDuplicate`), and the gate keys on the (original) offset, so the duplicate-ack releases exactly when the original is quorum-fsync'd:
- already quorum-committed → written immediately (`WriteNow`/`WriteNowBatch`);
- below/at quorum → withheld (`Parked`), released onto the connection's outbox on quorum-fsync;
- at the #864 backlog cap → typed not-enough-replicas `Err`.

A fire-and-forget produce never yields `AppendedDuplicate` (it yields `FireAndForgetAppended`), so no no-reply produce is withheld. **Single-node / no-cluster behavior is byte-identical** (the `has_client_ack_gate` fast path writes the immediate `PubAckDuplicate` exactly as before).

## Test

`a_dedup_hit_c2_fsync_produce_routes_through_the_quorum_gate`: a dedup hit below quorum withholds the `PubAckDuplicate` (fails on the old immediate-ack code); a dedup hit at quorum writes it.

## Verification
- `cargo test -p ironbus-server` — green
- `cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic` + `cargo fmt --all --check` — clean

Closes #917
