### PR TITLE
fix(config): warn on unknown keys in the reserved config sections instead of silently swallowing them (#898)

### DIFF
--- a/crates/ironbus-cli/src/config_file.rs
+++ b/crates/ironbus-cli/src/config_file.rs
@@ -107,7 +107,8 @@ pub struct FileLayer {
     /// (durations/sizes as decimal-integer strings, bools as `true`/`false`, lists comma-joined,
     /// plain strings as-is), so the file value flows through the same parse path as an env value.
     by_env_name: BTreeMap<String, String>,
-    /// Non-fatal warnings to surface (unknown keys downgraded by `--allow-unknown-config`).
+    /// Non-fatal warnings to surface (unknown keys downgraded by `--allow-unknown-config`, and
+    /// reserved-but-unwired sections whose keys are accepted-but-ignored per #898).
     warnings: Vec<String>,
     /// True when the file explicitly set ANY retention key (drives the coupled-set
     /// "retention requested but all off" check, which fires only on an explicit request).
@@ -248,6 +249,12 @@ pub fn load_config_file(
             return Err(ConfigFileError::UnknownKeys(unknown));
         }
     }
+    // A reserved-but-unwired section (`[auth]`/`[observability]`/`[compression]`) parses clean but
+    // silently swallows every key (#898). Surface each such section as a non-fatal WARN so a
+    // misplaced security/codec setting is not believed-applied while being dead. This is
+    // independent of `--allow-unknown-config`: the section is tolerated by design, but its
+    // accepted-but-ignored keys still warrant a loud warning.
+    warnings.extend(config::reserved_section_warnings(&key_set));
 
     // Build the env-name override layer from the KNOWN keys only (an unknown key, if it reached
     // here, was downgraded and is ignored, never wired into a knob).
@@ -482,11 +489,22 @@ mod tests {
     }
 
     #[test]
-    fn a_reserved_section_key_is_tolerated() {
+    fn a_reserved_section_key_is_tolerated_but_warned() {
         let doc = "[observability]\nmetrics_addr = \"127.0.0.1:9000\"\n[auth]\ntoken = \"x\"\n";
         let layer = load_config_file("/x.toml", false, &reader(doc)).unwrap();
-        // No rejection, no warning: a reserved-but-unwired section is allowed.
-        assert!(layer.warnings().is_empty());
+        // NOT rejected (the frozen-section contract still starts the broker), but #898 requires a
+        // loud non-fatal WARN so the accepted-but-ignored keys are not silently swallowed.
+        let warnings = layer.warnings();
+        assert_eq!(warnings.len(), 2, "{warnings:?}");
+        assert!(warnings.iter().all(|w| w.contains("IGNORED")));
+        assert!(warnings.iter().any(|w| w.contains("[auth]")
+            && w.contains("auth.token")
+            && w.contains("--auth-config")));
+        assert!(warnings
+            .iter()
+            .any(|w| w.contains("[observability]") && w.contains("observability.metrics_addr")));
+        // The reserved keys are still NOT wired into any knob.
+        assert!(layer.lookup_env_name("IRONBUS_METRICS_ADDR").is_none());
     }
 
     #[test]

--- a/crates/ironbus-core/src/config.rs
+++ b/crates/ironbus-core/src/config.rs
@@ -740,6 +740,48 @@ pub fn validate_known_keys(keys: &RawKeyMap) -> Vec<UnknownKey> {
     unknown
 }
 
+/// Scans `keys` for entries under a reserved-but-unwired section ([`is_reserved_section`]) and
+/// returns one non-fatal WARNING per such section that carries keys.
+///
+/// The reserved sections (`[auth]`/`[observability]`/`[compression]`) are FROZEN by the #14
+/// stability contract, so [`validate_known_keys`] tolerates them: a file that carries them still
+/// STARTS instead of being rejected as unknown. But none of their keys is wired on this build —
+/// auth is configured only by `--auth-config` and compression only by `--compression`, so a key
+/// placed under one of these headings is accepted-but-IGNORED. That silent swallow is a
+/// false-confidence footgun (#898): an operator believes they enabled auth or a codec via the
+/// main config file, but the setting is dead and unannounced, and a typo that happens to land
+/// under a reserved heading is swallowed the same way. This surfaces it as a loud WARN WITHOUT
+/// failing the start, closing the gap the strict unknown-key check deliberately leaves open.
+/// PURE: consults only the key NAMES (never the values), so it stays IO-free and deterministic.
+#[must_use]
+pub fn reserved_section_warnings(keys: &RawKeyMap) -> Vec<String> {
+    let mut by_section: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
+    for key in keys.keys() {
+        if let Some((section, _)) = key.split_once('.') {
+            if is_reserved_section(section) {
+                by_section.entry(section).or_default().push(key);
+            }
+        }
+    }
+    by_section
+        .into_iter()
+        .map(|(section, keys_in_section)| {
+            // Point at the flag that actually wires the feature, so the operator can fix the file.
+            let hint = match section {
+                "auth" => "; auth is configured via `--auth-config`",
+                "compression" => "; compression is configured via `--compression`",
+                _ => "",
+            };
+            // `keys` is a BTreeMap, so `keys_in_section` is already sorted -> deterministic text.
+            let joined = keys_in_section.join(", ");
+            format!(
+                "reserved config section `[{section}]` is accepted but IGNORED on this build: \
+                 key(s) {joined} have no effect{hint}"
+            )
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -886,6 +928,42 @@ mod tests {
         assert_eq!(unknown.len(), 1, "{unknown:?}");
         assert_eq!(unknown[0].key, "storage.segmnet_size");
         assert_eq!(unknown[0].suggestion, Some("storage.segment_size"));
+    }
+
+    #[test]
+    fn reserved_section_keys_are_tolerated_but_warned_as_ignored() {
+        // #898: a reserved-but-unwired section still parses clean (validate_known_keys returns it
+        // as no unknown), but its keys are accepted-but-ignored, so they must NOT be silent.
+        let mut keys = RawKeyMap::new();
+        keys.insert("auth.require".to_string(), "true".to_string());
+        keys.insert("compression.codec".to_string(), "zstd".to_string());
+        keys.insert("observability.metrics_addr".to_string(), "x".to_string());
+        // A wired key produces no reserved-section warning.
+        keys.insert("storage.segment_size".to_string(), "64MiB".to_string());
+
+        // Still not rejected as unknown (the frozen-section contract is unchanged).
+        assert!(validate_known_keys(&keys).is_empty());
+
+        let warnings = reserved_section_warnings(&keys);
+        // One warning per reserved section that carries keys; the wired `storage` key is silent.
+        assert_eq!(warnings.len(), 3, "{warnings:?}");
+        assert!(warnings.iter().all(|w| w.contains("IGNORED")));
+        assert!(warnings.iter().any(|w| w.contains("[auth]")
+            && w.contains("auth.require")
+            && w.contains("--auth-config")));
+        assert!(warnings.iter().any(|w| w.contains("[compression]")
+            && w.contains("compression.codec")
+            && w.contains("--compression")));
+        assert!(warnings
+            .iter()
+            .any(|w| w.contains("[observability]") && w.contains("observability.metrics_addr")));
+    }
+
+    #[test]
+    fn a_file_with_no_reserved_keys_produces_no_such_warning() {
+        let mut keys = RawKeyMap::new();
+        keys.insert("storage.segment_size".to_string(), "64MiB".to_string());
+        assert!(reserved_section_warnings(&keys).is_empty());
     }
 
     // ---- coupled-set validation ----


### PR DESCRIPTION
## What (#898)

The reserved config sections `[auth]`/`[observability]`/`[compression]` silently swallowed every key, so a misplaced security/codec setting was ignored with no signal.

## Fix

An unknown key in a reserved section now emits a **warning** (with a wiring-flag hint where one exists), instead of being silently dropped. Valid configs are unaffected and the semantics are unchanged (reserved-section keys are still not wired — the warning is purely a misconfiguration signal).

## Verification
- fmt + clippy (`-D warnings -W pedantic`, core + cli) clean; ironbus-core config tests 20 + 2 new green
- Reviewed across 3 adversarial lenses — valid keys unaffected, semantics unchanged, warning does not break parsing

Note: the hot config-**reload** path discards `layer.warnings()` entirely (pre-existing), so reserved-section warnings surface on initial load but not on reload — a small follow-up.

Closes #898
