### PR TITLE
perf(storage): fan out group-commit fdatasync barriers concurrently, join-all before any ack (#823)

### DIFF
--- a/crates/ironbus-storage/src/fault.rs
+++ b/crates/ironbus-storage/src/fault.rs
@@ -94,6 +94,13 @@ pub struct FaultControl {
     /// rather than permanently freezing the writer (#867): arm 1, drive a roll, then assert a later
     /// append succeeds once the fault has cleared. `0` disables it.
     fail_create_new: Arc<AtomicU64>,
+    /// A test-only fast-path flag (#823): `true` ONLY while a sync rendezvous is armed. A disarmed
+    /// sync therefore pays a single atomic load (no lock) — the common case for every other fault
+    /// test — before short-circuiting the rendezvous below.
+    rendezvous_armed: Arc<AtomicBool>,
+    /// The condvar-backed sync rendezvous used to PROVE the group-commit fdatasync fan-out (#823)
+    /// runs its K per-fd barriers CONCURRENTLY rather than serially. See [`RendezvousGate`].
+    rendezvous: Arc<RendezvousGate>,
 }
 
 /// A condvar-backed gate the sync path waits on while closed (#177): `open` starts open (syncs pass),
@@ -115,6 +122,38 @@ impl Default for SyncGate {
             cv: Condvar::new(),
         }
     }
+}
+
+/// A test-only rendezvous latch (#823) that PROVES the group-commit fdatasync fan-out runs its `K`
+/// per-fd barriers CONCURRENTLY rather than serially. While armed (`width > 0`), every
+/// `sync_data`/`sync_all` entry JOINS the rendezvous: it bumps `entered`, wakes waiters, and BLOCKS
+/// until either `entered` reaches `width` (all `width` barriers are inside their `fdatasync` AT THE
+/// SAME TIME — the overlap #823 promises, which latches the sticky `reached` proof) or `release` is
+/// set (the test's bounded deadline elapsed, so a SERIALIZED fan-out — which can never get more than
+/// one barrier inside at once — drains instead of hanging forever). Everything is condvar-based; the
+/// syncing threads never wall-clock-sleep, so the check is deterministic.
+#[derive(Debug, Default)]
+struct RendezvousGate {
+    state: Mutex<RendezvousState>,
+    cv: Condvar,
+}
+
+/// The mutable state behind a [`RendezvousGate`].
+#[derive(Debug, Default)]
+struct RendezvousState {
+    /// The rendezvous width: how many barriers must be inside a `fdatasync` at once before the group
+    /// is released. `0` disarms the rendezvous (entries pass straight through).
+    width: usize,
+    /// How many syncs are CURRENTLY inside the rendezvous (bumped on entry, dropped on exit). A
+    /// serial fan-out never gets this above 1, because the sole in-flight barrier holds the shared
+    /// work-queue lock and no sibling can even reach its `sync_data`.
+    entered: usize,
+    /// Sticky proof that `entered` reached `width` at least once — i.e. the barriers genuinely
+    /// overlapped. This is the assertion the overlap test reads.
+    reached: bool,
+    /// Force-drain: once the test's deadline sets this, every parked (or subsequently entering) sync
+    /// passes straight through, so a serialized fan-out RETURNS instead of hanging the test forever.
+    release: bool,
 }
 
 impl FaultControl {
@@ -320,6 +359,61 @@ impl FaultControl {
         self.sync_count.load(Ordering::SeqCst)
     }
 
+    /// Arms the sync rendezvous (#823) to `width`: while armed, every `sync_data`/`sync_all` entry
+    /// joins a rendezvous of `width` participants (see [`RendezvousGate`]) so the group-commit
+    /// fdatasync fan-out overlap test can PROVE `width` barriers were inside their `fdatasync` at the
+    /// same time. Pass `0` to disarm. Arm this ONLY immediately before the fan-out under test, so no
+    /// unrelated sync (segment creation, an earlier flush) joins the rendezvous by accident.
+    pub fn arm_sync_rendezvous(&self, width: usize) {
+        let mut st = self
+            .rendezvous
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        st.width = width;
+        st.entered = 0;
+        st.reached = false;
+        st.release = false;
+        // The fast-path flag: a disarmed sync (`width == 0`) short-circuits on one atomic load.
+        self.rendezvous_armed.store(width != 0, Ordering::SeqCst);
+        // Wake anything left parked from a prior group so it cannot wedge a later one.
+        self.rendezvous.cv.notify_all();
+    }
+
+    /// Blocks (on the condvar, bounded by `timeout`, no busy-wait) until the armed sync rendezvous is
+    /// REACHED — all `width` barriers were inside their `fdatasync` simultaneously — then force-drains
+    /// the gate so any still-parked syncs proceed and the fan-out can return. Returns whether the
+    /// rendezvous was reached within the deadline: `true` PROVES the barriers overlapped (a concurrent
+    /// fan-out); `false` means the fan-out serialized (only ever one barrier inside at once) and the
+    /// deadline elapsed. The unconditional force-drain guarantees the caller never hangs on a serial
+    /// fan-out — it fails the assertion instead.
+    #[must_use]
+    pub fn wait_for_rendezvous_or_release(&self, timeout: std::time::Duration) -> bool {
+        let deadline = std::time::Instant::now() + timeout;
+        let mut st = self
+            .rendezvous
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        while !st.reached {
+            let Some(remaining) = deadline.checked_duration_since(std::time::Instant::now()) else {
+                break;
+            };
+            let (guard, _timed_out) = self
+                .rendezvous
+                .cv
+                .wait_timeout(st, remaining)
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            st = guard;
+        }
+        let reached = st.reached;
+        // Force-drain unconditionally: a serial fan-out is still parked (or about to enter) and must
+        // proceed so the fan-out returns and the test can join it and assert (rather than hang).
+        st.release = true;
+        self.rendezvous.cv.notify_all();
+        reached
+    }
+
     /// Closes the READ gate (#809): the NEXT positioned `read_at` blocks until [`open_read_gate`], so a
     /// test can park a fetch-serve mid-read. Already-passed reads are unaffected.
     ///
@@ -408,6 +502,39 @@ impl FaultControl {
                     .unwrap_or_else(std::sync::PoisonError::into_inner);
             }
         }
+    }
+
+    /// The rendezvous hook (#823) at the top of the data-sync path: if a sync rendezvous is armed,
+    /// join it. Bumps `entered`, wakes waiters, and BLOCKS until `entered` reaches `width` (all
+    /// barriers inside a `fdatasync` at once — latches `reached`) or the test force-releases the gate.
+    /// Disarmed, it is a single atomic load and returns. A serialized fan-out never gets `entered`
+    /// above 1 (the sole in-flight barrier holds the shared work-queue lock, so no sibling can reach
+    /// here), so `reached` stays false and the overlap test fails.
+    fn enter_sync_rendezvous(&self) {
+        if !self.rendezvous_armed.load(Ordering::SeqCst) {
+            return;
+        }
+        let mut st = self
+            .rendezvous
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if st.width == 0 {
+            return;
+        }
+        st.entered = st.entered.saturating_add(1);
+        if st.entered >= st.width {
+            st.reached = true;
+        }
+        self.rendezvous.cv.notify_all();
+        while !st.reached && !st.release {
+            st = self
+                .rendezvous
+                .cv
+                .wait(st)
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+        }
+        st.entered = st.entered.saturating_sub(1);
     }
 
     fn sync_should_fail(&self) -> bool {
@@ -670,6 +797,10 @@ impl<F: RandomAccessFile> RandomAccessFile for FaultFile<F> {
     }
 
     fn sync_data(&self) -> io::Result<()> {
+        // Join the group-commit rendezvous FIRST (#823, top of the data-sync path): the overlap test
+        // arms it so all K fan-out barriers must be inside their `fdatasync` at once to proceed —
+        // disarmed (every other test) this is one atomic load and a return.
+        self.control.enter_sync_rendezvous();
         // Count the sync and, if the gate is closed, park here until it opens (the stalled-disk model,
         // #177). Done BEFORE the fail check so a test can either stall a sync (gate) or fail it.
         self.control.enter_sync_gate();
@@ -680,6 +811,7 @@ impl<F: RandomAccessFile> RandomAccessFile for FaultFile<F> {
     }
 
     fn sync_all(&self) -> io::Result<()> {
+        self.control.enter_sync_rendezvous();
         self.control.enter_sync_gate();
         if self.control.sync_should_fail() {
             return Err(injected_sync_error());

--- a/crates/ironbus-storage/src/log.rs
+++ b/crates/ironbus-storage/src/log.rs
@@ -976,6 +976,98 @@ where
         .collect()
 }
 
+/// The upper bound on the number of covering `fdatasync` barriers ONE group-commit tick fans out
+/// concurrently (#823). Same shape as [`RECOVERY_OPEN_MAX_WORKERS`]: a small fixed cap keeps the
+/// barrier fan-out from ever spawning one-thread-per-dirtied-fd on a wide (K = hundreds) tick, while
+/// still overlapping the blocking syscalls; the effective width is `min(this, cores, K)`.
+pub(crate) const COMMIT_BARRIER_MAX_WORKERS: usize = 8;
+
+/// Fans out the K per-fd covering `fdatasync` barriers of ONE group-commit tick
+/// ([`crate::streamset::StreamSet::commit_tick`] / [`crate::partitioned::PartitionedStream::commit_tick`])
+/// across a bounded [`std::thread::scope`] worker set, so the tick's barrier phase costs
+/// `max(barrier)` instead of `sum(barrier)` (#823). Each dirtied partition/stream is its OWN [`Log`]
+/// over its own segment set, so its covering `fdatasync` is on an INDEPENDENT fd and the K barriers
+/// are embarrassingly parallel; the kernel cannot batch `fdatasync` across fds, but the barriers can
+/// OVERLAP in wall time. Returns one `(tag, barrier result)` per input; the returned order is NOT
+/// input order (results come back in completion order), so the caller reassembles by `tag`.
+///
+/// Mirrors [`par_recover_open`] / [`Log::par_scan_segments`]: a fixed set of scoped workers steals the
+/// `(tag, &mut Log)` barriers off one shared queue, so a fast fd's worker immediately picks up the
+/// next barrier rather than blocking behind a slow one; helpers are spawned FALLIBLY via
+/// `Builder::spawn_scoped` and the MAIN thread is itself the final participant, so OS thread
+/// exhaustion degrades to fewer helpers (or fully serial) instead of panicking. No external threadpool
+/// (no rayon). The effective width is `min(COMMIT_BARRIER_MAX_WORKERS, cores, K)`; a single dirtied fd
+/// (the common `P = 1` / default-stream tick) runs inline on the calling thread with NO threads
+/// spawned — byte- and behaviour-identical to the old serial barrier loop.
+///
+/// ## Durability invariant (paramount)
+/// This ONLY parallelizes the blocking `fdatasync` SYSCALLS. It does NOT touch any durable-head or
+/// ack bookkeeping: each barrier is a disjoint `&mut Log` (no two barriers touch shared state, so the
+/// ack/commit accounting cannot race), and this returns ONLY after EVERY barrier has completed (a full
+/// JOIN). The caller MUST therefore run its durable-head advance / ack-release pass ONLY after this
+/// returns, and advance a fd's durable head ONLY on that fd's `Ok(())` result — a fd whose barrier
+/// returned `Err` (froze) must have its commits FAIL (durable head not advanced, acks stay parked),
+/// never acked. No ack in the group is released until after this join, so I2 (ack-implies-durable) and
+/// the per-fd freeze isolation are byte-identical to the serial loop.
+pub(crate) fn par_sync_data_only<F: Filesystem, C: Clock>(
+    barriers: Vec<(usize, &mut Log<F, C>)>,
+) -> Vec<(usize, Result<(), StorageError>)> {
+    let total = barriers.len();
+    let workers = std::thread::available_parallelism()
+        .map_or(1, std::num::NonZeroUsize::get)
+        .min(COMMIT_BARRIER_MAX_WORKERS)
+        .min(total);
+    if workers <= 1 {
+        // One barrier, one core, or a single-worker cap: run the fdatasyncs inline (no threads, no
+        // queue), byte-identical to the old serial barrier loop.
+        return barriers
+            .into_iter()
+            .map(|(tag, log)| (tag, log.sync_data_only()))
+            .collect();
+    }
+    // Shared work queue of the remaining `(tag, &mut Log)` barriers. Each participant locks the queue
+    // just long enough to POP one barrier (O(1), not the blocking fsync) and then runs that fd's
+    // `fdatasync` OUTSIDE the lock, so the barriers themselves overlap. The `&mut Log` handles are
+    // disjoint (each names a different fd/writer), so no barrier can observe or mutate another's
+    // writer state — the pop order does not matter because the caller reassembles by `tag`.
+    // `&mut Log` is `Send` (`Log: Send`), so `Mutex<Vec<(usize, &mut Log)>>` is `Sync`.
+    let queue: std::sync::Mutex<Vec<(usize, &mut Log<F, C>)>> = std::sync::Mutex::new(barriers);
+    std::thread::scope(|s| {
+        // Helpers are spawned FALLIBLY: a worker that cannot be created (OS thread exhaustion) is
+        // simply skipped, and the main thread below is the final participant that drains whatever is
+        // left — so even if EVERY helper fails to spawn, every barrier still runs (serially, inline).
+        let handles: Vec<_> = (0..workers.saturating_sub(1))
+            .filter_map(|k| {
+                let queue = &queue;
+                std::thread::Builder::new()
+                    .name(format!("ib-commit-fsync-{k}"))
+                    .spawn_scoped(s, move || {
+                        let mut local: Vec<(usize, Result<(), StorageError>)> = Vec::new();
+                        while let Some((tag, log)) =
+                            queue.lock().expect("commit barrier queue poisoned").pop()
+                        {
+                            local.push((tag, log.sync_data_only()));
+                        }
+                        local
+                    })
+                    .ok()
+            })
+            .collect();
+        // The main thread is the final participant: drain whatever barriers remain (this alone covers
+        // the whole set if no helper spawned).
+        let mut all: Vec<(usize, Result<(), StorageError>)> = Vec::with_capacity(total);
+        while let Some((tag, log)) = queue.lock().expect("commit barrier queue poisoned").pop() {
+            all.push((tag, log.sync_data_only()));
+        }
+        // JOIN every helper before returning: no barrier result — and so no ack — is released until
+        // every fd's fdatasync has completed.
+        for h in handles {
+            all.extend(h.join().expect("commit-tick fsync worker panicked"));
+        }
+        all
+    })
+}
+
 impl<F: Filesystem, C: Clock> Log<F, C> {
     /// Opens the log in `fs`, recovering the active segment or creating a fresh one.
     ///

--- a/crates/ironbus-storage/src/log.rs
+++ b/crates/ironbus-storage/src/log.rs
@@ -1043,9 +1043,21 @@ pub(crate) fn par_sync_data_only<F: Filesystem, C: Clock>(
                     .name(format!("ib-commit-fsync-{k}"))
                     .spawn_scoped(s, move || {
                         let mut local: Vec<(usize, Result<(), StorageError>)> = Vec::new();
-                        while let Some((tag, log)) =
-                            queue.lock().expect("commit barrier queue poisoned").pop()
-                        {
+                        loop {
+                            // Drop the queue `MutexGuard` right after the O(1) `pop` — BEFORE the
+                            // blocking `fdatasync` below — so the K barriers actually overlap. Under
+                            // edition-2021 temporary scoping, a guard created in a `while let`
+                            // SCRUTINEE lives until the END of the loop body, which would hold the
+                            // shared queue lock across `sync_data_only` and force every barrier
+                            // strictly SERIAL (the #823 regression: tick latency becomes sum, not
+                            // max). The explicit block scopes the guard to the pop alone, so the
+                            // fdatasync runs with the lock released and the participants run
+                            // concurrently.
+                            let Some((tag, log)) =
+                                ({ queue.lock().expect("commit barrier queue poisoned").pop() })
+                            else {
+                                break;
+                            };
                             local.push((tag, log.sync_data_only()));
                         }
                         local
@@ -1056,7 +1068,14 @@ pub(crate) fn par_sync_data_only<F: Filesystem, C: Clock>(
         // The main thread is the final participant: drain whatever barriers remain (this alone covers
         // the whole set if no helper spawned).
         let mut all: Vec<(usize, Result<(), StorageError>)> = Vec::with_capacity(total);
-        while let Some((tag, log)) = queue.lock().expect("commit barrier queue poisoned").pop() {
+        loop {
+            // Same guard-scoping as the helpers above: drop the queue lock right after the `pop` so
+            // this final participant's `fdatasync` overlaps the helpers' rather than running under a
+            // held lock (which would serialize the whole fan-out — the #823 regression).
+            let Some((tag, log)) = ({ queue.lock().expect("commit barrier queue poisoned").pop() })
+            else {
+                break;
+            };
             all.push((tag, log.sync_data_only()));
         }
         // JOIN every helper before returning: no barrier result — and so no ack — is released until
@@ -4526,6 +4545,99 @@ mod tests {
             headers: b"",
             payload,
         }
+    }
+
+    /// Builds `k` independent logs, each rooted in its OWN in-memory disk but SHARING one
+    /// [`FaultControl`](crate::fault::FaultControl), each with a record appended and
+    /// flushed-but-not-synced — so every log owes exactly one covering `fdatasync`
+    /// ([`has_unsynced_records`](Log::has_unsynced_records)). The shared control lets the sync
+    /// rendezvous count barriers across all K fds (a barrier per fd). No sync fires here (open runs
+    /// while the rendezvous is disarmed; `flush_no_sync` never syncs).
+    fn build_dirtied_logs(
+        control: &crate::fault::FaultControl,
+        k: usize,
+    ) -> Vec<Log<crate::fault::FaultFs<InMemoryFs>, ManualClock>> {
+        (0..k)
+            .map(|_| {
+                let fs = crate::fault::FaultFs::with_control(InMemoryFs::new(), control.clone());
+                let mut log = Log::open(fs, ManualClock::new(), small_config()).unwrap();
+                log.append(&rec(b"payload")).unwrap();
+                log.flush_no_sync().unwrap();
+                assert!(
+                    log.has_unsynced_records(),
+                    "a dirtied log must owe exactly one barrier"
+                );
+                log
+            })
+            .collect()
+    }
+
+    #[test]
+    fn group_commit_barriers_overlap_and_do_not_serialize() {
+        use crate::fault::FaultControl;
+        // #823 regression: `par_sync_data_only` must run its K per-fd `fdatasync` barriers
+        // CONCURRENTLY (tick latency = max(barrier), not sum). If the shared work-queue's MutexGuard
+        // is held across the blocking `fdatasync` (the edition-2021 `while let`-scrutinee drop trap),
+        // the barriers SERIALIZE and this test fails — the froze/synced-SET tests can never catch that
+        // because the results are identical whether the fdatasyncs overlapped or not.
+        //
+        // How it proves overlap: every barrier's `fdatasync` joins a rendezvous in the fault fs. The
+        // group is released only once `width` barriers are inside their `fdatasync` AT THE SAME TIME.
+        // A serial fan-out can never get more than one barrier in at once (the in-flight one holds the
+        // queue lock, so no sibling can even reach its `fdatasync`), so the rendezvous is never
+        // reached; after a bounded deadline this thread force-drains and the assertion FAILS. A
+        // concurrent fan-out reaches it in microseconds and PASSES.
+        const K: usize = 4;
+        // The fan-out's effective width = min(cores, cap, K): at most this many barriers are ever
+        // inside a `fdatasync` at once, so the rendezvous must expect exactly this many, not K.
+        let width = std::thread::available_parallelism()
+            .map_or(1, std::num::NonZeroUsize::get)
+            .min(COMMIT_BARRIER_MAX_WORKERS)
+            .min(K);
+
+        if width < 2 {
+            // Single-core (or single-worker) CI: `par_sync_data_only` runs the fdatasyncs INLINE with
+            // no threads, so there is NO overlap to observe. Prove the fan-out still completes every
+            // barrier, but SKIP the strict overlap assertion (it would be meaningless with one worker,
+            // and a width-1 rendezvous would trivially "reach" on the first entrant).
+            let control = FaultControl::default();
+            let mut logs = build_dirtied_logs(&control, K);
+            let barriers = logs.iter_mut().enumerate().collect();
+            let results = par_sync_data_only(barriers);
+            assert_eq!(results.len(), K);
+            assert!(results.iter().all(|(_, r)| r.is_ok()));
+            return;
+        }
+
+        let control = FaultControl::default();
+        let mut logs = build_dirtied_logs(&control, K);
+        // Arm the rendezvous to the effective worker width, then run the REAL fan-out on a driver
+        // thread while THIS thread enforces a bounded deadline — so a serial fan-out fails fast
+        // instead of hanging the suite forever.
+        control.arm_sync_rendezvous(width);
+        let reached = std::thread::scope(|s| {
+            let barriers = logs.iter_mut().enumerate().collect();
+            let driver = s.spawn(move || par_sync_data_only(barriers));
+            // The deadline is enormous versus the microseconds a concurrent rendezvous needs (a
+            // correct fan-out returns on the rendezvous notify, never waiting the full timeout), so
+            // this is NOT timing-flaky; the deadline only bites — failing fast — when the fan-out has
+            // serialized.
+            let reached =
+                control.wait_for_rendezvous_or_release(std::time::Duration::from_secs(10));
+            let results = driver.join().expect("fan-out driver panicked");
+            assert_eq!(results.len(), K, "every barrier ran");
+            assert!(
+                results.iter().all(|(_, r)| r.is_ok()),
+                "no barrier should freeze under a clean fs"
+            );
+            reached
+        });
+        assert!(
+            reached,
+            "the {width} group-commit fdatasync barriers must OVERLAP (>= {width} inside a fdatasync \
+             at once); a failure here means they serialized — the queue MutexGuard is held across the \
+             blocking fdatasync (#823)"
+        );
     }
 
     // A record carrying an explicit producer timestamp, for the age-retention tests.

--- a/crates/ironbus-storage/src/partitioned.rs
+++ b/crates/ironbus-storage/src/partitioned.rs
@@ -102,7 +102,9 @@
 //!   from the `StreamSet` storage primitive.
 
 use crate::fs::Filesystem;
-use crate::log::{par_recover_open, Append, Log, LogConfig, RECOVERY_OPEN_MAX_WORKERS};
+use crate::log::{
+    par_recover_open, par_sync_data_only, Append, Log, LogConfig, RECOVERY_OPEN_MAX_WORKERS,
+};
 use crate::loss::LossReport;
 use crate::naming::partition_subdir_name;
 use crate::segment::{OwnedRecord, StorageError};
@@ -422,9 +424,11 @@ impl<F: Filesystem, C: Clock> PartitionedStream<F, C> {
     /// The tick has three passes over the DIRTIED partitions ([`Log::has_unsynced_records`]):
     ///   1. **flush** — [`Log::flush_no_sync`] drains each dirtied partition's `pending` to the page
     ///      cache (cheap, no fsync);
-    ///   2. **barrier** — [`Log::sync_data_only`] issues the covering `fdatasync` on each dirtied
-    ///      partition's fd (K dirtied partitions = K barriers; the kernel cannot batch `fdatasync`
-    ///      across fds);
+    ///   2. **barrier** — [`crate::log::par_sync_data_only`] issues the covering `fdatasync` on each
+    ///      dirtied partition's fd (K dirtied partitions = K barriers; the kernel cannot batch
+    ///      `fdatasync` across fds, but because each partition is an INDEPENDENT fd the K barriers are
+    ///      FANNED OUT concurrently across a bounded scoped-worker set and JOINED before any ack
+    ///      releases, so the tick's barrier phase costs max(barrier) not sum(barrier), #823);
     ///   3. **release** — for each partition whose barrier SUCCEEDED,
     ///      [`Log::advance_synced_offset_after_external_sync`] advances its durable head, reported in
     ///      [`PartitionCommitOutcome::synced`].
@@ -442,55 +446,72 @@ impl<F: Filesystem, C: Clock> PartitionedStream<F, C> {
     /// reported, not raised, so one frozen partition does not abort a sibling's commit.
     #[must_use]
     pub fn commit_tick(&mut self) -> PartitionCommitOutcome {
-        // Pick the DIRTIED partitions up front (index order, deterministic). A clean/cold partition —
-        // or a frozen one — is never touched, so a tick's cost scales with the dirtied set, not P.
-        let dirtied: Vec<usize> = self
+        // `i` always comes from enumerating `self.partitions`, whose length is `P <= u32::MAX`, so
+        // the conversion is exact; the non-panicking `unwrap_or` fallback is unreachable (it keeps
+        // `commit_tick` panic-free, so `missing_panics_doc` stays satisfied).
+        let to_idx = |i: usize| PartitionIndex::new(u32::try_from(i).unwrap_or(u32::MAX));
+
+        let dirtied_count = self
             .partitions
             .iter()
-            .enumerate()
-            .filter(|(_, log)| log.has_unsynced_records())
-            .map(|(i, _)| i)
-            .collect();
+            .filter(|log| log.has_unsynced_records())
+            .count();
 
         let mut outcome = PartitionCommitOutcome {
-            synced: Vec::with_capacity(dirtied.len()),
+            synced: Vec::with_capacity(dirtied_count),
             froze: Vec::new(),
             fdatasyncs_issued: 0,
         };
+        // Every froze index (from a PASS-1 flush freeze OR a PASS-2 barrier freeze) lands here and is
+        // sorted into ascending partition-index order at the end, byte-identical to the serial loop.
+        let mut froze: Vec<usize> = Vec::new();
 
-        for i in dirtied {
-            let log = &mut self.partitions[i];
-            // `i` came from enumerating `self.partitions`, whose length is `P <= u32::MAX`, so the
-            // conversion is exact; the non-panicking `unwrap_or` fallback is unreachable (it keeps
-            // `commit_tick` panic-free, so `missing_panics_doc` stays satisfied).
-            let idx = PartitionIndex::new(u32::try_from(i).unwrap_or(u32::MAX));
-
-            // PASS 1 — flush this partition's pending bytes to the page cache (no fsync). A flush
-            // failure is the fatal frozen-writer class, identical to a failed barrier: record the
-            // freeze, do NOT advance the durable head, and continue with the siblings.
-            if log.flush_no_sync().is_err() {
-                outcome.fdatasyncs_issued += 1; // the barrier this partition owed, frozen pre-sync
-                outcome.froze.push(idx);
+        // PASS 1 (serial, cheap): flush each DIRTIED partition's pending bytes to the page cache (no
+        // fsync), in index order. A flush failure is the fatal frozen-writer class, identical to a
+        // failed barrier: record the freeze and do NOT advance the durable head. A partition that
+        // flushes OK hands its disjoint `&mut Log` to the barrier fan-out. Every dirtied partition
+        // owes exactly one barrier, counted here whether it flush-froze or reaches PASS 2 (identical
+        // count to the serial loop).
+        let mut barriers: Vec<(usize, &mut Log<F, C>)> = Vec::with_capacity(dirtied_count);
+        for (i, log) in self.partitions.iter_mut().enumerate() {
+            if !log.has_unsynced_records() {
                 continue;
             }
-
-            // PASS 2 — the covering fdatasync on THIS partition's fd. K dirtied partitions => K
-            // barriers (fdatasync cannot be batched across fds). One barrier per dirtied partition is
-            // counted whether it succeeds or freezes the writer.
             outcome.fdatasyncs_issued += 1;
-            if log.sync_data_only().is_err() {
-                // The barrier failed: this one partition is now frozen read-only, its acks stay PARKED
-                // (I2 upheld). Siblings continue.
-                outcome.froze.push(idx);
+            if log.flush_no_sync().is_err() {
+                froze.push(i);
                 continue;
             }
-
-            // PASS 3 — the barrier returned: advance THIS partition's durable head and report the
-            // offset up to which its parked acks may release. Per-partition I2.
-            log.advance_synced_offset_after_external_sync();
-            outcome.synced.push((idx, log.synced_offset()));
+            barriers.push((i, log));
         }
 
+        // PASS 2 (fan-out): issue the K covering fdatasyncs CONCURRENTLY across a bounded scoped-worker
+        // set, then JOIN every barrier before ANY ack is released. Each partition is its own fd/`Log`
+        // (disjoint `&mut`), so the barriers are independent and the tick's barrier phase now costs
+        // max(barrier) instead of sum(barrier) (#823). DURABILITY: `par_sync_data_only` returns only
+        // after EVERY barrier has completed, and PASS 3 advances a partition's durable head ONLY on
+        // its `Ok(())` result — a failed fd freezes ONLY its own commits, never a sibling's, and no
+        // ack releases until after this join.
+        let mut barrier_results = par_sync_data_only(barriers);
+        // Reassemble in ASCENDING partition-index order (the fan-out returns completion order), so the
+        // durable-head advance / ack-release pass below is deterministic and byte-identical to serial.
+        barrier_results.sort_unstable_by_key(|(i, _)| *i);
+
+        // PASS 3 (serial, deterministic): for each partition whose barrier returned, advance its
+        // durable head and report its ack-release offset (per-partition I2 — acks release only now,
+        // after its own fdatasync); a partition whose barrier failed freezes (acks stay parked).
+        for (i, result) in barrier_results {
+            if result.is_ok() {
+                let log = &mut self.partitions[i];
+                log.advance_synced_offset_after_external_sync();
+                outcome.synced.push((to_idx(i), log.synced_offset()));
+            } else {
+                froze.push(i);
+            }
+        }
+
+        froze.sort_unstable();
+        outcome.froze = froze.into_iter().map(to_idx).collect();
         outcome
     }
 }
@@ -1087,6 +1108,109 @@ mod tests {
             .is_err());
         let p1 = stream.partition(PartitionIndex::new(1)).unwrap();
         assert_eq!(p1.synced_offset(), p1.next_offset());
+    }
+
+    /// #823: with K>1 partitions dirtied in ONE tick the K covering fdatasyncs are FANNED OUT
+    /// concurrently across a bounded scoped-worker set, yet the outcome stays byte-identical to the
+    /// old serial barrier loop. Under a total fsync fault EVERY dirtied fd's barrier fails on its own
+    /// (per-fd freeze isolation survives the fan-out), the froze set is reported in ASCENDING
+    /// partition-index order (deterministic reassembly, NOT thread-completion order), and — the
+    /// paramount durability invariant — NO partition's durable head advanced and NO ack was released,
+    /// because every barrier is JOINED before the release pass runs.
+    #[test]
+    fn fanned_out_barrier_freeze_is_deterministic_and_acks_nothing() {
+        let (fs, control): (FaultFs<InMemoryFs>, FaultControl) = FaultFs::new(InMemoryFs::new());
+        let (mut stream, _) =
+            PartitionedStream::open(&fs, ManualClock::new(), cfg(), count(5)).unwrap();
+
+        // Dirty partitions 0..4 (leave 4 cold), several records each — K = 4 barriers in one tick.
+        for _ in 0..4 {
+            for i in 0..4u32 {
+                stream
+                    .partition_mut(PartitionIndex::new(i))
+                    .unwrap()
+                    .append(&keyless(b"r"))
+                    .unwrap();
+            }
+        }
+        // The durable head of each dirtied partition BEFORE the tick (trails its append head).
+        let before_heads: Vec<_> = (0..4u32)
+            .map(|i| {
+                stream
+                    .partition(PartitionIndex::new(i))
+                    .unwrap()
+                    .synced_offset()
+            })
+            .collect();
+
+        // Fail EVERY fdatasync: each of the K fanned-out barriers must fail independently.
+        control.set_fail_sync(true);
+        let outcome = stream.commit_tick();
+        control.set_fail_sync(false);
+
+        // One barrier counted per dirtied partition; the cold partition 4 cost nothing.
+        assert_eq!(outcome.fdatasyncs_issued, 4);
+        // I2 / durability invariant: not one partition acked when its barrier failed.
+        assert!(
+            outcome.synced.is_empty(),
+            "no commit acked when its covering fdatasync failed"
+        );
+        // The froze set is deterministic ascending index order, regardless of worker completion order.
+        let froze_idx: Vec<u32> = outcome.froze.iter().map(|p| p.get()).collect();
+        assert_eq!(
+            froze_idx,
+            vec![0, 1, 2, 3],
+            "froze reported in deterministic ascending partition-index order"
+        );
+        // Every dirtied fd froze on its OWN barrier fault, and NONE advanced its durable head — the
+        // release pass ran only after the join, so a failed barrier released no ack.
+        for (i, before) in before_heads.iter().enumerate() {
+            let idx = PartitionIndex::new(u32::try_from(i).unwrap());
+            let log = stream.partition(idx).unwrap();
+            assert_eq!(
+                log.synced_offset(),
+                *before,
+                "a frozen partition's durable head must NOT advance"
+            );
+            assert!(
+                !log.is_writable(),
+                "each dirtied fd froze on its own barrier"
+            );
+        }
+    }
+
+    /// #823: with K>1 partitions dirtied and NO fault, the fanned-out barriers all succeed and the
+    /// outcome is byte-identical to serial — every dirtied fd synced (ascending order), each durable
+    /// head advanced to its append head, exactly K barriers issued.
+    #[test]
+    fn fanned_out_barriers_all_succeed_and_advance_every_durable_head() {
+        let (fs, control): (FaultFs<InMemoryFs>, FaultControl) = FaultFs::new(InMemoryFs::new());
+        let (mut stream, _) =
+            PartitionedStream::open(&fs, ManualClock::new(), cfg(), count(6)).unwrap();
+        for _ in 0..3 {
+            for i in 0..6u32 {
+                stream
+                    .partition_mut(PartitionIndex::new(i))
+                    .unwrap()
+                    .append(&keyless(b"r"))
+                    .unwrap();
+            }
+        }
+        let before = control.sync_count();
+        let outcome = stream.commit_tick();
+        assert_eq!(control.sync_count() - before, 6, "K=6 covering fdatasyncs");
+        assert_eq!(outcome.fdatasyncs_issued, 6);
+        assert!(outcome.froze.is_empty());
+        let synced_idx: Vec<u32> = outcome.synced.iter().map(|(p, _)| p.get()).collect();
+        assert_eq!(
+            synced_idx,
+            vec![0, 1, 2, 3, 4, 5],
+            "synced in ascending order"
+        );
+        for i in 0..6u32 {
+            let log = stream.partition(PartitionIndex::new(i)).unwrap();
+            assert_eq!(log.synced_offset(), log.next_offset());
+        }
     }
 
     /// A foreign directory under a P>1 stream's root (not a canonical `p-*/` name) is left alone at

--- a/crates/ironbus-storage/src/streamset.rs
+++ b/crates/ironbus-storage/src/streamset.rs
@@ -107,7 +107,9 @@
 
 use crate::fs::Filesystem;
 use crate::layout::STREAMS_SUBDIR;
-use crate::log::{par_recover_open, Append, Log, LogConfig, RECOVERY_OPEN_MAX_WORKERS};
+use crate::log::{
+    par_recover_open, par_sync_data_only, Append, Log, LogConfig, RECOVERY_OPEN_MAX_WORKERS,
+};
 use crate::loss::LossReport;
 use crate::naming::{
     is_valid_stream_name, parse_stream_subdir_name, stream_subdir_name, MAX_STREAM_NAME_LEN,
@@ -537,9 +539,12 @@ impl<F: Filesystem, C: Clock> StreamSet<F, C> {
     /// records — [`Log::has_unsynced_records`]):
     ///   1. **flush**: [`Log::flush_no_sync`] drains each dirtied stream's `pending` buffer to the
     ///      page cache (independent per fd, cheap, no fsync);
-    ///   2. **barrier**: [`Log::sync_data_only`] issues the covering `fdatasync` on each dirtied
-    ///      stream's fd — K dirtied streams = K barriers (the kernel cannot batch `fdatasync` across
-    ///      different fds; this is honest, see [`CommitOutcome`]);
+    ///   2. **barrier**: [`crate::log::par_sync_data_only`] issues the covering `fdatasync` on each
+    ///      dirtied stream's fd — K dirtied streams = K barriers (the kernel cannot batch `fdatasync`
+    ///      across different fds; this is honest, see [`CommitOutcome`]). Because each stream is an
+    ///      INDEPENDENT fd, the K barriers are FANNED OUT concurrently across a bounded scoped-worker
+    ///      set and JOINED before any ack releases, so the tick's barrier phase costs max(barrier)
+    ///      not sum(barrier) (#823);
     ///   3. **release**: for each stream whose barrier SUCCEEDED,
     ///      [`Log::advance_synced_offset_after_external_sync`] advances its durable head and the
     ///      returned [`CommitOutcome::synced`] reports the offset up to which its acks may release.
@@ -565,9 +570,10 @@ impl<F: Filesystem, C: Clock> StreamSet<F, C> {
     /// pre-#564 correctness-first path and is kept for callers that want fail-fast.)
     #[must_use]
     pub fn commit_tick(&mut self) -> CommitOutcome {
-        // Pick the DIRTIED streams up front (default-first, deterministic). A clean/cold stream — or
-        // a frozen one — is never touched, so a tick's cost scales with the hot set, not the total
-        // stream count. We snapshot the ids so the three passes below borrow each log mutably in turn.
+        // Snapshot the DIRTIED stream ids up front (default-first, deterministic BTreeMap key order).
+        // A clean/cold stream — or a frozen one — is never touched, so a tick's cost scales with the
+        // hot set, not the total stream count. The ordinal of each id in this Vec is the tag the
+        // barrier fan-out reassembles by, so the release pass stays in this deterministic order.
         let dirtied: Vec<StreamId> = self
             .streams
             .iter()
@@ -580,40 +586,73 @@ impl<F: Filesystem, C: Clock> StreamSet<F, C> {
             froze: Vec::new(),
             fdatasyncs_issued: 0,
         };
+        // Every froze ordinal (from a PASS-1 flush freeze OR a PASS-2 barrier freeze) lands here and
+        // is sorted into the deterministic dirtied order at the end, byte-identical to the serial loop.
+        let mut froze_ord: Vec<usize> = Vec::new();
 
-        for id in dirtied {
-            let Some(log) = self.streams.get_mut(&id) else {
-                // A stream cannot vanish mid-tick (no concurrent declare/drop here), but be defensive.
-                continue;
-            };
-
-            // PASS 1 — flush this stream's pending bytes to the page cache (no fsync). A flush
-            // failure is the fatal frozen-writer class, identical to a failed barrier: record the
-            // freeze, do NOT advance the durable head, and continue with the siblings.
-            if log.flush_no_sync().is_err() {
-                outcome.fdatasyncs_issued += 1; // the barrier this stream owed is accounted, frozen pre-sync
-                outcome.froze.push(id);
-                continue;
+        // PASS 1 (serial, cheap): flush each dirtied stream's pending bytes to the page cache (no
+        // fsync). A flush failure is the fatal frozen-writer class, identical to a failed barrier:
+        // record the freeze and do NOT advance the durable head. A stream that flushes OK hands its
+        // disjoint `&mut Log` to the barrier fan-out (tagged by its ordinal in `dirtied`). Every
+        // dirtied stream owes exactly one barrier, counted here whether it flush-froze or reaches
+        // PASS 2 (identical count to the serial loop).
+        //
+        // We resolve the `&mut Log` handles by draining the whole map with `iter_mut` and matching
+        // each entry against `dirtied` by ordinal, so the handles are disjoint (`get_mut` in a loop
+        // cannot yield K simultaneous `&mut`). `dirtied` is in the same key order as `iter_mut`, so a
+        // single forward walk aligns them.
+        let mut barriers: Vec<(usize, &mut Log<F, C>)> = Vec::with_capacity(dirtied.len());
+        {
+            let mut next = 0usize;
+            for (id, log) in &mut self.streams {
+                if next >= dirtied.len() {
+                    break;
+                }
+                if *id != dirtied[next] {
+                    continue; // a clean stream between two dirtied ones
+                }
+                let ord = next;
+                next += 1;
+                outcome.fdatasyncs_issued += 1;
+                if log.flush_no_sync().is_err() {
+                    froze_ord.push(ord);
+                    continue;
+                }
+                barriers.push((ord, log));
             }
-
-            // PASS 2 — the covering fdatasync on THIS stream's fd. K dirtied streams => K barriers
-            // (fdatasync cannot be batched across fds). One barrier per dirtied stream is counted
-            // whether it succeeds or freezes the writer.
-            outcome.fdatasyncs_issued += 1;
-            if log.sync_data_only().is_err() {
-                // The barrier failed: this one stream is now frozen read-only, its acks stay PARKED
-                // (I2 upheld — never ack-as-durable without a returned fdatasync). Siblings continue.
-                outcome.froze.push(id);
-                continue;
-            }
-
-            // PASS 3 — the barrier returned: advance THIS stream's durable head and report the
-            // offset up to which its parked acks may release. Per-stream I2: this stream's acks
-            // release only now, after its own fdatasync.
-            log.advance_synced_offset_after_external_sync();
-            outcome.synced.push((id, log.synced_offset()));
         }
 
+        // PASS 2 (fan-out): issue the K covering fdatasyncs CONCURRENTLY across a bounded scoped-worker
+        // set, then JOIN every barrier before ANY ack is released. Each stream is its own fd/`Log`
+        // (disjoint `&mut`), so the barriers are independent and the tick's barrier phase now costs
+        // max(barrier) instead of sum(barrier) (#823). DURABILITY: `par_sync_data_only` returns only
+        // after EVERY barrier has completed, and PASS 3 advances a stream's durable head ONLY on its
+        // `Ok(())` result — a failed fd freezes ONLY its own commits, never a sibling's, and no ack
+        // releases until after this join.
+        let mut barrier_results = par_sync_data_only(barriers);
+        // Reassemble in the deterministic dirtied order (the fan-out returns completion order).
+        barrier_results.sort_unstable_by_key(|(ord, _)| *ord);
+
+        // PASS 3 (serial, deterministic): for each stream whose barrier returned, advance its durable
+        // head and report its ack-release offset (per-stream I2 — acks release only now, after its own
+        // fdatasync); a stream whose barrier failed freezes (acks stay parked).
+        for (ord, result) in barrier_results {
+            let id = &dirtied[ord];
+            if result.is_ok() {
+                if let Some(log) = self.streams.get_mut(id) {
+                    log.advance_synced_offset_after_external_sync();
+                    outcome.synced.push((id.clone(), log.synced_offset()));
+                }
+            } else {
+                froze_ord.push(ord);
+            }
+        }
+
+        froze_ord.sort_unstable();
+        outcome.froze = froze_ord
+            .into_iter()
+            .map(|ord| dirtied[ord].clone())
+            .collect();
         outcome
     }
 
@@ -1070,6 +1109,66 @@ mod tests {
 
         // 30 records were committed across the 3 dirtied streams for 3 barriers: ~0.1 fsync/record.
         // Doubling the per-stream record count would NOT change the barrier count — O(1/batch).
+    }
+
+    /// #823: with K>1 streams dirtied in ONE tick the K covering fdatasyncs are FANNED OUT
+    /// concurrently across a bounded scoped-worker set, yet the outcome stays byte-identical to the
+    /// old serial barrier loop. Under a total fsync fault EVERY dirtied fd's barrier fails on its own
+    /// (per-stream freeze isolation survives the fan-out), the froze set is reported in the
+    /// deterministic default-first order (NOT thread-completion order), and — the paramount durability
+    /// invariant — NO stream's durable head advanced and NO ack released, because every barrier is
+    /// JOINED before the release pass runs.
+    #[test]
+    fn fanned_out_barrier_freeze_is_deterministic_and_acks_nothing() {
+        let (mut set, _, control) = open_faulty(InMemoryFs::new());
+        let def = StreamId::default_stream();
+        let a = StreamId::named("a").unwrap();
+        let b = StreamId::named("b").unwrap();
+        let c = StreamId::named("c").unwrap();
+        for id in [&a, &b, &c] {
+            set.declare(id).unwrap();
+        }
+        // Dirty all 4 streams (default, a, b, c), several records each — K = 4 barriers in one tick.
+        for _ in 0..4 {
+            for id in [&def, &a, &b, &c] {
+                set.append_to(id, &rec(b"r")).unwrap();
+            }
+        }
+        // Each dirtied stream's durable head BEFORE the tick (trails its append head).
+        let before: BTreeMap<StreamId, Offset> = [&def, &a, &b, &c]
+            .iter()
+            .map(|id| ((*id).clone(), set.get(id).unwrap().synced_offset()))
+            .collect();
+
+        control.set_fail_sync(true);
+        let outcome = set.commit_tick();
+        control.set_fail_sync(false);
+
+        assert_eq!(outcome.fdatasyncs_issued, 4);
+        assert!(
+            outcome.synced.is_empty(),
+            "no commit acked when its covering fdatasync failed"
+        );
+        // The froze set is the deterministic default-first (BTreeMap key) order, not completion order.
+        assert_eq!(
+            outcome.froze,
+            vec![def.clone(), a.clone(), b.clone(), c.clone()],
+            "froze reported in deterministic default-first order"
+        );
+        // Each dirtied fd froze on its OWN barrier fault; none advanced its durable head (the release
+        // pass ran only after the join, so a failed barrier released no ack).
+        for id in [&def, &a, &b, &c] {
+            let log = set.get(id).unwrap();
+            assert_eq!(
+                log.synced_offset(),
+                before[id],
+                "a frozen stream's durable head must NOT advance"
+            );
+            assert!(
+                !log.is_writable(),
+                "each dirtied fd froze on its own barrier"
+            );
+        }
     }
 
     /// PER-STREAM I2: each stream's durable head ([`Log::synced_offset`]) advances only after ITS OWN


### PR DESCRIPTION
## What (#823)

Group-commit issued the K `fdatasync` barriers **serially** across independent partition/stream fds, so barrier-phase latency was `sum(barrier)` instead of `max(barrier)`.

## Fix

A new `par_sync_data_only` fans the K barriers across a bounded scoped-worker set (mirroring #817/#822: `min(available_parallelism, COMMIT_BARRIER_MAX_WORKERS, K)`, fallible `spawn_scoped` + main-thread participation → degrades to serial under thread exhaustion), then **joins ALL barriers before releasing ANY ack** in the group. Results are reassembled in deterministic ascending / default-first order.

**Crash-consistency (proven by an adversarial durability lens):** the ordering is flush-all (PASS 1) → fsync-all-and-fully-join (PASS 2) → release/ack (PASS 3). An ack is released only on its fd's `Ok` barrier result, so **no ack can precede its `fdatasync`**; a crash after ack always finds the commit durable. A failing barrier freezes only its own fd (disjoint `&mut Log`), never acked; siblings proceed. Strictly stronger than the old serial loop (which advanced one stream's durable head before the next stream's fsync even ran).

**Concurrency is real (a review caught a first-cut regression):** the initial fan-out ran the blocking `fdatasync` inside a `while let Some(..) = queue.lock()...pop()` scrutinee, whose `MutexGuard` (edition 2021) lives until the end of the loop *body* — silently serializing all K barriers under the mutex (a net regression). Fixed by hoisting the lock+pop into a `let-else` block so the guard drops before the fsync. `group_commit_barriers_overlap_and_do_not_serialize` proves real overlap via a hard rendezvous (the group completes only when `width` barriers are inside `fdatasync` simultaneously) — verified to FAIL if the held-lock is reintroduced, non-flaky, single-core-safe.

## Verification
- fmt + clippy (`-D warnings -W clippy::pedantic`, storage + server) clean
- `cargo test -p ironbus-storage` 435 + integration (fsync-fault / crash-recovery / determinism / seeded-faults) green; `cargo test -p ironbus-server` 964 green
- New tests: the overlap test + `fanned_out_barrier_freeze_is_deterministic_and_acks_nothing` (K>1 total-fsync-fault → all freeze, nothing acked) + `fanned_out_barriers_all_succeed_and_advance_every_durable_head`
- Reviewed across 4 adversarial lenses (correctness, crash-consistency, error-handling, regression) — crash-consistency upheld; the held-lock regression found + fixed + guarded by the overlap test

Closes #823
