### PR TITLE
perf(core): offload per-record body CRC32C/xxh3 off the append actor (#830)

### DIFF
--- a/crates/ironbus-core/src/codec.rs
+++ b/crates/ironbus-core/src/codec.rs
@@ -22,7 +22,58 @@ use crate::format::{
 };
 use crate::raw::{read_u16, read_u32, read_u64};
 use crate::types::{RecordFlags, Seq};
-use xxhash_rust::xxh3::xxh3_64;
+use xxhash_rust::xxh3::{xxh3_64, Xxh3};
+
+/// Pre-computed per-record body checksums (issue #830), produced OFF the single-writer append
+/// actor on the producing connection thread that already holds the body bytes, then trusted by
+/// [`encode_precomputed`].
+///
+/// `body_crc` is the CRC32C over the contiguous stored body (`key ++ headers ++ payload`), the exact
+/// byte range [`encode`] would checksum. `xxh3` is `Some` iff the stored body reaches
+/// [`XXH3_PAYLOAD_THRESHOLD`] — the SAME condition [`encode`] uses to decide whether the second
+/// xxh3-64 field is present — so a `BodyChecksums` computed by [`BodyChecksums::compute`] over the
+/// same three slices always agrees with the frame [`encode`] emits.
+///
+/// This is safe to offload because the checksums are CORRUPTION-detection values RE-VALIDATED on
+/// every read: a wrong value here is not a trust boundary — it only makes the record fail its own
+/// CRC on read and surface as corrupt — so moving the COMPUTATION off the serialized actor cannot
+/// weaken any integrity guarantee. The on-disk bytes are byte-identical to the actor-computed frame
+/// whenever the precomputed values match the stored body (which [`encode_precomputed`] debug-asserts).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct BodyChecksums {
+    /// CRC32C (Castagnoli) over the contiguous body `key ++ headers ++ payload`.
+    pub body_crc: u32,
+    /// xxh3-64 over the same body byte range, `Some` iff the stored body reaches
+    /// [`XXH3_PAYLOAD_THRESHOLD`] (matching [`encode`]'s `HAS_XXH3` condition), else `None`.
+    pub xxh3: Option<u64>,
+}
+
+impl BodyChecksums {
+    /// Computes the body checksums over the contiguous body `key ++ headers ++ payload`
+    /// INCREMENTALLY, with no intermediate concatenation buffer, producing exactly the values
+    /// [`encode`] computes over the bytes it lays down. CRC32C is folded across the three slices
+    /// (`crc32c(key)`, then `crc32c_append` over headers then payload — equal to a single pass over
+    /// the concatenation), and the xxh3-64 streaming hasher is fed the same three slices in order.
+    /// The xxh3-64 is present under the identical [`XXH3_PAYLOAD_THRESHOLD`] rule [`encode`] applies,
+    /// measured on the STORED body length (the bytes actually written).
+    #[must_use]
+    pub fn compute(key: &[u8], headers: &[u8], payload: &[u8]) -> BodyChecksums {
+        let body_len = key.len() + headers.len() + payload.len();
+        let mut body_crc = crc32c::crc32c(key);
+        body_crc = crc32c::crc32c_append(body_crc, headers);
+        body_crc = crc32c::crc32c_append(body_crc, payload);
+        let xxh3 = if body_len >= XXH3_PAYLOAD_THRESHOLD as usize {
+            let mut hasher = Xxh3::new();
+            hasher.update(key);
+            hasher.update(headers);
+            hasher.update(payload);
+            Some(hasher.digest())
+        } else {
+            None
+        };
+        BodyChecksums { body_crc, xxh3 }
+    }
+}
 
 /// A borrowed view of a record, used both as the input to [`encode`] and the
 /// output of [`decode`]. It owns no memory; slices borrow the caller's buffer.
@@ -112,6 +163,42 @@ impl std::error::Error for DecodeError {}
 /// Returns [`EncodeError::TooLarge`] if the total framed size would exceed the
 /// 1 GiB format ceiling.
 pub fn encode(rec: &RecordView<'_>, out: &mut Vec<u8>) -> Result<usize, EncodeError> {
+    encode_impl(rec, None, out)
+}
+
+/// Encodes `rec` like [`encode`], but TRUSTS the caller-supplied `checksums` for the body instead of
+/// computing them on this thread (issue #830). The body CRC32C (and, for a large body, the xxh3-64)
+/// are lifted off the single-writer append actor and onto the producing connection thread, which
+/// already holds the body bytes; the actor then only memcpys the body and writes the precomputed
+/// trailer.
+///
+/// `checksums` MUST have been computed by [`BodyChecksums::compute`] over the SAME
+/// `key`/`headers`/`payload` slices this `rec` carries, i.e. the exact stored body. When they match,
+/// the emitted frame is byte-identical to [`encode`]'s. A mismatch is not a memory- or trust-safety
+/// hazard — the checksum is re-validated on read, so a wrong value only makes the record fail its own
+/// CRC on read (surfaced as corrupt) — but it would durably store an unreadable record, so this is a
+/// caller contract a debug build asserts. Callers that re-inject or rewrite the body (compression,
+/// DLQ redrive, replication apply) must use [`encode`], which recomputes.
+///
+/// # Errors
+/// Returns [`EncodeError::TooLarge`] if the total framed size would exceed the 1 GiB format ceiling.
+pub fn encode_precomputed(
+    rec: &RecordView<'_>,
+    checksums: BodyChecksums,
+    out: &mut Vec<u8>,
+) -> Result<usize, EncodeError> {
+    encode_impl(rec, Some(checksums), out)
+}
+
+/// The shared framing core behind [`encode`] and [`encode_precomputed`]. When `precomputed` is
+/// `Some`, the body checksums are trusted (computed off-actor, #830); when `None`, they are computed
+/// here over the body bytes just laid down, exactly as before. Either way the emitted frame layout is
+/// identical.
+fn encode_impl(
+    rec: &RecordView<'_>,
+    precomputed: Option<BodyChecksums>,
+    out: &mut Vec<u8>,
+) -> Result<usize, EncodeError> {
     let key_len = u32::try_from(rec.key.len()).map_err(|_| EncodeError::TooLarge)?;
     let hdr_len = u32::try_from(rec.headers.len()).map_err(|_| EncodeError::TooLarge)?;
     let payload_len = u32::try_from(rec.payload.len()).map_err(|_| EncodeError::TooLarge)?;
@@ -162,14 +249,34 @@ pub fn encode(rec: &RecordView<'_>, out: &mut Vec<u8>) -> Result<usize, EncodeEr
     out.extend_from_slice(rec.headers);
     out.extend_from_slice(rec.payload);
     let body = &out[body_start..body_start + body_len];
-    let body_crc = crc32c::crc32c(body);
+    // Trust the off-actor precomputed checksums when supplied (#830), else compute them here over the
+    // body just laid down. A debug build re-derives them from the body to pin the caller contract that
+    // the precomputed values describe the exact stored bytes; a mismatch would durably store a record
+    // that fails its own CRC on read, so it is a bug, not a silent divergence.
+    let checksums = match precomputed {
+        Some(c) => {
+            debug_assert_eq!(
+                c,
+                BodyChecksums::compute(rec.key, rec.headers, rec.payload),
+                "precomputed body checksums must match the stored body (#830)"
+            );
+            c
+        }
+        None => BodyChecksums {
+            body_crc: crc32c::crc32c(body),
+            xxh3: if has_xxh3 { Some(xxh3_64(body)) } else { None },
+        },
+    };
     // The xxh3-64 covers the same body byte range as `body_crc`, and the field precedes
-    // the trailer so the 8-byte trailer (`body_crc` then `total_len`) is unchanged.
+    // the trailer so the 8-byte trailer (`body_crc` then `total_len`) is unchanged. `has_xxh3` is
+    // derived from the stored body length above and always agrees with `checksums.xxh3` for a
+    // correctly-computed `BodyChecksums`; the `unwrap_or_else` recomputes rather than panic if a
+    // caller passed an inconsistent value, keeping the frame well-formed.
     if has_xxh3 {
-        let xxh3 = xxh3_64(body);
+        let xxh3 = checksums.xxh3.unwrap_or_else(|| xxh3_64(body));
         out.extend_from_slice(&xxh3.to_le_bytes());
     }
-    out.extend_from_slice(&body_crc.to_le_bytes());
+    out.extend_from_slice(&checksums.body_crc.to_le_bytes());
     out.extend_from_slice(&total_u32.to_le_bytes());
     Ok(total)
 }
@@ -350,6 +457,88 @@ mod tests {
         let n = encode(&rec, &mut buf).unwrap();
         assert_eq!(n, buf.len());
         buf
+    }
+
+    // #830: the off-actor incremental body checksums must equal the one-shot checksums the actor path
+    // computes over the contiguous stored body, at and around the xxh3 threshold and with empty
+    // components. If this diverges, `encode_precomputed` would store an unreadable record.
+    #[test]
+    fn precomputed_body_checksums_match_one_shot() {
+        let cases: &[(&[u8], &[u8], &[u8])] = &[
+            (b"", b"", b""),
+            (b"k", b"", b"payload"),
+            (b"", b"headers", b""),
+            (b"key", b"headers", b"payload"),
+        ];
+        for &(key, headers, payload) in cases {
+            let mut body = Vec::new();
+            body.extend_from_slice(key);
+            body.extend_from_slice(headers);
+            body.extend_from_slice(payload);
+            let got = BodyChecksums::compute(key, headers, payload);
+            assert_eq!(got.body_crc, crc32c::crc32c(&body), "crc {key:?}");
+            assert_eq!(got.xxh3, None, "sub-threshold has no xxh3 {key:?}");
+        }
+        // A body at the threshold: the incremental xxh3-64 must equal the one-shot over the concat.
+        let big_key = vec![0x11u8; 100];
+        let big_hdr = vec![0x22u8; 100];
+        let big_pay = vec![0x33u8; XXH3_PAYLOAD_THRESHOLD as usize];
+        let mut body = Vec::new();
+        body.extend_from_slice(&big_key);
+        body.extend_from_slice(&big_hdr);
+        body.extend_from_slice(&big_pay);
+        let got = BodyChecksums::compute(&big_key, &big_hdr, &big_pay);
+        assert_eq!(got.body_crc, crc32c::crc32c(&body));
+        assert_eq!(got.xxh3, Some(xxh3_64(&body)));
+    }
+
+    // #830: `encode_precomputed` with the correct off-actor checksums must produce a frame BYTE-FOR-BYTE
+    // identical to `encode`, both below and at/above the xxh3 threshold, and both must decode cleanly.
+    #[test]
+    fn encode_precomputed_is_byte_identical_to_encode() {
+        for payload_len in [0usize, 5, XXH3_PAYLOAD_THRESHOLD as usize] {
+            let payload = vec![0xA5u8; payload_len];
+            let rec = RecordView {
+                seq: Seq::new(9),
+                timestamp_ms: 42,
+                flags: RecordFlags::EMPTY,
+                key: b"key",
+                headers: b"hdr",
+                payload: &payload,
+            };
+            let mut baseline = Vec::new();
+            let n0 = encode(&rec, &mut baseline).unwrap();
+            let checks = BodyChecksums::compute(rec.key, rec.headers, rec.payload);
+            let mut offloaded = Vec::new();
+            let n1 = encode_precomputed(&rec, checks, &mut offloaded).unwrap();
+            assert_eq!(n0, n1, "len at payload_len={payload_len}");
+            assert_eq!(baseline, offloaded, "bytes at payload_len={payload_len}");
+            decode(&offloaded).expect("offloaded frame decodes");
+        }
+    }
+
+    // #830: `encode_precomputed` TRUSTS the caller's value — a deliberately wrong body_crc lands
+    // verbatim in the trailer (release build), and the record then fails its own CRC on read, i.e. a
+    // wrong offloaded checksum degrades to detected corruption, never a silent accept. Guarded off
+    // debug builds because the caller-contract debug_assert would (correctly) fire there.
+    #[test]
+    #[cfg(not(debug_assertions))]
+    fn encode_precomputed_wrong_crc_is_caught_as_corrupt_on_read() {
+        let rec = RecordView {
+            seq: Seq::new(1),
+            timestamp_ms: 1,
+            flags: RecordFlags::EMPTY,
+            key: b"",
+            headers: b"",
+            payload: b"body",
+        };
+        let bad = BodyChecksums {
+            body_crc: 0xDEAD_BEEF,
+            xxh3: None,
+        };
+        let mut buf = Vec::new();
+        encode_precomputed(&rec, bad, &mut buf).unwrap();
+        assert_eq!(decode(&buf), Err(DecodeError::BadBodyCrc));
     }
 
     #[test]

--- a/crates/ironbus-server/src/actor.rs
+++ b/crates/ironbus-server/src/actor.rs
@@ -131,6 +131,14 @@ pub struct OwnedAppend {
     pub headers: Bytes,
     /// The record payload.
     pub payload: Bytes,
+    /// The record's body checksums (CRC32C, plus xxh3-64 for a large body), PRE-COMPUTED off the
+    /// single-writer append actor on the producing connection thread that built this `OwnedAppend`
+    /// (issue #830). `Some` carries the offloaded value so the actor stores it without re-hashing the
+    /// body; `None` (the default for test/replay/re-injection constructors) makes the actor compute
+    /// the checksum on the append path exactly as before. The value describes the producer-supplied
+    /// body (`key ++ headers ++ payload`); the engine trusts it only when the record is stored with
+    /// that exact body (it is dropped when the write-path compression seam rewrites the body).
+    pub body_checksums: Option<ironbus_core::codec::BodyChecksums>,
     /// The OPT-IN dedup identity (#3, #33): `Some` iff the publish carried a `msg_id` (the dedup
     /// opt-in), owned so it can cross the channel. `None` is the default no-dedup produce.
     pub dedup: Option<OwnedDedup>,
@@ -1253,7 +1261,7 @@ fn produce_once<F: Filesystem, C: Clock + Clone>(
         headers: &append.headers,
         payload: &append.payload,
     };
-    match engine.append_no_sync_dedup(&view, dedup_request(append)) {
+    match engine.append_no_sync_dedup_checked(&view, dedup_request(append), append.body_checksums) {
         // A fresh append: the covering fsync decides durability (I2). A fire-and-forget produce is
         // made durable identically but maps to the no-ack outcome (#11), so the direct path matches
         // the real actor's QoS-0 contract.
@@ -1817,7 +1825,7 @@ fn process_produce<F, C>(
         headers: &append.headers,
         payload: &append.payload,
     };
-    match engine.append_no_sync_dedup(&view, dedup_request(append)) {
+    match engine.append_no_sync_dedup_checked(&view, dedup_request(append), append.body_checksums) {
         Ok(crate::engine::AppendOutcome::Appended(offset)) => {
             // An accepted produce feeds the broker-side retry-budget accept count (#69), so the
             // observed retry ratio stays meaningful under load.
@@ -2052,6 +2060,12 @@ mod tests {
             key: Bytes::new(),
             headers: Bytes::new(),
             payload: Bytes::copy_from_slice(payload),
+            // Carry the REAL offloaded body checksum (#830) as the session does, so every actor produce
+            // test drives the `encode_precomputed` path; the codec's debug_assert then pins that the
+            // off-actor incremental value matches the actor-computed one across the whole suite.
+            body_checksums: Some(ironbus_core::codec::BodyChecksums::compute(
+                b"", b"", payload,
+            )),
             dedup: None,
             enqueue_monotonic_nanos: 0,
             fire_and_forget: false,
@@ -2078,6 +2092,9 @@ mod tests {
             key: Bytes::new(),
             headers: Bytes::new(),
             payload: Bytes::copy_from_slice(payload),
+            body_checksums: Some(ironbus_core::codec::BodyChecksums::compute(
+                b"", b"", payload,
+            )),
             dedup: Some(OwnedDedup {
                 producer_id: Bytes::copy_from_slice(producer_id),
                 epoch,

--- a/crates/ironbus-server/src/engine.rs
+++ b/crates/ironbus-server/src/engine.rs
@@ -24,6 +24,7 @@ use ironbus_core::attempt::{
 use ironbus_core::backpressure::{AimdLimiter, Codel, FsyncHeadroom, RetryBudget, TokenBucket};
 use ironbus_core::binding::{single_home, Resolution};
 use ironbus_core::clock::Clock;
+use ironbus_core::codec::BodyChecksums;
 use ironbus_core::compress::{
     compress_payload, Codec, CompressConfig, DEFAULT_MAX_DECOMPRESSED_BYTES,
 };
@@ -5266,6 +5267,27 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
     /// rejection and increments `produce_rejected`; any other storage error propagates. Nothing is
     /// written and no statistic moves on an error.
     pub fn append_no_sync(&mut self, message: &Append<'_>) -> Result<Offset, EngineError> {
+        self.append_no_sync_checked(message, None)
+    }
+
+    /// The body-checksum-offload variant of [`Engine::append_no_sync`] (issue #830): `precomputed`
+    /// carries the record's body CRC32C (and, for a large body, xxh3-64) computed OFF this
+    /// single-writer actor, on the producing connection thread that already held the body bytes.
+    ///
+    /// The precomputed value describes the PRODUCER-SUPPLIED body (`key ++ headers ++ payload`). It is
+    /// therefore trusted ONLY when the record is stored with that exact body — i.e. the pass-through
+    /// path. When the write-path compression seam below REWRITES the body (it stores `comp.stored`
+    /// instead of the original payload), the precomputed checksum no longer describes the stored bytes,
+    /// so it is DROPPED and the codec recomputes over the compressed body. Compression is opt-in and
+    /// off by default, so the common produce path takes the offload.
+    ///
+    /// # Errors
+    /// Same as [`Engine::append_no_sync`].
+    pub fn append_no_sync_checked(
+        &mut self,
+        message: &Append<'_>,
+        precomputed: Option<BodyChecksums>,
+    ) -> Result<Offset, EngineError> {
         // The write-path compression seam (#430, ADR-0003). The pass-through guard on an ALREADY
         // COMPRESSED message is load-bearing: the wire legally delivers bit 0 set (a producer may
         // publish a pre-compressed stored object), and compressing it again would wrap a
@@ -5310,7 +5332,17 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
                 _ => message,
             }
         };
-        let offset = match self.append_with_policy(to_append) {
+        // Trust the off-actor precomputed checksum ONLY when the stored body IS the producer's
+        // original body (the pass-through path). If the compression seam substituted `to_append =
+        // &stored`, the body differs, so drop the precomputed value and let the codec recompute over
+        // the compressed bytes. `ptr::eq` distinguishes the pass-through (`to_append == message`) from
+        // the compressed store (`to_append == &stored`).
+        let effective_precomputed = if core::ptr::eq(to_append, message) {
+            precomputed
+        } else {
+            None
+        };
+        let offset = match self.append_with_policy(to_append, effective_precomputed) {
             Ok(offset) => offset,
             Err(e) => {
                 // A drop-new shed: count the rejection (a shed-rate signal) but advance no produce
@@ -5386,16 +5418,37 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         message: &Append<'_>,
         dedup: Option<DedupRequest<'_>>,
     ) -> Result<AppendOutcome, EngineError> {
+        self.append_no_sync_dedup_checked(message, dedup, None)
+    }
+
+    /// The body-checksum-offload variant of [`Engine::append_no_sync_dedup`] (issue #830):
+    /// `precomputed` carries the body CRC32C (and, for a large body, xxh3-64) computed OFF this
+    /// single-writer actor on the producing connection thread. It is threaded to whichever internal
+    /// append path this dedup decision reaches (no-dedup, `msg_id` window, or idempotent sequence);
+    /// every fresh append ultimately funnels through [`Engine::append_no_sync_checked`], which trusts
+    /// the value only when the stored body equals the producer's body. A dedup hit, fence, or
+    /// out-of-order rejection appends nothing and ignores it.
+    ///
+    /// # Errors
+    /// Same as [`Engine::append_no_sync_dedup`].
+    pub fn append_no_sync_dedup_checked(
+        &mut self,
+        message: &Append<'_>,
+        dedup: Option<DedupRequest<'_>>,
+        precomputed: Option<BodyChecksums>,
+    ) -> Result<AppendOutcome, EngineError> {
         let Some(req) = dedup else {
             // No dedup requested: identical to the historical no-dedup append.
-            return self.append_no_sync(message).map(AppendOutcome::Appended);
+            return self
+                .append_no_sync_checked(message, precomputed)
+                .map(AppendOutcome::Appended);
         };
         // The idempotent-producer SEQUENCE path (V2-M8): when the publish carried a `seq`, route
         // through the DURABLE per-producer sequence high-water (effectively-once across a restart + a
         // long offline gap) INSTEAD of the time-bounded `msg_id` window. This is the Kafka-style
         // dedup-to-exactly-once-append + zombie-epoch fencing + out-of-order rejection.
         if let Some(seq) = req.seq {
-            return self.append_no_sync_seq(message, req.producer_id, req.epoch, seq);
+            return self.append_no_sync_seq(message, req.producer_id, req.epoch, seq, precomputed);
         }
         let now = self.log.now_monotonic();
         match self
@@ -5417,7 +5470,7 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
                     self.counters.dedup_out_of_window =
                         self.counters.dedup_out_of_window.saturating_add(1);
                 }
-                let offset = self.append_no_sync(message)?;
+                let offset = self.append_no_sync_checked(message, precomputed)?;
                 // Record the mapping at append time (offset assigned), so a same-batch duplicate is
                 // caught before the covering fsync. The reply is still parked behind that fsync, so a
                 // dedup hit never returns an offset that is not (or will not be) durable.
@@ -5461,6 +5514,7 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         producer_id: &[u8],
         epoch: u64,
         seq: u64,
+        precomputed: Option<BodyChecksums>,
     ) -> Result<AppendOutcome, EngineError> {
         let now = self.log.now_monotonic();
         match self.producer_seq.check(producer_id, epoch, seq, now) {
@@ -5483,7 +5537,7 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
                 // sequenced produce's high-water can be persisted on the next checkpoint tick (and a
                 // file-creation IO error fails the produce rather than silently losing durability).
                 self.ensure_producer_seq_checkpoint()?;
-                let offset = self.append_no_sync(message)?;
+                let offset = self.append_no_sync_checked(message, precomputed)?;
                 // Advance the high-water at append time (offset assigned), so a same-batch retry of
                 // this seq dedups before the covering fsync. The reply is still parked behind that
                 // fsync, so a duplicate never returns an offset that is not (or will not be) durable.
@@ -6093,17 +6147,35 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
     /// segment-by-segment without ever admitting the produce. It is therefore a FINAL drop-new
     /// rejection under EVERY policy (it propagates straight back, the same as under `DropNew`), so
     /// the producer is told to back off and the flash-wear governor protects the disk it is meant to.
-    fn append_with_policy(&mut self, message: &Append<'_>) -> Result<Offset, StorageError> {
-        match self.log.append(message) {
+    fn append_with_policy(
+        &mut self,
+        message: &Append<'_>,
+        precomputed: Option<BodyChecksums>,
+    ) -> Result<Offset, StorageError> {
+        match self.log_append(message, precomputed) {
             Ok(offset) => Ok(offset),
             // Only the genuine disk-full byte-cap shed is reclaimable by a reap, so only it may drive
             // the `DropOldest` reclaim-then-retry loop. The daily-write-budget shed and any other
             // storage error (a frozen writer, an oversized record) propagate unchanged; under DropNew
             // every rejection is final too.
             Err(e) if e.is_at_capacity() && self.disk_full_policy == DiskFullPolicy::DropOldest => {
-                self.make_room_then_append(message, e)
+                self.make_room_then_append(message, precomputed, e)
             }
             Err(e) => Err(e),
+        }
+    }
+
+    /// Dispatches to [`Log::append`] or [`Log::append_precomputed`] (#830): when the producing
+    /// connection thread precomputed the body checksums off the actor, trust them; otherwise compute
+    /// them on the append path as before. The on-disk frame is byte-identical either way.
+    fn log_append(
+        &mut self,
+        message: &Append<'_>,
+        precomputed: Option<BodyChecksums>,
+    ) -> Result<Offset, StorageError> {
+        match precomputed {
+            Some(checksums) => self.log.append_precomputed(message, checksums),
+            None => self.log.append(message),
         }
     }
 
@@ -6115,6 +6187,7 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
     fn make_room_then_append(
         &mut self,
         message: &Append<'_>,
+        precomputed: Option<BodyChecksums>,
         at_capacity: StorageError,
     ) -> Result<Offset, StorageError> {
         let mut last = at_capacity;
@@ -6155,7 +6228,7 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
             // Retry the append now that space was freed. A success ends the loop; another
             // at-capacity means one freed segment was not enough, so loop and free more (the loop
             // terminates because each pass either frees a segment or hits the active-only guard).
-            match self.log.append(message) {
+            match self.log_append(message, precomputed) {
                 Ok(offset) => return Ok(offset),
                 Err(e) if e.is_at_capacity() => {
                     last = e;

--- a/crates/ironbus-server/src/session.rs
+++ b/crates/ironbus-server/src/session.rs
@@ -27,6 +27,7 @@ use crate::engine::{
 use bytes::Bytes;
 use ironbus_core::binding::{single_home, Resolution};
 use ironbus_core::clock::Clock;
+use ironbus_core::codec::BodyChecksums;
 use ironbus_core::compress::{validate_descriptor_shape, DEFAULT_MAX_DECOMPRESSED_BYTES};
 use ironbus_core::confirm::{ConfirmStatus, ReadyConfirm};
 use ironbus_core::dedup::{MAX_MSG_ID_LEN, MAX_PRODUCER_ID_LEN};
@@ -1417,6 +1418,10 @@ impl Session {
             key: Bytes::copy_from_slice(msg.key),
             headers: Bytes::copy_from_slice(msg.headers),
             payload: Bytes::copy_from_slice(msg.payload),
+            // Offload the per-record body CRC32C (and xxh3-64 for a large body) onto THIS producing
+            // connection thread (#830), over the same wire slices copied above, so the single-writer
+            // actor stores the checksum instead of computing it on its serialized path.
+            body_checksums: Some(BodyChecksums::compute(msg.key, msg.headers, msg.payload)),
             dedup,
             // Stamp the ENQUEUE instant from the engine's clock seam (a LOCAL read, no actor
             // round-trip), so the engine can measure the admission SOJOURN for the CoDel shed (#68).
@@ -3137,6 +3142,11 @@ impl Session {
             key: Bytes::copy_from_slice(msg.key),
             headers: Bytes::copy_from_slice(msg.headers),
             payload: Bytes::copy_from_slice(msg.payload),
+            // The named-stream produce routes through `produce_in_stream` (its own StreamSet log),
+            // NOT the default-stream actor append path that consumes the offloaded checksum (#830), so
+            // computing one here would be discarded work: leave it `None` and let that path checksum as
+            // before.
+            body_checksums: None,
             dedup,
             enqueue_monotonic_nanos: engine.now_monotonic_nanos(),
             fire_and_forget: false,
@@ -3716,6 +3726,10 @@ impl Session {
             key: Bytes::copy_from_slice(msg.key),
             headers: Bytes::copy_from_slice(msg.headers),
             payload: Bytes::copy_from_slice(msg.payload),
+            // The subject-routed produce resolves to a stream and appends via `produce_in_stream` (its
+            // own StreamSet log), NOT the default-stream actor append path that consumes the offloaded
+            // checksum (#830), so leave it `None` rather than compute a value that path discards.
+            body_checksums: None,
             dedup,
             enqueue_monotonic_nanos: engine.now_monotonic_nanos(),
             fire_and_forget: false,
@@ -9964,6 +9978,7 @@ mod tests {
                 key: Bytes::new(),
                 headers: Bytes::new(),
                 payload: Bytes::from_static(b"primer"),
+                body_checksums: None,
                 dedup: None,
                 enqueue_monotonic_nanos: 0,
                 fire_and_forget: false,

--- a/crates/ironbus-storage/src/log.rs
+++ b/crates/ironbus-storage/src/log.rs
@@ -19,7 +19,7 @@ use crate::segment::{
 };
 use bytes::Bytes;
 use ironbus_core::clock::Clock;
-use ironbus_core::codec::RecordView;
+use ironbus_core::codec::{BodyChecksums, RecordView};
 use ironbus_core::format::{
     RECORD_HEADER_LEN, RECORD_TRAILER_LEN, SEGMENT_FOOTER_LEN, SEGMENT_HEADER_LEN,
 };
@@ -249,8 +249,15 @@ pub struct Append<'a> {
 /// the per-record write into the segment writer differs, so the on-disk bytes are identical either way.
 #[derive(Clone, Copy)]
 enum AppendSource<'a> {
-    /// Re-frame + re-checksum the record through [`codec::encode`] (via [`SegmentWriter::append`]).
-    Encode(&'a Append<'a>),
+    /// Re-frame the record through the codec (via [`SegmentWriter::append`] /
+    /// [`SegmentWriter::append_precomputed`]). `precomputed` carries the body checksums computed OFF
+    /// the single-writer actor on the producing connection thread (issue #830) when present, so the
+    /// actor skips the serialized body CRC32C/xxh3 pass; `None` computes them on the append path
+    /// exactly as before. Either way the on-disk frame is byte-identical.
+    Encode {
+        record: &'a Append<'a>,
+        precomputed: Option<BodyChecksums>,
+    },
     /// Copy an already-sealed, already-validated frame verbatim (via
     /// [`SegmentWriter::append_verbatim`]), skipping the redundant re-encode + re-checksum. `frame`
     /// is one complete on-disk record frame the caller decoded in place; `view` is that decode's
@@ -2559,7 +2566,38 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
     /// space is exhausted or the record is too large to frame, [`StorageError::WriterFrozen`] if a
     /// prior fatal error froze the writer, or an IO error from the write.
     pub fn append(&mut self, record: &Append<'_>) -> Result<Offset, StorageError> {
-        self.append_inner(AppendSource::Encode(record), true)
+        self.append_inner(
+            AppendSource::Encode {
+                record,
+                precomputed: None,
+            },
+            true,
+        )
+    }
+
+    /// Appends one record whose body checksums were PRE-COMPUTED off the single-writer append actor,
+    /// on the producing connection thread that already held the body bytes (issue #830). Identical to
+    /// [`Log::append`] in every observable effect — the same cap/budget/roll prologue, id reservation,
+    /// seek-index and write-amplification accounting, and the SAME on-disk frame bytes — except the
+    /// body CRC32C (and, for a large body, the xxh3-64) come from `checksums` rather than being
+    /// computed on the serialized append path. The caller GUARANTEES `checksums` describes `record`'s
+    /// exact stored body; a mismatch is not a safety hazard (the checksum is re-validated on read) but
+    /// would durably store a self-corrupt record.
+    ///
+    /// # Errors
+    /// Same as [`Log::append`].
+    pub fn append_precomputed(
+        &mut self,
+        record: &Append<'_>,
+        checksums: BodyChecksums,
+    ) -> Result<Offset, StorageError> {
+        self.append_inner(
+            AppendSource::Encode {
+                record,
+                precomputed: Some(checksums),
+            },
+            true,
+        )
     }
 
     /// Appends an already-sealed, already-VALIDATED frame VERBATIM — the follower replication ingest
@@ -2599,7 +2637,13 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
     /// Same as [`append`](Log::append) (byte-cap / daily-budget sheds, `SegmentFull`, `WriterFrozen`, IO),
     /// minus anything roll-specific.
     pub fn append_without_roll(&mut self, record: &Append<'_>) -> Result<Offset, StorageError> {
-        self.append_inner(AppendSource::Encode(record), false)
+        self.append_inner(
+            AppendSource::Encode {
+                record,
+                precomputed: None,
+            },
+            false,
+        )
     }
 
     /// Force-seal the active segment and start a fresh one — exactly the seal the implicit soft-cap roll
@@ -2650,7 +2694,10 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
         seq: Seq,
     ) -> Result<(Offset, u64, u64), StorageError> {
         let (offset, pos_before) = match source {
-            AppendSource::Encode(record) => {
+            AppendSource::Encode {
+                record,
+                precomputed,
+            } => {
                 let view = RecordView {
                     seq,
                     timestamp_ms: record.timestamp_ms,
@@ -2661,7 +2708,13 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
                 };
                 let writer = self.active.as_mut().ok_or(StorageError::WriterFrozen)?;
                 let pos_before = writer.write_pos();
-                let offset = writer.append(&view)?;
+                // Offload the body checksum onto the producing connection thread when it precomputed
+                // it (#830); otherwise the codec computes it here as before. The framed bytes are
+                // identical.
+                let offset = match precomputed {
+                    Some(checksums) => writer.append_precomputed(&view, checksums)?,
+                    None => writer.append(&view)?,
+                };
                 (offset, pos_before)
             }
             AppendSource::Verbatim { frame, view } => {
@@ -2698,7 +2751,7 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
         // the write-amplification meters below and are the ONLY per-source difference before the
         // write. Reading them once up front keeps the cap / budget / roll prologue source-agnostic.
         let (key_len, headers_len, payload_len) = match &source {
-            AppendSource::Encode(record) => {
+            AppendSource::Encode { record, .. } => {
                 (record.key.len(), record.headers.len(), record.payload.len())
             }
             AppendSource::Verbatim { view, .. } => {

--- a/crates/ironbus-storage/src/segment.rs
+++ b/crates/ironbus-storage/src/segment.rs
@@ -10,7 +10,7 @@
 use crate::io::RandomAccessFile;
 use crate::loss::{CapViolation, ReasonCode};
 use bytes::{Bytes, BytesMut};
-use ironbus_core::codec::{self, DecodeError, RecordView};
+use ironbus_core::codec::{self, BodyChecksums, DecodeError, RecordView};
 use ironbus_core::format::{
     COMPACTION_META_LEN, RECORD_HEADER_LEN, RECORD_TRAILER_LEN, RECORD_XXH3_LEN,
     SEGMENT_FOOTER_LEN, SEGMENT_HEADER_LEN, XXH3_PAYLOAD_THRESHOLD,
@@ -689,6 +689,37 @@ impl<F: RandomAccessFile> SegmentWriter<F> {
     /// overflow, [`StorageError::Record`] if the record is too large to frame, or an
     /// IO error from the write.
     pub fn append(&mut self, record: &RecordView<'_>) -> Result<Offset, StorageError> {
+        self.append_encoded(record, None)
+    }
+
+    /// Appends one record whose body checksums were PRE-COMPUTED off the single-writer actor on the
+    /// producing connection thread (issue #830). Identical to [`SegmentWriter::append`] except the
+    /// body CRC32C (and, for a large body, the xxh3-64) come from `checksums` instead of being
+    /// computed here on the serialized append path. The caller GUARANTEES `checksums` describes this
+    /// `record`'s exact stored body (`key ++ headers ++ payload`), so the on-disk frame is
+    /// byte-identical to what [`SegmentWriter::append`] would produce; a mismatch is not a safety
+    /// hazard (the checksum is re-validated on read) but would durably store a self-corrupt record,
+    /// which a debug build asserts against in the codec.
+    ///
+    /// # Errors
+    /// Same as [`SegmentWriter::append`].
+    pub fn append_precomputed(
+        &mut self,
+        record: &RecordView<'_>,
+        checksums: BodyChecksums,
+    ) -> Result<Offset, StorageError> {
+        self.append_encoded(record, Some(checksums))
+    }
+
+    /// The shared body behind [`SegmentWriter::append`] and [`SegmentWriter::append_precomputed`]:
+    /// frames `record` into the pending buffer, trusting `precomputed` body checksums when `Some`
+    /// (#830) or computing them in the codec when `None`. The on-disk bytes and all writer bookkeeping
+    /// are identical either way.
+    fn append_encoded(
+        &mut self,
+        record: &RecordView<'_>,
+        precomputed: Option<BodyChecksums>,
+    ) -> Result<Offset, StorageError> {
         if self.record_count == u32::MAX {
             return Err(StorageError::SegmentFull);
         }
@@ -704,7 +735,11 @@ impl<F: RandomAccessFile> SegmentWriter<F> {
         // intermediate copy. The bytes reach the file at the next flush point; on encode failure
         // the buffer is truncated back so a rejected record leaves no partial frame behind.
         let before = self.pending.len();
-        if codec::encode(record, &mut self.pending).is_err() {
+        let encoded = match precomputed {
+            Some(checksums) => codec::encode_precomputed(record, checksums, &mut self.pending),
+            None => codec::encode(record, &mut self.pending),
+        };
+        if encoded.is_err() {
             self.pending.truncate(before);
             return Err(StorageError::SegmentFull);
         }


### PR DESCRIPTION
[low] #830: offload per-record body CRC32C/xxh3 from the single-writer actor onto the producing connection thread. Byte-identical on-disk frame (conformance/determinism gates green); a ptr::eq gate drops the precomputed value on the compression seam (recomputes over compressed bytes); a debug_assert re-derives + a release-only test proves a wrong offloaded checksum degrades to detected BadBodyCrc on read, never silent trust. Reviewed across 3 adversarial lenses.

Closes #830

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>