### PR TITLE
perf(cluster): single-copy leader fetch-response framer on the live data-plane path (#825)

### DIFF
--- a/crates/ironbus-server/src/cluster/replication.rs
+++ b/crates/ironbus-server/src/cluster/replication.rs
@@ -185,10 +185,20 @@ pub struct FetchResponseBody {
 }
 
 impl FetchResponseBody {
-    /// Encode this response to its fixed-header + verbatim-bytes body.
+    /// The encoded body length (fixed header + verbatim frame bytes), i.e. the number of bytes
+    /// [`encode`](Self::encode) / [`encode_into`](Self::encode_into) produce. Lets the data-plane
+    /// framer size its single outbound buffer without a throw-away intermediate encode (#825).
     #[must_use]
-    pub fn encode(&self) -> Vec<u8> {
-        let mut out = Vec::with_capacity(FETCH_RESPONSE_HEADER_LEN + self.frame_bytes.len());
+    pub fn encoded_len(&self) -> usize {
+        FETCH_RESPONSE_HEADER_LEN + self.frame_bytes.len()
+    }
+
+    /// Append this response (fixed header then verbatim `frame_bytes`) to `out`, materializing the
+    /// zero-copy [`Bytes`] run EXACTLY ONCE. Both the standalone [`encode`](Self::encode) and the
+    /// data-plane peer framer append straight into their own outbound buffer through here, so the
+    /// leader copies the (up to 8 MiB) run a single time on egress instead of the former three
+    /// (layer body -> partition-prefixed body -> framed frame) — #825. The wire bytes are unchanged.
+    pub fn encode_into(&self, out: &mut Vec<u8>) {
         out.extend_from_slice(&self.high_watermark.to_le_bytes());
         out.extend_from_slice(&self.first_offset.to_le_bytes());
         out.extend_from_slice(&self.record_count.to_le_bytes());
@@ -197,6 +207,13 @@ impl FetchResponseBody {
         let frame_len = u32::try_from(self.frame_bytes.len()).unwrap_or(u32::MAX);
         out.extend_from_slice(&frame_len.to_le_bytes());
         out.extend_from_slice(&self.frame_bytes);
+    }
+
+    /// Encode this response to its fixed-header + verbatim-bytes body.
+    #[must_use]
+    pub fn encode(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(self.encoded_len());
+        self.encode_into(&mut out);
         out
     }
 

--- a/crates/ironbus-server/src/cluster/serve.rs
+++ b/crates/ironbus-server/src/cluster/serve.rs
@@ -230,6 +230,14 @@ pub fn encode_dataplane_peer_frame(
     partition: u64,
     frame: &DataPlaneFrame,
 ) -> Result<Vec<u8>, DataPlaneWireError> {
+    // Fast path for the big FETCH RESPONSE: its `frame_bytes` are a zero-copy `Bytes` view of a
+    // sealed segment (#810) and can be up to 8 MiB. The generic path below would copy them THREE
+    // times on the leader (layer body -> partition-prefixed body -> framed out); instead build the
+    // final framed buffer directly so the run is materialized EXACTLY ONCE. The bytes are identical
+    // to the generic encoding (#825).
+    if let DataPlaneFrame::FetchResponse(resp) = frame {
+        return encode_fetch_response_peer_frame(partition, resp);
+    }
     let layer_body = encode_dataplane_body(frame);
     let mut body = Vec::with_capacity(PARTITION_PREFIX_LEN + layer_body.len());
     body.extend_from_slice(&partition.to_le_bytes());
@@ -244,6 +252,43 @@ pub fn encode_dataplane_peer_frame(
         FrameError::FrameTooLarge { len } => DataPlaneWireError::Oversized { len },
         e @ FrameError::EmptyFrame => DataPlaneWireError::Frame(e),
     })?;
+    Ok(out)
+}
+
+/// Frame one FETCH RESPONSE directly into its final `[len][type][partition-le][layer body]` buffer,
+/// copying the (up to 8 MiB) zero-copy `frame_bytes` run EXACTLY ONCE (#825). This is the byte-for-byte
+/// equivalent of the generic [`encode_dataplane_peer_frame`] path for a `FetchResponse`, with the same
+/// bounds and the same error values, but without the two throw-away intermediate copies of the run.
+///
+/// # Errors
+/// Returns [`DataPlaneWireError::Oversized`] if the partition-prefixed body exceeds
+/// [`MAX_DATAPLANE_FRAME_BYTES`] or the framed length would exceed [`MAX_FRAME_LEN`].
+fn encode_fetch_response_peer_frame(
+    partition: u64,
+    resp: &FetchResponseBody,
+) -> Result<Vec<u8>, DataPlaneWireError> {
+    // Body = partition prefix + the response's fixed header + verbatim frame bytes (same as the
+    // generic path's `body`), bounded by the data-plane cap before anything is materialized.
+    let body_len = PARTITION_PREFIX_LEN + resp.encoded_len();
+    if body_len as u64 > u64::from(MAX_DATAPLANE_FRAME_BYTES) {
+        return Err(DataPlaneWireError::Oversized {
+            len: body_len as u64,
+        });
+    }
+    // Envelope frame length is the type byte plus the body, matching `encode_frame`'s own check.
+    let frame_len = 1u64 + body_len as u64;
+    let Some(frame_len) = u32::try_from(frame_len)
+        .ok()
+        .filter(|&l| l <= MAX_FRAME_LEN)
+    else {
+        return Err(DataPlaneWireError::Oversized { len: frame_len });
+    };
+    let mut out = Vec::with_capacity(5 + body_len);
+    out.extend_from_slice(&frame_len.to_le_bytes());
+    out.push(FrameType::FetchResponse.as_u8());
+    out.extend_from_slice(&partition.to_le_bytes());
+    // The single copy of the run into the outbound buffer (header + verbatim frame bytes).
+    resp.encode_into(&mut out);
     Ok(out)
 }
 
@@ -1935,6 +1980,56 @@ mod tests {
             assert_eq!(consumed, bytes.len(), "exactly one frame consumed");
             assert_eq!(got_p, p, "partition prefix round-trips");
             assert_eq!(&got_frame, frame, "frame round-trips byte-faithful");
+        }
+    }
+
+    #[test]
+    fn fetch_response_single_copy_framer_is_byte_identical_to_the_generic_path() {
+        // #825: the FetchResponse fast path (`encode_fetch_response_peer_frame`) frames the run with
+        // a single copy. Prove its bytes are IDENTICAL to the generic
+        // `encode_frame(FetchResponse, [partition-le ++ resp.encode()])` encoding the follower
+        // decodes — the conformance byte-identity guarantee — across empty, tiny, and large runs.
+        for run_len in [0usize, 5, 1024, 3 * 1024 * 1024] {
+            let payload: Vec<u8> = (0..run_len)
+                .map(|i| u8::try_from(i % 251).unwrap())
+                .collect();
+            let resp = FetchResponseBody {
+                high_watermark: 987_654_321,
+                first_offset: 42,
+                record_count: 9,
+                frame_bytes: bytes::Bytes::from(payload),
+            };
+            let partition = 3u64;
+
+            // The reference (generic) encoding: partition prefix + resp body, framed.
+            let mut ref_body = partition.to_le_bytes().to_vec();
+            ref_body.extend_from_slice(&resp.encode());
+            let mut reference = Vec::new();
+            proto_encode_frame(FrameType::FetchResponse, &ref_body, &mut reference)
+                .expect("reference frames");
+
+            let fast = encode_dataplane_peer_frame(
+                partition,
+                &DataPlaneFrame::FetchResponse(resp.clone()),
+            )
+            .expect("fast-path frames");
+
+            assert_eq!(
+                fast, reference,
+                "fast-path FetchResponse framing must be byte-identical (run_len={run_len})"
+            );
+
+            // And it must still decode back to the same partition + frame.
+            let (got_p, got_frame, consumed) = decode_dataplane_peer_frame(&fast)
+                .expect("decode ok")
+                .expect("a complete frame");
+            assert_eq!(consumed, fast.len(), "exactly one frame consumed");
+            assert_eq!(got_p, partition, "partition round-trips");
+            assert_eq!(
+                got_frame,
+                DataPlaneFrame::FetchResponse(resp),
+                "frame round-trips byte-faithful"
+            );
         }
     }
 


### PR DESCRIPTION
## What (#825)

#810 already made `FetchResponseBody.frame_bytes` a refcount `Bytes` and both `serve_fetch` paths use `run.bytes.clone()` (eliminating the original `to_vec`). The remaining waste was copies #2/#3: the **live** production serializer — `DataPlaneLink` (real `TcpStream` via `run_dataplane_reader`), not the test-only in-process `ReplicationLink` — copied the run three times per follower fetch: `encode_dataplane_body` → `b.encode()` (layer body), then the partition-prefixed `body`, then `encode_frame`'s `out`.

## Fix

- `replication.rs`: split `FetchResponseBody::encode` into `encode_into(&mut Vec)` + `encoded_len()`; `encode()` delegates — single-sourced layout, no wire drift.
- `serve.rs`: an `encode_fetch_response_peer_frame` fast path (dispatched from the top of `encode_dataplane_peer_frame` for `FetchResponse`) builds `[len][type][partition-le][header][verbatim run]` directly, copying `frame_bytes` **exactly once**, with the same `MAX_DATAPLANE_FRAME_BYTES` / `MAX_FRAME_LEN` bounds and identical `Oversized` error values as the generic path.

Wire bytes are **byte-for-byte identical** to the generic `encode_frame(FetchResponse, partition ++ resp.encode())`; all other frame types keep the unchanged generic path. (The optional `write_vectored` literal-zero-copy item was declined — `write_all_vectored` is unstable; the accepted #810/#920 zero-copy bar is refcount-clone + a single `extend_from_slice`, now met.)

## Verification
- fmt + clippy (`-D warnings -W clippy::pedantic`, server + storage) clean; `cargo test -p ironbus-server -p ironbus-storage` green
- New test `fetch_response_single_copy_framer_is_byte_identical_to_the_generic_path` asserts byte-equality across empty/5B/1KiB/3MiB runs + round-trips through `decode_dataplane_peer_frame`; existing `every_dataplane_frame_round_trips_over_the_peer_codec` still green
- Reviewed across 3 adversarial lenses — all SHIP (byte-identity proven statically + by test, error-value parity confirmed, live production path confirmed)

Closes #825
