### PR TITLE
perf(storage): recover named streams and partitions in parallel across bounded workers (#822)

### DIFF
--- a/crates/ironbus-storage/src/log.rs
+++ b/crates/ironbus-storage/src/log.rs
@@ -877,6 +877,105 @@ struct ReadBounds {
     max_bytes: Option<usize>,
 }
 
+/// The peak number of concurrent [`Log::open`] recoveries a multi-stream / multi-partition boot
+/// runs across (#822): the OUTER, cross-subtree recovery width. Each inner `Log::open` SEPARATELY
+/// bounds its own per-segment scan to [`Log::RECOVERY_SCAN_MAX_WORKERS`] (#817), so the peak live
+/// thread count is at most `RECOVERY_OPEN_MAX_WORKERS * RECOVERY_SCAN_MAX_WORKERS` — a CONSTANT,
+/// INDEPENDENT of the stream/partition/segment counts on disk. So `streams * partitions * segments`
+/// recovery work never explodes into that many threads: both levels are bounded worker sets, never
+/// one-thread-per-item.
+pub(crate) const RECOVERY_OPEN_MAX_WORKERS: usize = 8;
+
+/// Runs `open` for every item across a bounded [`std::thread::scope`] worker set, returning one
+/// result per item in the SAME order as `items` (index-aligned to it), regardless of the order the
+/// workers finished. This is the OUTER, cross-subtree half of recovery (#822): each item is an
+/// independent, byte-isolated stream/partition subtree, so opening them is embarrassingly parallel;
+/// the caller then folds the index-aligned results into its `BTreeMap` / `Vec` in deterministic
+/// key/index order, byte-for-byte identical to the strictly serial open (including WHICH item's
+/// error surfaces first — the caller `?`-propagates in item order).
+///
+/// Mirrors [`Log::par_scan_segments`] (the INNER per-segment pattern): a fixed set of scoped workers
+/// steals items off one shared atomic cursor, so a fast subtree's worker immediately picks up the
+/// next item rather than blocking on a slow one. Helpers are spawned FALLIBLY via
+/// `Builder::spawn_scoped` and the MAIN thread is itself the final participant, so a cold-boot OS
+/// thread exhaustion degrades to fewer helpers (or fully serial) instead of panicking. No external
+/// threadpool (no rayon). The effective width is `min(max_workers, cores, items)`; a single item
+/// (or a single-worker cap) runs inline with no threads spawned — so the common single-log
+/// deployment (one default stream, `count == 1`) opens on the calling thread exactly as before.
+pub(crate) fn par_recover_open<W, T, S>(
+    items: &[W],
+    max_workers: usize,
+    open: S,
+) -> Vec<Result<T, StorageError>>
+where
+    W: Sync,
+    T: Send,
+    S: Fn(&W) -> Result<T, StorageError> + Send + Sync,
+{
+    let total = items.len();
+    let workers = std::thread::available_parallelism()
+        .map_or(1, std::num::NonZeroUsize::get)
+        .min(max_workers)
+        .min(total);
+    if workers <= 1 {
+        // One subtree, one core, or a single-worker cap: run inline, no threads, no cursor.
+        return items.iter().map(&open).collect();
+    }
+    let cursor = std::sync::atomic::AtomicUsize::new(0);
+    // Each participant returns the (index, result) pairs it computed; we reassemble by index so the
+    // returned order is item order no matter who won which item. Helpers are spawned FALLIBLY via
+    // `Builder::spawn_scoped`: if a worker thread cannot be created (OS thread exhaustion on a cold
+    // boot) we simply run with fewer helpers, and the main thread is itself the final participant —
+    // so even if EVERY helper fails to spawn, every index is still opened inline. Recovery therefore
+    // degrades to serial rather than panicking, matching the resilience this boot path demands.
+    let collected: Vec<(usize, Result<T, StorageError>)> = std::thread::scope(|s| {
+        let handles: Vec<_> = (0..workers.saturating_sub(1))
+            .filter_map(|k| {
+                let cursor = &cursor;
+                let open = &open;
+                std::thread::Builder::new()
+                    .name(format!("ib-recover-open-{k}"))
+                    .spawn_scoped(s, move || {
+                        let mut local: Vec<(usize, Result<T, StorageError>)> = Vec::new();
+                        loop {
+                            let i = cursor.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                            if i >= total {
+                                break;
+                            }
+                            local.push((i, open(&items[i])));
+                        }
+                        local
+                    })
+                    .ok()
+            })
+            .collect();
+        // The main thread is the final participant: drain whatever indices remain (this alone covers
+        // 0..total if no helper spawned).
+        let mut all: Vec<(usize, Result<T, StorageError>)> = Vec::with_capacity(total);
+        loop {
+            let i = cursor.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            if i >= total {
+                break;
+            }
+            all.push((i, open(&items[i])));
+        }
+        for h in handles {
+            all.extend(h.join().expect("recovery open worker panicked"));
+        }
+        all
+    });
+    let mut slots: Vec<Option<Result<T, StorageError>>> = (0..total).map(|_| None).collect();
+    for (i, r) in collected {
+        slots[i] = Some(r);
+    }
+    // Every index in 0..total is assigned exactly once (the cursor hands each out once), so no slot
+    // is None here.
+    slots
+        .into_iter()
+        .map(|r| r.expect("every recovery open index was assigned"))
+        .collect()
+}
+
 impl<F: Filesystem, C: Clock> Log<F, C> {
     /// Opens the log in `fs`, recovering the active segment or creating a fresh one.
     ///
@@ -8609,5 +8708,56 @@ mod tests {
         // It still works normally.
         log.append(&rec(b"still")).unwrap();
         assert_eq!(log.next_offset(), Offset::new(7));
+    }
+
+    /// #822 discriminator for the OUTER cross-subtree recovery pool: [`par_recover_open`] MUST return
+    /// results index-aligned to `items`, regardless of the order the workers finish — the whole
+    /// determinism guarantee of parallel recovery rests on this reassembly. The closure deliberately
+    /// finishes EARLIER indices LATER (a descending artificial delay), so a naive impl that collected
+    /// in completion order would scramble the vector; the correct by-index reassembly stays ordered.
+    /// (On a single-core box the pool runs inline in item order — still index-aligned — so this test
+    /// is not flaky either way.)
+    #[test]
+    fn par_recover_open_returns_results_in_item_order_regardless_of_completion() {
+        let items: Vec<usize> = (0..64).collect();
+        let out = par_recover_open(&items, RECOVERY_OPEN_MAX_WORKERS, |&i| {
+            // Earlier indices sleep LONGER, so completion order tends to be the REVERSE of item
+            // order under real concurrency. Micros keep the test fast.
+            std::thread::sleep(std::time::Duration::from_micros((64 - i as u64) * 4));
+            Ok::<_, StorageError>(i * 10)
+        });
+        let values: Result<Vec<usize>, _> = out.into_iter().collect();
+        let values = values.expect("no item errored");
+        assert_eq!(
+            values,
+            items.iter().map(|&i| i * 10).collect::<Vec<_>>(),
+            "results are index-aligned to the input, not to completion order"
+        );
+    }
+
+    /// #822: [`par_recover_open`] surfaces the FIRST failing item's error in ITEM order (the caller
+    /// `?`-propagates the index-aligned vector in order), so which error wins is deterministic and
+    /// matches the serial loop — never whichever worker happened to fail first.
+    #[test]
+    fn par_recover_open_first_error_is_the_lowest_failing_index() {
+        let items: Vec<usize> = (0..32).collect();
+        let out = par_recover_open(&items, RECOVERY_OPEN_MAX_WORKERS, |&i| {
+            if i == 7 || i == 20 {
+                return Err(StorageError::SegmentIdMismatch {
+                    file_id: i as u64,
+                    header_id: 999,
+                });
+            }
+            Ok::<_, StorageError>(i)
+        });
+        // Fold in item order exactly as the recovery callers do.
+        let first_err = out.into_iter().collect::<Result<Vec<_>, _>>().unwrap_err();
+        match first_err {
+            StorageError::SegmentIdMismatch { file_id, .. } => assert_eq!(
+                file_id, 7,
+                "the lowest failing index wins, deterministically"
+            ),
+            other => panic!("unexpected error: {other:?}"),
+        }
     }
 }

--- a/crates/ironbus-storage/src/partitioned.rs
+++ b/crates/ironbus-storage/src/partitioned.rs
@@ -102,7 +102,7 @@
 //!   from the `StreamSet` storage primitive.
 
 use crate::fs::Filesystem;
-use crate::log::{Append, Log, LogConfig};
+use crate::log::{par_recover_open, Append, Log, LogConfig, RECOVERY_OPEN_MAX_WORKERS};
 use crate::loss::LossReport;
 use crate::naming::partition_subdir_name;
 use crate::segment::{OwnedRecord, StorageError};
@@ -211,7 +211,11 @@ impl<F: Filesystem + Clone, C: Clock + Clone> PartitionedStream<F, C> {
     /// partition's own summary, and a torn/corrupt partition recovers to ITS OWN valid prefix without
     /// shortening or corrupting any sibling (the resilience-isolation property). Total recovery work is
     /// O(Σ records across all partitions) — each partition's recovery is its existing single-log
-    /// recovery, run once.
+    /// recovery, run once. The partitions (`count > 1`) are opened in PARALLEL across a bounded worker
+    /// set ([`par_recover_open`], #822): each is a byte-isolated subtree, and the index-aligned results
+    /// are pushed in index order, so the recovered `partitions` vector, every [`PartitionRecovery`],
+    /// and the first error surfaced are byte-for-byte identical to a strictly serial open. The
+    /// single-partition (`count == 1`) path opens inline on the calling thread, unchanged.
     ///
     /// # Errors
     /// Propagates a [`StorageError`] from opening/recovering any partition (including the fail-closed
@@ -236,13 +240,22 @@ impl<F: Filesystem + Clone, C: Clock + Clone> PartitionedStream<F, C> {
         } else {
             // P > 1: each partition i is an INDEPENDENT log at root/p-<08x(i)>/. The partition subdir
             // is created on first open (Filesystem::subdir creates it) and recovered on reopen. Open
-            // them in index order so `partitions[i]` is partition i.
-            for i in 0..count.get() {
+            // them in PARALLEL across a bounded worker set (#822): each partition recovers over its
+            // own durable bytes alone, so a torn segment in one cannot touch a sibling. Results are
+            // index-aligned to `0..count`; the fold below pushes them in index order, so
+            // `partitions[i]` is partition i and every `PartitionRecovery` (and the first error
+            // surfaced) is byte-for-byte the serial-open result.
+            let indices: Vec<u32> = (0..count.get()).collect();
+            let opened = par_recover_open(&indices, RECOVERY_OPEN_MAX_WORKERS, |&i| {
                 let dir = partition_subdir_name(i);
                 let part_fs = root.subdir(&dir).map_err(StorageError::Io)?;
                 let log = Log::open(part_fs, clock.clone(), config)?;
-                let idx = PartitionIndex::new(i);
-                recoveries.push(recovery_of(idx, &log));
+                let recovery = recovery_of(PartitionIndex::new(i), &log);
+                Ok::<_, StorageError>((recovery, log))
+            });
+            for result in opened {
+                let (recovery, log) = result?;
+                recoveries.push(recovery);
                 partitions.push(log);
             }
         }
@@ -900,6 +913,54 @@ mod tests {
                 .len(),
             1
         );
+    }
+
+    /// #822: with MANY partitions (well past the outer worker cap), the PARALLEL open recovers each
+    /// partition's OWN data at its OWN index, byte-for-byte identical across repeated cold opens. A
+    /// worker-order (mis-assembled) recovery would place partition i's records at the wrong index;
+    /// this pins `partitions[i]` to partition i and asserts reproducibility.
+    #[test]
+    fn many_partitions_recover_in_parallel_deterministically() {
+        let fs = InMemoryFs::new();
+        // 20 partitions > RECOVERY_OPEN_MAX_WORKERS (8): the outer pool genuinely steals work.
+        let p = 20u32;
+        {
+            let (mut stream, _) = open(&fs, p);
+            // Partition i gets exactly i+1 records, each tagged with its partition index.
+            for i in 0..p {
+                for r in 0..=i {
+                    stream
+                        .partition_mut(PartitionIndex::new(i))
+                        .unwrap()
+                        .append(&keyless(format!("p{i:02}-r{r}").as_bytes()))
+                        .unwrap();
+                }
+            }
+            stream.sync_all().unwrap();
+        }
+
+        let (stream_a, rec_a) = open(&fs, p);
+        let (stream_b, rec_b) = open(&fs, p);
+
+        // Recovery vector is in partition-index order in BOTH opens.
+        assert_eq!(rec_a.len(), p as usize);
+        for i in 0..p {
+            assert_eq!(rec_a[i as usize].partition, PartitionIndex::new(i));
+            assert_eq!(rec_b[i as usize].partition, PartitionIndex::new(i));
+            assert!(rec_a[i as usize].loss_report.is_empty());
+            // Each partition holds exactly its OWN i+1 records — not a sibling's.
+            let read = stream_a
+                .read_range(PartitionIndex::new(i), Offset::ZERO, 1000, None)
+                .unwrap();
+            assert_eq!(read.len(), (i + 1) as usize, "partition {i} record count");
+            assert_eq!(&*read[0].payload, format!("p{i:02}-r0").as_bytes());
+            // Byte-identical from the second cold open.
+            let read_b = stream_b
+                .read_range(PartitionIndex::new(i), Offset::ZERO, 1000, None)
+                .unwrap();
+            assert_eq!(read.len(), read_b.len());
+            assert_eq!(&*read[i as usize].payload, &*read_b[i as usize].payload);
+        }
     }
 
     /// THE COMMIT COORDINATOR COMMITS MULTIPLE PARTITIONS IN ONE TICK, issuing exactly one fdatasync

--- a/crates/ironbus-storage/src/streamset.rs
+++ b/crates/ironbus-storage/src/streamset.rs
@@ -107,7 +107,7 @@
 
 use crate::fs::Filesystem;
 use crate::layout::STREAMS_SUBDIR;
-use crate::log::{Append, Log, LogConfig};
+use crate::log::{par_recover_open, Append, Log, LogConfig, RECOVERY_OPEN_MAX_WORKERS};
 use crate::loss::LossReport;
 use crate::naming::{
     is_valid_stream_name, parse_stream_subdir_name, stream_subdir_name, MAX_STREAM_NAME_LEN,
@@ -308,8 +308,13 @@ impl<F: Filesystem + Clone, C: Clock + Clone> StreamSet<F, C> {
     /// SKIPPED, never opened as a stream, exactly as a foreign file is skipped by segment recovery.
     ///
     /// Total recovery work is O(Σ records across all streams) — each stream's recovery is its
-    /// existing single-log recovery, run once. It could be parallelized later (each stream is fully
-    /// independent), but is sequential here; parallel recovery is not needed for correctness.
+    /// existing single-log recovery, run once. The named streams are opened in PARALLEL across a
+    /// bounded worker set ([`par_recover_open`], #822): each stream is a byte-isolated subtree, so a
+    /// torn segment in one cannot touch a sibling or the root, and the index-aligned results are
+    /// folded into the `BTreeMap` in key order — so the recovered map, every [`StreamRecovery`], and
+    /// the first error surfaced are byte-for-byte identical to a strictly serial open. The DEFAULT
+    /// stream is opened FIRST, serially (its #670 marker check fail-closes the whole boot before any
+    /// named-stream work), exactly as before.
     ///
     /// A data dir with no `streams/` subtree (the common single-log deployment) opens with ONLY the
     /// default stream and never materializes `streams/`, so its on-disk shape is unchanged.
@@ -340,23 +345,36 @@ impl<F: Filesystem + Clone, C: Clock + Clone> StreamSet<F, C> {
         //    opened as an INDEPENDENT Log at `streams/<dir>/`; a foreign directory is skipped.
         if fs.subdir_exists(STREAMS_SUBDIR).map_err(StorageError::Io)? {
             let streams_fs = fs.subdir(STREAMS_SUBDIR).map_err(StorageError::Io)?;
-            for dir in streams_fs.list_subdirs().map_err(StorageError::Io)? {
-                let Some(name) = parse_stream_subdir_name(&dir) else {
-                    // A stray/foreign directory under streams/ (not a canonical hex stream name):
-                    // skip it, exactly as segment recovery skips a foreign file. It never opens as a
-                    // stream and never shadows a real one.
-                    continue;
-                };
-                let id = StreamId(name);
-                // Open the named stream's INDEPENDENT log at streams/<dir>/. Its recovery is over its
-                // own durable bytes alone: a torn segment here cannot touch the root log or a sibling.
+            // Enumerate the named-stream subtrees SERIALLY (cheap dir listing + name parse), skipping
+            // any stray/foreign directory (not a canonical hex stream name) exactly as before — it
+            // never opens as a stream and never shadows a real one. `list_subdirs` is already sorted,
+            // so `named` is in a deterministic order.
+            let named: Vec<(StreamId, String)> = streams_fs
+                .list_subdirs()
+                .map_err(StorageError::Io)?
+                .into_iter()
+                .filter_map(|dir| parse_stream_subdir_name(&dir).map(|name| (StreamId(name), dir)))
+                .collect();
+            // Open every named stream's INDEPENDENT log at streams/<dir>/ in PARALLEL across a
+            // bounded worker set (#822). Each open recovers over its own durable bytes alone: a torn
+            // segment here cannot touch the root log or a sibling. Results are index-aligned to
+            // `named`; the fold below inserts them into the BTreeMap in key order, so the recovered
+            // map + summaries are byte-for-byte the serial-open result.
+            let opened = par_recover_open(&named, RECOVERY_OPEN_MAX_WORKERS, |(_, dir)| {
                 let log = Log::open(
-                    streams_fs.subdir(&dir).map_err(StorageError::Io)?,
+                    streams_fs.subdir(dir).map_err(StorageError::Io)?,
                     clock.clone(),
                     config,
                 )?;
-                recoveries.insert(id.clone(), recovery_of(&log));
-                streams.insert(id, log);
+                let recovery = recovery_of(&log);
+                Ok::<_, StorageError>((recovery, log))
+            });
+            // Fold in `named` order: `?` surfaces the FIRST failing stream's error exactly as the
+            // serial loop did (which stopped at the first failing dir in the same order).
+            for (result, (id, _dir)) in opened.into_iter().zip(named.iter()) {
+                let (recovery, log) = result?;
+                recoveries.insert(id.clone(), recovery);
+                streams.insert(id.clone(), log);
             }
         }
 
@@ -1271,5 +1289,63 @@ mod tests {
         let outcome = set.commit_tick();
         assert_eq!(control.sync_count() - before, 0);
         assert_eq!(outcome, CommitOutcome::default());
+    }
+
+    /// #822: with MANY named streams (well past the outer worker cap), the PARALLEL open recovers
+    /// every stream's own data, in a DETERMINISTIC id order, byte-for-byte identical across repeated
+    /// cold opens — the parallel path's reassembly must be reproducible, never dependent on which
+    /// worker won which stream. This exercises the bounded outer pool (streams > workers) end to end.
+    #[test]
+    fn many_named_streams_recover_in_parallel_deterministically() {
+        let fs = InMemoryFs::new();
+        let def = StreamId::default_stream();
+        // 24 named streams > RECOVERY_OPEN_MAX_WORKERS (8), so the outer pool genuinely steals work.
+        let ids: Vec<StreamId> = (0..24)
+            .map(|i| StreamId::named(&format!("stream-{i:03}")).unwrap())
+            .collect();
+        {
+            let (mut set, _) = open(&fs);
+            for id in &ids {
+                set.declare(id).unwrap();
+            }
+            set.append_to(&def, &rec(b"default")).unwrap();
+            // Each named stream i gets exactly i+1 records tagged with its index, so a mis-assembled
+            // (worker-order) recovery would surface as a stream holding the WRONG records.
+            for (i, id) in ids.iter().enumerate() {
+                for r in 0..=i {
+                    set.append_to(id, &rec(format!("s{i:03}-r{r}").as_bytes()))
+                        .unwrap();
+                }
+            }
+            set.sync_all().unwrap();
+        }
+
+        // Two independent cold opens must agree exactly (reproducibility of the parallel path).
+        let (set_a, rec_a) = open(&fs);
+        let (set_b, rec_b) = open(&fs);
+
+        // Deterministic id order: default first, then the named streams in sorted order.
+        let mut expected_order = vec![def.clone()];
+        expected_order.extend(ids.iter().cloned());
+        expected_order.sort();
+        assert_eq!(set_a.stream_ids(), expected_order);
+        assert_eq!(set_b.stream_ids(), set_a.stream_ids());
+
+        for (i, id) in ids.iter().enumerate() {
+            // Same recovery summary from both opens (clean, no loss).
+            assert!(rec_a[id].loss_report.is_empty(), "{} clean", id.name());
+            assert_eq!(
+                rec_a[id].recovered_truncated_bytes,
+                rec_b[id].recovered_truncated_bytes
+            );
+            // Each stream holds exactly its OWN records — not a sibling's.
+            let read = set_a.read_range(id, Offset::ZERO, 1000, None).unwrap();
+            assert_eq!(read.len(), i + 1, "{} has its own record count", id.name());
+            assert_eq!(&*read[0].payload, format!("s{i:03}-r0").as_bytes());
+            // Byte-identical read from the second open.
+            let read_b = set_b.read_range(id, Offset::ZERO, 1000, None).unwrap();
+            assert_eq!(read.len(), read_b.len());
+            assert_eq!(&*read[i].payload, &*read_b[i].payload);
+        }
     }
 }


### PR DESCRIPTION
## What (#822)

Cross-stream / cross-partition `Log::open` (recovery) was fully serial despite each stream/partition log living in its own byte-isolated directory subtree.

## Fix

`StreamSet::open`'s named-stream loop and `PartitionedStream::open`'s multi-partition loop now recover in parallel via a new `par_recover_open`, mirroring #817's `par_scan_segments`: a bounded scoped-worker set (`min(available_parallelism, RECOVERY_OPEN_MAX_WORKERS=8, items)`, fallible `spawn_scoped` + main-thread participation → degrades to serial under thread exhaustion) steals items off one atomic cursor. Results are collected as `(index, result)` and **reassembled strictly in item order**, so the recovered map/Vec and every `StreamRecovery`/`PartitionRecovery` is byte-for-byte deterministic, and callers `?`-propagate in item order so the lowest-index error wins exactly as the serial path. Each `open` touches only its own byte-isolated subtree — no shared mutable state. Total parallelism is bounded to a constant (outer 8 × inner #817 8), not one-thread-per-item; the default stream / single-partition path still opens inline.

## Verification
- fmt + clippy (`-D warnings -W clippy::pedantic`, storage + server) clean; `cargo test -p ironbus-storage -p ironbus-server` green incl. determinism / reproducibility / corruption-recovery suites
- 4 new tests: item-order-regardless-of-completion (descending sleeps), lowest-failing-index error selection, 24 named streams (> 8-worker cap) byte-identical across 2 cold opens, 20 partitions each pinned
- Reviewed across 3 adversarial lenses incl. a determinism lens — id-ordered assembly, deterministic error selection, bounded concurrency, no cross-stream race all confirmed

Closes #822
