### PR TITLE
fix(server): release the half-open slot when the Connect handshake resolves, not at teardown (#880)

### DIFF
--- a/crates/ironbus-server/src/preauth.rs
+++ b/crates/ironbus-server/src/preauth.rs
@@ -377,19 +377,22 @@ impl PreAuthGuard {
         self.lock_ips().len()
     }
 
-    /// The current half-open count (for tests).
+    /// The current half-open count (for tests, incl. the #880 session-level release test).
     #[cfg(test)]
-    fn half_open_count(&self) -> usize {
+    pub(crate) fn half_open_count(&self) -> usize {
         self.half_open.load(Ordering::Acquire)
     }
 }
 
-/// An RAII slot for one half-open (accepted-but-not-yet-authed) connection (#633). Held by the
-/// connection handler for the whole handshake window; on drop (handshake resolved — success, failure,
-/// or disconnect) it decrements the global half-open count, so a stalled/slowloris half-open client
-/// holds at most one slot and the count can never leak. It OWNS an `Arc` clone of the guard so it is
-/// `'static` and moves into the spawned handler thread. When the half-open cap is disabled the slot is
-/// inert (`guard: None`), so a no-cap broker pays nothing.
+/// An RAII slot for one half-open (accepted-but-not-yet-authed) connection (#633). Handed to the
+/// connection's [`Session`](crate::session::Session) (`with_half_open_slot`) and dropped when the
+/// `Connect` HANDSHAKE RESOLVES — a well-formed `Connect`, whether auth succeeds or fails (#880) — or,
+/// for a slowloris that never sends a well-formed `Connect`, when the connection times out and drops
+/// the session. On drop it decrements the global half-open count, so a stalled half-open client holds
+/// at most one slot, the count can never leak, AND an authenticated long-lived connection no longer
+/// pins a slot (so the cap measures mid-handshake connections, not total ones). It OWNS an `Arc` clone
+/// of the guard so it is `'static` and moves into the spawned handler thread. When the half-open cap is
+/// disabled the slot is inert (`guard: None`), so a no-cap broker pays nothing.
 #[derive(Debug)]
 pub struct HalfOpenSlot {
     guard: Option<Arc<PreAuthGuard>>,

--- a/crates/ironbus-server/src/server.rs
+++ b/crates/ironbus-server/src/server.rs
@@ -414,12 +414,12 @@ where
                         active: slot_active,
                         connz: Arc::clone(&connz_for_conn),
                     };
-                    // Hold the half-open slot (#633) for the WHOLE handshake window: it is dropped here
-                    // when the handler returns (handshake resolved — success, failure, or disconnect),
-                    // decrementing the global half-open count, so a stalled/slowloris half-open client
-                    // holds at most one slot and the count can never leak. `None` when the half-open cap
-                    // is disabled (the slot is inert).
-                    let _half_open = half_open_slot;
+                    // Hand the half-open slot (#633) to the session so it is released when the `Connect`
+                    // HANDSHAKE RESOLVES (a well-formed Connect, success or failure), not at connection
+                    // teardown — so the `--max-preauth-connections` cap measures connections still
+                    // mid-handshake, NOT authenticated long-lived ones (#880). A slowloris that never
+                    // sends a well-formed Connect keeps it until the read timeout closes the connection.
+                    // `None` when the half-open cap is disabled (no slot to hand over).
                     let _ = handle_connection(
                         stream,
                         &engine,
@@ -429,6 +429,7 @@ where
                         preauth_for_conn,
                         peer_ip,
                         audit_for_conn,
+                        half_open_slot,
                     );
                 });
                 if spawn_outcome.is_err() {
@@ -470,6 +471,7 @@ fn handle_connection<F, C>(
     preauth: Option<Arc<crate::preauth::PreAuthGuard>>,
     peer_ip: std::net::IpAddr,
     audit: Option<crate::audit::AuditEmitter>,
+    half_open_slot: Option<crate::preauth::HalfOpenSlot>,
 ) -> std::io::Result<()>
 where
     F: Filesystem + Clone + 'static,
@@ -501,6 +503,13 @@ where
     // no-op when no audit sink is configured (the byte-for-byte historical path).
     if let Some(emitter) = audit {
         session = session.with_audit(emitter);
+    }
+    // Hand the half-open (#633) slot to the session so it is released when the `Connect` handshake
+    // RESOLVES (a well-formed Connect), not at connection teardown (#880) — so the cap measures
+    // mid-handshake connections, not authenticated long-lived ones. `None` (no half-open cap wired) and
+    // an inert slot are both harmless no-ops on drop.
+    if let Some(slot) = half_open_slot {
+        session = session.with_half_open_slot(slot);
     }
     // The read/dispatch loop, run to completion so the cleanup below ALWAYS executes on exit:
     // whether the client closed cleanly, a read/write timed out, or a malformed frame ended the
@@ -1134,6 +1143,7 @@ mod tests {
                     &connz,
                     None,
                     peer.ip(),
+                    None,
                     None,
                 )
             }

--- a/crates/ironbus-server/src/session.rs
+++ b/crates/ironbus-server/src/session.rs
@@ -977,12 +977,6 @@ impl Session {
                 return Ok(());
             }
         };
-        // A well-formed Connect: the handshake is now RESOLVING (auth below succeeds or fails, then this
-        // connection is authenticated or closed). Release the half-open (pre-auth) slot here so the #633
-        // half-open cap measures connections still mid-handshake, not authenticated long-lived ones
-        // (#880). A bad-credential flood is bounded by the per-IP auth-failure lockout, not this cap, so
-        // releasing before the auth verdict is correct; an inert slot (no cap configured) is a no-op.
-        self.half_open_slot = None;
         // AUTHENTICATE FIRST (#631, V2-M7), before any negotiation or `connected` flip. On an
         // auth-required broker (an identity table is configured) the `Connect` MUST carry a valid
         // credential; the resolved identity's scope set is PINNED to the connection for its lifetime. On
@@ -1028,6 +1022,12 @@ impl Session {
                     mechanism,
                     outcome: crate::audit::Outcome::Failure,
                 });
+                // The handshake has RESOLVED (auth FAILED, AFTER the memory-hard Argon2id verify above):
+                // release the half-open slot (#880). Dropping it only AFTER the verify keeps the #633
+                // half-open cap as the documented GLOBAL backstop on concurrent unauthenticated verifies
+                // (preauth.rs §2) — a distributed flood must not be able to run more concurrent verifies
+                // than the cap by freeing the slot before the verify.
+                self.half_open_slot = None;
                 reply_auth_violation(out);
                 return Err(SessionError::AuthViolation);
             };
@@ -1060,6 +1060,13 @@ impl Session {
                 connz.record_authenticated();
             }
         }
+        // The handshake has RESOLVED (authenticated, or a no-auth broker with nothing to verify): release
+        // the half-open slot (#880) so an authenticated long-lived connection no longer pins it. Done
+        // AFTER the auth block (the memory-hard Argon2id verify), so the #633 half-open cap stays the
+        // documented GLOBAL backstop on concurrent unauthenticated verifies; a slowloris that never
+        // reaches here keeps its slot until the connection times out. An inert / `None` slot is a no-op,
+        // and a repeated Connect re-runs this idempotently (the slot is already released).
+        self.half_open_slot = None;
         self.connected = true;
         // Record the client's request (re-recorded on a repeated Connect, which re-negotiates
         // idempotently). It is also used by the lazy `credit_ceiling` fallback for a session that never
@@ -7249,6 +7256,72 @@ mod tests {
         // The cap is free again: a new accept succeeds even though the first connection is still open
         // and authenticated. Pre-fix the slot stayed held for the whole connection and this failed.
         assert!(guard.on_accept("5.6.7.8".parse().unwrap()).is_ok());
+    }
+
+    #[test]
+    fn the_half_open_slot_releases_after_the_auth_verdict_on_both_success_and_failure() {
+        use crate::preauth::{PreAuthConfig, PreAuthGuard};
+        // #880 (post-verdict release): on an AUTH-REQUIRED broker the half-open slot is dropped only
+        // AFTER the auth verdict (so the #633 cap stays the global backstop on concurrent unauthenticated
+        // Argon2id verifies). It is released on BOTH a FAILED Connect (through the auth-failure branch)
+        // and a successful one — but never before the verify runs.
+        let cfg = PreAuthConfig {
+            per_ip_rate_per_sec: 0,
+            per_ip_burst: 0,
+            half_open_cap: 4,
+            lockout_threshold: 0,
+            lockout_window_ms: 0,
+            lockout_cooldown_ms: 0,
+        };
+        let connz = Arc::new(crate::connz::ConnectionMetrics::new());
+        let guard = Arc::new(PreAuthGuard::new(
+            cfg,
+            Arc::new(ManualClock::new()) as Arc<dyn Clock>,
+            connz,
+        ));
+        let e = DirectEngine::new(engine());
+        let token = b"a-secret-token-of-32-bytes-len!!";
+
+        // A FAILED auth (no credential on an auth-required broker) still releases the slot — through the
+        // auth-failure branch, AFTER the verify.
+        let slot_fail = guard.on_accept("1.1.1.1".parse().unwrap()).unwrap();
+        assert_eq!(guard.half_open_count(), 1);
+        let mut s = Session::with_member_id_and_auth(
+            MemberId::new(0),
+            bearer_auth(token, &[Scope::Publish]),
+            None,
+        )
+        .with_half_open_slot(slot_fail);
+        let mut out = Vec::new();
+        assert!(matches!(
+            s.process(&e, &frame(FrameType::Connect, b""), &mut out)
+                .unwrap_err(),
+            SessionError::AuthViolation
+        ));
+        assert_eq!(
+            guard.half_open_count(),
+            0,
+            "a failed auth releases the slot (in the auth-failure branch, after the verify)"
+        );
+
+        // A SUCCESSFUL auth releases the slot too.
+        let slot_ok = guard.on_accept("2.2.2.2".parse().unwrap()).unwrap();
+        assert_eq!(guard.half_open_count(), 1);
+        let mut s2 = Session::with_member_id_and_auth(
+            MemberId::new(1),
+            bearer_auth(token, &[Scope::Publish]),
+            None,
+        )
+        .with_half_open_slot(slot_ok);
+        let mut out2 = Vec::new();
+        s2.process(&e, &connect_with_bearer(token), &mut out2)
+            .unwrap();
+        assert!(s2.authenticated);
+        assert_eq!(
+            guard.half_open_count(),
+            0,
+            "a successful auth releases the slot"
+        );
     }
 
     #[test]

--- a/crates/ironbus-server/src/session.rs
+++ b/crates/ironbus-server/src/session.rs
@@ -448,6 +448,12 @@ pub struct Session {
     /// a later scope denial. Empty until authenticated; never a credential. Only meaningful on an
     /// auth-required broker (a no-auth broker never authenticates and never denies a scope).
     identity_name: String,
+    /// The half-open (accepted-but-not-yet-authenticated) slot (#633, #880): held from accept until the
+    /// `Connect` handshake RESOLVES, then dropped here (decrementing the global half-open count) so the
+    /// `--max-preauth-connections` cap measures connections still mid-handshake, NOT authenticated
+    /// long-lived ones. `None` when no half-open cap is wired, or once the handshake has resolved. A
+    /// slowloris that never sends a well-formed `Connect` keeps it until the connection times out.
+    half_open_slot: Option<crate::preauth::HalfOpenSlot>,
 }
 
 impl Session {
@@ -512,6 +518,18 @@ impl Session {
         peer_ip: std::net::IpAddr,
     ) -> Session {
         self.preauth = Some((guard, peer_ip));
+        self
+    }
+
+    /// Hands the connection's half-open (#633) RAII slot to the session, so it is dropped when the
+    /// `Connect` handshake RESOLVES (a well-formed `Connect`, success or failure) rather than at
+    /// connection teardown — making the `--max-preauth-connections` cap measure connections still
+    /// mid-handshake, NOT authenticated long-lived ones (#880). A builder-style setter (like
+    /// [`with_preauth`](Session::with_preauth)) so only the server's live accept path opts in; an inert
+    /// slot (no half-open cap configured) is a harmless no-op on drop.
+    #[must_use]
+    pub fn with_half_open_slot(mut self, slot: crate::preauth::HalfOpenSlot) -> Session {
+        self.half_open_slot = Some(slot);
         self
     }
 
@@ -951,12 +969,20 @@ impl Session {
         let req = match decode_connect(body) {
             Ok(req) => req,
             // A non-empty but malformed Connect body: surface a typed error and keep the connection
-            // open. The credit is not fixed, so a subsequent valid Connect/Flow still negotiates.
+            // open. The credit is not fixed, so a subsequent valid Connect/Flow still negotiates. The
+            // handshake is NOT resolved, so the half-open slot is intentionally KEPT — the client is
+            // still mid-handshake and a slowloris must not be able to free its slot with garbage.
             Err(e) => {
                 reply_err(out, &e.to_string());
                 return Ok(());
             }
         };
+        // A well-formed Connect: the handshake is now RESOLVING (auth below succeeds or fails, then this
+        // connection is authenticated or closed). Release the half-open (pre-auth) slot here so the #633
+        // half-open cap measures connections still mid-handshake, not authenticated long-lived ones
+        // (#880). A bad-credential flood is bounded by the per-IP auth-failure lockout, not this cap, so
+        // releasing before the auth verdict is correct; an inert slot (no cap configured) is a no-op.
+        self.half_open_slot = None;
         // AUTHENTICATE FIRST (#631, V2-M7), before any negotiation or `connected` flip. On an
         // auth-required broker (an identity table is configured) the `Connect` MUST carry a valid
         // credential; the resolved identity's scope set is PINNED to the connection for its lifetime. On
@@ -7177,6 +7203,52 @@ mod tests {
             out.is_empty(),
             "a fire-and-forget dedup hit must send no frame: {out:?}"
         );
+    }
+
+    #[test]
+    fn the_half_open_slot_is_released_when_the_connect_handshake_resolves() {
+        use crate::preauth::{PreAuthConfig, PreAuthGuard};
+        // #880: a well-formed Connect must release the half-open (#633) slot when the handshake
+        // resolves, so `--max-preauth-connections` measures connections still mid-handshake, NOT
+        // authenticated long-lived ones. With a cap of 1, an authed connection that kept its slot would
+        // block every later accept — a self-inflicted availability outage.
+        let cfg = PreAuthConfig {
+            per_ip_rate_per_sec: 0,
+            per_ip_burst: 0,
+            half_open_cap: 1,
+            lockout_threshold: 0,
+            lockout_window_ms: 0,
+            lockout_cooldown_ms: 0,
+        };
+        let connz = Arc::new(crate::connz::ConnectionMetrics::new());
+        let guard = Arc::new(PreAuthGuard::new(
+            cfg,
+            Arc::new(ManualClock::new()) as Arc<dyn Clock>,
+            connz,
+        ));
+        let slot = guard.on_accept("1.2.3.4".parse().unwrap()).unwrap();
+        assert_eq!(
+            guard.half_open_count(),
+            1,
+            "the accept reserved the half-open slot"
+        );
+        // The cap of 1 is full while the first connection is mid-handshake: a second accept is refused.
+        assert!(guard.on_accept("5.6.7.8".parse().unwrap()).is_err());
+
+        // The connection sends a well-formed Connect: the handshake resolves and the slot is released.
+        let mut s = Session::new().with_half_open_slot(slot);
+        let mut out = Vec::new();
+        s.process(&AtCapacityEngine, &frame(FrameType::Connect, b""), &mut out)
+            .unwrap();
+        assert_eq!(
+            guard.half_open_count(),
+            0,
+            "the slot was released when the Connect handshake resolved (#880)"
+        );
+
+        // The cap is free again: a new accept succeeds even though the first connection is still open
+        // and authenticated. Pre-fix the slot stayed held for the whole connection and this failed.
+        assert!(guard.on_accept("5.6.7.8".parse().unwrap()).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## The bug (#880)

The `HalfOpenSlot` from `PreAuthGuard::on_accept` is documented as bounding only "accepted-but-not-yet-authenticated" connections, released "when the handshake resolves." In reality it was owned by the spawn closure (`let _half_open = half_open_slot;`) and dropped only when `handle_connection` returned — i.e. when the whole connection ended. A successfully authenticated, long-lived client kept its slot for its entire session.

So `--max-preauth-connections` silently became a cap on **total** concurrent connections: an operator sizing it small per the documented half-open semantic (e.g. 256) while `--max-connections` is large (e.g. 10000) gets legit authenticated client #257 rejected with `rejected_total{reason=half_open_cap}` — a self-inflicted availability outage (connections here are explicitly long-lived, so steady-state `half_open` ≈ live connection count).

## The fix

Hand the slot to the `Session` (`with_half_open_slot`) and drop it the moment a **well-formed `Connect`** resolves the handshake — right after the malformed-body check, before the auth verdict (a bad-credential flood is bounded by the per-IP auth-failure lockout, not this cap):
- a **malformed** `Connect` keeps the slot (the client may still retry a valid one — still mid-handshake);
- a **slowloris** that never sends a well-formed `Connect` keeps it until the read timeout closes the connection (slowloris defense preserved);
- a **resolved** handshake (auth success or failure) releases it.

The cap now measures connections still mid-handshake, as documented. The `HalfOpenSlot` rustdoc is corrected (held by the session, released at `Connect` resolution); the module/`on_accept` docs already described this behavior and are now accurate.

## Test

`the_half_open_slot_is_released_when_the_connect_handshake_resolves`: with `half_open_cap=1`, an accept reserves the slot and a second accept is refused; a well-formed `Connect` releases it (count → 0); a later accept then succeeds even though the first connection stays open and authenticated (this fails pre-fix, where the slot stayed held for the whole connection).

## Verification
- `cargo test -p ironbus-server` — green
- `cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic` + `cargo fmt --all --check` — clean

Closes #880
