### PR TITLE
fix(core): remove the Secret newtype's unused non-constant-time PartialEq/Eq (#897)

### DIFF
--- a/crates/ironbus-server/src/auth.rs
+++ b/crates/ironbus-server/src/auth.rs
@@ -40,7 +40,14 @@ use zeroize::Zeroize;
 /// the single explicit [`Secret::expose`] accessor (no `Deref`, no public field), and the bytes are
 /// zeroed on drop with a non-elidable write so the optimizer cannot remove the clear. A struct that
 /// holds a `Secret` and derives `Debug` therefore renders the field as the placeholder for free.
-#[derive(Clone, PartialEq, Eq)]
+///
+/// Equality is DELIBERATELY not derived (#897): a derived `PartialEq`/`Eq` synthesizes a
+/// data-dependent, early-exit `==` over the secret bytes — precisely the timing-oracle primitive the
+/// bearer path avoids via `subtle::ConstantTimeEq`. The type has no equality consumers, and its
+/// safety narrative (redaction by construction) implies callers need not think about how a `Secret`
+/// compares; leaving the derive off keeps that footgun unreachable. If secret equality is ever needed,
+/// hand-implement it over `subtle::ConstantTimeEq` and document that the comparison is constant-time.
+#[derive(Clone)]
 pub struct Secret(Vec<u8>);
 
 impl Secret {


### PR DESCRIPTION
The `Secret` newtype derived `PartialEq`/`Eq` (a non-constant-time byte compare) on the secret container, contradicting its safety-by-construction doc — a timing side-channel if ever used to compare secrets. The derive is **unused** (no `==`/`!=`, no Eq-keyed container over `Secret`), so it's removed (a single-line change), making the timing footgun unreachable and the doc match the code. clippy/fmt clean; 967 server + core/conformance/determinism green. Reviewed across 3 adversarial lenses.

Closes #897