### PR TITLE
perf(cluster): follower appends the validated verbatim frame instead of re-encoding each replicated record (#820)

### DIFF
--- a/crates/ironbus-server/src/cluster/replication.rs
+++ b/crates/ironbus-server/src/cluster/replication.rs
@@ -79,7 +79,7 @@ use ironbus_proto::frame::{
     decode_frame_with_cap, encode_frame, FrameDecode, FrameError, FrameType, MAX_FRAME_LEN,
 };
 use ironbus_storage::fs::Filesystem;
-use ironbus_storage::log::{Append, Log, TruncateOutcome};
+use ironbus_storage::log::{Log, TruncateOutcome};
 use ironbus_storage::read_plane::ReadPlane;
 use ironbus_storage::segment::StorageError;
 
@@ -377,6 +377,20 @@ pub enum ReplicationError {
         /// The number of complete frames actually decoded from the bytes.
         actual: u32,
     },
+    /// A validated frame's EMBEDDED (already-CRC'd) sequence number did not equal the follower's
+    /// POSITIONAL next sequence (#820). The verbatim-append fast path copies the leader's sealed
+    /// frame byte-for-byte, which is only byte-identical to a local re-encode when the follower would
+    /// have assigned that exact seq. A mismatch means the lineages diverged (a leader-epoch fork the
+    /// deferred C2-I4 reconciliation, #599, would handle), so the follower fails CLOSED before
+    /// appending rather than write a frame whose embedded seq contradicts its position.
+    SeqMismatch {
+        /// The log offset the frame would have been appended at.
+        at_offset: u64,
+        /// The sequence embedded in the (validated) frame.
+        embedded: u64,
+        /// The sequence the follower would have assigned positionally (its current `next_seq`).
+        expected: u64,
+    },
     /// An [`FrameType::OffsetForLeaderEpoch`] (#599) request/response body was malformed: a wrong
     /// length or a bad `kind` discriminant byte. Fail closed; the epoch handshake never guesses.
     MalformedEpochQuery {
@@ -443,6 +457,14 @@ impl core::fmt::Display for ReplicationError {
             ReplicationError::RecordCountMismatch { claimed, actual } => write!(
                 f,
                 "replication fetch response record_count {claimed} != {actual} complete frames decoded"
+            ),
+            ReplicationError::SeqMismatch {
+                at_offset,
+                embedded,
+                expected,
+            } => write!(
+                f,
+                "replication frame at offset {at_offset} carries embedded seq {embedded} != follower positional seq {expected}; fail-closed"
             ),
             ReplicationError::MalformedEpochQuery { len } => {
                 write!(f, "malformed leader-epoch offset query body ({len} bytes)")
@@ -787,16 +809,21 @@ impl<F: Filesystem, C: Clock> Follower<F, C> {
     ///
     /// This is the security-critical core. The leader's `frame_bytes` are UNTRUSTED peer bytes. They
     /// are walked front-to-back; each frame is decoded with the intact-record predicate
-    /// ([`ironbus_core::codec::decode`]); a frame that passes is re-appended (reproducing the leader's
-    /// byte-identical frame); a frame that FAILS is rejected and the apply stops there with a typed
-    /// [`ReplicationError::CorruptFrame`] — **nothing from the bad frame onward is appended**. The
-    /// records validated-and-appended before a bad frame are kept and synced (the longest valid
-    /// prefix of this response), exactly the I1 / I3 fail-at-first-bad-frame discipline the local
-    /// recovery path already holds.
+    /// ([`ironbus_core::codec::decode`]); a frame that passes is appended VERBATIM (#820) — the origin
+    /// already produced the canonical sealed frame and the follower is at the identical seq/offset, so
+    /// the validated bytes ARE the byte-identical frame, and copying them straight in skips the
+    /// redundant re-encode + re-checksum. A frame that FAILS decode is rejected and the apply stops
+    /// there with a typed [`ReplicationError::CorruptFrame`] — **nothing from the bad frame onward is
+    /// appended**. The records validated-and-appended before a bad frame are kept and synced (the
+    /// longest valid prefix of this response), exactly the I1 / I3 fail-at-first-bad-frame discipline
+    /// the local recovery path already holds. The CRC is still fully VALIDATED on receipt; only the
+    /// redundant re-ENCODE the follower used to perform is removed.
     ///
     /// # Errors
     /// - [`ReplicationError::NonContiguous`] if the response does not continue the follower's log.
     /// - [`ReplicationError::CorruptFrame`] if any frame fails CRC re-validation (fail-closed).
+    /// - [`ReplicationError::SeqMismatch`] if a validated frame's embedded seq does not match the
+    ///   follower's positional seq (a diverged lineage) — fail-closed before appending it.
     /// - [`ReplicationError::RecordCountMismatch`] if the byte run does not hold the claimed count.
     /// - [`ReplicationError::Storage`] if a local append / sync fails.
     pub fn apply_fetch_response(
@@ -843,17 +870,29 @@ impl<F: Filesystem, C: Clock> Follower<F, C> {
                     return Err(ReplicationError::CorruptFrame { at_offset, reason });
                 }
             };
-            // Re-append the validated record's content. The follower's log assigns the SAME offset /
-            // sequence positionally (both logs advance from 0 in order), so re-encoding through the
-            // identical codec reproduces the leader's frame byte-for-byte.
-            let append = Append {
-                timestamp_ms: view.timestamp_ms,
-                flags: view.flags,
-                key: view.key,
-                headers: view.headers,
-                payload: view.payload,
-            };
-            self.log.append(&append)?;
+            // Byte-identity guard (#820): the follower assigns the offset/sequence POSITIONALLY (both
+            // logs advance from 0 in order), and the validated frame carries the leader's embedded,
+            // already-CRC'd seq. They MUST agree, or copying the frame verbatim would NOT reproduce
+            // what a local re-encode would have produced. Fail CLOSED before appending if they differ
+            // (a diverged lineage the deferred epoch-truncation reconciliation, #599, would handle);
+            // the validated-and-appended prefix is synced below before we return.
+            let expected_seq = self.log.next_seq().get();
+            if view.seq.get() != expected_seq {
+                self.log.sync()?;
+                return Err(ReplicationError::SeqMismatch {
+                    at_offset,
+                    embedded: view.seq.get(),
+                    expected: expected_seq,
+                });
+            }
+            // Append the leader's VALIDATED frame VERBATIM (#820). `codec::decode` above already
+            // verified this frame's header CRC32C, body CRC32C, and (for large bodies) xxh3-64; the
+            // origin already produced the canonical sealed frame and the follower is at the identical
+            // seq/offset, so the bytes are byte-for-byte what the old re-encode path emitted. Copying
+            // them straight in skips the redundant re-frame + re-checksum (the same crc32c/xxh3 the
+            // decode just computed) — only the re-ENCODE is removed, the validation stays on decode.
+            self.log
+                .append_frame_verbatim(&bytes[cursor..cursor + frame_len], &view)?;
             appended += 1;
             cursor += frame_len;
         }
@@ -1254,6 +1293,7 @@ mod tests {
     use ironbus_core::types::RecordFlags;
     use ironbus_storage::fs::InMemoryFs;
     use ironbus_storage::io::RandomAccessFile;
+    use ironbus_storage::log::Append;
     use ironbus_storage::log::LogConfig;
 
     /// A small segment cap so a handful of records rolls to multiple segments — proving replication
@@ -1384,6 +1424,60 @@ mod tests {
         let follower_recs = follower.log().read_from(Offset::ZERO, 1000).unwrap();
         assert_eq!(follower_recs, leader_recs);
         assert_eq!(follower_recs.len(), 40);
+    }
+
+    // ----- fail-closed: the verbatim-append byte-identity guard (#820) -----
+
+    /// A validated frame whose EMBEDDED (already-CRC'd) seq does not match the follower's POSITIONAL
+    /// `next_seq` must be rejected BEFORE it is appended verbatim (#820): copying such a frame would
+    /// write on-disk bytes a local re-encode at that position would never have produced, so the
+    /// follower fails CLOSED. This exercises the `SeqMismatch` guard added with the verbatim-append
+    /// fast path — the check that upholds byte-identity now that the frame is copied, not re-encoded.
+    #[test]
+    fn follower_rejects_a_frame_whose_embedded_seq_diverges_from_its_position() {
+        use ironbus_core::codec::RecordView;
+        use ironbus_core::types::Seq;
+
+        // Hand-encode ONE valid frame (its CRCs are correct, so it passes decode) that carries seq 7,
+        // even though a fresh follower assigns position 0 (offset 0 / seq 0) to its first record.
+        let view = RecordView {
+            seq: Seq::new(7),
+            timestamp_ms: 1,
+            flags: RecordFlags::EMPTY,
+            key: b"",
+            headers: b"",
+            payload: b"diverged",
+        };
+        let mut frame = Vec::new();
+        codec::encode(&view, &mut frame).expect("encode a valid frame");
+
+        // first_offset 0 continues a fresh follower's log contiguously (so this is NOT a NonContiguous
+        // rejection), but the embedded seq 7 != the follower's positional seq 0.
+        let resp = FetchResponseBody {
+            high_watermark: 1,
+            first_offset: 0,
+            record_count: 1,
+            frame_bytes: Bytes::from(frame),
+        };
+
+        let mut follower = Follower::new(open_log(InMemoryFs::new(), small_config()));
+        let err = follower
+            .apply_fetch_response(&resp)
+            .expect_err("a frame with a diverged embedded seq must be rejected");
+        match err {
+            ReplicationError::SeqMismatch {
+                at_offset,
+                embedded,
+                expected,
+            } => {
+                assert_eq!(at_offset, 0);
+                assert_eq!(embedded, 7);
+                assert_eq!(expected, 0);
+            }
+            other => panic!("expected SeqMismatch, got {other:?}"),
+        }
+        // Fail-closed: nothing was appended, the follower's log is untouched.
+        assert_eq!(follower.next_fetch_offset().get(), 0);
     }
 
     // ----- fail-closed: a follower REJECTS a corrupted / tampered fetched frame -----

--- a/crates/ironbus-storage/src/log.rs
+++ b/crates/ironbus-storage/src/log.rs
@@ -242,6 +242,26 @@ pub struct Append<'a> {
     pub payload: &'a [u8],
 }
 
+/// How [`Log::append_inner`] lays one record into the active segment: RE-ENCODE a producer-supplied
+/// [`Append`] into a fresh canonical frame (the produce path), or copy a PRE-VALIDATED verbatim frame
+/// the follower already CRC-checked on ingest (#820). Both share the identical cap / daily-budget /
+/// roll prologue, id reservation, seek-index maintenance, and write-amplification accounting — only
+/// the per-record write into the segment writer differs, so the on-disk bytes are identical either way.
+#[derive(Clone, Copy)]
+enum AppendSource<'a> {
+    /// Re-frame + re-checksum the record through [`codec::encode`] (via [`SegmentWriter::append`]).
+    Encode(&'a Append<'a>),
+    /// Copy an already-sealed, already-validated frame verbatim (via
+    /// [`SegmentWriter::append_verbatim`]), skipping the redundant re-encode + re-checksum. `frame`
+    /// is one complete on-disk record frame the caller decoded in place; `view` is that decode's
+    /// result. The caller GUARANTEES `view.seq` equals the log's positional `next_seq`, so the copied
+    /// bytes are byte-identical to what the `Encode` path would have produced (a debug assert checks it).
+    Verbatim {
+        frame: &'a [u8],
+        view: &'a RecordView<'a>,
+    },
+}
+
 /// The three composable retention bounds the segment reaper enforces (refs #13, #80). A sealed
 /// segment is eligible to delete when ANY ENABLED bound says it should be (the log is over the
 /// byte bound, OR over the count bound, OR the segment is older than the age bound); each bound is
@@ -2096,7 +2116,32 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
     /// space is exhausted or the record is too large to frame, [`StorageError::WriterFrozen`] if a
     /// prior fatal error froze the writer, or an IO error from the write.
     pub fn append(&mut self, record: &Append<'_>) -> Result<Offset, StorageError> {
-        self.append_inner(record, true)
+        self.append_inner(AppendSource::Encode(record), true)
+    }
+
+    /// Appends an already-sealed, already-VALIDATED frame VERBATIM — the follower replication ingest
+    /// fast path (#820). `frame` is one complete on-disk record frame the caller has just decoded in
+    /// place with the intact-record predicate ([`codec::decode`]); `view` is that decode's result.
+    /// The leader already produced the canonical frame and the follower assigns the SAME
+    /// `seq`/offset positionally, so the frame is byte-identical to what [`Log::append`] would
+    /// re-encode from `view` — copying it verbatim skips the redundant re-frame + re-checksum (the
+    /// crc32c-over-header, crc32c-over-body, and, for large bodies, xxh3-64 that the decode just
+    /// verified). Everything else — the byte-cap and daily-write-budget sheds, the soft-size-cap
+    /// roll, id reservation, the resident seek index, and the write-amplification meters — is
+    /// IDENTICAL to [`Log::append`].
+    ///
+    /// The caller MUST guarantee `view.seq == self.next_seq()` (the frame's embedded, already-CRC'd
+    /// sequence matches the follower's positional assignment); a debug assert checks it. This method
+    /// does NOT re-validate `frame` — validation is the caller's decode step.
+    ///
+    /// # Errors
+    /// Identical to [`Log::append`] (byte-cap / daily-budget sheds, `SegmentFull`, `WriterFrozen`, IO).
+    pub fn append_frame_verbatim(
+        &mut self,
+        frame: &[u8],
+        view: &RecordView<'_>,
+    ) -> Result<Offset, StorageError> {
+        self.append_inner(AppendSource::Verbatim { frame, view }, true)
     }
 
     /// Like [`append`](Log::append) but NEVER triggers the implicit soft-size-cap roll: the record
@@ -2111,7 +2156,7 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
     /// Same as [`append`](Log::append) (byte-cap / daily-budget sheds, `SegmentFull`, `WriterFrozen`, IO),
     /// minus anything roll-specific.
     pub fn append_without_roll(&mut self, record: &Append<'_>) -> Result<Offset, StorageError> {
-        self.append_inner(record, false)
+        self.append_inner(AppendSource::Encode(record), false)
     }
 
     /// Force-seal the active segment and start a fresh one — exactly the seal the implicit soft-cap roll
@@ -2150,11 +2195,73 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
         Ok(active.write_pos() >= self.config.max_segment_bytes && active.record_count() > 0)
     }
 
+    /// Write ONE record into the active segment, either RE-ENCODING it through the codec or copying
+    /// an already-validated verbatim frame (#820). `seq` is the id the log reserved for it. Returns
+    /// `(offset, pos_before, frame_len)`: the assigned log offset, the byte position the frame starts
+    /// at in the segment, and its encoded byte length. Either path advances the writer's `write_pos`
+    /// by exactly the frame length, so `frame_len` (the write-position delta) is measured identically
+    /// and equals `frame.len()` on the verbatim path.
+    fn write_source(
+        &mut self,
+        source: AppendSource<'_>,
+        seq: Seq,
+    ) -> Result<(Offset, u64, u64), StorageError> {
+        let (offset, pos_before) = match source {
+            AppendSource::Encode(record) => {
+                let view = RecordView {
+                    seq,
+                    timestamp_ms: record.timestamp_ms,
+                    flags: record.flags,
+                    key: record.key,
+                    headers: record.headers,
+                    payload: record.payload,
+                };
+                let writer = self.active.as_mut().ok_or(StorageError::WriterFrozen)?;
+                let pos_before = writer.write_pos();
+                let offset = writer.append(&view)?;
+                (offset, pos_before)
+            }
+            AppendSource::Verbatim { frame, view } => {
+                // Byte-identity invariant: the follower assigns `seq` positionally, and the copied
+                // frame carries the leader's embedded (already-CRC'd) `seq`. They MUST match, or the
+                // verbatim bytes would diverge from what the encode path produces. The caller
+                // (replication ingest) enforces this with a typed error; assert it here too.
+                debug_assert_eq!(
+                    view.seq, seq,
+                    "verbatim frame seq must equal the follower's positional next_seq (#820)"
+                );
+                let writer = self.active.as_mut().ok_or(StorageError::WriterFrozen)?;
+                let pos_before = writer.write_pos();
+                let offset = writer.append_verbatim(frame, seq, view.timestamp_ms)?;
+                (offset, pos_before)
+            }
+        };
+        // The FRAME length is the writer's write-position delta across the append (the segment writer
+        // advances `write_pos` by exactly the encoded record's byte length: header + body + trailer).
+        // Measuring the delta avoids re-encoding the record just to size it.
+        let frame_len = self
+            .active
+            .as_ref()
+            .map_or(0, |w| w.write_pos().saturating_sub(pos_before));
+        Ok((offset, pos_before, frame_len))
+    }
+
     fn append_inner(
         &mut self,
-        record: &Append<'_>,
+        source: AppendSource<'_>,
         allow_roll: bool,
     ) -> Result<Offset, StorageError> {
+        // The producer-supplied logical content lengths (key + headers + payload, no framing) drive
+        // the write-amplification meters below and are the ONLY per-source difference before the
+        // write. Reading them once up front keeps the cap / budget / roll prologue source-agnostic.
+        let (key_len, headers_len, payload_len) = match &source {
+            AppendSource::Encode(record) => {
+                (record.key.len(), record.headers.len(), record.payload.len())
+            }
+            AppendSource::Verbatim { view, .. } => {
+                (view.key.len(), view.headers.len(), view.payload.len())
+            }
+        };
         // Hard durable-log byte cap (the drop-new shed): when the log is at or over the cap,
         // reject the produce and write nothing, advancing no offset or sequence. The check is
         // at-or-over BEFORE the append (like the segment cap), so the log overshoots by at most
@@ -2222,24 +2329,10 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
             .next_offset
             .checked_next()
             .ok_or(StorageError::SegmentFull)?;
-        let view = RecordView {
-            seq,
-            timestamp_ms: record.timestamp_ms,
-            flags: record.flags,
-            key: record.key,
-            headers: record.headers,
-            payload: record.payload,
-        };
-        let writer = self.active.as_mut().ok_or(StorageError::WriterFrozen)?;
-        // The encoded FRAME length is the writer's write-position delta across the append (the
-        // segment writer advances `write_pos` by exactly the encoded record's byte length: header +
-        // body + trailer). Measuring the delta avoids re-encoding the record just to size it.
-        let pos_before = writer.write_pos();
-        let offset = writer.append(&view)?;
-        let frame_len = self
-            .active
-            .as_ref()
-            .map_or(0, |w| w.write_pos().saturating_sub(pos_before));
+        // Lay the record into the active segment (encode-and-checksum, or copy the already-validated
+        // verbatim frame). Returns the assigned offset, the frame's start byte position, and its
+        // encoded length — the seek-index maintenance below needs all three.
+        let (offset, pos_before, frame_len) = self.write_source(source, seq)?;
         // The ids advance only after the write returns Ok.
         self.next_seq = next_seq;
         self.next_offset = next_offset;
@@ -2280,11 +2373,9 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
         // written to the segment. `physical / logical` over the run is the flash write-amplification
         // ratio, defined over stored bytes: under the default codec it can inflate for small
         // compressible payloads even as the real flash wear per user byte falls.
-        let logical = record
-            .key
-            .len()
-            .saturating_add(record.headers.len())
-            .saturating_add(record.payload.len());
+        let logical = key_len
+            .saturating_add(headers_len)
+            .saturating_add(payload_len);
         self.logical_bytes_written = self
             .logical_bytes_written
             .saturating_add(u64::try_from(logical).unwrap_or(u64::MAX));

--- a/crates/ironbus-storage/src/segment.rs
+++ b/crates/ironbus-storage/src/segment.rs
@@ -706,6 +706,68 @@ impl<F: RandomAccessFile> SegmentWriter<F> {
         Ok(Offset::new(offset))
     }
 
+    /// Appends a PRE-ENCODED, ALREADY-VALIDATED frame VERBATIM — the follower replication ingest
+    /// fast path (#820). `frame` is one complete on-disk record frame the caller has just decoded
+    /// in place with the intact-record predicate ([`codec::decode`]: magic, version, header CRC32C,
+    /// body CRC32C, and — for large bodies — xxh3-64). Because the leader already produced the
+    /// canonical sealed frame and the follower assigns the SAME `seq`/offset positionally, the frame
+    /// is byte-identical to what [`SegmentWriter::append`] would re-encode from the decoded record;
+    /// copying it verbatim skips the redundant re-frame + re-checksum (the same crc32c-over-header,
+    /// crc32c-over-body, and xxh3-64 the decode just verified). `seq` and `timestamp_ms` are the
+    /// decoded frame's own values, carried in for the writer's `last_seq` / `max_timestamp_ms`
+    /// bookkeeping only — they are NOT re-embedded (the bytes are copied as-is).
+    ///
+    /// This does NOT re-validate `frame`: validation is the caller's decode step. Passing bytes that
+    /// are not a single complete, already-validated frame would corrupt the segment. Its byte effect
+    /// (the pending buffer content and `write_pos` advance) is identical to `append` of the record
+    /// `frame` decodes to.
+    ///
+    /// # Errors
+    /// Returns [`StorageError::SegmentFull`] if the record count or byte length would overflow, or an
+    /// IO error from a spill flush (rolled back to the exact pre-append state, as in `append`).
+    pub fn append_verbatim(
+        &mut self,
+        frame: &[u8],
+        seq: Seq,
+        timestamp_ms: u64,
+    ) -> Result<Offset, StorageError> {
+        if self.record_count == u32::MAX {
+            return Err(StorageError::SegmentFull);
+        }
+        // Offsets are monotonic and never reused; refuse to wrap the offset space rather than mint a
+        // duplicate id (mirrors `append`).
+        let offset = self
+            .header
+            .base_offset
+            .get()
+            .checked_add(u64::from(self.record_count))
+            .ok_or(StorageError::SegmentFull)?;
+        // Copy the verbatim frame straight into the shared pending buffer — ONE contiguous memcpy in
+        // place of the codec's re-encode (4 extend_from_slice copies + 2x crc32c + xxh3). The bytes
+        // reach the file at the next flush point, exactly like an encoded frame.
+        let len = u64::try_from(frame.len()).map_err(|_| StorageError::SegmentFull)?;
+        let before = self.pending.len();
+        self.pending.extend_from_slice(frame);
+        let pos_before = self.write_pos;
+        let end = pos_before
+            .checked_add(len)
+            .ok_or(StorageError::SegmentFull)?;
+        self.write_pos = end;
+        // Spill under the same bound as `append`, with the same #859 torn-writer roll back on a
+        // mid-append flush IO error (restore `pending` and `write_pos` before `record_count` bumps).
+        if self.pending.len() >= PENDING_SPILL_BYTES {
+            if let Err(e) = self.flush_pending() {
+                self.pending.truncate(before);
+                self.write_pos = pos_before;
+                return Err(e);
+            }
+        }
+        self.record_count += 1;
+        self.last_seq = seq;
+        self.max_timestamp_ms = self.max_timestamp_ms.max(timestamp_ms);
+        Ok(Offset::new(offset))
+    }
+
     /// Flushes appended records to durable storage (fdatasync). A record is durable
     /// once this returns.
     ///


### PR DESCRIPTION
## What (#820)

The follower apply path in `cluster/replication.rs` **re-encoded** every replicated record — recomputing CRC32C/xxh3 and rewriting the frame — even though it had just received (and CRC-validated) the leader's already-canonical sealed frame. A redundant per-record decode-then-re-encode on the hot replication path.

## Fix

The follower now **appends the validated verbatim frame bytes** it received, mirroring the zero-copy spirit of #810/#920. `codec::decode` still runs on every untrusted incoming frame BEFORE the append (fail-closed `CorruptFrame` on any error — CRC/xxh3 validation is **not** dropped, only the re-encode is), then `SegmentWriter::append_verbatim` writes the exact decoded frame slice `&bytes[cursor..cursor+frame_len]`.

The on-disk bytes are **byte-identical** to the old re-encode path (the leader's frames are already canonical). The one field that previously differed — `seq` (the old path silently rewrote a diverged frame with the follower's positional seq) — is now closed by a new **`SeqMismatch` fail-closed guard**: the frame's embedded (CRC-covered) seq is compared to the follower's positional `next_seq()` and any divergence fails closed. That is a strict correctness *improvement* over the old silent rewrite.

Refactor: `Log::append_inner` takes an `AppendSource {Encode | Verbatim}` so the cap / daily-budget / roll prologue, id reservation, seek-index maintenance, and write-amp meters stay a single source of truth. `append_frame_verbatim` / `SegmentWriter::append_verbatim` each have exactly one caller, behind the seq guard, with a `debug_assert_eq!(view.seq, seq)` backing the always-on typed guard.

## Verification
- fmt + clippy (`-D warnings -W clippy::pedantic`, storage + server) clean
- `cargo test -p ironbus-storage` full suite green; `cargo test -p ironbus-server` incl. `cluster::replication` 25/25 (corrupt/tampered-frame rejection tests) green
- Reviewed across 3 adversarial lenses — on-disk byte-identity confirmed, CRC/tamper validation confirmed retained, no unguarded verbatim bypass

Closes #820
