### PR TITLE
fix(server): surface swallowed cluster reader-thread spawn failures with backoff (#870)

### DIFF
--- a/crates/ironbus-server/src/cluster/mod.rs
+++ b/crates/ironbus-server/src/cluster/mod.rs
@@ -372,3 +372,103 @@ pub(crate) fn heavy_cluster_test_guard() -> std::sync::MutexGuard<'static, ()> {
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
 }
+
+/// Handle the result of spawning a detached per-link reader thread from a cluster accept loop (#870).
+///
+/// The cluster accept loops (the metadata-plane listener, the data-plane peer listener, and the
+/// cross-cluster serve listener) spawn ONE detached reader thread per accepted link.
+/// [`std::thread::Builder::spawn`] returns `Err` on OS thread-creation refusal — EAGAIN under
+/// `RLIMIT_NPROC`, fd exhaustion, or low memory — all reachable in this thread-per-link model under a
+/// connection flood or resource pressure. Historically the `Result` was discarded with `let _ =`: the
+/// accepted stream was dropped with NO log, NO metric, and NO backpressure, and the accept loop
+/// immediately looped back to `accept()` — a tight accept-then-drop spin (a CPU-burning livelock while
+/// a remote dialer keeps reconnecting). The net effect was invisible follower/peer link loss: the
+/// leader silently stops serving a follower's fetch/ack (ISR shrink / under-replication) or drops a
+/// peer's Raft/heartbeat link (false failure detection → spurious elections), with nothing in the logs.
+///
+/// This surfaces the failure the CLUSTER way — via TRACING, not Prometheus (cluster link events use
+/// tracing) — at `warn`, ONCE per failure episode: `warned` latches so a sustained flood cannot itself
+/// become a log-volume vector, and a later SUCCESSFUL spawn resets it (the episode ended). It returns
+/// `true` to tell the caller to BACK OFF the accept loop (a bounded interruptible sleep) rather than
+/// tight-spin. On the failure path the spawn closure has already been consumed and dropped by
+/// `Builder::spawn`, which closed the accepted `TcpStream` it captured — so the link is released
+/// cleanly and no fd is leaked.
+///
+/// `link_kind` names the link for the log field (e.g. `"metadata peer"`, `"data-plane peer"`,
+/// `"cross-cluster serve"`). Generic over the join-handle type so the failure path is unit-testable
+/// without actually creating an OS thread.
+pub(crate) fn on_reader_spawn_result<H>(
+    result: &std::io::Result<H>,
+    warned: &mut bool,
+    link_kind: &str,
+) -> bool {
+    match result {
+        Ok(_) => {
+            *warned = false;
+            false
+        }
+        Err(e) => {
+            if !*warned {
+                tracing::warn!(
+                    error = %e,
+                    link_kind,
+                    "cluster: failed to spawn a per-link reader thread; accepted link dropped, backing off the accept loop"
+                );
+                *warned = true;
+            }
+            true
+        }
+    }
+}
+
+#[cfg(test)]
+mod reader_spawn_tests {
+    use super::on_reader_spawn_result;
+    use std::io;
+
+    /// A spawn FAILURE must be surfaced (return `true` = "back off") and must LATCH the warn flag, so
+    /// a sustained flood logs once rather than once-per-link. Fails without the #870 fix, which
+    /// replaced the silent `let _ = ...spawn(...)` with this handling.
+    #[test]
+    fn spawn_failure_signals_backoff_and_latches_the_warning() {
+        let mut warned = false;
+        let err: io::Result<()> = Err(io::Error::from(io::ErrorKind::WouldBlock));
+
+        // First failure of an episode: back off AND latch.
+        assert!(
+            on_reader_spawn_result(&err, &mut warned, "test peer"),
+            "a spawn failure must signal the accept loop to back off rather than tight-spin"
+        );
+        assert!(
+            warned,
+            "the first failure of an episode must latch the warn flag"
+        );
+
+        // Still failing: keep backing off, but the warn stays latched (logged once per episode).
+        assert!(
+            on_reader_spawn_result(&err, &mut warned, "test peer"),
+            "a sustained failure episode must keep backing off"
+        );
+        assert!(
+            warned,
+            "a sustained episode keeps the warn latched (no per-link log flood)"
+        );
+    }
+
+    /// A subsequent successful spawn ends the episode: no back-off, and the warn flag resets so the
+    /// NEXT failure episode logs again.
+    #[test]
+    fn spawn_success_ends_the_episode_and_resets_the_warning() {
+        let mut warned = true;
+        let ok: io::Result<()> = Ok(());
+
+        assert!(
+            !on_reader_spawn_result(&ok, &mut warned, "test peer"),
+            "a successful spawn must not signal a back-off"
+        );
+        assert!(
+            !warned,
+            "a successful spawn resets the episode so the next failure warns again"
+        );
+    }
+}

--- a/crates/ironbus-server/src/cluster/runtime.rs
+++ b/crates/ironbus-server/src/cluster/runtime.rs
@@ -1818,6 +1818,11 @@ fn run_listener(
     registry: Arc<Mutex<PeerRegistry>>,
     shutdown: Arc<AtomicBool>,
 ) {
+    // Latches while a reader-thread spawn-failure episode is ongoing, so the failure is logged ONCE
+    // per episode rather than once per refused link (#870): under thread/fd exhaustion the accept loop
+    // could otherwise turn a per-link warn into its own log-volume vector. Reset by the next successful
+    // spawn (see `on_reader_spawn_result`).
+    let mut spawn_warned = false;
     while !shutdown.load(Ordering::Acquire) {
         match listener.accept() {
             Ok((stream, _addr)) => {
@@ -1835,9 +1840,17 @@ fn run_listener(
                 let tx = inbound_tx.clone();
                 let reg = Arc::clone(&registry);
                 let sd = Arc::clone(&shutdown);
-                let _ = std::thread::Builder::new()
+                // Spawn a detached reader for this peer link. Previously the spawn `Result` was
+                // discarded with `let _ =`, silently dropping the accepted link (and tight-looping
+                // accept-then-drop) on an EAGAIN/ENOMEM spawn failure — masking peer link loss under
+                // thread/fd pressure (#870). Now surface the failure via tracing and back off.
+                let spawn_result = std::thread::Builder::new()
                     .name("ib-cluster-read".to_string())
                     .spawn(move || run_reader(PeerLink::new(stream), tx, reg, sd));
+                if super::on_reader_spawn_result(&spawn_result, &mut spawn_warned, "metadata peer")
+                {
+                    sleep_interruptible(TICK_INTERVAL, &shutdown);
+                }
             }
             Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
                 sleep_interruptible(TICK_INTERVAL, &shutdown);

--- a/crates/ironbus-server/src/cluster/serve.rs
+++ b/crates/ironbus-server/src/cluster/serve.rs
@@ -1152,6 +1152,10 @@ fn run_dataplane_listener<F, C>(
     // connection flood, and a per-link warn under that flood would itself be an unbounded log-volume
     // vector. Reset the moment the loop next admits a link (the episode ended).
     let mut cap_warned = false;
+    // Latches while a reader-thread spawn-failure episode is ongoing, so the failure is logged ONCE per
+    // episode (like `cap_warned`) and the loop backs off instead of tight-looping accept-then-drop
+    // under thread/fd exhaustion (#870). Reset by the next successful spawn.
+    let mut spawn_warned = false;
     while !shutdown.load(Ordering::Acquire) {
         match listener.accept() {
             Ok((stream, _addr)) => {
@@ -1202,15 +1206,17 @@ fn run_dataplane_listener<F, C>(
                         let _slot = slot;
                         run_dataplane_reader(DataPlaneLink::new(stream), &server, &release, &sd);
                     });
-                if spawn_result.is_err() {
-                    // The OS refused thread creation (EAGAIN/ENOMEM): the failed closure was dropped,
-                    // which released the reserved reader slot (`slot`'s drop) and closed the stream.
-                    // Previously the spawn result was discarded with `let _ =`, swallowing the failure
-                    // silently (#865). Log it so an operator sees the thread/fd pressure, then keep
-                    // accepting rather than wedging the listener.
-                    tracing::warn!(
-                        "data plane: failed to spawn an inbound peer reader thread; link dropped"
-                    );
+                // The OS may refuse thread creation (EAGAIN/ENOMEM): the failed closure is dropped,
+                // which releases the reserved reader slot (`slot`'s drop) and closes the stream.
+                // Previously (#865) the failure was logged but the loop kept tight-looping
+                // accept-then-drop; surface it via tracing (once per episode) AND back off so a
+                // transient thread/fd exhaustion cannot become a hot accept-spin (#870).
+                if super::on_reader_spawn_result(
+                    &spawn_result,
+                    &mut spawn_warned,
+                    "data-plane peer",
+                ) {
+                    sleep_interruptible(DATAPLANE_POLL, &shutdown);
                 }
             }
             Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {

--- a/crates/ironbus-server/src/cluster/serve_accept.rs
+++ b/crates/ironbus-server/src/cluster/serve_accept.rs
@@ -235,6 +235,10 @@ fn run_serve_listener<F, C>(
     F: Filesystem + Send + Sync + 'static,
     C: Clock + Send + 'static,
 {
+    // Latches while a reader-thread spawn-failure episode is ongoing, so the failure is logged ONCE per
+    // episode rather than once per refused link (#870): under thread/fd exhaustion a per-link warn would
+    // itself be a log-volume vector. Reset by the next successful spawn (see `on_reader_spawn_result`).
+    let mut spawn_warned = false;
     while !shutdown.load(Ordering::Acquire) {
         match listener.accept() {
             Ok((stream, _addr)) => {
@@ -250,11 +254,22 @@ fn run_serve_listener<F, C>(
                 let serve_plane = config.serve_plane.clone();
                 let hub_receiver = config.hub_receiver.clone();
                 let sd = Arc::clone(shutdown);
-                let _ = std::thread::Builder::new()
+                // Spawn a detached reader for this cross-cluster link. Previously the spawn `Result` was
+                // discarded with `let _ =`, silently dropping the accepted link (and tight-looping
+                // accept-then-drop) on an EAGAIN/ENOMEM spawn failure (#870). Now surface it via tracing
+                // and back off.
+                let spawn_result = std::thread::Builder::new()
                     .name("ib-xcluster-read".to_string())
                     .spawn(move || {
                         run_serve_reader(stream, serve_plane.as_ref(), hub_receiver.as_ref(), &sd);
                     });
+                if super::on_reader_spawn_result(
+                    &spawn_result,
+                    &mut spawn_warned,
+                    "cross-cluster serve",
+                ) {
+                    sleep_interruptible(SERVE_ACCEPT_POLL, shutdown);
+                }
             }
             Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
                 sleep_interruptible(SERVE_ACCEPT_POLL, shutdown);


### PR DESCRIPTION
## What (#870)

A cluster per-link reader thread-spawn failure (`std::thread::Builder::spawn` returning `Err` under thread/fd exhaustion) was silently swallowed by `let _ = ...spawn(...)` in the accept loops — the follower/peer link was simply never served, with no signal, and (in the data-plane loop) could hot-spin.

## Fix

A shared `on_reader_spawn_result` helper wires all **three** production per-link accept loops (metadata `runtime.rs`, data-plane `serve.rs`, cross-cluster `serve_accept.rs`): on spawn failure it emits a `tracing::warn` (latched once per failure episode, reset on the next success — no log-flood vector) and returns a signal to **back off** via each loop's existing interruptible poll interval; on success it resets the latch. The failed closure is dropped, closing the accepted `TcpStream` (and releasing the data-plane `DataPlaneReaderSlot`), so no fd/slot leaks. Success path is byte-identical (detached reader as before). Per the cluster convention this uses tracing, not a Prometheus counter.

## Verification
- fmt + clippy (`-D warnings -W pedantic`) clean; `cargo test -p ironbus-server` 956 passed
- Discriminating tests `reader_spawn_tests` (spawn-failure signals back-off + latches; success resets) — both fail against the old `let _ =`
- Reviewed across 3 adversarial lenses — all 3 sites covered (the rest are `#[cfg(test)]`), no leak, no hot-spin, no perturbed counters

Closes #870
