### PR TITLE
fix(storage): quarantine + LossReport a committed compacted segment with body corruption instead of silently unlinking it (#836, #980)

### DIFF
--- a/crates/ironbus-storage/src/log.rs
+++ b/crates/ironbus-storage/src/log.rs
@@ -1635,9 +1635,20 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
     ///    and must stitch into one offset-contiguous-at-the-segment-boundary chain; the sequence
     ///    half advances by the covered SPAN across a compacted segment, not the survivor count.
     ///
-    /// Neither reconciliation emits a `LossReport` event: a discarded orphan's data is fully present
-    /// in the originals, and an unlinked superseded original's surviving records are present in the
-    /// compacted segment, so no durable record is actually lost (the I1 to I4 invariants hold).
+    /// The orphan-discard and superseded-original reconciliations emit NO `LossReport` event: a
+    /// discarded orphan's data is fully present in the originals, and an unlinked superseded
+    /// original's surviving records are present in the compacted segment, so no durable record is
+    /// actually lost (the I1 to I4 invariants hold). The ONE exception (#836) is a COMMITTED
+    /// compacted segment (footer + meta CRC-valid) whose BODY is corrupt: it is the sole durable
+    /// copy of the survivors it covers, so it is NOT silently unlinked like a crash-before-commit
+    /// orphan — it is quarantined (a forensic copy) and its covered survivor loss IS accounted in
+    /// the `LossReport` (fail-closed + reported, never a silent drop).
+    ///
+    /// Long for the same reason [`Log::build_compacted_chain`] is: the classify MAP, the serial
+    /// side-effecting FOLD (orphan unlink, #836 committed-but-corrupt quarantine + loss accounting),
+    /// and the three overlap/supersede reconciliations are one cohesive procedure that does not
+    /// factor below the line limit without obscuring the ordering the on-disk image depends on.
+    #[allow(clippy::too_many_lines)]
     fn recover_with_compaction(
         fs: F,
         clock: C,
@@ -1658,12 +1669,32 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
             /// A compacted-flagged segment with a torn/CRC-bad trailing footer or block: it did NOT
             /// reach its commit point, so the serial fold unlinks it as a crash-before-commit orphan.
             CompactedOrphan { id: u64 },
+            /// #836: a COMMITTED compacted segment (its footer AND meta block both decoded
+            /// CRC-VALID, proving it reached its commit point) whose BODY is corrupt (a survivor
+            /// frame failed its CRC, or the footer count / body length disagrees). It is the SOLE
+            /// durable copy of the survivors it covers, so it must NEVER be silently unlinked like a
+            /// crash-before-commit orphan: the serial fold QUARANTINES it (a forensic copy) and
+            /// accounts the covered survivor loss in the `LossReport`, then removes the poisoned live
+            /// copy. Carries the survivor byte region + count estimate needed to quarantine + account
+            /// the loss (the covered offset range travels on the typed error for its diagnostics).
+            CompactedCorrupt {
+                id: u64,
+                record_region_start: u64,
+                record_region_end: u64,
+                record_count_estimate: u64,
+            },
         }
         let classified = Self::par_scan_segments(&fs, ids, |fs, id| {
             let reader = SegmentReader::open(fs.open(&segment_file_name(id))?)?;
             if reader.header().is_compacted() {
-                if let Some(scan) = reader.scan_compacted()? {
-                    Ok(Classified::Compacted(CompactedCandidate {
+                // Three distinct outcomes (#836): a valid committed compacted segment (`Ok(Some)`),
+                // a crash-before-commit orphan with no valid trailer (`Ok(None)`, silently unlinked
+                // below because nothing was committed), and a COMMITTED-but-body-corrupt segment
+                // (`Err(CorruptCompacted)`: footer+meta CRC-valid but the body is bit-rotted / count
+                // -inconsistent). The last is the sole durable copy of acked survivors, so it must be
+                // QUARANTINED + reported, never conflated with the orphan unlink.
+                match reader.scan_compacted() {
+                    Ok(Some(scan)) => Ok(Classified::Compacted(CompactedCandidate {
                         id,
                         record_count: scan.records.len() as u64,
                         max_timestamp_ms: scan.max_timestamp_ms,
@@ -1674,9 +1705,22 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
                             covered_end_seq: scan.meta.covered_end_seq,
                         },
                         valid_end: scan.valid_end,
-                    }))
-                } else {
-                    Ok(Classified::CompactedOrphan { id })
+                    })),
+                    Ok(None) => Ok(Classified::CompactedOrphan { id }),
+                    Err(StorageError::CorruptCompacted {
+                        segment_id: _,
+                        covered_base_offset: _,
+                        covered_end_offset: _,
+                        record_region_start,
+                        record_region_end,
+                        record_count_estimate,
+                    }) => Ok(Classified::CompactedCorrupt {
+                        id,
+                        record_region_start,
+                        record_region_end,
+                        record_count_estimate,
+                    }),
+                    Err(e) => Err(e),
                 }
             } else {
                 let scan = reader.scan_recovery()?;
@@ -1697,13 +1741,57 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
         });
         let mut ordinaries: Vec<OrdinaryCandidate> = Vec::new();
         let mut compacteds: Vec<CompactedCandidate> = Vec::new();
+        // #836: loss events for any COMMITTED-but-body-corrupt compacted segment quarantined below,
+        // carried into `build_compacted_chain` so they land in the recovered log's `LossReport` and
+        // are subject to the I3 bounded-loss caps alongside any active-segment torn tail.
+        let mut corrupt_losses: Vec<LossEvent> = Vec::new();
         for c in classified {
             match c? {
                 Classified::Ordinary(o) => ordinaries.push(o),
                 Classified::Compacted(cc) => compacteds.push(cc),
                 Classified::CompactedOrphan { id } => {
                     // A compacted-flagged segment with a torn/CRC-bad trailing footer or block did
-                    // NOT reach its commit point: discard it as a crash-before-commit orphan.
+                    // NOT reach its commit point: discard it as a crash-before-commit orphan. Nothing
+                    // was committed, so the originals remain authoritative and this is not a loss.
+                    fs.remove(&segment_file_name(id))?;
+                    fs.sync_dir()?;
+                }
+                Classified::CompactedCorrupt {
+                    id,
+                    record_region_start,
+                    record_region_end,
+                    record_count_estimate,
+                } => {
+                    // #836: a COMMITTED compacted segment (footer+meta CRC-valid) whose body is
+                    // corrupt is the SOLE durable copy of the survivors it covers, so it must NEVER
+                    // be silently unlinked like a crash-before-commit orphan. Fail closed exactly as
+                    // the active-segment corruption path does: COPY the poisoned survivor region into
+                    // the forensic quarantine store, account the covered survivor loss in the
+                    // `LossReport`, THEN remove the poisoned live copy so it is neither re-triggered
+                    // every boot nor served as truth. The reason is `CorruptRecordBody` (a survivor
+                    // record can no longer be trusted): it counts as data loss and is quarantined,
+                    // the same boundary the active-segment skip uses.
+                    let event = LossEvent::span(
+                        id,
+                        record_region_start,
+                        record_region_end,
+                        record_count_estimate.max(1),
+                        ReasonCode::CorruptRecordBody,
+                    );
+                    // Forensic COPY (never a silent drop), best-effort: a quarantine IO failure never
+                    // blocks recovery, exactly like the active-segment corruption skip.
+                    if let Ok(source) = fs.open(&segment_file_name(id)) {
+                        let _ = crate::quarantine::quarantine_corrupt_span(
+                            &fs,
+                            &source,
+                            &event,
+                            config.max_quarantine_bytes,
+                        );
+                    }
+                    corrupt_losses.push(event);
+                    // Remove the poisoned live copy AFTER the forensic capture: this mirrors the
+                    // orphan unlink, but only once the loss is preserved (quarantine) and reported
+                    // (LossReport), so it is never a SILENT drop.
                     fs.remove(&segment_file_name(id))?;
                     fs.sync_dir()?;
                 }
@@ -1761,8 +1849,16 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
 
         // Step 4: build the reconciled, offset-ordered slot list and verify the chain stitches at
         // segment boundaries. Each entry carries its covered/actual base and end so the continuity
-        // check uses the covered span across a compacted segment.
-        Self::build_compacted_chain(fs, clock, config, keep_ordinary, keep_compacted)
+        // check uses the covered span across a compacted segment. Any #836 committed-but-corrupt
+        // loss events are threaded in so they land in the recovered log's `LossReport`.
+        Self::build_compacted_chain(
+            fs,
+            clock,
+            config,
+            keep_ordinary,
+            keep_compacted,
+            corrupt_losses,
+        )
     }
 
     /// Stitches the reconciled ordinary + compacted candidate set into the recovered [`Log`],
@@ -1780,6 +1876,7 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
         config: LogConfig,
         ordinaries: Vec<OrdinaryCandidate>,
         compacteds: Vec<CompactedCandidate>,
+        corrupt_losses: Vec<LossEvent>,
     ) -> Result<Log<F, C>, StorageError> {
         // A reconciled chain entry, sorted by covered/actual base offset.
         enum Entry {
@@ -1927,6 +2024,17 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
             pending_roll: None,
         };
 
+        // #836: record the covered survivor loss of any COMMITTED-but-corrupt compacted segment the
+        // reconciliation quarantined + removed above. These are real DATA-loss events (unlike the
+        // orphan/superseded unlinks, which lose nothing), so they must show up in the recovered
+        // log's `LossReport` and be subject to the I3 bounded-loss caps below, exactly like an
+        // active-segment corruption skip. The forensic bytes were already copied to `quarantine/`
+        // during the fold; `quarantined_bytes` was seeded from `persisted_bytes` above, which
+        // already reflects them.
+        for event in corrupt_losses {
+            log.loss_report.push(event);
+        }
+
         match active {
             // The highest-range entry is an UNSEALED ordinary segment: it is the active WAL. Drop
             // any torn or unsynced tail and resume appending at the valid prefix end, exactly as the
@@ -1988,8 +2096,11 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
         }
 
         // I3 bounded-loss caps, identical to the v1 path: fail closed rather than accept unbounded
-        // silent loss. The reconciliation itself emits no loss event (no durable record was lost),
-        // so the only loss here is an active-segment torn tail, exactly as in v1 recovery.
+        // silent loss. The orphan/superseded reconciliation unlinks lose nothing (their data is
+        // present elsewhere), so the only loss events here are an active-segment torn tail and any
+        // #836 committed-but-corrupt compacted segment the reconciliation quarantined — the latter
+        // is exactly why the cap matters, so a cascade of corrupt compacted segments fails closed
+        // rather than silently dropping every survivor they covered.
         let per_event_cap = log
             .config
             .max_segment_bytes

--- a/crates/ironbus-storage/src/segment.rs
+++ b/crates/ironbus-storage/src/segment.rs
@@ -75,6 +75,32 @@ pub enum StorageError {
         /// The sequence actually stored.
         found: u64,
     },
+    /// A COMMITTED compacted (v2) segment was found to have a corrupt BODY on a later recovery
+    /// (#836). Its trailing v2 footer AND its 44-byte compaction-meta block BOTH decoded
+    /// CRC-VALID, which proves the segment reached its compaction commit point, yet a survivor
+    /// frame failed its CRC (bit-rot of committed data) or the footer's `record_count` / body
+    /// length disagrees with the decoded survivors. This is DELIBERATELY DISTINCT from the
+    /// crash-before-commit orphan that [`SegmentReader::scan_compacted`] reports as `Ok(None)`
+    /// (no valid trailer at all): a committed compacted segment is the SOLE durable copy of the
+    /// survivors it covers, so recovery must NEVER silently unlink it as an orphan — it
+    /// QUARANTINES the poisoned segment (a forensic copy) and accounts the covered survivor loss
+    /// in the [`crate::loss::LossReport`], rather than dropping acked data unreported.
+    CorruptCompacted {
+        /// The compacted segment's id.
+        segment_id: u64,
+        /// The lowest covered SOURCE offset, from the CRC-valid compaction-meta block.
+        covered_base_offset: u64,
+        /// One past the highest covered SOURCE offset, from the CRC-valid compaction-meta block.
+        covered_end_offset: u64,
+        /// The byte offset where the survivor record region begins (the segment header end).
+        record_region_start: u64,
+        /// The byte offset where the survivor record region ends (the footer start). The span
+        /// `[record_region_start, record_region_end)` is the corrupt survivor region to quarantine.
+        record_region_end: u64,
+        /// The survivor count the CRC-valid footer claims: a best-effort lower bound on the
+        /// records lost, for the loss report's `records_lost_estimate`.
+        record_count_estimate: u64,
+    },
     /// The log writer is frozen: a fatal IO error left it without a valid active
     /// segment, so it refuses further writes rather than risk corruption.
     WriterFrozen,
@@ -183,6 +209,17 @@ impl core::fmt::Display for StorageError {
             } => write!(
                 f,
                 "record {index} has sequence {found}, expected {expected}"
+            ),
+            StorageError::CorruptCompacted {
+                segment_id,
+                covered_base_offset,
+                covered_end_offset,
+                ..
+            } => write!(
+                f,
+                "committed compacted segment {segment_id} (covering offsets \
+                 [{covered_base_offset}, {covered_end_offset})) has a corrupt body past its \
+                 CRC-valid footer/meta; quarantining rather than silently unlinking"
             ),
             StorageError::WriterFrozen => write!(f, "log writer is frozen after a fatal error"),
             StorageError::OffsetOutOfRange { requested, oldest } => write!(
@@ -1688,10 +1725,22 @@ impl<F: RandomAccessFile> SegmentReader<F> {
         let mut prev_seq: Option<u64> = None;
         while cursor < body.len() {
             let Ok((view, consumed)) = codec::decode(&body[cursor..]) else {
-                // A torn or corrupt frame inside a committed compacted segment is corruption, not a
-                // torn tail (the footer+block are present and CRC-valid past this point), so the
-                // segment is structurally inconsistent: refuse it rather than serve a partial set.
-                return Ok(None);
+                // A torn or corrupt frame inside a COMMITTED compacted segment is bit-rot of acked
+                // data, NOT a crash-before-commit torn tail: the trailing footer AND meta block both
+                // decoded CRC-VALID above (~line 1663-1670), which PROVES this segment reached its
+                // compaction commit point. It is the SOLE durable copy of the survivors it covers, so
+                // it must NEVER be conflated with the `Ok(None)` orphan (which recovery silently
+                // unlinks). Signal the committed-but-corrupt case DISTINCTLY (#836), carrying the
+                // covered range (from the CRC-valid meta) and the survivor byte region, so recovery
+                // QUARANTINES it and accounts the loss instead of dropping it unreported.
+                return Err(StorageError::CorruptCompacted {
+                    segment_id: self.header.segment_id,
+                    covered_base_offset: meta.covered_base_offset,
+                    covered_end_offset: meta.covered_end_offset,
+                    record_region_start: header_end,
+                    record_region_end: footer_start,
+                    record_count_estimate: u64::from(footer.record_count),
+                });
             };
             let seq = view.seq.get();
             // Strictly increasing and within the covered sequence span.
@@ -1720,9 +1769,20 @@ impl<F: RandomAccessFile> SegmentReader<F> {
         if u64::from(footer.record_count) != records.len() as u64
             || cursor as u64 != footer_start - header_end
         {
-            // The footer's record count or the body length disagrees with the decoded survivors:
-            // the segment is not a self-consistent compacted segment.
-            return Ok(None);
+            // The footer's record count or the body length disagrees with the decoded survivors.
+            // The footer AND meta block both decoded CRC-VALID above, so this is a COMMITTED
+            // compacted segment (past its commit point), not a crash-before-commit orphan: its
+            // survivors are the sole durable copy. Signal the committed-but-corrupt case DISTINCTLY
+            // (#836) so recovery quarantines it and accounts the loss, rather than the silent
+            // `Ok(None)` orphan unlink that would drop acked data unreported.
+            return Err(StorageError::CorruptCompacted {
+                segment_id: self.header.segment_id,
+                covered_base_offset: meta.covered_base_offset,
+                covered_end_offset: meta.covered_end_offset,
+                record_region_start: header_end,
+                record_region_end: footer_start,
+                record_count_estimate: u64::from(footer.record_count),
+            });
         }
         Ok(Some(CompactedScan {
             header: self.header,

--- a/crates/ironbus-storage/tests/compaction_crash.rs
+++ b/crates/ironbus-storage/tests/compaction_crash.rs
@@ -120,63 +120,98 @@ fn fully_compacted_sole_copy() -> (InMemoryFs, Vec<OwnedRecord>, Vec<OwnedRecord
     (fs, before, want, compacted_id)
 }
 
-/// The final assertion shared by both #836 variants: after the corruption, `Log::open` must NOT
-/// silently unlink-and-lose the sole compacted copy. Acceptable outcomes are (a) fail-closed with a
-/// typed `StorageError`, or (b) recover while KEEPING the compacted file (or a `quarantine/` copy)
-/// and, if any covered survivor offset is dropped from the read, recording it in the `LossReport`.
-/// The forbidden outcome is a silent success that unlinks the file, drops survivors, and emits NO
-/// loss event — unbounded silent data loss, the worst recovery outcome.
+/// The final assertion shared by both #836 variants: after the corruption of a COMMITTED compacted
+/// segment (its footer + meta stay CRC-valid), `Log::open` must fail closed by QUARANTINING the sole
+/// durable copy and ACCOUNTING the covered survivor loss in the `LossReport` — never the silent
+/// crash-before-commit-orphan unlink that drops every survivor unreported.
+///
+/// This is the post-#836-fix expectation (the pre-fix behaviour reproduced the silent sole-copy
+/// loss). It asserts, precisely:
+/// 1. `Log::open` SUCCEEDS (recovery quarantines + reports rather than aborting the whole boot);
+/// 2. the poisoned segment is QUARANTINED — a forensic copy exists under `quarantine/`, so it is
+///    provably NOT silently gone;
+/// 3. the `LossReport` accounts the covered survivors as real DATA loss (a `CorruptRecordBody` event
+///    on the compacted segment id, with a `records_lost_estimate` covering every survivor), so the
+///    survivors that dropped out of the live read did so ACCOUNTED, never silently.
 fn assert_not_silently_lost(fs: InMemoryFs, compacted_id: u64, want_survivors: &[OwnedRecord]) {
-    match Log::open(fs, ManualClock::new(), small_config()) {
-        Err(_) => {
-            // Fail-closed: recovery refused to interpret the structurally inconsistent committed
-            // compacted segment rather than silently discarding it. Acceptable.
-        }
-        Ok(recovered) => {
-            // Read the whole recovered log TOLERANTLY: after a silent unlink the survivors below the
-            // new oldest offset are gone, so `read_from(ZERO, ..)` itself errors `OffsetOutOfRange`
-            // — that error is already proof of loss, so treat it as "nothing recovered from origin"
-            // rather than letting an incidental unwrap mask the real assertion below.
-            let head = recovered.flushed_offset().get();
-            let got = recovered
-                .read_from(Offset::ZERO, usize::try_from(head).unwrap_or(usize::MAX))
-                .unwrap_or_default();
-            let got_offsets: std::collections::HashSet<u64> =
-                got.iter().map(|r| r.offset.get()).collect();
-            let lost: Vec<u64> = want_survivors
-                .iter()
-                .map(|r| r.offset.get())
-                .filter(|o| !got_offsets.contains(o))
-                .collect();
-            let loss_reported = !recovered.loss_report().is_empty();
-            let fs = recovered.into_filesystem();
-            let file_present = fs.exists(&segment_file_name(compacted_id)).unwrap();
-            let quarantined = fs.subdir_exists("quarantine").unwrap();
+    let recovered = Log::open(fs, ManualClock::new(), small_config())
+        .expect("recovery must quarantine + report the committed-but-corrupt compacted segment, not fail the whole boot");
 
-            assert!(
-                lost.is_empty() || loss_reported || file_present || quarantined,
-                "SILENT SOLE-COPY DATA LOSS (#836): recovery unlinked the committed compacted \
-                 segment as if it were a crash-before-commit orphan. Survivor offsets {lost:?} \
-                 vanished with NO LossReport, the compacted file is gone (present={file_present}), \
-                 and nothing was quarantined (quarantine_dir={quarantined}). Recovery must fail \
-                 closed or quarantine, never silently drop the sole durable copy."
-            );
-        }
-    }
+    // Read every record STILL LIVE, from the recovered log's earliest retained offset (quarantining
+    // the poisoned compacted segment raises the oldest offset past its covered range, so a
+    // `read_from(ZERO, ..)` would just error `OffsetOutOfRange`). The survivors the compacted segment
+    // was the SOLE copy of are absent from this live read: they are the genuinely-lost set, distinct
+    // from a survivor that also lived in an un-compacted segment (e.g. the keyless tail).
+    let head = recovered.flushed_offset().get();
+    let got = recovered
+        .read_from(
+            recovered.earliest_offset(),
+            usize::try_from(head).unwrap_or(usize::MAX),
+        )
+        .unwrap_or_default();
+    let got_offsets: std::collections::HashSet<u64> = got.iter().map(|r| r.offset.get()).collect();
+    let lost: Vec<u64> = want_survivors
+        .iter()
+        .map(|r| r.offset.get())
+        .filter(|o| !got_offsets.contains(o))
+        .collect();
+
+    // The LossReport must ACCOUNT the covered survivor loss: a data-loss event on the poisoned
+    // compacted segment, estimating at least as many records as it held survivors.
+    let report = recovered.loss_report().clone();
+    let accounted_records =
+        report.records_lost_for(ironbus_storage::loss::ReasonCode::CorruptRecordBody);
+    let event_for_segment = report
+        .events
+        .iter()
+        .any(|e| e.segment_id == compacted_id && e.reason_code.is_data_loss());
+
+    let fs = recovered.into_filesystem();
+    let quarantined = fs.subdir_exists("quarantine").unwrap();
+
+    // (1) At least one sole-copy survivor left the LIVE log (the poisoned segment WAS the sole
+    // durable copy of the survivors it covered)...
+    assert!(
+        !lost.is_empty(),
+        "the sole-copy survivors the poisoned compacted segment covered must drop out of the live \
+         read once it is quarantined"
+    );
+    // (2) ...but the segment is QUARANTINED (a forensic copy), never silently unlinked...
+    assert!(
+        quarantined,
+        "SILENT SOLE-COPY DATA LOSS (#836): the committed compacted segment must be quarantined \
+         (a forensic copy under quarantine/), not unlinked as a crash-before-commit orphan"
+    );
+    // (3) ...and the covered survivor loss is ACCOUNTED in the LossReport (fail-closed + reported):
+    // a data-loss event on the poisoned segment, estimating at least as many lost records as
+    // vanished from the live read. The keyless tail survivor (offset 12) lives in an un-compacted
+    // segment, so it stays durable and is NOT counted here — only the compacted segment's own
+    // survivors are the sole-copy loss.
+    assert!(
+        !report.is_empty() && event_for_segment && report.data_loss_bytes() > 0,
+        "SILENT SOLE-COPY DATA LOSS (#836): recovery must emit a data-loss LossReport event for the \
+         quarantined compacted segment {compacted_id}, never drop the sole durable copy unreported \
+         (report={report:?})"
+    );
+    assert!(
+        accounted_records >= lost.len() as u64,
+        "the LossReport must account at least the {} vanished sole-copy survivors as lost records, \
+         got {accounted_records}",
+        lost.len()
+    );
 }
 
 /// #836 variant 1: a mid-body survivor bit-flip in a committed compacted segment (the trailing
 /// footer + 44-byte compaction block are left intact, so they stay CRC-valid and decode). This is
-/// NOT a crash-before-commit orphan — the segment reached its commit point — yet `scan_compacted`
-/// collapses the corrupt-body case into the same `Ok(None)` a torn footer yields, and recovery then
-/// unlinks the SOLE durable copy of every survivor it covered.
+/// NOT a crash-before-commit orphan — the segment reached its commit point — so `scan_compacted`
+/// must report it DISTINCTLY from the `Ok(None)` a torn footer yields, and recovery must quarantine
+/// + account the SOLE durable copy rather than silently unlinking it.
 ///
-/// KNOWN-FAILING / CONFIRMED BUG (#836): under the current recovery this reproduces silent
-/// sole-copy data loss — `Log::open` succeeds, the compacted file is unlinked, offsets 0..12 vanish
-/// with no `LossReport` and no quarantine. Marked `#[ignore]` so CI stays green; un-ignore it once
-/// recovery distinguishes a post-commit corrupt body (fail-closed or quarantine) from a
-/// crash-before-commit orphan. Run explicitly with `cargo test -- --ignored` to see it fail today.
-#[ignore = "#836: recovery silently unlinks a mid-body-corrupt committed compacted segment (sole-copy data loss); un-ignore once recovery fails closed / quarantines"]
+/// Regression guard for the fix: `scan_compacted` returns the typed `Err(CorruptCompacted)` on the
+/// mid-body corruption branch, and `Log::open` quarantines the poisoned segment and records the
+/// covered survivor loss in the `LossReport`. Before the fix this reproduced silent sole-copy data
+/// loss (the file was unlinked, offsets 10..12 vanished with no `LossReport` and no quarantine); if
+/// that silent-unlink ever regresses, `assert_not_silently_lost` fails.
 #[test]
 fn mid_body_corruption_in_a_committed_compacted_segment_is_not_silently_unlinked() {
     let (fs, _before, want, compacted_id) = fully_compacted_sole_copy();
@@ -193,18 +228,20 @@ fn mid_body_corruption_in_a_committed_compacted_segment_is_not_silently_unlinked
     file.sync_all().unwrap();
     fs.sync_dir().unwrap();
 
-    // The flip drives `scan_compacted` down the mid-body corruption `Ok(None)` branch (footer + meta
-    // still decode, but a survivor frame fails its CRC), the precise case recovery must not conflate
-    // with an uncommitted orphan.
+    // The flip drives `scan_compacted` down the mid-body corruption branch (footer + meta still
+    // decode CRC-valid, but a survivor frame fails its CRC). Post-fix that returns the DISTINCT typed
+    // `Err(CorruptCompacted)`, never the crash-before-commit `Ok(None)` recovery would unlink.
     {
         let reader =
             SegmentReader::open(fs.open(&segment_file_name(compacted_id)).unwrap()).unwrap();
         let scan = reader.scan_compacted();
         assert!(
-            matches!(scan, Ok(None)) || scan.is_err(),
-            "the byte flip makes the committed compacted segment un-scannable: `Ok(None)` today \
-             (the mid-body corruption branch), or a typed error under a fail-closed fix — never a \
-             valid scan"
+            matches!(
+                scan,
+                Err(ironbus_storage::segment::StorageError::CorruptCompacted { .. })
+            ),
+            "a mid-body-corrupt COMMITTED compacted segment must report the distinct \
+             CorruptCompacted signal, not the crash-before-commit Ok(None) orphan"
         );
     }
 
@@ -214,12 +251,12 @@ fn mid_body_corruption_in_a_committed_compacted_segment_is_not_silently_unlinked
 /// #836 variant 2: a footer `record_count` / body-length DISAGREEMENT past the valid trailers. The
 /// footer and meta block are re-stamped with a fresh, CRC-valid footer whose `record_count` no
 /// longer matches the survivors on disk, so `scan_compacted` decodes every frame and both trailers
-/// cleanly, then returns `Ok(None)` at the count cross-check (segment.rs) — again indistinguishable,
-/// to recovery, from a crash-before-commit orphan, and again the sole copy is unlinked.
+/// cleanly, then hits the count cross-check (segment.rs). That segment reached its commit point, so
+/// it must be reported DISTINCTLY from a crash-before-commit orphan and quarantined, not unlinked.
 ///
-/// KNOWN-FAILING / CONFIRMED BUG (#836), sibling of the mid-body variant: same silent sole-copy
-/// loss via the third `Ok(None)` case. `#[ignore]`d so CI stays green; un-ignore once fixed.
-#[ignore = "#836: recovery silently unlinks a footer-count-inconsistent committed compacted segment (sole-copy data loss); un-ignore once recovery fails closed / quarantines"]
+/// Regression guard, sibling of the mid-body variant: the count cross-check returns the typed
+/// `Err(CorruptCompacted)` and recovery quarantines + accounts the loss. Before the fix this
+/// reproduced the same silent sole-copy loss via the third `Ok(None)` case.
 #[test]
 fn footer_count_disagreement_in_a_committed_compacted_segment_is_not_silently_unlinked() {
     let (fs, _before, want, compacted_id) = fully_compacted_sole_copy();
@@ -243,15 +280,19 @@ fn footer_count_disagreement_in_a_committed_compacted_segment_is_not_silently_un
     fs.sync_dir().unwrap();
 
     // The re-stamped footer is CRC-valid but disagrees with the body count, so `scan_compacted`
-    // returns `Ok(None)` at the count cross-check — the third case collapsed into the orphan branch.
+    // returns the DISTINCT typed `Err(CorruptCompacted)` at the count cross-check — never the
+    // crash-before-commit `Ok(None)` orphan recovery would silently unlink.
     {
         let reader =
             SegmentReader::open(fs.open(&segment_file_name(compacted_id)).unwrap()).unwrap();
         let scan = reader.scan_compacted();
         assert!(
-            matches!(scan, Ok(None)) || scan.is_err(),
-            "the count bump makes the committed compacted segment un-scannable: `Ok(None)` today \
-             (the footer/body-length disagreement branch), or a typed error under a fix"
+            matches!(
+                scan,
+                Err(ironbus_storage::segment::StorageError::CorruptCompacted { .. })
+            ),
+            "a footer-count-inconsistent COMMITTED compacted segment must report the distinct \
+             CorruptCompacted signal, not the crash-before-commit Ok(None) orphan"
         );
     }
 

--- a/crates/ironbus-storage/tests/compaction_crash.rs
+++ b/crates/ironbus-storage/tests/compaction_crash.rs
@@ -19,7 +19,8 @@
 
 use bytes::Bytes;
 use ironbus_core::clock::ManualClock;
-use ironbus_core::segment::SegmentHeader;
+use ironbus_core::format::{COMPACTION_META_LEN, SEGMENT_FOOTER_LEN, SEGMENT_HEADER_LEN};
+use ironbus_core::segment::{SegmentFooter, SegmentHeader};
 use ironbus_core::types::Offset;
 use ironbus_storage::compaction::CompactionConfig;
 use ironbus_storage::fault::FaultFs;
@@ -89,6 +90,172 @@ fn all_records(log: &Log<InMemoryFs, ManualClock>) -> Vec<OwnedRecord> {
     let head = log.flushed_offset().get();
     log.read_from(Offset::ZERO, usize::try_from(head).unwrap())
         .unwrap()
+}
+
+/// Builds a dirty log, FULLY compacts it on a clean disk (so the compacted segment is durable and
+/// its covered originals are unlinked — the compacted segment is now the SOLE durable copy of its
+/// survivors), and returns the disk, the pre-compaction record set, the covered survivor set, and
+/// the id of the committed compacted segment. This is the exact starting image #836 describes: a
+/// mid-body bit-flip in this segment must NOT be conflated with a crash-before-commit orphan.
+fn fully_compacted_sole_copy() -> (InMemoryFs, Vec<OwnedRecord>, Vec<OwnedRecord>, u64) {
+    let (fs, before, _head) = build_dirty_log(InMemoryFs::new());
+    let want = expected_survivors(&before);
+    let mut log = Log::open(fs, ManualClock::new(), small_config()).unwrap();
+    let out = log.maybe_compact(&CompactionConfig::enabled()).unwrap();
+    assert!(
+        out.compacted_segment_id.is_some(),
+        "the pass produced a committed compacted segment"
+    );
+    let fs = log.into_filesystem();
+    let compacted_id = segment_ids(&fs)
+        .unwrap()
+        .into_iter()
+        .find(|&id| {
+            SegmentReader::open(fs.open(&segment_file_name(id)).unwrap())
+                .unwrap()
+                .header()
+                .is_compacted()
+        })
+        .expect("a committed compacted segment exists on disk");
+    (fs, before, want, compacted_id)
+}
+
+/// The final assertion shared by both #836 variants: after the corruption, `Log::open` must NOT
+/// silently unlink-and-lose the sole compacted copy. Acceptable outcomes are (a) fail-closed with a
+/// typed `StorageError`, or (b) recover while KEEPING the compacted file (or a `quarantine/` copy)
+/// and, if any covered survivor offset is dropped from the read, recording it in the `LossReport`.
+/// The forbidden outcome is a silent success that unlinks the file, drops survivors, and emits NO
+/// loss event — unbounded silent data loss, the worst recovery outcome.
+fn assert_not_silently_lost(fs: InMemoryFs, compacted_id: u64, want_survivors: &[OwnedRecord]) {
+    match Log::open(fs, ManualClock::new(), small_config()) {
+        Err(_) => {
+            // Fail-closed: recovery refused to interpret the structurally inconsistent committed
+            // compacted segment rather than silently discarding it. Acceptable.
+        }
+        Ok(recovered) => {
+            // Read the whole recovered log TOLERANTLY: after a silent unlink the survivors below the
+            // new oldest offset are gone, so `read_from(ZERO, ..)` itself errors `OffsetOutOfRange`
+            // — that error is already proof of loss, so treat it as "nothing recovered from origin"
+            // rather than letting an incidental unwrap mask the real assertion below.
+            let head = recovered.flushed_offset().get();
+            let got = recovered
+                .read_from(Offset::ZERO, usize::try_from(head).unwrap_or(usize::MAX))
+                .unwrap_or_default();
+            let got_offsets: std::collections::HashSet<u64> =
+                got.iter().map(|r| r.offset.get()).collect();
+            let lost: Vec<u64> = want_survivors
+                .iter()
+                .map(|r| r.offset.get())
+                .filter(|o| !got_offsets.contains(o))
+                .collect();
+            let loss_reported = !recovered.loss_report().is_empty();
+            let fs = recovered.into_filesystem();
+            let file_present = fs.exists(&segment_file_name(compacted_id)).unwrap();
+            let quarantined = fs.subdir_exists("quarantine").unwrap();
+
+            assert!(
+                lost.is_empty() || loss_reported || file_present || quarantined,
+                "SILENT SOLE-COPY DATA LOSS (#836): recovery unlinked the committed compacted \
+                 segment as if it were a crash-before-commit orphan. Survivor offsets {lost:?} \
+                 vanished with NO LossReport, the compacted file is gone (present={file_present}), \
+                 and nothing was quarantined (quarantine_dir={quarantined}). Recovery must fail \
+                 closed or quarantine, never silently drop the sole durable copy."
+            );
+        }
+    }
+}
+
+/// #836 variant 1: a mid-body survivor bit-flip in a committed compacted segment (the trailing
+/// footer + 44-byte compaction block are left intact, so they stay CRC-valid and decode). This is
+/// NOT a crash-before-commit orphan — the segment reached its commit point — yet `scan_compacted`
+/// collapses the corrupt-body case into the same `Ok(None)` a torn footer yields, and recovery then
+/// unlinks the SOLE durable copy of every survivor it covered.
+///
+/// KNOWN-FAILING / CONFIRMED BUG (#836): under the current recovery this reproduces silent
+/// sole-copy data loss — `Log::open` succeeds, the compacted file is unlinked, offsets 0..12 vanish
+/// with no `LossReport` and no quarantine. Marked `#[ignore]` so CI stays green; un-ignore it once
+/// recovery distinguishes a post-commit corrupt body (fail-closed or quarantine) from a
+/// crash-before-commit orphan. Run explicitly with `cargo test -- --ignored` to see it fail today.
+#[ignore = "#836: recovery silently unlinks a mid-body-corrupt committed compacted segment (sole-copy data loss); un-ignore once recovery fails closed / quarantines"]
+#[test]
+fn mid_body_corruption_in_a_committed_compacted_segment_is_not_silently_unlinked() {
+    let (fs, _before, want, compacted_id) = fully_compacted_sole_copy();
+
+    // Flip one byte inside a NON-TAIL survivor frame: 8 bytes past the 64-byte header lands in the
+    // first survivor's frame, well before the footer. The footer (32) + meta block (44) at the very
+    // end are untouched, so they still decode CRC-valid — the exact ambiguous shape #836 names.
+    let file = fs.open(&segment_file_name(compacted_id)).unwrap();
+    let flip_at = SEGMENT_HEADER_LEN as u64 + 8;
+    let mut b = [0u8; 1];
+    file.read_exact_at(&mut b, flip_at).unwrap();
+    b[0] ^= 0xFF;
+    file.write_all_at(&b, flip_at).unwrap();
+    file.sync_all().unwrap();
+    fs.sync_dir().unwrap();
+
+    // The flip drives `scan_compacted` down the mid-body corruption `Ok(None)` branch (footer + meta
+    // still decode, but a survivor frame fails its CRC), the precise case recovery must not conflate
+    // with an uncommitted orphan.
+    {
+        let reader =
+            SegmentReader::open(fs.open(&segment_file_name(compacted_id)).unwrap()).unwrap();
+        let scan = reader.scan_compacted();
+        assert!(
+            matches!(scan, Ok(None)) || scan.is_err(),
+            "the byte flip makes the committed compacted segment un-scannable: `Ok(None)` today \
+             (the mid-body corruption branch), or a typed error under a fail-closed fix — never a \
+             valid scan"
+        );
+    }
+
+    assert_not_silently_lost(fs, compacted_id, &want);
+}
+
+/// #836 variant 2: a footer `record_count` / body-length DISAGREEMENT past the valid trailers. The
+/// footer and meta block are re-stamped with a fresh, CRC-valid footer whose `record_count` no
+/// longer matches the survivors on disk, so `scan_compacted` decodes every frame and both trailers
+/// cleanly, then returns `Ok(None)` at the count cross-check (segment.rs) — again indistinguishable,
+/// to recovery, from a crash-before-commit orphan, and again the sole copy is unlinked.
+///
+/// KNOWN-FAILING / CONFIRMED BUG (#836), sibling of the mid-body variant: same silent sole-copy
+/// loss via the third `Ok(None)` case. `#[ignore]`d so CI stays green; un-ignore once fixed.
+#[ignore = "#836: recovery silently unlinks a footer-count-inconsistent committed compacted segment (sole-copy data loss); un-ignore once recovery fails closed / quarantines"]
+#[test]
+fn footer_count_disagreement_in_a_committed_compacted_segment_is_not_silently_unlinked() {
+    let (fs, _before, want, compacted_id) = fully_compacted_sole_copy();
+
+    // Re-stamp the trailing footer with record_count + 1 and a VALID v2 CRC, leaving the survivor
+    // frames and the meta block exactly as they are. The footer now describes one more record than
+    // the body holds, driving the footer/body-length disagreement branch.
+    let file = fs.open(&segment_file_name(compacted_id)).unwrap();
+    let file_len = file.len().unwrap();
+    let footer_start = file_len - COMPACTION_META_LEN as u64 - SEGMENT_FOOTER_LEN as u64;
+    let mut fbuf = [0u8; SEGMENT_FOOTER_LEN];
+    file.read_exact_at(&mut fbuf, footer_start).unwrap();
+    let footer = SegmentFooter::decode(&fbuf).expect("the committed footer decodes");
+    let tampered = SegmentFooter {
+        record_count: footer.record_count + 1,
+        ..footer
+    };
+    file.write_all_at(&tampered.encode_v2(), footer_start)
+        .unwrap();
+    file.sync_all().unwrap();
+    fs.sync_dir().unwrap();
+
+    // The re-stamped footer is CRC-valid but disagrees with the body count, so `scan_compacted`
+    // returns `Ok(None)` at the count cross-check — the third case collapsed into the orphan branch.
+    {
+        let reader =
+            SegmentReader::open(fs.open(&segment_file_name(compacted_id)).unwrap()).unwrap();
+        let scan = reader.scan_compacted();
+        assert!(
+            matches!(scan, Ok(None)) || scan.is_err(),
+            "the count bump makes the committed compacted segment un-scannable: `Ok(None)` today \
+             (the footer/body-length disagreement branch), or a typed error under a fix"
+        );
+    }
+
+    assert_not_silently_lost(fs, compacted_id, &want);
 }
 
 #[test]


### PR DESCRIPTION
## What (#836 [test/high] → surfaced the #980 high-severity silent data-loss bug)

The #836 coverage surfaced a **silent sole-copy data-loss bug** (#980, same class as the #868 critical). After compaction the compacted segment is the **sole durable copy** of its survivors. `SegmentReader::scan_compacted` returned `Ok(None)` for two post-commit body inconsistencies — a mid-body corrupt survivor frame, and a footer `record_count`/body-length disagreement — even though the footer + 44-byte meta had already decoded **CRC-valid** (proving the segment reached its commit point). `Log::recover_with_compaction` treated any `Ok(None)` as a crash-before-commit orphan and **unlinked the file**, silently dropping every covered survivor with no LossReport, no quarantine, no fail-closed.

## Fix (mirrors #868: require proof-of-not-committed before destroying acked data)

- New typed `StorageError::CorruptCompacted { segment_id, covered_base/end_offset, record_region, record_count_estimate }`. The two post-commit branches now return `Err(CorruptCompacted)` (carrying the covered range from the CRC-valid meta) instead of `Ok(None)`; a genuine crash-before-commit (torn/CRC-bad footer or meta) still returns `Ok(None)`.
- `recover_with_compaction` classifies `Err(CorruptCompacted)` as a new `Classified::CompactedCorrupt`: it **quarantines** the poisoned survivor region (existing `quarantine::quarantine_corrupt_span`), appends a `ReasonCode::CorruptRecordBody` `LossEvent` for the covered survivors (threaded into the recovered `LossReport`, subject to the I3 bounded-loss caps so a cascade fails closed), then removes the poisoned live copy — **never a silent drop**.
- The genuine crash-before-commit orphan → unlink path is unchanged (guarded by `crash_before_the_commit_point_keeps_the_originals`).

## Verification
- The two reproducing tests are **un-ignored and now pass** (`mid_body_corruption_...`, `footer_count_disagreement_...`): each asserts `scan_compacted` returns `Err(CorruptCompacted)`, `Log::open` succeeds, the segment is quarantined (not silently gone), and the `LossReport` accounts the covered survivors — they'd fail if the silent-unlink regressed.
- fmt + clippy (`-D warnings -W clippy::pedantic`) clean; `cargo test -p ironbus-storage` (436 lib + corruption_corpus/crash_recovery/quarantine_recovery/**determinism byte-identical-disk-image**/seeded_faults all green); `cargo test -p ironbus-server` 971 green.

Closes #836, #980
