### PR TITLE
perf(cluster): make leaf-push and geo-mirror-pull frame_bytes a zero-copy Bytes (#920)

### DIFF
--- a/crates/ironbus-server/src/cluster/geo.rs
+++ b/crates/ironbus-server/src/cluster/geo.rs
@@ -91,6 +91,7 @@
 //!   conflict handling is OUT OF SCOPE — this is read-only mirror + fan-in source
 //!   (single-origin-of-truth, no conflict).
 
+use bytes::Bytes;
 use std::collections::BTreeMap;
 use std::io::{self, Read, Write};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -254,8 +255,10 @@ pub struct MirrorPullResponse {
     /// How many complete CRC-framed records `frame_bytes` carries.
     pub record_count: u32,
     /// The contiguous CRC-framed on-disk record frames — the origin's bytes VERBATIM (UNTRUSTED on the
-    /// puller until re-validated).
-    pub frame_bytes: Vec<u8>,
+    /// puller until re-validated). A zero-copy `Bytes` (#920): the serve path hands back a refcount-bump
+    /// clone of the storage layer's `RawByteRun.bytes` rather than `to_vec()`-ing the whole run per
+    /// mirror-pull, exactly as #810 did for the replication path.
+    pub frame_bytes: Bytes,
 }
 
 impl MirrorPullResponse {
@@ -306,7 +309,7 @@ impl MirrorPullResponse {
             origin_high_watermark,
             first_offset,
             record_count,
-            frame_bytes: body[PULL_RESPONSE_PREFIX_LEN..].to_vec(),
+            frame_bytes: Bytes::copy_from_slice(&body[PULL_RESPONSE_PREFIX_LEN..]),
         })
     }
 }
@@ -510,7 +513,7 @@ impl<'a, F: Filesystem> OriginServer<'a, F> {
             origin_high_watermark: hw,
             first_offset: sealed.run.first_offset.get(),
             record_count: u32::try_from(sealed.run.record_count).unwrap_or(u32::MAX),
-            frame_bytes: sealed.run.bytes.to_vec(),
+            frame_bytes: sealed.run.bytes.clone(),
         })
     }
 }
@@ -943,7 +946,7 @@ impl<F: Filesystem, C: Clock> MirrorApplier<F, C> {
         let mut at = 0usize;
         let mut seen = 0u64; // frames CONSUMED (skipped-as-already-applied + appended) = origin-offset progress
         let mut applied = 0u64; // frames actually APPENDED this pull
-        let bytes = resp.frame_bytes.as_slice();
+        let bytes = resp.frame_bytes.as_ref();
         while at < bytes.len() {
             let at_origin_offset = cursor + seen;
             let (view, frame_len) = match codec::decode(&bytes[at..]) {
@@ -1526,7 +1529,7 @@ mod tests {
             origin_high_watermark: 9,
             first_offset: 3,
             record_count: 2,
-            frame_bytes: vec![1, 2, 3, 4, 5],
+            frame_bytes: Bytes::from_static(&[1, 2, 3, 4, 5]),
         };
         let bytes = resp.encode();
         assert_eq!(MirrorPullResponse::decode(&bytes).unwrap(), resp);
@@ -1887,7 +1890,7 @@ mod tests {
                     &mut b,
                 )
                 .unwrap();
-                b
+                Bytes::from(b)
             },
         };
         assert!(matches!(
@@ -1937,7 +1940,7 @@ mod tests {
             origin_high_watermark: 2,
             first_offset: 0,
             record_count: 2,
-            frame_bytes: frames,
+            frame_bytes: Bytes::from(frames),
         };
         let err = app.apply_pull_response("o/", &resp).unwrap_err();
         assert!(

--- a/crates/ironbus-server/src/cluster/leaf.rs
+++ b/crates/ironbus-server/src/cluster/leaf.rs
@@ -94,6 +94,7 @@
 //! * Gateway/supercluster FEDERATION (symmetric cluster-to-cluster) is the SEPARATE #626 — NOT here; the
 //!   leaf-spoke is asymmetric hub + many leaves.
 
+use bytes::Bytes;
 use std::io::{self, Read, Write};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
@@ -306,8 +307,10 @@ pub struct LeafPushRequest {
     /// How many complete CRC-framed records `frame_bytes` carries.
     pub record_count: u32,
     /// The contiguous CRC-framed local record frames — the leaf's bytes VERBATIM (UNTRUSTED on the hub
-    /// until re-validated, exactly like a geo pull response on the puller).
-    pub frame_bytes: Vec<u8>,
+    /// until re-validated, exactly like a geo pull response on the puller). A zero-copy `Bytes` (#920):
+    /// the serve path hands back a refcount-bump clone of the storage layer's `RawByteRun.bytes` rather
+    /// than `to_vec()`-ing the whole run per fan-out leaf, exactly as #810 did for the replication path.
+    pub frame_bytes: Bytes,
 }
 
 impl LeafPushRequest {
@@ -375,7 +378,7 @@ impl LeafPushRequest {
             stream,
             from_leaf_offset,
             record_count,
-            frame_bytes: body[name_end..].to_vec(),
+            frame_bytes: Bytes::copy_from_slice(&body[name_end..]),
         })
     }
 }
@@ -526,7 +529,7 @@ impl<'a, F: Filesystem> LeafForwarder<'a, F> {
             stream: hub_stream.to_string(),
             from_leaf_offset: sealed.run.first_offset.get(),
             record_count: u32::try_from(sealed.run.record_count).unwrap_or(u32::MAX),
-            frame_bytes: sealed.run.bytes.to_vec(),
+            frame_bytes: sealed.run.bytes.clone(),
         })
     }
 }
@@ -595,7 +598,7 @@ impl<F: Filesystem, C: Clock> HubPushReceiver<F, C> {
         // syncs the validated prefix, and is surfaced — the hub NEVER appends a byte it has not validated.
         let mut at = 0usize;
         let mut appended = 0u64;
-        let bytes = req.frame_bytes.as_slice();
+        let bytes = req.frame_bytes.as_ref();
         while at < bytes.len() {
             let at_leaf_offset = from + appended;
             let (view, frame_len) = match codec::decode(&bytes[at..]) {
@@ -1058,7 +1061,7 @@ mod tests {
             stream: "orders".to_string(),
             from_leaf_offset: 42,
             record_count: 2,
-            frame_bytes: vec![1, 2, 3, 4, 5],
+            frame_bytes: Bytes::from_static(&[1, 2, 3, 4, 5]),
         };
         let bytes = req.encode().unwrap();
         assert_eq!(LeafPushRequest::decode(&bytes).unwrap(), req);
@@ -1070,7 +1073,7 @@ mod tests {
             stream: String::new(),
             from_leaf_offset: 0,
             record_count: 0,
-            frame_bytes: Vec::new(),
+            frame_bytes: Bytes::new(),
         };
         let bytes = req.encode().unwrap();
         assert_eq!(LeafPushRequest::decode(&bytes).unwrap(), req);
@@ -1108,7 +1111,7 @@ mod tests {
             stream: "x".repeat(MAX_ORIGIN_STREAM_LEN + 1),
             from_leaf_offset: 0,
             record_count: 0,
-            frame_bytes: Vec::new(),
+            frame_bytes: Bytes::new(),
         };
         assert!(matches!(
             req.encode(),
@@ -1122,7 +1125,7 @@ mod tests {
             stream: "s".to_string(),
             from_leaf_offset: 0,
             record_count: 0,
-            frame_bytes: Vec::new(),
+            frame_bytes: Bytes::new(),
         }
         .encode()
         .unwrap();
@@ -1309,7 +1312,7 @@ mod tests {
             stream: "orders".to_string(),
             from_leaf_offset: 0,
             record_count: 2,
-            frame_bytes: frames,
+            frame_bytes: Bytes::from(frames),
         };
         let err = hub.apply_push(&req).unwrap_err();
         assert!(


### PR DESCRIPTION
## What (#920, #810 sibling)

#810 made the leader replication `FetchResponseBody.frame_bytes` a `Bytes` so `serve_fetch` returns a refcount-bump clone of the storage layer's zero-copy `RawByteRun.bytes` instead of `to_vec()`. Two sibling structs on distinct fan-out paths carried the identical latent copy:

- `LeafPushRequest.frame_bytes` (hub→leaf push), built via `sealed.run.bytes.to_vec()`
- `MirrorPullResponse.frame_bytes` (geo mirror-pull), built via `sealed.run.bytes.to_vec()`

Both threw away the zero-copy `Bytes` ⇒ K full-payload memcpys + K transient `Vec` allocations per fan-out round.

## Fix

Both fields → `Bytes`; both serve paths return `run.bytes.clone()` (a refcount bump), exactly as #810. **Wire encoding is byte-identical**: `encode` already uses `extend_from_slice(&frame_bytes)` (`Bytes` derefs to `[u8]`); `decode` now does the same single owned `Bytes::copy_from_slice` on the receiver. The one `as_slice()` reader on each path → `as_ref()`; the byte-tamper tests rebuild the now-immutable `Bytes` after mutating their staging `Vec`.

Sound by the same storage contract #810 relied on: the source `Bytes` is per-call and immutable post-`freeze`.

## Verification
- leaf/geo wire round-trip + CRC-re-validation tests pass unchanged (byte-identity)
- `cargo test --workspace --all-features` — green
- `cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic` + `cargo fmt --all --check` — clean

Closes #920
