### PR TITLE
fix(server): charge txn prepared half-message payloads in the refuse-to-boot RAM guard + a configurable --max-prepared (#909)

### DIFF
--- a/crates/ironbus-cli/src/config_file.rs
+++ b/crates/ironbus-cli/src/config_file.rs
@@ -180,6 +180,7 @@ fn key_to_env_name(key: &str) -> Option<&'static str> {
         "delivery.dedup_max_ids" => "IRONBUS_DEDUP_MAX_IDS",
         "delivery.dedup_window_ms" => "IRONBUS_DEDUP_WINDOW_MS",
         "delivery.dedup_max_producers" => "IRONBUS_DEDUP_MAX_PRODUCERS",
+        "delivery.max_prepared" => "IRONBUS_MAX_PREPARED",
         "network.listen" => "IRONBUS_ADDR",
         "network.health_addr" => "IRONBUS_HEALTH_ADDR",
         "network.health_allow_public" => "IRONBUS_HEALTH_ALLOW_PUBLIC",

--- a/crates/ironbus-cli/src/main.rs
+++ b/crates/ironbus-cli/src/main.rs
@@ -380,6 +380,12 @@ const DEFAULT_DEDUP_WINDOW_MS: u64 = ironbus_core::dedup::DEFAULT_WINDOW_NANOS /
 /// `producer_id` over the cap evicts the least-recently-active window. Floored to 1 by the engine.
 const DEFAULT_DEDUP_MAX_PRODUCERS: usize = ironbus_core::dedup::DEFAULT_MAX_PRODUCERS;
 
+/// The default cap on concurrently-PREPARED transactional half messages (#909), sourced from the
+/// engine's [`ironbus_core::txn::DEFAULT_MAX_PREPARED`] so the CLI and engine default stay one source of
+/// truth. The `txn_id` is wire-supplied, so this caps the resident prepared-payload RAM the refuse-to-
+/// boot guard charges; `edge-tiny` lowers it (each slot is a maximal frame). Floored to 1 by the engine.
+const DEFAULT_MAX_PREPARED: usize = ironbus_core::txn::DEFAULT_MAX_PREPARED;
+
 /// The disk-full overflow policy parsed from `serve --disk-full-policy` (#82). A platform-neutral,
 /// `Copy` mirror of the engine's policy enum, so it lives in the (non-Unix-gated) `ServeConfig` and
 /// is validated on every platform; the Unix on-disk path maps it to the engine's `DiskFullPolicy`.
@@ -671,6 +677,11 @@ struct ProfilePreset {
     /// `dedup.max_producers` (`--dedup-max-producers`): the cap on concurrently-tracked dedup windows.
     /// `edge-tiny` LOWERS it (#878) for the same reason.
     dedup_max_producers: usize,
+    /// `txn.max_prepared` (`--max-prepared`): the cap on concurrently-PREPARED transactional half
+    /// messages (#909). Each prepared half message buffers a full producer-controlled record in RAM,
+    /// so `edge-tiny` LOWERS it (each slot is a maximal frame) to a handful so the guard's term-7
+    /// charge fits its 64 MiB ceiling; `balanced`/`throughput` use the shipped default.
+    max_prepared: usize,
 }
 
 /// The `edge-tiny` preset: `docs/CONFIG.md` section 6, identical to the `tiny` table in
@@ -701,6 +712,11 @@ const EDGE_TINY_PRESET: ProfilePreset = ProfilePreset {
     // leaving comfortable headroom under the 64 MiB ceiling alongside the ~15 MiB buffers and any store.
     dedup_max_ids: 256,
     dedup_max_producers: 64,
+    // LOWERED prepared cap (#909): the shipped default (65_536) implies ~1 TiB of buffered half-message
+    // payloads in the worst case (each a maximal ~16 MiB frame), which the guard now charges (term 7) and
+    // would refuse under 64 MiB. A tiny edge node runs few concurrent transactions, so 2 prepared slots
+    // (~32 MiB) is a bounded ceiling that still leaves headroom under 64 MiB alongside the other terms.
+    max_prepared: 2,
 };
 
 /// The `balanced` preset: THE default, and EXACTLY the compiled-in `DEFAULT_*` constant set, so a
@@ -727,6 +743,9 @@ const BALANCED_PRESET: ProfilePreset = ProfilePreset {
     // off, their ~269 GiB worst case is not charged against any ceiling).
     dedup_max_ids: DEFAULT_DEDUP_MAX_IDS,
     dedup_max_producers: DEFAULT_DEDUP_MAX_PRODUCERS,
+    // `balanced` IS the default knob set, so it keeps the shipped prepared cap (with the guard off, its
+    // ~1 TiB worst case is not charged against any ceiling).
+    max_prepared: DEFAULT_MAX_PREPARED,
 };
 
 /// The `throughput` preset: `docs/CONFIG.md` section 6, wide buffers for a multi-core hub. 256 MiB
@@ -751,6 +770,8 @@ const THROUGHPUT_PRESET: ProfilePreset = ProfilePreset {
     // A hub sizes RAM out of band (guard off), so it keeps the shipped default dedup caps.
     dedup_max_ids: DEFAULT_DEDUP_MAX_IDS,
     dedup_max_producers: DEFAULT_DEDUP_MAX_PRODUCERS,
+    // A hub sizes RAM out of band (guard off), so it keeps the shipped default prepared cap.
+    max_prepared: DEFAULT_MAX_PREPARED,
 };
 
 /// The smallest segment size cap `serve` accepts: below this, segments proliferate
@@ -2224,6 +2245,11 @@ struct ServeFlags {
     /// The cap on the NUMBER of distinct per-producer dedup windows (#33); `None` falls back to the
     /// default. Bounds the TOTAL dedup memory under a flood of distinct `producer_id`s.
     dedup_max_producers: Option<usize>,
+    /// The cap on concurrently-PREPARED transactional half messages (#909); `None` falls back to the
+    /// profile preset (the shipped default for `balanced`/`throughput`, a lowered handful for
+    /// `edge-tiny`). Bounds the resident prepared-half-message RAM the refuse-to-boot guard charges
+    /// under a `TxnPrepare` flood of distinct `txn_id`s.
+    max_prepared: Option<usize>,
     /// The durability LEVEL (#341, #379) selected by `--durability-level` / `IRONBUS_DURABILITY_LEVEL`.
     /// `None` resolves to the default `sync` (ack-implies-durable, I2, zero acked loss). An unknown
     /// name is a usage error.
@@ -2514,6 +2540,9 @@ fn collect_serve_flags(args: &[String]) -> Result<ServeFlags, CliError> {
             }
             "--dedup-max-producers" => {
                 f.dedup_max_producers = Some(take_number("--dedup-max-producers", args, &mut i)?);
+            }
+            "--max-prepared" => {
+                f.max_prepared = Some(take_number("--max-prepared", args, &mut i)?);
             }
             "--disk-full-policy" => {
                 f.disk_full_policy = Some(take_value("--disk-full-policy", args, &mut i)?);
@@ -3085,6 +3114,15 @@ fn parse_serve_flags_with_env_and_reader(
                 f.dedup_max_producers,
                 env,
                 preset.dedup_max_producers,
+            )?,
+            // #909: the prepared cap takes its default from the PROFILE PRESET (edge-tiny lowers it so the
+            // charged prepared-payload RAM term fits its 64 MiB ceiling; balanced/throughput keep the
+            // shipped default), still overridable by env/flag — exactly like the dedup caps above.
+            max_prepared: resolve_number(
+                "--max-prepared",
+                f.max_prepared,
+                env,
+                preset.max_prepared,
             )?,
             // The durability level and its interval triggers (#341, #379). The level is resolved
             // above (flag > env > default `sync`); the interval triggers take their defaults when not
@@ -4609,6 +4647,12 @@ fn validate_ram_ceiling(config: &ServeConfig) -> Result<(), CliError> {
         // count is bounded only by these caps, not the connection count.
         dedup_max_producers: u64::try_from(config.dedup_max_producers).unwrap_or(u64::MAX),
         dedup_max_ids: u64::try_from(config.dedup_max_ids).unwrap_or(u64::MAX),
+        // Term 7, the prepared transactional half messages (#909): charged at the CONFIGURED cap, so a
+        // config whose prepared cap cannot stay under the ceiling is refused (the shipped 65_536 default
+        // is ~1 TiB of maximal half-message frames; the edge-tiny preset lowers it). `txn_id` is
+        // wire-supplied, so the count is bounded only by this cap, not the connection count. The engine
+        // honors it via `Engine::set_txn_max_prepared`, so the charge is a true bound.
+        max_prepared: u64::try_from(config.max_prepared).unwrap_or(u64::MAX),
     };
     match ironbus_server::rss::fits_under_ram_ceiling(&footprint) {
         ironbus_server::rss::RamCeilingVerdict::Disabled
@@ -4810,6 +4854,14 @@ struct ServeConfig {
     /// flood of distinct ids cannot grow RAM without bound. Default 4096
     /// (`DEFAULT_DEDUP_MAX_PRODUCERS`); floored to 1 by the engine.
     dedup_max_producers: usize,
+    /// The cap on concurrently-PREPARED transactional half messages (#909): the most half messages the
+    /// txn 2PC store buffers (durable + resident) before a further `TxnPrepare` is refused. The `txn_id`
+    /// is wire-supplied and attacker-chosen, so this bounds the resident prepared-payload RAM the
+    /// refuse-to-boot guard charges (term 7) — the txn sibling of `dedup_max_producers`. Threaded into
+    /// the engine via `Engine::set_txn_max_prepared`. Default `65_536` (`DEFAULT_MAX_PREPARED`); `edge-tiny`
+    /// LOWERS it (each slot is a maximal frame) so the guard fits its 64 MiB ceiling; floored to 1 by the
+    /// engine.
+    max_prepared: usize,
     /// The DURABILITY LEVEL (#341, #379): how an ack relates to the covering `fdatasync`. Default
     /// [`DurabilityLevelArg::Sync`] (ack only after the covering fdatasync, I2, ZERO acked loss on a
     /// power cut), so a zero-config broker is power-loss safe. The relaxed levels weaken I2 by a
@@ -4972,6 +5024,8 @@ impl ServeConfig {
             dedup_max_ids: DEFAULT_DEDUP_MAX_IDS,
             dedup_window_ms: DEFAULT_DEDUP_WINDOW_MS,
             dedup_max_producers: DEFAULT_DEDUP_MAX_PRODUCERS,
+            // #909: the bench broker uses the shipped default prepared cap (the guard is off here).
+            max_prepared: DEFAULT_MAX_PREPARED,
             // The bench broker runs the default durable level (#341): ack-implies-durable, the same
             // power-loss-safe guarantee the shipped `serve` default carries.
             durability_level: DurabilityLevelArg::Sync,
@@ -6232,6 +6286,7 @@ fn materialized_config_line(config: &ServeConfig, addr: &str, data_dir: Option<&
          max_retained_bytes={} max_age_ms={} max_messages={} health_liveness_window_ms={} \
          actor_watchdog_bound_ms={} \
          enable_admin={} ram_ceiling_bytes={} dedup_max_ids={} dedup_max_producers={} \
+         max_prepared={} \
          durability_level={durability_level} \
          power_loss_safe={power_loss_safe} compression={compression} flush_interval_ms={} \
          flush_max_bytes={} async_loss_ack={} wal_fsync_headroom_bytes={} storage={storage} \
@@ -6260,6 +6315,7 @@ fn materialized_config_line(config: &ServeConfig, addr: &str, data_dir: Option<&
         config.ram_ceiling_bytes,
         config.dedup_max_ids,
         config.dedup_max_producers,
+        config.max_prepared,
         config.flush_interval_ms,
         config.flush_max_bytes,
         config.async_loss_ack,
@@ -9176,6 +9232,12 @@ fn open_engine_with<F: Filesystem + Clone>(
     )
     .map_err(|e| CliError::Internal(format!("opening broker {context}: {e}")))?;
     let mut engine = engine;
+    // Bound the concurrently-PREPARED transactional half messages (#909): the refuse-to-boot RAM guard
+    // charges `max_prepared * a maximal frame` (term 7), so the engine MUST honor the configured cap
+    // (else the guard's proof is a lie). Applied here at boot (server-side, not on the wire), exactly
+    // like the compaction / key-shared config below; a broker whose txn store is created lazily on the
+    // first `TxnPrepare` picks up the remembered value. `edge-tiny` lowers it so its ceiling fits.
+    engine.set_txn_max_prepared(config.max_prepared);
     // Enable OPT-IN key compaction (#337) when `--compact` was passed (OFF by default). It runs the
     // off-hot-path compactor after each produce-path reaper run; it never touches the active segment,
     // so it cannot block an append. A broker without `--compact` is byte-for-byte unchanged.
@@ -12762,6 +12824,8 @@ mod tests {
             dedup_max_ids: DEFAULT_DEDUP_MAX_IDS,
             dedup_window_ms: DEFAULT_DEDUP_WINDOW_MS,
             dedup_max_producers: DEFAULT_DEDUP_MAX_PRODUCERS,
+            // #909: the shipped default prepared cap (the guard is off unless a ceiling is set).
+            max_prepared: DEFAULT_MAX_PREPARED,
             // The default durable level (#341): a test config that does not opt in stays power-loss
             // safe (ack-implies-durable), so an unrelated test never accidentally relaxes durability.
             durability_level: DurabilityLevelArg::Sync,
@@ -16190,6 +16254,8 @@ mod tests {
             dedup_max_ids: DEFAULT_DEDUP_MAX_IDS,
             dedup_window_ms: DEFAULT_DEDUP_WINDOW_MS,
             dedup_max_producers: DEFAULT_DEDUP_MAX_PRODUCERS,
+            // #909: the shipped default prepared cap (the guard is off unless a ceiling is set).
+            max_prepared: DEFAULT_MAX_PREPARED,
             // The default durable level (#341): a test config that does not opt in stays power-loss
             // safe (ack-implies-durable), so an unrelated test never accidentally relaxes durability.
             durability_level: DurabilityLevelArg::Sync,
@@ -16282,12 +16348,50 @@ mod tests {
             // ~269 GiB dedup term would (correctly) refuse to boot.
             dedup_max_ids: 256,
             dedup_max_producers: 64,
+            // #909: the edge-tiny preset also lowers the prepared cap (each slot is a maximal frame);
+            // the shipped default (65_536) would imply ~1 TiB of half messages and refuse to boot.
+            max_prepared: 2,
             ..validation_config()
         };
         assert!(
             validate_serve_config(&cfg).is_ok(),
-            "edge-tiny caps (with lowered dedup) fit under the 64 MiB ceiling, so the broker must boot"
+            "edge-tiny caps (with lowered dedup + prepared) fit under the 64 MiB ceiling, so the broker \
+             must boot"
         );
+    }
+
+    #[test]
+    fn validate_refuses_edge_tiny_with_a_blown_up_max_prepared() {
+        // #909: edge-tiny FITS at its lowered `--max-prepared` (2 slots), but restoring the shipped
+        // default (65_536) under the same 64 MiB ceiling implies ~1 TiB of buffered half-message
+        // payloads — provably over, so the guard refuses to boot. This is the txn sibling of the #878
+        // dedup refusal and the exact defect #909 closes: pre-#909 the guard did not charge the prepared
+        // payloads, so an edge box booted under 64 MiB yet a `TxnPrepare` flood of distinct txn_ids could
+        // pin the default 65_536 maximal records in RAM and OOM it.
+        let cfg = ServeConfig {
+            max_connections: 32,
+            consumer_credit: 8,
+            consumer_credit_bytes: 256 * 1024,
+            max_groups: 64,
+            max_streams: 64,
+            max_in_flight: 256,
+            ram_ceiling_bytes: EDGE_TINY_RAM_CEILING,
+            dedup_max_ids: 256,
+            dedup_max_producers: 64,
+            // The BLOWN knob: the shipped default prepared cap under the tiny ceiling.
+            max_prepared: DEFAULT_MAX_PREPARED,
+            ..validation_config()
+        };
+        match validate_serve_config(&cfg) {
+            Err(CliError::Usage(m)) => {
+                assert!(m.contains("--ram-ceiling-bytes"), "names the ceiling: {m}");
+                assert!(m.contains("refuses to boot"), "{m}");
+                assert_eq!(CliError::Usage(m).exit_code(), EXIT_USAGE);
+            }
+            other => panic!(
+                "a default --max-prepared under a 64 MiB ceiling must be refused, got {other:?}"
+            ),
+        }
     }
 
     #[test]
@@ -16356,6 +16460,9 @@ mod tests {
             // fits its 64 MiB ceiling; the shipped 4096 * 100_000 defaults would refuse.
             dedup_max_ids: 256,
             dedup_max_producers: 64,
+            // #909: the lowered prepared cap keeps term 7 small (~32 MiB), so these #445 memory-fold
+            // tests flip PURELY on the store, not on a blown prepared term.
+            max_prepared: 2,
             ..validation_config()
         }
     }
@@ -16414,38 +16521,42 @@ mod tests {
     #[test]
     fn the_store_fold_charges_one_image_a_two_image_mutant_over_refuses_here() {
         // PINS THE MULTIPLIER at the validate level, where the model test alone cannot: the edge-tiny
-        // buffer terms (~15 MiB) PLUS the #878 dedup term (~11 MiB, edge-tiny's lowered caps) sum to
-        // ~26 MiB, so with a 32 MiB store cap the worst case is ~58 MiB charged at ONE image (fits the
-        // 64 MiB ceiling, BOOTS — the correct post-#492 verdict for the single-image EphemeralFile
-        // backend) and ~90 MiB charged at TWO (refuses). The ceiling sits BETWEEN the one-image and
-        // two-image floors, so a STALE 2x mutant (the pre-#492 InMemoryFile live+durable charge)
-        // OVER-refuses this exact valid config and fails here. Companion to the rss model test, which
-        // pins the literal 1 in the formula; this one proves the 1 reaches the real boot verdict with
-        // no slack. (The 1 GiB test above pins the OTHER direction: a fold-removal mutant that charges
-        // 0x boots a config that must refuse, so together they fix the multiplier at exactly 1.)
+        // buffer terms (~15 MiB) PLUS the #878 dedup term (~11 MiB) PLUS the #909 prepared term (~32 MiB,
+        // edge-tiny's 2-slot cap at a maximal frame each) sum to ~58 MiB, leaving ~6 MiB of headroom under
+        // the 64 MiB ceiling. So with a 4 MiB store cap the worst case is ~62 MiB charged at ONE image
+        // (fits, BOOTS — the correct post-#492 verdict for the single-image EphemeralFile backend) and
+        // ~66 MiB charged at TWO (refuses). The ceiling sits BETWEEN the one-image and two-image floors,
+        // so a STALE 2x mutant (the pre-#492 InMemoryFile live+durable charge) OVER-refuses this exact
+        // valid config and fails here. Companion to the rss model test, which pins the literal 1 in the
+        // formula; this one proves the 1 reaches the real boot verdict with no slack. (The 1 GiB test
+        // above pins the OTHER direction: a fold-removal mutant that charges 0x boots a config that must
+        // refuse, so together they fix the multiplier at exactly 1.) The store cap is small because the
+        // #909 prepared term now consumes most of the tiny ceiling's headroom.
         let cfg = ServeConfig {
             storage: StorageArg::Memory,
             ephemeral_loss_ack: true,
-            max_total_bytes: 32 * 1024 * 1024,
+            max_total_bytes: 4 * 1024 * 1024,
             ..edge_tiny_caps()
         };
         assert!(
             validate_serve_config(&cfg).is_ok(),
-            "32 MiB of store cap is 32 MiB of store image (post-#492 single image); with ~15 MiB \
-             of buffers that fits the 64 MiB ceiling and must boot — a stale 2x mutant over-refuses"
+            "4 MiB of store cap is 4 MiB of store image (post-#492 single image); with the ~58 MiB \
+             of edge-tiny buffers + dedup + prepared terms that fits the 64 MiB ceiling and must boot \
+             — a stale 2x mutant over-refuses"
         );
     }
 
     #[test]
     fn memory_storage_boots_when_the_ceiling_covers_the_store_and_buffers() {
         // The fold's accepting direction: a memory-mode config whose ceiling covers the buffer
-        // terms PLUS the store image (1 * max-total-bytes, post-#492) validates and boots. 8 MiB
-        // of cap means 8 MiB of store image; with the ~15 MiB edge-tiny buffer worst case plus the
-        // ~11 MiB #878 dedup term that sums to ~34 MiB, well under the 64 MiB ceiling.
+        // terms PLUS the store image (1 * max-total-bytes, post-#492) validates and boots. 4 MiB
+        // of cap means 4 MiB of store image; with the ~15 MiB edge-tiny buffer worst case plus the
+        // ~11 MiB #878 dedup term plus the ~32 MiB #909 prepared term that sums to ~62 MiB, just
+        // under the 64 MiB ceiling.
         let cfg = ServeConfig {
             storage: StorageArg::Memory,
             ephemeral_loss_ack: true,
-            max_total_bytes: 8 * 1024 * 1024,
+            max_total_bytes: 4 * 1024 * 1024,
             ..edge_tiny_caps()
         };
         assert!(

--- a/crates/ironbus-core/src/config.rs
+++ b/crates/ironbus-core/src/config.rs
@@ -391,6 +391,10 @@ pub const KEY_TABLE: &[KeySpec] = &[
         key: "delivery.dedup_max_producers",
         kind: KeyKind::Integer,
     },
+    KeySpec {
+        key: "delivery.max_prepared",
+        kind: KeyKind::Integer,
+    },
     // [network]
     KeySpec {
         key: "network.listen",

--- a/crates/ironbus-core/src/txn.rs
+++ b/crates/ironbus-core/src/txn.rs
@@ -294,6 +294,20 @@ impl TxnTable {
         self.config
     }
 
+    /// Retunes the concurrently-PREPARED cap IN PLACE (floored to 1), so a deployment can bound the
+    /// resident prepared-half-message RAM at boot without reopening the store (#909, the transactional
+    /// sibling of the #878 dedup cap; the refuse-to-boot RAM guard charges this cap, so the engine must
+    /// actually honor the lowered value). Mirrors how [`crate::txn::BackCheckConfig`] is retuned on the
+    /// open store via the engine's `set_back_check_config`.
+    ///
+    /// Lowering the cap below the count of already-`Prepared` txns does NOT evict any live half message
+    /// — a prepared payload is durable, undelivered data that must never be dropped (the same "refuse
+    /// the new, never forget an existing" discipline `prepare` already follows). It only refuses
+    /// FURTHER prepares until the prepared backlog drains under the new cap.
+    pub fn set_max_prepared(&mut self, max_prepared: usize) {
+        self.config.max_prepared = max_prepared.max(1);
+    }
+
     /// The number of currently-`Prepared` (unresolved) transactions.
     #[must_use]
     pub fn prepared_count(&self) -> usize {
@@ -1160,6 +1174,35 @@ mod tests {
         });
         assert_eq!(t.config().max_prepared, 1);
         assert_eq!(t.config().max_resolved_tombstones, 1);
+    }
+
+    #[test]
+    fn set_max_prepared_retunes_the_cap_in_place_and_floors_to_one() {
+        // #909: the RAM guard charges the prepared cap, so a deployment retunes it at boot; the engine
+        // applies it to the open table via this setter. A lowered cap is enforced on the NEXT prepare,
+        // and a `0` floors to 1 (like `new`), never disabling the bound.
+        let mut t = TxnTable::new(TxnConfig {
+            max_prepared: 10,
+            max_resolved_tombstones: 10,
+        });
+        t.prepare(b"a", 1).unwrap();
+        t.prepare(b"b", 2).unwrap();
+        // Lower the cap below the live count: existing prepares are NOT evicted, but a further prepare is
+        // refused until the backlog drains.
+        t.set_max_prepared(2);
+        assert_eq!(t.config().max_prepared, 2);
+        assert_eq!(t.prepared_count(), 2);
+        assert_eq!(
+            t.prepare(b"c", 3),
+            Err(TxnError::TooManyPrepared { cap: 2 }),
+            "a prepare past the retuned cap is refused"
+        );
+        // Resolving one frees a slot; a fresh prepare then fits under the retuned cap.
+        t.commit(b"a", 4).unwrap();
+        t.prepare(b"c", 5).unwrap();
+        // A zero cap floors to 1 rather than disabling the bound.
+        t.set_max_prepared(0);
+        assert_eq!(t.config().max_prepared, 1);
     }
 
     #[test]

--- a/crates/ironbus-server/src/engine.rs
+++ b/crates/ironbus-server/src/engine.rs
@@ -2640,6 +2640,12 @@ pub struct Engine<F: Filesystem, C: Clock> {
     /// timeout / retry cadence / attempt cap. Defaults to [`ironbus_core::txn::BackCheckConfig::default`]
     /// (a 30 s timeout, a 15 s retry, a 5-attempt cap), the production-safe schedule.
     back_check_config: ironbus_core::txn::BackCheckConfig,
+    /// The cap on concurrently-PREPARED transactional half messages (#909): applied to the txn store's
+    /// [`ironbus_core::txn::TxnTable`] at open AND whenever set via [`Engine::set_txn_max_prepared`], so
+    /// a deployment can bound the resident prepared-half-message RAM the refuse-to-boot guard charges
+    /// (the txn sibling of the #878 dedup cap). Defaults to [`ironbus_core::txn::DEFAULT_MAX_PREPARED`]
+    /// (`65_536`); an edge profile LOWERS it so the guard's term-7 charge fits its RAM ceiling.
+    txn_max_prepared: usize,
     /// The per-STREAM default message TTL (V2-M4, #549): a record reached on the poll path whose
     /// EFFECTIVE TTL (the lower of this and the record's own per-message TTL) has passed against the
     /// WALL-clock seam (anchored to the record's durable producer `timestamp_ms`) is EXPIRED — skipped
@@ -3066,6 +3072,11 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
             // The back-check tunables (#640 part 2): the production-safe default schedule until an
             // operator (or a test) overrides it via `set_back_check_config`.
             back_check_config: ironbus_core::txn::BackCheckConfig::default(),
+            // The concurrently-prepared cap (#909): the shipped default until an operator lowers it via
+            // `set_txn_max_prepared` (an edge profile does, so the refuse-to-boot guard's term-7 charge
+            // fits its ceiling). An eager-recovered txn store above opened with the default cap is
+            // retuned to this value by the boot-time setter, exactly like `back_check_config`.
+            txn_max_prepared: ironbus_core::txn::DEFAULT_MAX_PREPARED,
             // Empty by default: no group is key_shared until an operator configures one (#64), so an
             // unconfigured engine is plain competing everywhere and unchanged.
             key_shared_groups: std::collections::BTreeSet::new(),
@@ -4142,7 +4153,10 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
                 self.log.filesystem(),
                 self.log.clock_clone(),
                 self.txn_config,
-                ironbus_core::txn::TxnConfig::default(),
+                ironbus_core::txn::TxnConfig {
+                    max_prepared: self.txn_max_prepared,
+                    ..ironbus_core::txn::TxnConfig::default()
+                },
                 self.back_check_config,
             )
             .map_err(EngineError::Storage)?;
@@ -4500,6 +4514,28 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         if let Some(store) = self.txn.as_mut() {
             store.back_check_mut().set_config(config);
         }
+    }
+
+    /// Sets the concurrently-PREPARED cap (#909): the maximum transactional half messages that may be
+    /// buffered (durable + resident) at once before a further `TxnPrepare` is refused. Server-side only
+    /// (NOT on the wire), like [`Engine::set_back_check_config`]. Applied to the open txn store's
+    /// lifecycle table immediately (so it takes effect without a reopen) AND remembered for a later lazy
+    /// open. A deployment configures it once at boot; the default is
+    /// [`ironbus_core::txn::DEFAULT_MAX_PREPARED`] (`65_536`), which an edge profile lowers so the
+    /// refuse-to-boot RAM guard's prepared-payload term fits the ceiling. Lowering it below the current
+    /// prepared count never drops a live half message (durable, undelivered data); it only refuses
+    /// further prepares until the backlog drains under the cap.
+    pub fn set_txn_max_prepared(&mut self, max_prepared: usize) {
+        self.txn_max_prepared = max_prepared;
+        if let Some(store) = self.txn.as_mut() {
+            store.table_mut().set_max_prepared(max_prepared);
+        }
+    }
+
+    /// The active concurrently-PREPARED cap (#909), for the refuse-to-boot guard's accounting and tests.
+    #[must_use]
+    pub fn txn_max_prepared(&self) -> usize {
+        self.txn_max_prepared
     }
 
     /// Registers (or re-registers, after a reconnect) producer connection `member` as the live listener
@@ -16836,6 +16872,34 @@ mod tests {
         assert_eq!(off, Offset::new(0));
         assert_eq!(e.txn_prepared_count(), 0);
         assert_eq!(drain_visible(&mut e), vec![b"half".to_vec()]);
+    }
+
+    #[test]
+    fn set_txn_max_prepared_lowers_the_cap_the_engine_actually_enforces() {
+        // #909 HONESTY LINK: the refuse-to-boot RAM guard charges `max_prepared * a maximal frame`
+        // (term 7), so the engine MUST actually enforce the lowered cap — else the guard's proof is a
+        // lie (it charges 2 slots while the engine would buffer 65_536). This test drives the cap down to
+        // 1 and asserts the SECOND distinct prepare is REFUSED with `TooManyPrepared`, so the resident
+        // prepared-payload backlog is bounded by exactly the value the guard charged.
+        let mut e = open(config(10, 5));
+        e.set_txn_max_prepared(1);
+        assert_eq!(e.txn_max_prepared(), 1);
+        // The setter applies even when the txn store is lazily created on this first prepare.
+        e.txn_prepare(b"tx1", "", &txn_half(b"one"), b"").unwrap();
+        assert_eq!(e.txn_prepared_count(), 1);
+        match e.txn_prepare(b"tx2", "", &txn_half(b"two"), b"") {
+            Err(EngineError::Txn(ironbus_core::txn::TxnError::TooManyPrepared { cap })) => {
+                assert_eq!(
+                    cap, 1,
+                    "the enforced cap is the lowered value the guard charged"
+                );
+            }
+            other => panic!("a second prepare past the lowered cap must be refused, got {other:?}"),
+        }
+        // The refused txn left no residue; the one prepared half message is still resolvable.
+        assert_eq!(e.txn_prepared_count(), 1);
+        e.txn_rollback(b"tx1").unwrap();
+        assert_eq!(e.txn_prepared_count(), 0);
     }
 
     #[test]

--- a/crates/ironbus-server/src/rss.rs
+++ b/crates/ironbus-server/src/rss.rs
@@ -255,6 +255,21 @@ pub const DEDUP_ENTRY_BYTES: u64 = 2 * ironbus_core::dedup::MAX_MSG_ID_LEN as u6
 /// default cap, ~tens of KiB at edge-tiny), dominated by the per-entry term above.
 pub const DEDUP_PRODUCER_KEY_BYTES: u64 = 3 * ironbus_core::dedup::MAX_MSG_ID_LEN as u64 + 384;
 
+/// The upper bound on ONE prepared transactional half message's RESIDENT bytes, the per-slot charge of
+/// the refuse-to-boot guard's txn term (`docs/RAM_BUDGET.md` term 7, #909). A prepared half message
+/// (`ironbus_storage::txn::HalfMessage`) buffers the original record VERBATIM — its `key` + `headers` +
+/// `payload` (plus the small `txn_id` + `stream` + struct/`HashMap`-entry overhead) — and the whole
+/// original record is bounded by the protocol frame cap, so one buffered half message is at most
+/// [`MAX_FRAME_LEN`](ironbus_proto::frame::MAX_FRAME_LEN) resident. This mirrors term 1, which likewise
+/// bounds one in-flight payload at a maximal frame; the `MAX_FRAME_LEN` headroom over a 16 MiB record
+/// body (its `+64 KiB`) absorbs the `txn_id` / `stream` / struct overhead, so the constant is a true
+/// UPPER bound. The guard charges it per `max_prepared` slot, so the proof holds whatever sizes a producer
+/// prepares.
+// `u64::from` is not yet const-callable, so a widening `as` cast is the only option in a `const`; it is
+// lossless (u32 -> u64) so the `cast_lossless` pedantic lint is a false positive here.
+#[allow(clippy::cast_lossless)]
+pub const PREPARED_HALF_MESSAGE_BYTES: u64 = ironbus_proto::frame::MAX_FRAME_LEN as u64;
+
 /// The configuration the refuse-to-boot RAM guard ([`fits_under_ram_ceiling`]) reasons about: the
 /// bounded-buffer knobs from `docs/RAM_BUDGET.md` plus `max_connections` (a server-level cap that
 /// bounds the in-flight set, the read buffers, and the thread stacks). Every field is a CONFIGURED
@@ -294,6 +309,13 @@ pub struct RamFootprintConfig {
     /// `--dedup-max-ids`: the per-producer dedup window depth (the count of remembered `msg_id`s).
     /// Bounds the per-window RAM at `dedup_max_ids` * [`DEDUP_ENTRY_BYTES`].
     pub dedup_max_ids: u64,
+    /// `--max-prepared`: the cap on concurrently-PREPARED transactional half messages (#909). Each
+    /// prepared half message buffers a full producer-controlled record VERBATIM in RAM, and the
+    /// `txn_id` is wire-supplied and attacker-chosen, so a `TxnPrepare` flood can pin up to this many
+    /// maximal records — bounded ONLY by this cap, not the connection count. The guard MUST charge it
+    /// (term 7), exactly as it charges the dedup cap (#878) and `consumer_credit`, which likewise cost
+    /// nothing until used. `0` is floored to 1 by the engine, so a `0` here charges one slot.
+    pub max_prepared: u64,
 }
 
 /// The worst-case STEADY-STATE bounded-buffer footprint (in bytes) the configured caps imply,
@@ -340,6 +362,17 @@ pub struct RamFootprintConfig {
 ///   until a consumer connects). At the shipped defaults (`4096 * 100_000 * ~704 ~= 269 GiB`) this
 ///   refuses any small ceiling, so an edge profile MUST lower `--dedup-max-ids`/`--dedup-max-producers`
 ///   (the `edge-tiny` preset does).
+/// - **Term 7, the prepared transactional half messages (#909).** `max_prepared` *
+///   [`PREPARED_HALF_MESSAGE_BYTES`]. The txn 2PC store buffers the FULL payload of every
+///   prepared-but-unresolved half message in RAM (`ironbus_storage::txn`'s `prepared_payloads`), keyed
+///   by the wire-supplied, attacker-chosen `txn_id`, so a `TxnPrepare` flood can pin up to `max_prepared`
+///   maximal records — the SAME un-summed, config-capped, attacker-bounded RAM source as the dedup
+///   windows (term 6). It is bounded only by `max_prepared`, NOT the connection count, so the guard
+///   charges the cap exactly as it charges the dedup cap. At the shipped default (`65_536 * ~16 MiB` ≈
+///   1 TiB) this refuses any small ceiling, so an edge profile MUST lower `--max-prepared` (the
+///   `edge-tiny` preset does, to a handful of slots, since each slot is a full maximal frame). The
+///   engine HONORS the lowered cap (`Engine::set_txn_max_prepared` retunes the txn table), so the
+///   charge is a true bound, not a paper one.
 ///
 /// NOT counted here, and WHY (this is the honest boundary of what the guard can prove):
 ///
@@ -424,11 +457,25 @@ pub fn worst_case_buffer_bytes(config: &RamFootprintConfig) -> u64 {
                 .saturating_mul(DEDUP_PRODUCER_KEY_BYTES),
         );
 
+    // Term 7, the PREPARED transactional half messages (`docs/RAM_BUDGET.md` section 8, #909): the txn
+    // 2PC store buffers up to `max_prepared` full half-message records in RAM, keyed by the wire-supplied
+    // `txn_id`, so the worst case is every slot holding a maximal record. Bounded only by the configured
+    // cap (not the connection count), so the guard charges the cap — the txn sibling of term 6. The
+    // engine honors the lowered cap via `Engine::set_txn_max_prepared`, so this is a real bound.
+    // Saturating, so an absurd cap refuses rather than wraps. `.max(1)` mirrors the engine's floor
+    // (`Engine::set_txn_max_prepared` clamps to >= 1), so a configured `0` still charges the one slot
+    // the engine will actually admit — matching the `max_prepared` doc.
+    let term7_prepared = config
+        .max_prepared
+        .max(1)
+        .saturating_mul(PREPARED_HALF_MESSAGE_BYTES);
+
     term1
         .saturating_add(term3)
         .saturating_add(term4_memory_store)
         .saturating_add(term5)
         .saturating_add(term6_dedup)
+        .saturating_add(term7_prepared)
 }
 
 /// The verdict of the refuse-to-boot RAM guard for a configuration ([`fits_under_ram_ceiling`]).
@@ -508,6 +555,11 @@ mod tests {
             // ~269 GiB and refuse here).
             dedup_max_producers: 64,
             dedup_max_ids: 256,
+            // The edge-tiny preset LOWERS the prepared cap (#909): each prepared half message is a full
+            // maximal frame (~16 MiB), so with ~26 MiB already spent on the other terms, only a couple of
+            // prepared slots fit under 64 MiB. 2 slots is ~32 MiB — the whole worst case lands just under
+            // the ceiling. The shipped default (65_536) would imply ~1 TiB and refuse here.
+            max_prepared: 2,
         }
     }
 
@@ -580,6 +632,7 @@ mod tests {
             in_memory_store_bytes: 0,
             dedup_max_producers: 64,
             dedup_max_ids: 1024,
+            max_prepared: 2,
         };
         assert!(matches!(
             fits_under_ram_ceiling(&cfg),
@@ -606,6 +659,7 @@ mod tests {
             in_memory_store_bytes: 0,
             dedup_max_producers: 0, // dedup off: this test isolates the term-1 count charge
             dedup_max_ids: 0,
+            max_prepared: 0, // prepared cap off (floored to 1 elsewhere): isolate the term-1 charge
         };
         let worst = worst_case_buffer_bytes(&cfg);
         // Term 1 alone is `max_connections * consumer_credit * MAX_FRAME_LEN`; the whole worst case is
@@ -636,6 +690,7 @@ mod tests {
             in_memory_store_bytes: 0,
             dedup_max_producers: 64,
             dedup_max_ids: 1024,
+            max_prepared: 2,
         };
         let high_count = RamFootprintConfig {
             consumer_credit: u64::from(ironbus_core::backpressure::DEFAULT_CREDIT_CEILING),
@@ -766,6 +821,106 @@ mod tests {
             }) > baseline,
             "a dedup_max_ids bump must STRICTLY grow the worst case (term 6 is charged)"
         );
+        // #909: a prepared-cap bump must STRICTLY grow the worst case — this PINS that term 7 is summed.
+        // A `>= baseline` check would pass even if term 7 were dropped (the mutant would equal the
+        // baseline), so this asserts strict `>`. The delta is exactly one `PREPARED_HALF_MESSAGE_BYTES`.
+        assert!(
+            worst_case_buffer_bytes(&RamFootprintConfig {
+                max_prepared: base.max_prepared + 1,
+                ..base
+            }) > baseline,
+            "a max_prepared bump must STRICTLY grow the worst case (term 7 is charged)"
+        );
+    }
+
+    #[test]
+    fn the_prepared_cap_is_charged_at_one_maximal_frame_per_slot() {
+        // #909 EXACT-CHARGE DRIFT TEST. Term 7 charges EXACTLY one maximal frame per prepared slot, so
+        // bumping `max_prepared` by N grows the worst case by N * PREPARED_HALF_MESSAGE_BYTES. The delta
+        // is asserted against a HARD product of the frame constant (not the function under test), so a
+        // dropped or drifted term-7 multiplier fails here.
+        let base = edge_tiny_footprint();
+        let bumped = RamFootprintConfig {
+            max_prepared: base.max_prepared + 3,
+            ..base
+        };
+        assert_eq!(
+            worst_case_buffer_bytes(&bumped),
+            worst_case_buffer_bytes(&base) + 3 * PREPARED_HALF_MESSAGE_BYTES,
+            "each prepared slot must be charged exactly one maximal frame (term 7)"
+        );
+        // The per-slot charge is a full protocol frame, not a token estimate: a half message buffers the
+        // whole record verbatim.
+        assert_eq!(
+            PREPARED_HALF_MESSAGE_BYTES,
+            u64::from(ironbus_proto::frame::MAX_FRAME_LEN)
+        );
+    }
+
+    #[test]
+    fn the_shipped_default_prepared_cap_is_refused_under_a_tiny_ceiling() {
+        // #909: the shipped-default prepared cap (65_536 half messages) implies ~1 TiB of buffered
+        // half-message payloads in the worst case, which CANNOT fit a 64 MiB edge ceiling. Pre-#909 the
+        // guard did not charge the prepared payloads, so an edge-tiny box booted under 64 MiB yet a
+        // `TxnPrepare` flood of distinct txn_ids could pin up to 65_536 maximal records in RAM and OOM it
+        // — the same defect class as the #878 dedup gap. The guard now charges term 7 and PROVABLY
+        // refuses unless `--max-prepared` is lowered.
+        let cfg = RamFootprintConfig {
+            max_prepared: u64::try_from(ironbus_core::txn::DEFAULT_MAX_PREPARED).unwrap(),
+            ..edge_tiny_footprint()
+        };
+        match fits_under_ram_ceiling(&cfg) {
+            RamCeilingVerdict::Exceeds {
+                worst_case_bytes, ..
+            } => assert!(
+                // A hard literal floor, not a self-referential bound: 65_536 * 16 MiB is ~1 TiB, far over
+                // the 64 MiB ceiling.
+                worst_case_bytes >= 512 * 1024 * 1024 * 1024,
+                "the default prepared cap implies ~1 TiB, got {worst_case_bytes}"
+            ),
+            other => panic!(
+                "the shipped default prepared cap under a 64 MiB ceiling must be refused, got {other:?}"
+            ),
+        }
+    }
+
+    #[test]
+    fn the_edge_tiny_prepared_cap_fits_but_a_blown_override_is_refused() {
+        // #909 headline: the edge-tiny prepared cap (a handful of slots) FITS under 64 MiB, but blowing
+        // `--max-prepared` back up (even to a modest 8 slots ≈ 128 MiB of half messages) provably cannot,
+        // so the verdict flips from Fits to Exceeds purely on term 7.
+        let fits = edge_tiny_footprint();
+        assert!(matches!(
+            fits_under_ram_ceiling(&fits),
+            RamCeilingVerdict::Fits { .. }
+        ));
+        let blown = RamFootprintConfig {
+            max_prepared: 8,
+            ..fits
+        };
+        match fits_under_ram_ceiling(&blown) {
+            RamCeilingVerdict::Exceeds {
+                worst_case_bytes, ..
+            } => assert!(
+                worst_case_bytes >= 8 * u64::from(ironbus_proto::frame::MAX_FRAME_LEN),
+                "8 prepared slots is ~128 MiB of half messages, got {worst_case_bytes}"
+            ),
+            other => panic!(
+                "a blown --max-prepared under a 64 MiB ceiling must be refused, got {other:?}"
+            ),
+        }
+    }
+
+    #[test]
+    fn an_absurd_prepared_cap_saturates_rather_than_overflows() {
+        // Belt and braces (mirrors the store-cap saturation test): a u64::MAX prepared cap times the
+        // per-slot frame charge saturates to u64::MAX (the config is then refused under any real
+        // ceiling), never wraps to a small, spuriously-fitting worst case.
+        let cfg = RamFootprintConfig {
+            max_prepared: u64::MAX,
+            ..edge_tiny_footprint()
+        };
+        assert_eq!(worst_case_buffer_bytes(&cfg), u64::MAX);
     }
 
     #[test]

--- a/docs/RAM_BUDGET.md
+++ b/docs/RAM_BUDGET.md
@@ -350,6 +350,38 @@ term (it is small, bounded, and not a configured buffer cap), but the per-segmen
 bound above lets an operator add it to a hand sizing when many segments are pinned by
 a replaying consumer.
 
+### 8. Prepared transactional half messages (opt-in, #909)
+
+The transactional 2PC store
+(`crates/ironbus-storage/src/txn.rs`) buffers the FULL payload of every
+prepared-but-unresolved half message in RAM — `prepared_payloads: HashMap<Vec<u8>,
+HalfMessage>`, where each `HalfMessage` holds the original record's key + headers +
+payload VERBATIM. It costs NOTHING until a producer runs transactions (a
+non-transactional broker never materializes the `txn/` store), but once in use the
+`txn_id` is wire-supplied and attacker-chosen, so a `TxnPrepare` flood of distinct
+ids can pin one full record per prepared slot, bounded ONLY by the concurrently-
+prepared cap:
+
+```
+prepared_bytes <= max_prepared * (one half message's resident bytes)
+               <= max_prepared * MAX_FRAME_LEN
+```
+
+This is the SAME class of un-summed, config-capped, attacker-bounded RAM source as
+the dedup windows (section 6): un-bounded against the configured ceiling until the
+guard charges it. The cap is `--max-prepared` (default **65,536**,
+`DEFAULT_MAX_PREPARED`, `TxnConfig::max_prepared`, floored to 1). At the shipped
+default and a maximal ~16 MiB frame the worst case is `65_536 * 16 MiB ~= 1 TiB`, so
+a bounded ceiling MUST lower it. Because each slot is a whole maximal frame, even a
+handful of slots is a large fraction of a 64 MiB ceiling, so the `edge-tiny` preset
+lowers `--max-prepared` to **2** (~32 MiB). The engine HONORS the lowered cap
+(`Engine::set_txn_max_prepared` retunes the open txn table, mirroring
+`set_back_check_config`), so the charge is a true bound rather than a paper one: a
+prepare over the cap is REFUSED (`TxnError::TooManyPrepared`), never evicting a live,
+undelivered half message. An operator who needs more concurrent transactions raises
+BOTH `--max-prepared` and the ceiling (or sizes a byte-budget follow-up); the guard
+proves the two stay consistent at boot.
+
 ## A worked tiny-profile configuration that fits under 64 MiB
 
 Choose edge-safe knob values so the steady-state total provably sums under the
@@ -366,6 +398,7 @@ ceiling. These are the values you would pass to `serve` (or set via the
 | Max segment bytes | `--max-segment-bytes` | `8388608` (8 MiB) | DISK per segment (not RSS) |
 | Dedup window depth | `--dedup-max-ids` | `256` | remembered `msg_id`s per producer (term 6) |
 | Dedup producer cap | `--dedup-max-producers` | `64` | concurrently-tracked dedup windows (term 6) |
+| Prepared txn cap | `--max-prepared` | `2` | concurrently-prepared txn half messages (term 7) |
 
 Assume a representative edge record of ~16 KiB (key + headers + payload). Then:
 
@@ -393,6 +426,12 @@ caps regardless of whether a producer opts in at runtime (the proof is from the
 config): `dedup_max_producers * dedup_max_ids * ~704 bytes = 64 * 256 * ~704 ~= 11
 MiB` (plus a few KiB of producer keys).
 
+**Term 7, the prepared transactional half messages (#909).** Charged by the guard at
+the configured cap regardless of whether a producer runs transactions at runtime (the
+proof is from the config): `max_prepared * MAX_FRAME_LEN = 2 * ~16 MiB ~= 32 MiB`.
+Each slot is a whole maximal frame, so this term dominates the tiny profile; the
+shipped default (65,536) would be ~1 TiB and refuse.
+
 **Steady-state total (the bounded-buffer worst case the guard sums):**
 
 ```
@@ -401,13 +440,17 @@ term3 (group state)    1 MiB
 term4 (active segment) ~0
 term5 (fixed)         ~4 MiB
 term6 (dedup caps)    ~11 MiB
+term7 (prepared txns) ~32 MiB
 ---------------------------
-total                 ~20 MiB   <<  64 MiB ceiling
+total                 ~52 MiB   <  64 MiB ceiling
 ```
 
-The worst case lands well under the ceiling, leaving generous headroom. (A no-dedup
-workload allocates zero of term 6 at runtime, but the guard still charges the CAP, so
-the caps must fit — they do here.)
+The worst case lands under the ceiling. (A non-transactional or no-dedup workload
+allocates zero of terms 6/7 at runtime, but the guard still charges the CAPS, so the
+caps must fit — they do here. The prepared term dominates because each slot is a full
+maximal frame; a byte-budget knob that bounds the prepared BYTES rather than the slot
+count is the natural follow-up for an edge node that needs many small concurrent
+transactions.)
 
 ### The worst-case read-buffer caveat
 
@@ -451,7 +494,7 @@ configured caps imply provably exceeds the ceiling. The footprint is a CLOSED
 formula in the config (no live RSS), summing the FIRMLY-BOUNDED terms above:
 
 ```
-worst_case = term1 + term3 + term4mem + term5 + term6
+worst_case = term1 + term3 + term4mem + term5 + term6 + term7
 
 term1 (per-connection in-flight payloads, the firm RAM bound)
      = max_connections * per_conn_inflight
@@ -471,6 +514,13 @@ term6 (the opt-in per-producer dedup windows, #878)
   producer_id is wire-supplied, so the window COUNT is bounded only by the caps,
   NOT the connection count; at the shipped 4096 * 100_000 defaults this is ~269 GiB,
   so a bounded ceiling MUST lower the dedup caps (the edge-tiny preset does).
+term7 (the prepared transactional half messages, #909)
+     = max_prepared * PREPARED_HALF_MESSAGE_BYTES (MAX_FRAME_LEN, ~16 MiB: one
+       prepared half message buffers a whole maximal record verbatim in RAM)
+  txn_id is wire-supplied, so the prepared COUNT is bounded only by the cap, NOT the
+  connection count; at the shipped 65_536 default this is ~1 TiB, so a bounded ceiling
+  MUST lower --max-prepared (the edge-tiny preset lowers it to 2). The engine honors
+  the lowered cap (Engine::set_txn_max_prepared), so this is a real bound.
 ```
 
 THE MEMORY-BACKEND STORE FOLD (#445, refs #443): on DISK the store is term 4 of


### PR DESCRIPTION
## What (#909)

The refuse-to-boot RAM guard (sibling of #878) that refuses to start when worst-case resident buffers exceed the budget did **not** account for the txn 2PC store's prepared half-message payloads — a `TxnPrepare` flood (attacker-chosen `txn_id`) could pin up to `max_prepared` maximal records in RAM, uncounted, and OOM despite the guard.

## Fix

Add **term 7** to `worst_case_buffer_bytes`: `max_prepared.max(1) * PREPARED_HALF_MESSAGE_BYTES` (the `.max(1)` mirrors the engine's floor so a configured `0` still charges the one slot the engine admits). `max_prepared` is a configurable cap (`--max-prepared`, wired through config, with an edge-tiny profile value), and the engine genuinely enforces the charged cap via `Engine::set_txn_max_prepared` (`TxnTable::prepare` rejects with `TooManyPrepared` beyond it). Non-txn accounting is unchanged.

## Verification
- fmt + clippy (`-D warnings -W pedantic`, server/core/cli) clean; `cargo test -p ironbus-server -p ironbus-storage` green
- Reviewed across 3 adversarial lenses — the previously-uncounted OOM source is now charged + enforced, no false refuse-to-boot at realistic caps

## Follow-up (filed separately)
The optional exact byte-budget (`--max-prepared-bytes`) is deferred — honest enforcement needs per-prepare byte accounting; the count-based charge (the issue's sanctioned point 2) closes the OOM vector.

Closes #909
