### PR TITLE
fix(server): drop the DLQ dedup group entry on evict so the dedup map cannot leak across group lifecycles (#905)

### DIFF
--- a/crates/ironbus-server/src/engine.rs
+++ b/crates/ironbus-server/src/engine.rs
@@ -6283,6 +6283,15 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         if ghost == GhostPolicy::Release {
             self.group_last_checkpointed.remove(group);
         }
+        // Free the evicted group's DLQ dedup entry (#905). Only when the sink is ALREADY open — never
+        // force it open here, so a broker that never dead-lettered still never creates `dlq/`. The
+        // evicted group's cursor is gone, so nothing re-poisons under it in-process; a reopen rebuilds
+        // any still-durable entries from the DLQ records regardless. Without this, the per-group key
+        // (an empty-after-pruning `BTreeSet` plus the group-name `String`) leaks once per evicted
+        // group that ever dead-lettered, reclaimed only on reopen.
+        if let Some(sink) = self.dlq.as_mut() {
+            sink.forget_group(group);
+        }
         Ok(())
     }
 
@@ -8242,6 +8251,14 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
     #[must_use]
     pub fn dlq_records(&self) -> u64 {
         self.dlq.as_ref().map_or(0, DlqSink::records)
+    }
+
+    /// The highest source offset the DLQ dedup set CURRENTLY tracks for `group`, or `None` if the
+    /// group is not tracked (or the sink is not open). Test-only inspection of the per-group dedup
+    /// map used to prove the evicted-group entry is dropped (#905).
+    #[cfg(test)]
+    fn dlq_dedup_highest_for_group(&self, group: &str) -> Option<u64> {
+        self.dlq.as_ref().and_then(|s| s.highest_for_group(group))
     }
 
     /// The number of messages currently in flight (leased, not yet acked).
@@ -13855,6 +13872,71 @@ mod tests {
         assert!(
             !e.group_last_checkpointed.contains_key("caught"),
             "explicit unsub releases the ghost"
+        );
+    }
+
+    #[test]
+    fn evicting_a_group_drops_its_dlq_dedup_entry() {
+        // #905: evicting a group that has dead-lettered must FREE its per-group DLQ dedup entry, not
+        // leak the (group-name String + BTreeSet) once per evicted group lifecycle. We construct a
+        // RESIDUAL entry that prune_below cannot reach — a dead-letter of a HIGHER offset committed
+        // while a LOWER one is still leased, then the lower one acked through the NORMAL (non-pruning)
+        // ack path — so the entry survives to eviction time. Pre-fix it leaks; post-fix evict_group
+        // forgets it.
+        let mut e = open(config_with_idle_evict_ms(10));
+        produce(&mut e, b"a"); // offset 0
+        produce(&mut e, b"b"); // offset 1
+
+        // Lease offset 0 in "g" (stays UNCOMMITTED, so the committed watermark holds at 0).
+        let d0 = message(e.poll_in("g", 0).unwrap());
+
+        // Dead-letter the HIGHER offset 1 while offset 0 is still leased: committed stays 0, so
+        // prune_below("g", 0) keeps offset 1's exact-membership entry.
+        let rec1 = e
+            .log
+            .read_from(Offset::new(1), 1)
+            .unwrap()
+            .into_iter()
+            .next()
+            .unwrap();
+        e.dead_letter_in("g", Offset::new(1), 2, rec1).unwrap();
+        assert_eq!(
+            e.dlq_dedup_highest_for_group("g"),
+            Some(1),
+            "the dead-lettered higher offset is tracked while the lower one is still leased"
+        );
+
+        // Ack offset 0 through the NORMAL ack path: the cursor bridges past offset 1 (committed -> 2),
+        // but the normal ack path does NOT prune the dedup set, so {1} is now a residual entry above
+        // no live use — exactly the kind that would leak on eviction.
+        assert_eq!(e.ack_in("g", &d0.token), AckResult::Acked);
+        assert_eq!(
+            e.committed_offset_in("g"),
+            e.flushed_offset(),
+            "g is caught up"
+        );
+        assert_eq!(
+            e.dlq_dedup_highest_for_group("g"),
+            Some(1),
+            "the residual entry survives the normal ack (prune runs only on the dead-letter path)"
+        );
+
+        // "g" is caught up and lease-free: the explicit-Unsub reclaim evicts it now.
+        assert!(
+            e.evict_group_if_idle("g"),
+            "caught-up, lease-free -> evicted"
+        );
+        assert!(!e.has_group("g"));
+        assert_eq!(
+            e.dlq_dedup_highest_for_group("g"),
+            None,
+            "#905: evicting the group drops its DLQ dedup entry (no per-lifecycle leak)"
+        );
+        // The durable DLQ record is untouched — only the in-memory dedup key was freed.
+        assert_eq!(
+            e.dlq_records(),
+            1,
+            "the durable dead-letter record survives"
         );
     }
 

--- a/crates/ironbus-storage/src/dlq.rs
+++ b/crates/ironbus-storage/src/dlq.rs
@@ -450,6 +450,18 @@ impl<F: Filesystem, C: Clock> DlqSink<F, C> {
         }
     }
 
+    /// Drops `group`'s entire dead-lettered offset set (key and all) when the group itself is torn
+    /// down (#905). Unlike [`DlqSink::prune_below`], which trims a still-live group's set against its
+    /// advancing cursor, this forgets a group that has been EVICTED: its cursor is gone, so nothing
+    /// in-process can re-poison under that name, and leaving the (now committed-past, often empty)
+    /// entry behind is a per-group-lifecycle memory leak in the map. Safe because the durable DLQ is
+    /// the source of truth: a fresh group of the same name that later dead-letters rebuilds its exact
+    /// set from [`DlqSink::rebuild_dead_lettered_set`] on reopen, and in-process re-adds on append.
+    /// A no-op when the group has no tracked dead-letters.
+    pub fn forget_group(&mut self, group: &str) {
+        self.dead_lettered.remove(group);
+    }
+
     /// Appends one poison record to the sink and makes it durable (fsync) BEFORE returning, then
     /// adds the source offset to the in-memory dead-lettered set. This is the durable half of the
     /// crash-atomic move: the caller appends-and-fsyncs HERE first, and only then commits the source
@@ -814,5 +826,39 @@ mod tests {
         // Pruning past everything drops the group entry entirely.
         sink.prune_below("a", 6);
         assert_eq!(sink.highest_for_group("a"), None);
+    }
+
+    #[test]
+    fn forget_group_drops_the_whole_entry_regardless_of_the_watermark() {
+        // #905: an EVICTED group's cursor is gone, so nothing re-poisons under it in-process; the
+        // dedup entry (even a non-empty one prune_below cannot reach) must be freed to avoid a
+        // per-group-lifecycle leak in the map, while OTHER groups are untouched.
+        let fs = InMemoryFs::new();
+        let mut sink = DlqSink::open(&fs, ManualClock::new(), config()).unwrap();
+        sink.append_poison("gone", &source_record(5, b"", b"", b"p"), 6)
+            .unwrap();
+        sink.append_poison("stays", &source_record(3, b"", b"", b"p"), 6)
+            .unwrap();
+        assert_eq!(sink.highest_for_group("gone"), Some(5));
+
+        // forget_group drops the entire "gone" entry (unlike prune_below, no watermark is consulted),
+        // leaving the durable record count and every other group intact.
+        sink.forget_group("gone");
+        assert_eq!(sink.highest_for_group("gone"), None);
+        assert!(!sink.already_dead_lettered("gone", 5));
+        assert_eq!(
+            sink.highest_for_group("stays"),
+            Some(3),
+            "other groups untouched"
+        );
+        assert_eq!(
+            sink.records(),
+            2,
+            "forget_group is in-memory only; records survive"
+        );
+
+        // Forgetting an untracked group is a harmless no-op.
+        sink.forget_group("never");
+        assert_eq!(sink.highest_for_group("never"), None);
     }
 }


### PR DESCRIPTION
The DLQ dedup map never dropped a group's entry on evict/forget_group, so the map grew unboundedly across group lifecycles (pre-existing, surfaced by #800). forget_group now drops the whole entry regardless of watermark, leaving other groups intact. Two discriminating tests (drops a non-empty entry prune_below cannot reach; other groups untouched). Reviewed across 3 adversarial lenses (confirmed no still-live group's dedup is dropped).

Closes #905

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
