### PR TITLE
test(proto): fuzz/property coverage for the six broker-ingress body decoders (#851)

### DIFF
--- a/crates/ironbus-proto/src/message.rs
+++ b/crates/ironbus-proto/src/message.rs
@@ -4044,8 +4044,13 @@ mod tests {
         }
 
         /// Decoding arbitrary bytes as any fallible body codec (PUB, ACK, DELIVER, DEAD_LETTER,
-        /// TRUNCATED) never panics and never reads out of bounds: each returns a typed
-        /// `BodyError` or a valid view, the property-level complement to the per-codec fuzz targets.
+        /// TRUNCATED, CONNECT, INFO, and the #851 stream/subject/txn ingress bodies) never panics and
+        /// never reads out of bounds: each returns a typed `BodyError` or a valid view, and for the
+        /// three verbatim carriers the carried `pub_body` re-decodes without panic — the property-level
+        /// complement to the per-codec fuzz targets. This is the fully-arbitrary sweep (mostly rejected
+        /// at the version gate); `framed_broker_ingress_bodies_round_trip_and_never_panic` is the
+        /// companion WELL-FRAMED sweep that reliably reaches the read-helper caps and the carrier
+        /// `decode_pub(pub_body)` composition.
         #[test]
         fn decoding_arbitrary_bytes_never_panics(bytes in prop::collection::vec(any::<u8>(), 0..64)) {
             let _ = decode_pub(&bytes);
@@ -4113,6 +4118,93 @@ mod tests {
             // SUB is infallible: any byte string is a valid body, and decoding it recovers the
             // exact bytes as the group, so it cannot panic either.
             prop_assert_eq!(decode_sub(&bytes).group, bytes.as_slice());
+            // #851: the six BROKER-INGRESS stream/subject/txn body decoders are untrusted attack
+            // surface too (a hostile PubTo/SubTo/TxnPrepare/PubSubject/SubSubject/BindSubject at the
+            // leader). Each rides the version+`field_len` frame and the capped `read_stream_id`/
+            // `read_subject`/`read_txn_id` helpers, none of which the six hand-picked reject cases
+            // sweep — so decoding any byte string must be a typed `BodyError` or a valid view, never a
+            // panic / over-read / over-allocation.
+            let _ = decode_sub_to(&bytes);
+            let _ = decode_bind_subject(&bytes);
+            let _ = decode_sub_subject(&bytes);
+            // The three VERBATIM CARRIERS expose `pub_body = r.rest()`, which the broker feeds straight
+            // into `decode_pub`. Drive that broker-as-used COMPOSITION on the fuzz input: on a decoded
+            // view, re-decoding the carried `pub_body` tail must also never panic.
+            if let Ok(view) = decode_pub_to(&bytes) {
+                let _ = decode_pub(view.pub_body);
+            }
+            if let Ok(view) = decode_pub_subject(&bytes) {
+                let _ = decode_pub(view.pub_body);
+            }
+            if let Ok(view) = decode_txn_prepare(&bytes) {
+                let _ = decode_pub(view.pub_body);
+            }
+        }
+
+        /// #851 (companion, WELL-FRAMED sweep): the fully-arbitrary sweep above almost never gets past
+        /// the fixed `STREAM_WIRE_BODY_VERSION` gate, so it rarely exercises the read-helper caps or the
+        /// verbatim-carrier `decode_pub(pub_body)` composition that are the real residual risk. Here the
+        /// six ingress bodies are built VALID (via their encoders) from arbitrary field contents, so
+        /// decode is driven all the way through the block and — for the carriers — leaves an ARBITRARY
+        /// `pub_body` tail. Each body must round-trip EXACTLY (a discriminating identity, not a mere
+        /// no-panic), and re-decoding the carrier `pub_body` tail with `decode_pub` (the broker-as-used
+        /// composition) must never panic on that arbitrary tail.
+        #[test]
+        fn framed_broker_ingress_bodies_round_trip_and_never_panic(
+            stream_id in prop::collection::vec(any::<u8>(), 0..80),
+            group in prop::collection::vec(any::<u8>(), 0..80),
+            subject in prop::collection::vec(any::<u8>(), 0..80),
+            txn_id in prop::collection::vec(any::<u8>(), 0..80),
+            pub_body in prop::collection::vec(any::<u8>(), 0..96),
+        ) {
+            // PubTo (verbatim carrier): stream_id + arbitrary pub_body tail.
+            let mut buf = Vec::new();
+            encode_pub_to(&PubToBody { stream_id: &stream_id, pub_body: &pub_body }, &mut buf).unwrap();
+            let v = decode_pub_to(&buf).unwrap();
+            prop_assert_eq!(v.stream_id, stream_id.as_slice());
+            prop_assert_eq!(v.pub_body, pub_body.as_slice());
+            let _ = decode_pub(v.pub_body);
+
+            // PubSubject (verbatim carrier): subject + arbitrary pub_body tail.
+            let mut buf = Vec::new();
+            encode_pub_subject(&PubSubjectBody { subject: &subject, pub_body: &pub_body }, &mut buf).unwrap();
+            let v = decode_pub_subject(&buf).unwrap();
+            prop_assert_eq!(v.subject, subject.as_slice());
+            prop_assert_eq!(v.pub_body, pub_body.as_slice());
+            let _ = decode_pub(v.pub_body);
+
+            // TxnPrepare (verbatim carrier): txn_id + stream_id + arbitrary pub_body tail.
+            let mut buf = Vec::new();
+            encode_txn_prepare(
+                &TxnPrepareBody { txn_id: &txn_id, stream_id: &stream_id, pub_body: &pub_body },
+                &mut buf,
+            ).unwrap();
+            let v = decode_txn_prepare(&buf).unwrap();
+            prop_assert_eq!(v.txn_id, txn_id.as_slice());
+            prop_assert_eq!(v.stream_id, stream_id.as_slice());
+            prop_assert_eq!(v.pub_body, pub_body.as_slice());
+            let _ = decode_pub(v.pub_body);
+
+            // SubTo: stream_id + group (both u16-len framed inside the block).
+            let mut buf = Vec::new();
+            encode_sub_to(&SubToBody { stream_id: &stream_id, group: &group }, &mut buf).unwrap();
+            let v = decode_sub_to(&buf).unwrap();
+            prop_assert_eq!(v.stream_id, stream_id.as_slice());
+            prop_assert_eq!(v.group, group.as_slice());
+
+            // SubSubject: subject + group.
+            let mut buf = Vec::new();
+            encode_sub_subject(&SubSubjectBody { subject: &subject, group: &group }, &mut buf).unwrap();
+            let v = decode_sub_subject(&buf).unwrap();
+            prop_assert_eq!(v.subject, subject.as_slice());
+            prop_assert_eq!(v.group, group.as_slice());
+
+            // BindSubject: stream_id + pattern.
+            let mut buf = Vec::new();
+            encode_bind_subject(&BindSubjectBody { stream_id: &stream_id, pattern: &subject }, &mut buf).unwrap();
+            let v = decode_bind_subject(&buf).unwrap();
+            prop_assert_eq!(v.stream_id, stream_id.as_slice());
+            prop_assert_eq!(v.pattern, subject.as_slice());
         }
 
         #[test]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -119,6 +119,50 @@ test = false
 doc = false
 bench = false
 
+# #851: the six broker-ingress stream/subject/txn body decoders (verbatim carriers also drive
+# `decode_pub` on the carried `pub_body` tail, the broker-as-used composition).
+[[bin]]
+name = "pub_to_body"
+path = "fuzz_targets/pub_to_body.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "sub_to_body"
+path = "fuzz_targets/sub_to_body.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "txn_prepare_body"
+path = "fuzz_targets/txn_prepare_body.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "pub_subject_body"
+path = "fuzz_targets/pub_subject_body.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "sub_subject_body"
+path = "fuzz_targets/sub_subject_body.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "bind_subject_body"
+path = "fuzz_targets/bind_subject_body.rs"
+test = false
+doc = false
+bench = false
+
 # Detach from the parent workspace (which is `crates/*`): a cargo-fuzz crate must build with the
 # nightly sanitizer toolchain, separately from the merge-blocking stable workspace.
 [workspace]

--- a/fuzz/fuzz_targets/bind_subject_body.rs
+++ b/fuzz/fuzz_targets/bind_subject_body.rs
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! Fuzz the BindSubject body decoder (#851): the broker parses this untrusted subject->stream
+//! binding frame body from the leader ingress, so decoding any byte string must never panic or read
+//! out of bounds, only return a typed BodyError or a valid view. A crasher found here becomes a
+//! permanent regression seed.
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = ironbus_proto::message::decode_bind_subject(data);
+});

--- a/fuzz/fuzz_targets/pub_subject_body.rs
+++ b/fuzz/fuzz_targets/pub_subject_body.rs
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! Fuzz the PubSubject body decoder (#851): the broker parses this untrusted subject-addressed
+//! producer frame body from the leader ingress, so decoding any byte string must never panic or read
+//! out of bounds, only return a typed BodyError or a valid view. PubSubject is a VERBATIM carrier: on
+//! a decoded view the broker feeds the `pub_body` tail straight into `decode_pub`, so drive that
+//! composition here too. A crasher found here becomes a permanent regression seed.
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(view) = ironbus_proto::message::decode_pub_subject(data) {
+        let _ = ironbus_proto::message::decode_pub(view.pub_body);
+    }
+});

--- a/fuzz/fuzz_targets/pub_to_body.rs
+++ b/fuzz/fuzz_targets/pub_to_body.rs
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! Fuzz the PubTo body decoder (#851): the broker parses this untrusted stream-addressed producer
+//! frame body from the leader ingress, so decoding any byte string must never panic or read out of
+//! bounds, only return a typed BodyError or a valid view. PubTo is a VERBATIM carrier: on a decoded
+//! view the broker feeds the `pub_body` tail straight into `decode_pub`, so drive that composition
+//! here too. A crasher found here becomes a permanent regression seed.
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(view) = ironbus_proto::message::decode_pub_to(data) {
+        let _ = ironbus_proto::message::decode_pub(view.pub_body);
+    }
+});

--- a/fuzz/fuzz_targets/sub_subject_body.rs
+++ b/fuzz/fuzz_targets/sub_subject_body.rs
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! Fuzz the SubSubject body decoder (#851): the broker parses this untrusted subject-addressed
+//! consumer frame body from the leader ingress, so decoding any byte string must never panic or read
+//! out of bounds, only return a typed BodyError or a valid view. A crasher found here becomes a
+//! permanent regression seed.
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = ironbus_proto::message::decode_sub_subject(data);
+});

--- a/fuzz/fuzz_targets/sub_to_body.rs
+++ b/fuzz/fuzz_targets/sub_to_body.rs
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! Fuzz the SubTo body decoder (#851): the broker parses this untrusted stream-addressed consumer
+//! frame body from the leader ingress, so decoding any byte string must never panic or read out of
+//! bounds, only return a typed BodyError or a valid view. A crasher found here becomes a permanent
+//! regression seed.
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = ironbus_proto::message::decode_sub_to(data);
+});

--- a/fuzz/fuzz_targets/txn_prepare_body.rs
+++ b/fuzz/fuzz_targets/txn_prepare_body.rs
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! Fuzz the TxnPrepare body decoder (#851): the broker parses this untrusted transactional
+//! half-message frame body from the leader ingress, so decoding any byte string must never panic or
+//! read out of bounds, only return a typed BodyError or a valid view. TxnPrepare is a VERBATIM
+//! carrier: on a decoded view the broker feeds the `pub_body` tail straight into `decode_pub`, so
+//! drive that composition here too. A crasher found here becomes a permanent regression seed.
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(view) = ironbus_proto::message::decode_txn_prepare(data) {
+        let _ = ironbus_proto::message::decode_pub(view.pub_body);
+    }
+});


### PR DESCRIPTION
[test/medium] #851: discriminating, DETERMINISTIC (non-flaky) coverage the issue describes; mutation-verified; test/fuzz-only. Reviewed across 3 adversarial lenses incl. a non-flakiness lens.

Closes #851

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>