### PR TITLE
feat(proto): tag the Err frame with the stable ErrorCode via a backward-compatible NUL-sentinel prefix (#883)

### DIFF
--- a/crates/ironbus-client-async/src/lib.rs
+++ b/crates/ironbus-client-async/src/lib.rs
@@ -106,8 +106,9 @@ fn frame_read_size(needed: usize, filled: usize) -> usize {
 #[doc(no_inline)]
 pub use ironbus_client::{
     pack_password_material, AuthCredential, AuthMechanism, ClientConfig, ClientError, DeadLetter,
-    Fetch, Gap, Message, ProduceAck, ProgressOutcome, StreamBatch, StreamConsumerConfig,
-    Truncation, TxnId, DEFAULT_STREAM_COMMIT_EVERY_BATCHES, DEFAULT_STREAM_FETCH_RECORDS,
+    Fetch, Gap, Message, ProduceAck, ProgressOutcome, ServerError, ServerErrorCode, StreamBatch,
+    StreamConsumerConfig, Truncation, TxnId, DEFAULT_STREAM_COMMIT_EVERY_BATCHES,
+    DEFAULT_STREAM_FETCH_RECORDS,
 };
 
 /// The proto body/codec types a caller constructs to drive [`AsyncClient`] (e.g. [`PubBody`]),
@@ -143,7 +144,7 @@ fn not_leader_error(body: &[u8]) -> ClientError {
 enum PubReply {
     Acked(u64),
     Duplicate(u64),
-    ServerErr(String),
+    ServerErr(ServerError),
     Pong,
     /// A cluster `NotLeader` redirect (#735): the produce landed on a non-leader replica and was NOT
     /// appended/acked; the leader's CLIENT-address hint (or `None` when unknown).
@@ -167,7 +168,7 @@ fn classify_pub_reply(ty: FrameType, body: &[u8]) -> Result<PubReply, ClientErro
             })?;
             Ok(PubReply::Duplicate(ack.offset))
         }
-        FrameType::Err => Ok(PubReply::ServerErr(String::from_utf8_lossy(body).into())),
+        FrameType::Err => Ok(PubReply::ServerErr(ServerError::from_wire(body))),
         FrameType::Pong => Ok(PubReply::Pong),
         // A cluster NotLeader redirect (#735): decode the leader hint (an empty hint -> `None`). The
         // produce was NOT appended/acked here; the caller reconnects/retries to the leader.
@@ -415,9 +416,7 @@ impl AsyncClient {
                 client.streams_enabled = info.streams;
                 Ok(client)
             }
-            (FrameType::Err, body) => {
-                Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
-            }
+            (FrameType::Err, body) => Err(ClientError::Server(ServerError::from_wire(&body))),
             (other, _) => Err(ClientError::Unexpected(other)),
         }
     }
@@ -526,9 +525,7 @@ impl AsyncClient {
                     duplicate: true,
                 })
             }
-            (FrameType::Err, body) => {
-                Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
-            }
+            (FrameType::Err, body) => Err(ClientError::Server(ServerError::from_wire(&body))),
             // A cluster NotLeader redirect: this node is not the leader, so the produce did NOT land
             // here. Surface the typed `NotLeader` error; the connection stays usable.
             (FrameType::NotLeader, body) => Err(not_leader_error(&body)),
@@ -802,9 +799,9 @@ impl AsyncClient {
                     // returning to keep the connection framed for reuse, exactly as FlowEnd and the
                     // old `read_frame` (drain-then-return) did. Materialize the owned message first
                     // since `body` borrows `self.buf`, which the drain then mutates.
-                    let msg = String::from_utf8_lossy(body).into_owned();
+                    let err = ServerError::from_wire(body);
                     self.buf.drain(..consumed);
-                    return Err(ClientError::Server(msg));
+                    return Err(ClientError::Server(err));
                 }
                 other => return Err(ClientError::Unexpected(other)),
             }
@@ -839,9 +836,7 @@ impl AsyncClient {
                     "ack reply was not a one-byte status",
                 )),
             },
-            (FrameType::Err, body) => {
-                Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
-            }
+            (FrameType::Err, body) => Err(ClientError::Server(ServerError::from_wire(&body))),
             (other, _) => Err(ClientError::Unexpected(other)),
         }
     }
@@ -893,8 +888,7 @@ impl AsyncClient {
                 },
                 (FrameType::Err, body) => {
                     if first_err.is_none() {
-                        first_err =
-                            Some(ClientError::Server(String::from_utf8_lossy(&body).into()));
+                        first_err = Some(ClientError::Server(ServerError::from_wire(&body)));
                     }
                 }
                 (other, _) => return Err(ClientError::Unexpected(other)),
@@ -939,9 +933,7 @@ impl AsyncClient {
                     "nack reply was not a one-byte status",
                 )),
             },
-            (FrameType::Err, body) => {
-                Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
-            }
+            (FrameType::Err, body) => Err(ClientError::Server(ServerError::from_wire(&body))),
             (other, _) => Err(ClientError::Unexpected(other)),
         }
     }
@@ -972,9 +964,7 @@ impl AsyncClient {
                     "term reply was not a one-byte status",
                 )),
             },
-            (FrameType::Err, body) => {
-                Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
-            }
+            (FrameType::Err, body) => Err(ClientError::Server(ServerError::from_wire(&body))),
             (other, _) => Err(ClientError::Unexpected(other)),
         }
     }
@@ -1010,9 +1000,7 @@ impl AsyncClient {
                     "progress reply was not a known one-byte status",
                 )),
             },
-            (FrameType::Err, body) => {
-                Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
-            }
+            (FrameType::Err, body) => Err(ClientError::Server(ServerError::from_wire(&body))),
             (other, _) => Err(ClientError::Unexpected(other)),
         }
     }
@@ -1025,9 +1013,7 @@ impl AsyncClient {
         self.send(FrameType::Ping, &[]).await?;
         match self.read_frame().await? {
             (FrameType::Pong, _) => Ok(()),
-            (FrameType::Err, body) => {
-                Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
-            }
+            (FrameType::Err, body) => Err(ClientError::Server(ServerError::from_wire(&body))),
             (other, _) => Err(ClientError::Unexpected(other)),
         }
     }
@@ -1049,9 +1035,7 @@ impl AsyncClient {
         self.send(FrameType::Sub, &body).await?;
         match self.read_frame().await? {
             (FrameType::Ok, _) => Ok(()),
-            (FrameType::Err, body) => {
-                Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
-            }
+            (FrameType::Err, body) => Err(ClientError::Server(ServerError::from_wire(&body))),
             (other, _) => Err(ClientError::Unexpected(other)),
         }
     }
@@ -1065,9 +1049,7 @@ impl AsyncClient {
         self.send(FrameType::Unsub, &[]).await?;
         match self.read_frame().await? {
             (FrameType::Ok, _) => Ok(()),
-            (FrameType::Err, body) => {
-                Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
-            }
+            (FrameType::Err, body) => Err(ClientError::Server(ServerError::from_wire(&body))),
             (other, _) => Err(ClientError::Unexpected(other)),
         }
     }
@@ -1091,9 +1073,7 @@ impl AsyncClient {
         self.send(FrameType::CumulativeAck, &body).await?;
         match self.read_frame().await? {
             (FrameType::Ok, _) => Ok(()),
-            (FrameType::Err, body) => {
-                Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
-            }
+            (FrameType::Err, body) => Err(ClientError::Server(ServerError::from_wire(&body))),
             (other, _) => Err(ClientError::Unexpected(other)),
         }
     }
@@ -1158,9 +1138,7 @@ impl AsyncClient {
         self.send(FrameType::StreamDeclare, &body).await?;
         match self.read_frame().await? {
             (FrameType::Ok, _) => Ok(()),
-            (FrameType::Err, body) => {
-                Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
-            }
+            (FrameType::Err, body) => Err(ClientError::Server(ServerError::from_wire(&body))),
             (other, _) => Err(ClientError::Unexpected(other)),
         }
     }
@@ -1191,9 +1169,7 @@ impl AsyncClient {
                     .map_err(|_| ClientError::BadResponse("malformed stream-info response"))?;
                 Ok((resp.exists, resp.head))
             }
-            (FrameType::Err, body) => {
-                Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
-            }
+            (FrameType::Err, body) => Err(ClientError::Server(ServerError::from_wire(&body))),
             (other, _) => Err(ClientError::Unexpected(other)),
         }
     }
@@ -1240,9 +1216,7 @@ impl AsyncClient {
                     .map_err(|_| ClientError::BadResponse("publish-to reply was not an offset"))?;
                 Ok(ack.offset)
             }
-            (FrameType::Err, body) => {
-                Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
-            }
+            (FrameType::Err, body) => Err(ClientError::Server(ServerError::from_wire(&body))),
             (other, _) => Err(ClientError::Unexpected(other)),
         }
     }
@@ -1272,9 +1246,7 @@ impl AsyncClient {
         self.send(FrameType::SubTo, &body).await?;
         match self.read_frame().await? {
             (FrameType::Ok, _) => Ok(()),
-            (FrameType::Err, body) => {
-                Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
-            }
+            (FrameType::Err, body) => Err(ClientError::Server(ServerError::from_wire(&body))),
             (other, _) => Err(ClientError::Unexpected(other)),
         }
     }
@@ -1387,9 +1359,7 @@ impl AsyncClient {
         self.send(FrameType::StreamCommit, &body).await?;
         match self.read_frame().await? {
             (FrameType::Ok, _) => Ok(()),
-            (FrameType::Err, body) => {
-                Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
-            }
+            (FrameType::Err, body) => Err(ClientError::Server(ServerError::from_wire(&body))),
             (other, _) => Err(ClientError::Unexpected(other)),
         }
     }
@@ -1481,9 +1451,7 @@ impl AsyncClient {
         self.send(FrameType::TxnPrepare, &body).await?;
         match self.read_frame().await? {
             (FrameType::Ok, _) => Ok(()),
-            (FrameType::Err, body) => {
-                Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
-            }
+            (FrameType::Err, body) => Err(ClientError::Server(ServerError::from_wire(&body))),
             (other, _) => Err(ClientError::Unexpected(other)),
         }
     }
@@ -1511,9 +1479,7 @@ impl AsyncClient {
                     .map_err(|_| ClientError::BadResponse("txn-commit reply was not an offset"))?;
                 Ok(ack.offset)
             }
-            (FrameType::Err, body) => {
-                Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
-            }
+            (FrameType::Err, body) => Err(ClientError::Server(ServerError::from_wire(&body))),
             (other, _) => Err(ClientError::Unexpected(other)),
         }
     }
@@ -1537,9 +1503,7 @@ impl AsyncClient {
         self.send(FrameType::TxnRollback, &body).await?;
         match self.read_frame().await? {
             (FrameType::Ok, _) => Ok(()),
-            (FrameType::Err, body) => {
-                Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
-            }
+            (FrameType::Err, body) => Err(ClientError::Server(ServerError::from_wire(&body))),
             (other, _) => Err(ClientError::Unexpected(other)),
         }
     }

--- a/crates/ironbus-client/src/lib.rs
+++ b/crates/ironbus-client/src/lib.rs
@@ -78,8 +78,13 @@ pub enum ClientError {
     Frame(FrameError),
     /// A malformed message body from the server.
     Body(BodyError),
-    /// The server replied with an error: the UTF-8 message it sent.
-    Server(String),
+    /// The server replied with an error: the human message it sent, PLUS the stable
+    /// machine-readable [`ServerErrorCode`] the broker tagged it with when one applies (#883), so a
+    /// caller branches on [`ServerError::code`] (retry-vs-fail, backpressure-vs-permanent-reject)
+    /// instead of substring-matching prose the broker is free to reword. The code is `None` for an
+    /// uncoded rejection (a malformed-body literal, the uniform auth violation, or a code this build
+    /// predates); the human message is always present.
+    Server(ServerError),
     /// The server replied with an unexpected (but known) frame type for the request.
     Unexpected(FrameType),
     /// The server sent a frame whose type tag this client does not recognize.
@@ -176,6 +181,106 @@ impl std::error::Error for ClientError {}
 impl From<io::Error> for ClientError {
     fn from(e: io::Error) -> Self {
         ClientError::Io(e)
+    }
+}
+
+/// The stable, machine-readable server rejection code (#883, #35), re-exported from `ironbus-proto`.
+#[doc(no_inline)]
+pub use ironbus_proto::err::ServerErrorCode;
+
+/// A server rejection: the stable machine-readable [`ServerErrorCode`] the broker tagged it with (when
+/// one applies), plus the human message it sent (#883). Carried by [`ClientError::Server`].
+///
+/// Branch on [`ServerError::code`] for control flow (retry-vs-fail, backpressure-vs-permanent-reject)
+/// — e.g. `Some(ServerErrorCode::AtCapacity)` is a benign, retryable drop-new shed, distinct from a
+/// permanent reject — and use the message for display only. `code` is `None` for an uncoded rejection
+/// (a malformed-body literal, the uniform anti-enumeration auth violation, or a newer code this build
+/// predates); the human message is always present.
+///
+/// The type dereferences to its message `str`, so an older caller that substring-matched the message
+/// keeps compiling and working unchanged while it migrates to the code.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ServerError {
+    /// The stable code the broker tagged this rejection with, or `None` when uncoded / unrecognized.
+    pub code: Option<ServerErrorCode>,
+    /// The human-readable message, for display.
+    pub message: String,
+}
+
+impl ServerError {
+    /// Decodes a wire `Err` frame body into its optional code and human message (#883).
+    #[must_use]
+    pub fn from_wire(body: &[u8]) -> ServerError {
+        let decoded = ironbus_proto::err::decode_err_body(body);
+        ServerError {
+            code: decoded.code,
+            message: decoded.message.into_owned(),
+        }
+    }
+
+    /// An uncoded rejection carrying only a human message (a client-synthesized error, e.g. a
+    /// `NotLeader` summary), with no stable code.
+    #[must_use]
+    pub fn uncoded(message: String) -> ServerError {
+        ServerError {
+            code: None,
+            message,
+        }
+    }
+
+    /// The stable machine-readable code the broker tagged this rejection with, or `None` when uncoded.
+    #[must_use]
+    pub fn code(&self) -> Option<ServerErrorCode> {
+        self.code
+    }
+
+    /// The human-readable message, for display.
+    #[must_use]
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+impl core::fmt::Display for ServerError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl core::ops::Deref for ServerError {
+    type Target = str;
+    fn deref(&self) -> &str {
+        &self.message
+    }
+}
+
+impl PartialEq<&str> for ServerError {
+    fn eq(&self, other: &&str) -> bool {
+        self.message == *other
+    }
+}
+
+impl PartialEq<str> for ServerError {
+    fn eq(&self, other: &str) -> bool {
+        self.message == other
+    }
+}
+
+impl PartialEq<String> for ServerError {
+    fn eq(&self, other: &String) -> bool {
+        &self.message == other
+    }
+}
+
+impl From<String> for ServerError {
+    fn from(message: String) -> ServerError {
+        ServerError::uncoded(message)
+    }
+}
+
+impl From<&str> for ServerError {
+    fn from(message: &str) -> ServerError {
+        ServerError::uncoded(message.to_string())
     }
 }
 
@@ -483,7 +588,7 @@ pub enum ProgressOutcome {
 enum PubReply {
     Acked(u64),
     Duplicate(u64),
-    ServerErr(String),
+    ServerErr(ServerError),
     Pong,
     /// A cluster `NotLeader` redirect (#735): the produce landed on a non-leader replica of the
     /// partition and was NOT appended/acked; the leader's CLIENT-address hint (or `None` when unknown).
@@ -530,7 +635,7 @@ struct StreamFlow {
     duplicates: u64,
     server_errors: u64,
     last_offset: Option<u64>,
-    first_server_err: Option<String>,
+    first_server_err: Option<ServerError>,
     /// The reader hit a fatal error and exited; the writer must stop waiting on it.
     reader_dead: bool,
 }
@@ -583,10 +688,10 @@ fn drain_stream_replies(
                 f.done += 1;
                 f.server_errors += 1;
                 if f.first_server_err.is_none() {
-                    f.first_server_err = Some(match hint {
+                    f.first_server_err = Some(ServerError::uncoded(match hint {
                         Some(addr) => format!("not leader: produce to the leader at {addr}"),
                         None => "not leader: the current leader is unknown".to_string(),
-                    });
+                    }));
                 }
             }
             // The terminal marker: the server's FIFO frame order guarantees every prior
@@ -750,7 +855,7 @@ fn classify_pub_reply(ty: FrameType, body: &[u8]) -> Result<PubReply, ClientErro
             })?;
             Ok(PubReply::Duplicate(ack.offset))
         }
-        FrameType::Err => Ok(PubReply::ServerErr(String::from_utf8_lossy(body).into())),
+        FrameType::Err => Ok(PubReply::ServerErr(ServerError::from_wire(body))),
         FrameType::Pong => Ok(PubReply::Pong),
         // A cluster NotLeader redirect (#735): decode the leader hint (an empty hint -> `None`). The
         // produce was NOT appended/acked here; the caller reconnects/retries to the leader.
@@ -824,9 +929,11 @@ pub struct StreamSummary {
     pub duplicates: u64,
     /// Produces the server rejected with an `Err` reply (each consumed its FIFO slot).
     pub server_errors: u64,
-    /// The first server `Err` body, kept verbatim so a caller can distinguish a benign shed
-    /// (`at capacity` under `drop-new`) from a real rejection.
-    pub first_server_error: Option<String>,
+    /// The first server rejection, carrying the stable [`ServerErrorCode`] (#883) so a caller can
+    /// distinguish a benign shed (`Some(ServerErrorCode::AtCapacity)` under `drop-new`) from a real
+    /// rejection by branching on [`ServerError::code`] rather than substring-matching the message. The
+    /// human message is still available (the type dereferences to it) for display.
+    pub first_server_error: Option<ServerError>,
     /// The offset carried by the last ack observed, if any message was acked.
     pub last_offset: Option<u64>,
 }
@@ -1048,9 +1155,7 @@ impl Client {
                 client.streams_enabled = info.streams;
                 Ok(client)
             }
-            (FrameType::Err, body) => {
-                Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
-            }
+            (FrameType::Err, body) => Err(ClientError::Server(ServerError::from_wire(&body))),
             (other, _) => Err(ClientError::Unexpected(other)),
         }
     }
@@ -1267,9 +1372,7 @@ impl Client {
                     duplicate: true,
                 })
             }
-            (FrameType::Err, body) => {
-                Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
-            }
+            (FrameType::Err, body) => Err(ClientError::Server(ServerError::from_wire(&body))),
             // A cluster NotLeader redirect (#735): this node is not the leader, so the produce did NOT
             // land here. Surface the typed `NotLeader` error (with the leader hint) so the caller can
             // reconnect/retry to the leader; the connection stays usable. `produce_to_leader` automates it.
@@ -1446,7 +1549,7 @@ impl Client {
                     // An Err for a Ping is not expected; surface it. Any other frame (e.g. a stray
                     // Deliver on a mixed producer/consumer connection) is not what this wait is for.
                     Some((FrameType::Err, body)) => {
-                        return Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
+                        return Err(ClientError::Server(ServerError::from_wire(&body)))
                     }
                     Some((other, _)) => return Err(ClientError::Unexpected(other)),
                 }
@@ -2001,9 +2104,9 @@ impl Client {
                     // returning to keep the connection framed for reuse, exactly as FlowEnd and the
                     // old `read_frame` (drain-then-return) did. Materialize the owned message first
                     // since `body` borrows `self.buf`, which the drain then mutates.
-                    let msg = String::from_utf8_lossy(body).into_owned();
+                    let err = ServerError::from_wire(body);
                     self.buf.drain(..consumed);
-                    return Err(ClientError::Server(msg));
+                    return Err(ClientError::Server(err));
                 }
                 other => return Err(ClientError::Unexpected(other)),
             }
@@ -2184,9 +2287,7 @@ impl Client {
         self.send(FrameType::StreamCommit, &body)?;
         match self.read_frame()? {
             (FrameType::Ok, _) => Ok(()),
-            (FrameType::Err, body) => {
-                Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
-            }
+            (FrameType::Err, body) => Err(ClientError::Server(ServerError::from_wire(&body))),
             (other, _) => Err(ClientError::Unexpected(other)),
         }
     }
@@ -2270,9 +2371,7 @@ impl Client {
                     "ack reply was not a one-byte status",
                 )),
             },
-            (FrameType::Err, body) => {
-                Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
-            }
+            (FrameType::Err, body) => Err(ClientError::Server(ServerError::from_wire(&body))),
             (other, _) => Err(ClientError::Unexpected(other)),
         }
     }
@@ -2337,8 +2436,7 @@ impl Client {
                 },
                 (FrameType::Err, body) => {
                     if first_err.is_none() {
-                        first_err =
-                            Some(ClientError::Server(String::from_utf8_lossy(&body).into()));
+                        first_err = Some(ClientError::Server(ServerError::from_wire(&body)));
                     }
                 }
                 (other, _) => return Err(ClientError::Unexpected(other)),
@@ -2383,9 +2481,7 @@ impl Client {
                     "nack reply was not a one-byte status",
                 )),
             },
-            (FrameType::Err, body) => {
-                Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
-            }
+            (FrameType::Err, body) => Err(ClientError::Server(ServerError::from_wire(&body))),
             (other, _) => Err(ClientError::Unexpected(other)),
         }
     }
@@ -2415,9 +2511,7 @@ impl Client {
                     "term reply was not a one-byte status",
                 )),
             },
-            (FrameType::Err, body) => {
-                Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
-            }
+            (FrameType::Err, body) => Err(ClientError::Server(ServerError::from_wire(&body))),
             (other, _) => Err(ClientError::Unexpected(other)),
         }
     }
@@ -2452,9 +2546,7 @@ impl Client {
                     "progress reply was not a known one-byte status",
                 )),
             },
-            (FrameType::Err, body) => {
-                Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
-            }
+            (FrameType::Err, body) => Err(ClientError::Server(ServerError::from_wire(&body))),
             (other, _) => Err(ClientError::Unexpected(other)),
         }
     }
@@ -2467,9 +2559,7 @@ impl Client {
         self.send(FrameType::Ping, &[])?;
         match self.read_frame()? {
             (FrameType::Pong, _) => Ok(()),
-            (FrameType::Err, body) => {
-                Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
-            }
+            (FrameType::Err, body) => Err(ClientError::Server(ServerError::from_wire(&body))),
             (other, _) => Err(ClientError::Unexpected(other)),
         }
     }
@@ -2498,9 +2588,7 @@ impl Client {
         self.send(FrameType::Sub, &body)?;
         match self.read_frame()? {
             (FrameType::Ok, _) => Ok(()),
-            (FrameType::Err, body) => {
-                Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
-            }
+            (FrameType::Err, body) => Err(ClientError::Server(ServerError::from_wire(&body))),
             (other, _) => Err(ClientError::Unexpected(other)),
         }
     }
@@ -2514,9 +2602,7 @@ impl Client {
         self.send(FrameType::Unsub, &[])?;
         match self.read_frame()? {
             (FrameType::Ok, _) => Ok(()),
-            (FrameType::Err, body) => {
-                Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
-            }
+            (FrameType::Err, body) => Err(ClientError::Server(ServerError::from_wire(&body))),
             (other, _) => Err(ClientError::Unexpected(other)),
         }
     }
@@ -2543,9 +2629,7 @@ impl Client {
         self.send(FrameType::CumulativeAck, &body)?;
         match self.read_frame()? {
             (FrameType::Ok, _) => Ok(()),
-            (FrameType::Err, body) => {
-                Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
-            }
+            (FrameType::Err, body) => Err(ClientError::Server(ServerError::from_wire(&body))),
             (other, _) => Err(ClientError::Unexpected(other)),
         }
     }
@@ -2573,9 +2657,7 @@ impl Client {
         self.send(FrameType::StreamDeclare, &body)?;
         match self.read_frame()? {
             (FrameType::Ok, _) => Ok(()),
-            (FrameType::Err, body) => {
-                Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
-            }
+            (FrameType::Err, body) => Err(ClientError::Server(ServerError::from_wire(&body))),
             (other, _) => Err(ClientError::Unexpected(other)),
         }
     }
@@ -2606,9 +2688,7 @@ impl Client {
                     .map_err(|_| ClientError::BadResponse("malformed stream-info response"))?;
                 Ok((resp.exists, resp.head))
             }
-            (FrameType::Err, body) => {
-                Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
-            }
+            (FrameType::Err, body) => Err(ClientError::Server(ServerError::from_wire(&body))),
             (other, _) => Err(ClientError::Unexpected(other)),
         }
     }
@@ -2652,9 +2732,7 @@ impl Client {
                     .map_err(|_| ClientError::BadResponse("publish-to reply was not an offset"))?;
                 Ok(ack.offset)
             }
-            (FrameType::Err, body) => {
-                Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
-            }
+            (FrameType::Err, body) => Err(ClientError::Server(ServerError::from_wire(&body))),
             (other, _) => Err(ClientError::Unexpected(other)),
         }
     }
@@ -2713,9 +2791,7 @@ impl Client {
         self.send(FrameType::TxnPrepare, &body)?;
         match self.read_frame()? {
             (FrameType::Ok, _) => Ok(()),
-            (FrameType::Err, body) => {
-                Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
-            }
+            (FrameType::Err, body) => Err(ClientError::Server(ServerError::from_wire(&body))),
             (other, _) => Err(ClientError::Unexpected(other)),
         }
     }
@@ -2746,9 +2822,7 @@ impl Client {
                     .map_err(|_| ClientError::BadResponse("txn-commit reply was not an offset"))?;
                 Ok(ack.offset)
             }
-            (FrameType::Err, body) => {
-                Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
-            }
+            (FrameType::Err, body) => Err(ClientError::Server(ServerError::from_wire(&body))),
             (other, _) => Err(ClientError::Unexpected(other)),
         }
     }
@@ -2773,9 +2847,7 @@ impl Client {
         self.send(FrameType::TxnRollback, &body)?;
         match self.read_frame()? {
             (FrameType::Ok, _) => Ok(()),
-            (FrameType::Err, body) => {
-                Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
-            }
+            (FrameType::Err, body) => Err(ClientError::Server(ServerError::from_wire(&body))),
             (other, _) => Err(ClientError::Unexpected(other)),
         }
     }
@@ -2824,9 +2896,7 @@ impl Client {
         self.send(FrameType::TxnListen, &body)?;
         match self.read_frame()? {
             (FrameType::Ok, _) => Ok(()),
-            (FrameType::Err, body) => {
-                Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
-            }
+            (FrameType::Err, body) => Err(ClientError::Server(ServerError::from_wire(&body))),
             (other, _) => Err(ClientError::Unexpected(other)),
         }
     }
@@ -2892,7 +2962,7 @@ impl Client {
                     // accompanies it in the same flush).
                     None | Some((FrameType::Pong, _)) => break,
                     Some((FrameType::Err, body)) => {
-                        return Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
+                        return Err(ClientError::Server(ServerError::from_wire(&body)))
                     }
                     // A stray frame (e.g. an Ok reply to a TxnCheckResult, or another frame on a mixed
                     // connection) is not what this loop is for: ignore it and keep draining the round.
@@ -2971,9 +3041,7 @@ impl Client {
         self.send(FrameType::SubTo, &body)?;
         match self.read_frame()? {
             (FrameType::Ok, _) => Ok(()),
-            (FrameType::Err, body) => {
-                Err(ClientError::Server(String::from_utf8_lossy(&body).into()))
-            }
+            (FrameType::Err, body) => Err(ClientError::Server(ServerError::from_wire(&body))),
             (other, _) => Err(ClientError::Unexpected(other)),
         }
     }

--- a/crates/ironbus-proto/src/err.rs
+++ b/crates/ironbus-proto/src/err.rs
@@ -1,0 +1,295 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! The wire `Err` frame body codec (#883): an OPTIONAL stable machine-readable code token in front
+//! of the existing free-form human message, so a client can branch on a code instead of substring-
+//! matching prose the broker is free to reword.
+//!
+//! # Backward-compatible layout
+//! The historical `Err` body was the raw UTF-8 message with no structure. To stay byte-identical for
+//! every UNCODED reply (the malformed-body literals, the uniform auth violation, and any error the
+//! server chooses not to tag), a coded body is marked by a single leading `NUL` (`0x00`) sentinel.
+//! A lone `0x00` is valid UTF-8 in general, but every uncoded `Err` message the server emits is
+//! printable human text that never begins with `NUL`, so a leading `0x00` unambiguously flags a
+//! coded body:
+//!
+//! - UNCODED: `[ message bytes … ]` (unchanged: byte-for-byte the pre-#883 body).
+//! - CODED:   `[ 0x00 ][ code_len: u8 ][ code_token: code_len bytes ][ message bytes … ]`.
+//!
+//! A decoder that sees a leading `0x00` reads the fixed code field, then the message follows exactly
+//! as before; a body that does NOT start with `0x00` is the raw message with NO code. The code token
+//! is one of the frozen `ErrorCode` spellings (`ironbus-server`'s `codes` module), so the client maps
+//! it to a typed [`ServerErrorCode`] and keeps the human string for display only.
+
+use std::borrow::Cow;
+
+/// The sentinel that marks a CODED `Err` body. No uncoded `Err` message the server emits begins with
+/// `NUL` (a lone `0x00` is valid UTF-8, but the server's human messages are all printable text), so a
+/// leading `0x00` unambiguously distinguishes a coded body from the historical raw-message body.
+const CODED_SENTINEL: u8 = 0x00;
+
+/// A stable, machine-readable server rejection code (#883, #35): the typed twin of the free-form `Err`
+/// message a client can branch on (retry-vs-fail, backpressure-vs-permanent-reject) instead of parsing
+/// prose. Each variant mirrors one frozen `ErrorCode` token the server places on the wire; an
+/// unrecognized token (a newer server code this client build predates) decodes as ABSENT (`None`) with
+/// the human message still intact, so a forward-incompatible code never masquerades as a wrong one.
+///
+/// The enum is `#[non_exhaustive]`: a future server code adds a variant without breaking a client that
+/// matches with a wildcard arm.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum ServerErrorCode {
+    /// `ERR_AT_CAPACITY`: the durable log is at its byte cap (the drop-new shed) — a benign,
+    /// retryable backpressure signal, NOT a permanent reject.
+    AtCapacity,
+    /// `ERR_STORAGE`: a generic storage fault.
+    Storage,
+    /// `ERR_PRODUCER_FENCED`: a produce presented a stale producer epoch (a zombie session).
+    ProducerFenced,
+    /// `ERR_OUT_OF_ORDER_SEQUENCE`: a sequenced idempotent produce skipped past the next sequence.
+    OutOfOrderSequence,
+    /// `ERR_CUMULATIVE_ACK_NOT_ALLOWED`: a cumulative ack on a competing / non-broadcast work-group.
+    CumulativeAckNotAllowed,
+    /// `ERR_CUMULATIVE_ACK_OUT_OF_RANGE`: a broadcast cumulative ack outside the retained window.
+    CumulativeAckOutOfRange,
+    /// `ERR_BROADCAST_GROUP_BUSY`: a second subscriber (or an unsafe flip) broke group-of-one.
+    BroadcastGroupBusy,
+    /// `ERR_BROADCAST_GROUP_NOT_NAMED`: a flip to broadcast named the default/empty group.
+    BroadcastGroupNotNamed,
+    /// `ERR_TOO_MANY_GROUPS`: a new named work-group exceeded the per-engine group cap.
+    TooManyGroups,
+    /// `ERR_TOO_MANY_STREAMS`: a new named stream exceeded the per-engine resident-stream cap.
+    TooManyStreams,
+    /// `ERR_INVALID_GROUP_NAME`: a work-group name was empty, too long, or non-graphic ASCII.
+    InvalidGroupName,
+    /// `ERR_INVALID_STREAM_NAME`: a named stream name was empty, too long, or non-graphic ASCII.
+    InvalidStreamName,
+    /// `ERR_UNKNOWN_STREAM`: a verb targeted a named stream that was never declared.
+    UnknownStream,
+    /// `ERR_MIRROR_READ_ONLY`: a client produce targeted a read-only cross-cluster mirror stream.
+    MirrorReadOnly,
+    /// `ERR_INVALID_SUBJECT`: a subject or bind pattern was not valid grammar.
+    InvalidSubject,
+    /// `ERR_BIND_REJECTED`: a bind would exceed the routing trie's fork bound.
+    BindRejected,
+    /// `ERR_NO_STREAM_FOR_SUBJECT`: a subject-addressed publish resolved to no bound stream.
+    NoStreamForSubject,
+    /// `ERR_AMBIGUOUS_SUBJECT`: a subject-addressed publish resolved to two-or-more bound streams.
+    AmbiguousSubject,
+    /// `ERR_GENERATION_EXHAUSTED`: the lease generation space is exhausted (unreachable in practice).
+    GenerationExhausted,
+    /// `ERR_MISSING_RECORD`: an internal invariant broke (a deliverable offset had no record).
+    MissingRecord,
+    /// `ERR_ZERO_MAX_IN_FLIGHT`: `max_in_flight` was zero, rejected at open.
+    ZeroMaxInFlight,
+    /// `ERR_TXN`: a transactional half-message verb was rejected by the lifecycle.
+    Txn,
+    /// `ERR_TXN_CHECK_UNAUTHORIZED`: a back-check answer was refused on ownership.
+    TxnCheckUnauthorized,
+}
+
+impl ServerErrorCode {
+    /// Maps a frozen `ErrorCode` token spelling to its typed code, or `None` for a token this build
+    /// does not recognize (a newer server code). The spellings are the NORMATIVE `ironbus-server`
+    /// `codes` constants; a drift is caught by the cross-crate test in that crate.
+    #[must_use]
+    pub fn from_token(token: &str) -> Option<Self> {
+        let code = match token {
+            "ERR_AT_CAPACITY" => Self::AtCapacity,
+            "ERR_STORAGE" => Self::Storage,
+            "ERR_PRODUCER_FENCED" => Self::ProducerFenced,
+            "ERR_OUT_OF_ORDER_SEQUENCE" => Self::OutOfOrderSequence,
+            "ERR_CUMULATIVE_ACK_NOT_ALLOWED" => Self::CumulativeAckNotAllowed,
+            "ERR_CUMULATIVE_ACK_OUT_OF_RANGE" => Self::CumulativeAckOutOfRange,
+            "ERR_BROADCAST_GROUP_BUSY" => Self::BroadcastGroupBusy,
+            "ERR_BROADCAST_GROUP_NOT_NAMED" => Self::BroadcastGroupNotNamed,
+            "ERR_TOO_MANY_GROUPS" => Self::TooManyGroups,
+            "ERR_TOO_MANY_STREAMS" => Self::TooManyStreams,
+            "ERR_INVALID_GROUP_NAME" => Self::InvalidGroupName,
+            "ERR_INVALID_STREAM_NAME" => Self::InvalidStreamName,
+            "ERR_UNKNOWN_STREAM" => Self::UnknownStream,
+            "ERR_MIRROR_READ_ONLY" => Self::MirrorReadOnly,
+            "ERR_INVALID_SUBJECT" => Self::InvalidSubject,
+            "ERR_BIND_REJECTED" => Self::BindRejected,
+            "ERR_NO_STREAM_FOR_SUBJECT" => Self::NoStreamForSubject,
+            "ERR_AMBIGUOUS_SUBJECT" => Self::AmbiguousSubject,
+            "ERR_GENERATION_EXHAUSTED" => Self::GenerationExhausted,
+            "ERR_MISSING_RECORD" => Self::MissingRecord,
+            "ERR_ZERO_MAX_IN_FLIGHT" => Self::ZeroMaxInFlight,
+            "ERR_TXN" => Self::Txn,
+            "ERR_TXN_CHECK_UNAUTHORIZED" => Self::TxnCheckUnauthorized,
+            _ => return None,
+        };
+        Some(code)
+    }
+
+    /// The frozen token spelling this code encodes to on the wire (the inverse of [`Self::from_token`]).
+    #[must_use]
+    pub fn as_token(self) -> &'static str {
+        match self {
+            Self::AtCapacity => "ERR_AT_CAPACITY",
+            Self::Storage => "ERR_STORAGE",
+            Self::ProducerFenced => "ERR_PRODUCER_FENCED",
+            Self::OutOfOrderSequence => "ERR_OUT_OF_ORDER_SEQUENCE",
+            Self::CumulativeAckNotAllowed => "ERR_CUMULATIVE_ACK_NOT_ALLOWED",
+            Self::CumulativeAckOutOfRange => "ERR_CUMULATIVE_ACK_OUT_OF_RANGE",
+            Self::BroadcastGroupBusy => "ERR_BROADCAST_GROUP_BUSY",
+            Self::BroadcastGroupNotNamed => "ERR_BROADCAST_GROUP_NOT_NAMED",
+            Self::TooManyGroups => "ERR_TOO_MANY_GROUPS",
+            Self::TooManyStreams => "ERR_TOO_MANY_STREAMS",
+            Self::InvalidGroupName => "ERR_INVALID_GROUP_NAME",
+            Self::InvalidStreamName => "ERR_INVALID_STREAM_NAME",
+            Self::UnknownStream => "ERR_UNKNOWN_STREAM",
+            Self::MirrorReadOnly => "ERR_MIRROR_READ_ONLY",
+            Self::InvalidSubject => "ERR_INVALID_SUBJECT",
+            Self::BindRejected => "ERR_BIND_REJECTED",
+            Self::NoStreamForSubject => "ERR_NO_STREAM_FOR_SUBJECT",
+            Self::AmbiguousSubject => "ERR_AMBIGUOUS_SUBJECT",
+            Self::GenerationExhausted => "ERR_GENERATION_EXHAUSTED",
+            Self::MissingRecord => "ERR_MISSING_RECORD",
+            Self::ZeroMaxInFlight => "ERR_ZERO_MAX_IN_FLIGHT",
+            Self::Txn => "ERR_TXN",
+            Self::TxnCheckUnauthorized => "ERR_TXN_CHECK_UNAUTHORIZED",
+        }
+    }
+}
+
+/// The decoded parts of an `Err` frame body: the optional typed code and the human message.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DecodedErr<'a> {
+    /// The typed rejection code the server tagged, or `None` for an uncoded (legacy-shape) body or a
+    /// code token this build does not recognize.
+    pub code: Option<ServerErrorCode>,
+    /// The free-form human-readable message, for display.
+    pub message: Cow<'a, str>,
+}
+
+/// Encodes an `Err` frame body: an optional frozen code `token` in front of the human `message`.
+///
+/// `token` is the NORMATIVE `ErrorCode` spelling (e.g. `"ERR_AT_CAPACITY"`). `None` writes the raw
+/// message with NO code, byte-identical to the pre-#883 body. A token longer than 255 bytes (never
+/// true of the frozen tokens) is written UNCODED as a defensive fallback so encode is infallible.
+pub fn encode_err_body(token: Option<&str>, message: &str, out: &mut Vec<u8>) {
+    match token.and_then(|tok| {
+        (!tok.is_empty())
+            .then_some(tok)
+            .zip(u8::try_from(tok.len()).ok())
+    }) {
+        Some((tok, code_len)) => {
+            out.push(CODED_SENTINEL);
+            out.push(code_len);
+            out.extend_from_slice(tok.as_bytes());
+            out.extend_from_slice(message.as_bytes());
+        }
+        None => out.extend_from_slice(message.as_bytes()),
+    }
+}
+
+/// Decodes an `Err` frame body written by [`encode_err_body`]. A body that does NOT begin with the
+/// coded sentinel is the historical raw message with no code; a malformed coded body (a truncated code
+/// field) falls back to treating the whole body as the message, so decode never errors.
+#[must_use]
+pub fn decode_err_body(body: &[u8]) -> DecodedErr<'_> {
+    if let Some((&CODED_SENTINEL, rest)) = body.split_first() {
+        if let Some((&code_len, after_len)) = rest.split_first() {
+            let code_len = usize::from(code_len);
+            if code_len <= after_len.len() {
+                let (token_bytes, message_bytes) = after_len.split_at(code_len);
+                let code = std::str::from_utf8(token_bytes)
+                    .ok()
+                    .and_then(ServerErrorCode::from_token);
+                return DecodedErr {
+                    code,
+                    message: String::from_utf8_lossy(message_bytes),
+                };
+            }
+        }
+    }
+    DecodedErr {
+        code: None,
+        message: String::from_utf8_lossy(body),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn uncoded_body_is_byte_identical_to_the_raw_message() {
+        // The pre-#883 shape: the raw UTF-8 message, no structure. Every UNCODED reply MUST stay
+        // byte-for-byte identical so existing consumers (and the auth-violation exact bytes) are
+        // untouched.
+        let mut out = Vec::new();
+        encode_err_body(None, "not connected", &mut out);
+        assert_eq!(out, b"not connected");
+    }
+
+    #[test]
+    fn coded_round_trips_the_code_and_keeps_the_message() {
+        let mut out = Vec::new();
+        encode_err_body(Some("ERR_AT_CAPACITY"), "at capacity", &mut out);
+        // The sentinel guards the coded shape; the human message still trails so a `.contains` reader
+        // on the whole body finds it.
+        assert_eq!(out[0], CODED_SENTINEL);
+        assert!(String::from_utf8_lossy(&out).contains("at capacity"));
+        let decoded = decode_err_body(&out);
+        assert_eq!(decoded.code, Some(ServerErrorCode::AtCapacity));
+        assert_eq!(decoded.message, "at capacity");
+    }
+
+    #[test]
+    fn a_raw_message_decodes_as_uncoded() {
+        let decoded = decode_err_body(b"malformed pub body");
+        assert_eq!(decoded.code, None);
+        assert_eq!(decoded.message, "malformed pub body");
+    }
+
+    #[test]
+    fn an_unrecognized_token_decodes_as_absent_but_keeps_the_message() {
+        // A newer server code this build predates: the typed code is ABSENT (never a wrong one) but the
+        // human message survives.
+        let mut out = Vec::new();
+        encode_err_body(Some("ERR_FROM_THE_FUTURE"), "some new reject", &mut out);
+        let decoded = decode_err_body(&out);
+        assert_eq!(decoded.code, None);
+        assert_eq!(decoded.message, "some new reject");
+    }
+
+    #[test]
+    fn a_truncated_coded_body_falls_back_to_the_whole_body_as_message() {
+        // A coded sentinel with a code_len that overruns the body: decode must not panic and must not
+        // invent a code.
+        let decoded = decode_err_body(&[CODED_SENTINEL, 40, b'x']);
+        assert_eq!(decoded.code, None);
+    }
+
+    #[test]
+    fn every_variant_round_trips_through_its_token() {
+        for code in [
+            ServerErrorCode::AtCapacity,
+            ServerErrorCode::Storage,
+            ServerErrorCode::ProducerFenced,
+            ServerErrorCode::OutOfOrderSequence,
+            ServerErrorCode::CumulativeAckNotAllowed,
+            ServerErrorCode::CumulativeAckOutOfRange,
+            ServerErrorCode::BroadcastGroupBusy,
+            ServerErrorCode::BroadcastGroupNotNamed,
+            ServerErrorCode::TooManyGroups,
+            ServerErrorCode::TooManyStreams,
+            ServerErrorCode::InvalidGroupName,
+            ServerErrorCode::InvalidStreamName,
+            ServerErrorCode::UnknownStream,
+            ServerErrorCode::MirrorReadOnly,
+            ServerErrorCode::InvalidSubject,
+            ServerErrorCode::BindRejected,
+            ServerErrorCode::NoStreamForSubject,
+            ServerErrorCode::AmbiguousSubject,
+            ServerErrorCode::GenerationExhausted,
+            ServerErrorCode::MissingRecord,
+            ServerErrorCode::ZeroMaxInFlight,
+            ServerErrorCode::Txn,
+            ServerErrorCode::TxnCheckUnauthorized,
+        ] {
+            assert_eq!(ServerErrorCode::from_token(code.as_token()), Some(code));
+        }
+    }
+}

--- a/crates/ironbus-proto/src/lib.rs
+++ b/crates/ironbus-proto/src/lib.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 //! Wire protocol frames and codecs for IronBus.
 
+pub mod err;
 pub mod frame;
 pub mod message;

--- a/crates/ironbus-server/src/codes.rs
+++ b/crates/ironbus-server/src/codes.rs
@@ -239,6 +239,49 @@ mod tests {
     use ironbus_storage::segment::StorageError;
 
     #[test]
+    // #883: the wire `Err` frame now carries the frozen `ErrorCode` token, which the client decodes to
+    // a typed `ironbus_proto::err::ServerErrorCode`. The token spellings are duplicated in the proto
+    // crate's `from_token` map (the client cannot depend on this crate); this test PINS the two together
+    // so a rename here that the proto map misses fails CI. Every code the server places on an `Err`
+    // frame — the `EngineError` rejections plus the `AppendOutcome` signals (`ERR_AT_CAPACITY`,
+    // `ERR_PRODUCER_FENCED`, `ERR_OUT_OF_ORDER_SEQUENCE`) — must round-trip through the proto enum.
+    fn every_wire_code_is_recognized_by_the_proto_decoder() {
+        use ironbus_proto::err::ServerErrorCode;
+        let wire_codes = [
+            ErrorCode::ERR_CUMULATIVE_ACK_NOT_ALLOWED,
+            ErrorCode::ERR_CUMULATIVE_ACK_OUT_OF_RANGE,
+            ErrorCode::ERR_BROADCAST_GROUP_BUSY,
+            ErrorCode::ERR_BROADCAST_GROUP_NOT_NAMED,
+            ErrorCode::ERR_TOO_MANY_GROUPS,
+            ErrorCode::ERR_TOO_MANY_STREAMS,
+            ErrorCode::ERR_INVALID_GROUP_NAME,
+            ErrorCode::ERR_INVALID_STREAM_NAME,
+            ErrorCode::ERR_UNKNOWN_STREAM,
+            ErrorCode::ERR_MIRROR_READ_ONLY,
+            ErrorCode::ERR_INVALID_SUBJECT,
+            ErrorCode::ERR_BIND_REJECTED,
+            ErrorCode::ERR_NO_STREAM_FOR_SUBJECT,
+            ErrorCode::ERR_AMBIGUOUS_SUBJECT,
+            ErrorCode::ERR_GENERATION_EXHAUSTED,
+            ErrorCode::ERR_MISSING_RECORD,
+            ErrorCode::ERR_ZERO_MAX_IN_FLIGHT,
+            ErrorCode::ERR_STORAGE,
+            ErrorCode::ERR_TXN,
+            ErrorCode::ERR_TXN_CHECK_UNAUTHORIZED,
+            ErrorCode::ERR_AT_CAPACITY,
+            ErrorCode::ERR_PRODUCER_FENCED,
+            ErrorCode::ERR_OUT_OF_ORDER_SEQUENCE,
+        ];
+        for code in wire_codes {
+            assert!(
+                ServerErrorCode::from_token(code.as_str()).is_some(),
+                "the proto decoder does not recognize the wire code `{}`",
+                code.as_str()
+            );
+        }
+    }
+
+    #[test]
     fn the_named_codes_have_their_frozen_spelling() {
         // The vectors and external clients pin these exact strings: a rename must fail here.
         assert_eq!(

--- a/crates/ironbus-server/src/session.rs
+++ b/crates/ironbus-server/src/session.rs
@@ -1716,7 +1716,7 @@ impl Session {
             // recoverable rejections: surface the engine's typed reason so the client learns why and
             // the connection stays open.
             Err(e) => {
-                reply_err(out, &e.to_string());
+                reply_err_coded(out, e.code().as_str(), &e.to_string());
                 Ok(())
             }
         }
@@ -2587,7 +2587,7 @@ impl Session {
             // recoverable rejections: surface the engine's typed reason and keep the connection open. Do
             // NOT also send a FlowEnd (the Err is the terminator), matching the Fetch error path.
             Err(e) => {
-                reply_err(out, &e.to_string());
+                reply_err_coded(out, e.code().as_str(), &e.to_string());
                 Ok(None)
             }
         }
@@ -2677,7 +2677,7 @@ impl Session {
                 Err(SessionError::EngineFatal(e))
             }
             Err(e) => {
-                reply_err(out, &e.to_string());
+                reply_err_coded(out, e.code().as_str(), &e.to_string());
                 Ok(None)
             }
         }
@@ -2732,7 +2732,7 @@ impl Session {
             // The wrong-mode reject and the out-of-range reject are client-visible, recoverable
             // rejections: surface the engine's typed reason and keep the connection open.
             Err(e) => {
-                reply_err(out, &e.to_string());
+                reply_err_coded(out, e.code().as_str(), &e.to_string());
                 Ok(())
             }
         }
@@ -2843,7 +2843,7 @@ impl Session {
                 // `subscribe_in` only ever returns this rejection (name/cap are still validated on
                 // the first FLOW, as before), so SUB stays infallible for the name/cap checks.
                 Err(e) => {
-                    reply_err(out, &e.to_string());
+                    reply_err_coded(out, e.code().as_str(), &e.to_string());
                     return Ok(());
                 }
             }
@@ -2964,7 +2964,7 @@ impl Session {
             // Idempotent: a first declare (`true`) and a re-declare (`false`) both reply a body-less Ok.
             Ok(_) => reply(out, FrameType::Ok, &[]),
             // A malformed/over-long NAMED name fails closed with the engine's typed reason.
-            Err(e) => reply_err(out, &e.to_string()),
+            Err(e) => reply_err_coded(out, e.code().as_str(), &e.to_string()),
         }
         Ok(())
     }
@@ -3182,7 +3182,7 @@ impl Session {
             // A malformed name or a non-fatal storage error (e.g. a byte-cap shed) is a typed,
             // connection-preserving reject, never a panic.
             Err(e) => {
-                reply_err(out, &e.to_string());
+                reply_err_coded(out, e.code().as_str(), &e.to_string());
                 Ok(())
             }
         }
@@ -3270,7 +3270,7 @@ impl Session {
                 Err(SessionError::EngineFatal(e))
             }
             Err(e) => {
-                reply_err(out, &e.to_string());
+                reply_err_coded(out, e.code().as_str(), &e.to_string());
                 Ok(())
             }
         }
@@ -3322,7 +3322,7 @@ impl Session {
                 Err(SessionError::EngineFatal(e))
             }
             Err(e) => {
-                reply_err(out, &e.to_string());
+                reply_err_coded(out, e.code().as_str(), &e.to_string());
                 Ok(())
             }
         }
@@ -3367,7 +3367,7 @@ impl Session {
                 Err(SessionError::EngineFatal(e))
             }
             Err(e) => {
-                reply_err(out, &e.to_string());
+                reply_err_coded(out, e.code().as_str(), &e.to_string());
                 Ok(())
             }
         }
@@ -3472,7 +3472,7 @@ impl Session {
                 // A conflicting flip (a Commit after the terminal default already rolled it back, or a
                 // racing producer-driven resolve) is refused by the part-1 path — surfaced as an Err, not
                 // a flip. The producer's listener treats this as "already settled", which is correct.
-                reply_err(out, &e.to_string());
+                reply_err_coded(out, e.code().as_str(), &e.to_string());
                 Ok(())
             }
         }
@@ -3595,7 +3595,7 @@ impl Session {
             Ok(_generation) => reply(out, FrameType::Ok, &[]),
             // A malformed pattern/name or a fork-bound rejection fails closed with the engine's typed
             // reason (and stable code); the previous binding table stays installed on a rejection.
-            Err(e) => reply_err(out, &e.to_string()),
+            Err(e) => reply_err_coded(out, e.code().as_str(), &e.to_string()),
         }
         Ok(())
     }
@@ -3746,7 +3746,7 @@ impl Session {
             // subject, or a non-fatal storage shed is a typed, connection-preserving reject — never a
             // panic and (critically) NEVER a silent drop.
             Err(e) => {
-                reply_err(out, &e.to_string());
+                reply_err_coded(out, e.code().as_str(), &e.to_string());
                 Ok(())
             }
         }
@@ -3814,7 +3814,7 @@ impl Session {
         let stream = match resolved {
             Ok(id) => id,
             Err(e) => {
-                reply_err(out, &e.to_string());
+                reply_err_coded(out, e.code().as_str(), &e.to_string());
                 return Ok(());
             }
         };
@@ -4072,6 +4072,19 @@ fn reply(out: &mut Vec<u8>, frame_type: FrameType, body: &[u8]) {
 
 fn reply_err(out: &mut Vec<u8>, message: &str) {
     reply(out, FrameType::Err, message.as_bytes());
+}
+
+/// Writes an `Err` frame that carries the STABLE machine-readable code `token` (#883) in front of the
+/// human `message`, so a client branches on the code rather than substring-matching prose the broker
+/// is free to reword. `token` is the NORMATIVE [`ErrorCode`](crate::codes::ErrorCode) spelling
+/// (e.g. `error.code().as_str()`); the human message is preserved verbatim for display. An UNCODED
+/// [`reply_err`] stays byte-identical to the pre-#883 body (the coded shape is marked by a leading
+/// sentinel a UTF-8 message never begins with), so the uniform auth violation and the malformed-body
+/// literals are untouched.
+fn reply_err_coded(out: &mut Vec<u8>, code_token: &str, message: &str) {
+    let mut body = Vec::with_capacity(2 + code_token.len() + message.len());
+    ironbus_proto::err::encode_err_body(Some(code_token), message, &mut body);
+    reply(out, FrameType::Err, &body);
 }
 
 /// Writes the single UNIFORM "Authorization Violation" `Err` frame (#631, V2-M7,
@@ -4437,7 +4450,11 @@ fn write_pub_reply(
         // connection stays open so the producer can re-handshake with a fresh epoch.
         ProduceOutcome::Fenced => {
             if !fire_and_forget {
-                reply_err(out, "fenced: stale producer epoch");
+                reply_err_coded(
+                    out,
+                    crate::codes::ErrorCode::ERR_PRODUCER_FENCED.as_str(),
+                    "fenced: stale producer epoch",
+                );
             }
             Ok(())
         }
@@ -4447,7 +4464,11 @@ fn write_pub_reply(
         // message; the connection stays open so the producer can resync from the expected sequence.
         ProduceOutcome::OutOfOrder => {
             if !fire_and_forget {
-                reply_err(out, "out-of-order producer sequence");
+                reply_err_coded(
+                    out,
+                    crate::codes::ErrorCode::ERR_OUT_OF_ORDER_SEQUENCE.as_str(),
+                    "out-of-order producer sequence",
+                );
             }
             Ok(())
         }
@@ -4467,7 +4488,11 @@ fn write_pub_reply(
         // retention frees space).
         ProduceOutcome::AtCapacity => {
             if !fire_and_forget {
-                reply_err(out, "at capacity");
+                reply_err_coded(
+                    out,
+                    crate::codes::ErrorCode::ERR_AT_CAPACITY.as_str(),
+                    "at capacity",
+                );
             }
             Ok(())
         }
@@ -8120,7 +8145,15 @@ mod tests {
         // generic "produce failed". The session did NOT end (pub_reply asserts process is Ok).
         let (ty, body) = pub_reply(&mut s, &e, payload);
         assert_eq!(ty, FrameType::Err);
-        assert_eq!(body, b"at capacity");
+        // #883: the shed now carries the STABLE `ERR_AT_CAPACITY` code in front of the human message,
+        // so a client branches on the code instead of substring-matching "at capacity". The message is
+        // preserved verbatim.
+        let decoded = ironbus_proto::err::decode_err_body(&body);
+        assert_eq!(
+            decoded.code,
+            Some(ironbus_proto::err::ServerErrorCode::AtCapacity)
+        );
+        assert_eq!(decoded.message, "at capacity");
         assert_ne!(
             body, b"produce failed",
             "a shed must be distinguishable from a transient failure"
@@ -8134,7 +8167,15 @@ mod tests {
         assert_eq!(one_response(&out).0, FrameType::Pong);
         let (ty, body) = pub_reply(&mut s, &e, payload);
         assert_eq!(ty, FrameType::Err);
-        assert_eq!(body, b"at capacity");
+        // #883: the shed now carries the STABLE `ERR_AT_CAPACITY` code in front of the human message,
+        // so a client branches on the code instead of substring-matching "at capacity". The message is
+        // preserved verbatim.
+        let decoded = ironbus_proto::err::decode_err_body(&body);
+        assert_eq!(
+            decoded.code,
+            Some(ironbus_proto::err::ServerErrorCode::AtCapacity)
+        );
+        assert_eq!(decoded.message, "at capacity");
         // The shed counter reflects both rejections; the one success was counted once.
         assert_eq!(e.engine_mut().counters().produce_rejected, 2);
         assert_eq!(e.engine_mut().counters().produced, 1);


### PR DESCRIPTION
## What (#883)

The `Err` frame carried only free-form text, forcing clients to substring-match for control flow (retryable vs fatal, etc.).

## Fix

The `Err` body now optionally carries the stable `ErrorCode` via a **backward-compatible** encoding: an uncoded body is byte-for-byte the pre-#883 raw message; a coded body is `[0x00][code_len: u8][code_token][message…]`. The leading `NUL` sentinel is safe because every uncoded `Err` message the server emits is printable text that never begins with `NUL`. A decoder that sees a leading `0x00` reads the fixed code field then the human message (unchanged); a body without it is the raw message with no code. The server tags its coded errors (`of_engine_error` → `codes` module), and **both** client crates (`ironbus-client` + the verbatim-port `ironbus-client-async`) decode the token to a typed `ServerErrorCode` while keeping the human string for display.

Uncoded replies (the malformed-body literals, the uniform auth violation) stay byte-identical, so the conformance byte-identity corpus is unaffected. A `.contains`-based reader (all in-repo clients) still matches the trailing message.

## Verification
- fmt + clippy (`-D warnings -W clippy::pedantic`, 4 crates) clean; `cargo test` (964 server incl. conformance_vectors/determinism, 150 proto, client + async) green
- Encode/decode round-trip + malformed-coded-body (truncated code, overrunning `code_len` — no panic) tests; a cross-crate `every_wire_code_is_recognized_by_the_proto_decoder` guard
- Reviewed across 3 adversarial lenses incl. a wire-compat lens — corpus byte-identity preserved, both clients decode, unknown/missing code degrades gracefully

(Milestone is pre-adoption: an old external client doing exact-`==` on the three now-coded literals would need `.contains` — acceptable, no external clients yet. The retryable ISR-Rejected path is left uncoded for lack of a frozen code — a candidate follow-up.)

Closes #883
