### PR TITLE
fix(server): remove the dead AuthOutcome::Failed variant + scope the authenticated flag to the auth-success block (#889)

### DIFF
--- a/crates/ironbus-server/src/auth.rs
+++ b/crates/ironbus-server/src/auth.rs
@@ -183,10 +183,17 @@ impl fmt::Display for AuthError {
 
 impl std::error::Error for AuthError {}
 
-/// The internal, audit-side reason an auth attempt failed or succeeded (#635, the "Authn outcome" /
-/// "Authz denial" audit events). This is the TRUSTED-side distinction the operator may see; it is
-/// NEVER sent to the client (which always gets the uniform [`AuthError`]). Carries only safe handles
-/// (the mechanism, the resolved identity name where known), never a credential.
+/// The internal, audit-side detail of a SUCCESSFUL auth (#635, the "Authn outcome" audit event). This
+/// is the TRUSTED-side distinction the operator may see; it is NEVER sent to the client (which always
+/// gets the uniform [`AuthError`]). Carries only safe handles (the resolved identity name, the pinned
+/// scope set), never a credential.
+///
+/// FAILURE is NOT a variant here: [`AuthConfig::authenticate`] returns [`Err(AuthError)`] on every
+/// failure, so an `Ok(AuthOutcome)` is by construction a success. Keeping this a value that can ONLY
+/// mean "authenticated" is deliberate: the session handshake destructures it with an irrefutable
+/// `let`, so the connection's `authenticated` flag can never be set without pinning a real identity's
+/// scopes, and adding any non-success variant here becomes a compile error at that call site rather
+/// than a silently-skipped bind (#889).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum AuthOutcome {
     /// Authentication succeeded; the connection is this identity with this pinned scope set.
@@ -195,11 +202,6 @@ pub enum AuthOutcome {
         identity: String,
         /// The pinned scope set.
         scopes: ScopeSet,
-    },
-    /// Authentication failed. The reason is the trusted-side detail; the wire sees only [`AuthError`].
-    Failed {
-        /// Which mechanism the client selected (`bearer` / `password` / `mtls`), or `unknown`.
-        mechanism: &'static str,
     },
 }
 
@@ -715,12 +717,20 @@ mod tests {
         let (id, outcome) = cfg.authenticate(&good, None).unwrap();
         assert_eq!(id.name, "producer");
         assert!(id.scopes.has(Scope::Publish) && !id.scopes.has(Scope::Subscribe));
-        assert!(matches!(outcome, AuthOutcome::Authenticated { .. }));
+        // #889: an `Ok` outcome is by construction `Authenticated` and CARRIES the real pinned state —
+        // the identity name and the identity's actual (non-empty) scope set, exactly what the session
+        // handshake flips `authenticated` on. A success outcome can never be a no-scope shell.
+        let AuthOutcome::Authenticated { identity, scopes } = &outcome;
+        assert_eq!(identity, "producer");
+        assert_eq!(*scopes, id.scopes);
+        assert!(scopes.has(Scope::Publish) && !scopes.has(Scope::Subscribe));
 
         let bad = AuthCredential {
             mechanism: WireMechanism::Bearer,
             material: b"the-wrong-token-entirely-here!!!".to_vec(),
         };
+        // The failure path is `Err(AuthError)`, NEVER `Ok(some-failed-outcome)` — the reason there is no
+        // `AuthOutcome::Failed` for an `Ok` to smuggle a decoupled auth state through (#889).
         assert_eq!(cfg.authenticate(&bad, None).unwrap_err(), AuthError);
     }
 

--- a/crates/ironbus-server/src/session.rs
+++ b/crates/ironbus-server/src/session.rs
@@ -1032,11 +1032,16 @@ impl Session {
                 return Err(SessionError::AuthViolation);
             };
             // Pin the identity's scopes (and the identity NAME, for a later scope-denial audit subject)
-            // for the connection lifetime. The NAME is a safe handle; no credential is retained.
-            if let crate::auth::AuthOutcome::Authenticated { identity, scopes } = &outcome {
-                self.scopes = *scopes;
-                self.identity_name.clone_from(identity);
-            }
+            // for the connection lifetime, then flip the auth flag. The NAME is a safe handle; no
+            // credential is retained. This is an IRREFUTABLE `let`: `authenticate` returns `Err` on every
+            // failure (handled by the `else` above), so an `Ok` outcome is by construction `Authenticated`.
+            // Binding here — rather than an `if let` with the flag flipped outside — couples the flag to
+            // the scope-pinning: `self.authenticated` can never be set without a resolved identity, and if
+            // a non-success variant is ever added to `AuthOutcome` this destructure fails to compile rather
+            // than silently leaving an authenticated-but-no-scope connection (#889).
+            let crate::auth::AuthOutcome::Authenticated { identity, scopes } = &outcome;
+            self.scopes = *scopes;
+            self.identity_name.clone_from(identity);
             self.authenticated = true;
             // Emit the SUCCESSFUL authn outcome to the audit stream (#635): the resolved identity NAME,
             // the mechanism, success — never the credential. Emitted AFTER the scopes are pinned, so a


### PR DESCRIPTION
A never-constructed `AuthOutcome::Failed` variant plus an unconditional `authenticated = true` was a latent auth-state coupling (a future change could set `authenticated` without a successful auth). The dead `Failed` variant is removed (enum doc updated), and `authenticated` is now set **inside** the auth-success block (session.rs:1036, an irrefutable `let` on the success match arm) — a compile-time guard so the flag cannot be decoupled from a genuine success verdict. Strengthened the bearer test (valid token accepted, others rejected). clippy/fmt clean; server suite green. Reviewed across 3 adversarial lenses incl. a security lens.

Closes #889