### PR TITLE
feat(txn): optional exact --max-prepared-bytes byte budget for prepared half messages (#958)

### DIFF
--- a/crates/ironbus-cli/src/config_file.rs
+++ b/crates/ironbus-cli/src/config_file.rs
@@ -182,6 +182,7 @@ fn key_to_env_name(key: &str) -> Option<&'static str> {
         "delivery.dedup_window_ms" => "IRONBUS_DEDUP_WINDOW_MS",
         "delivery.dedup_max_producers" => "IRONBUS_DEDUP_MAX_PRODUCERS",
         "delivery.max_prepared" => "IRONBUS_MAX_PREPARED",
+        "delivery.max_prepared_bytes" => "IRONBUS_MAX_PREPARED_BYTES",
         "network.listen" => "IRONBUS_ADDR",
         "network.health_addr" => "IRONBUS_HEALTH_ADDR",
         "network.health_allow_public" => "IRONBUS_HEALTH_ALLOW_PUBLIC",

--- a/crates/ironbus-cli/src/main.rs
+++ b/crates/ironbus-cli/src/main.rs
@@ -682,6 +682,10 @@ struct ProfilePreset {
     /// so `edge-tiny` LOWERS it (each slot is a maximal frame) to a handful so the guard's term-7
     /// charge fits its 64 MiB ceiling; `balanced`/`throughput` use the shipped default.
     max_prepared: usize,
+    /// `txn.max_prepared_bytes` (`--max-prepared-bytes`): the OPTIONAL exact resident-byte budget for
+    /// prepared half messages (#958). `0` = OFF (only the count cap binds) — every shipped preset leaves
+    /// it off, so it is a purely opt-in tightening an operator sets by flag/env.
+    max_prepared_bytes: u64,
 }
 
 /// The `edge-tiny` preset: `docs/CONFIG.md` section 6, identical to the `tiny` table in
@@ -717,6 +721,9 @@ const EDGE_TINY_PRESET: ProfilePreset = ProfilePreset {
     // would refuse under 64 MiB. A tiny edge node runs few concurrent transactions, so 2 prepared slots
     // (~32 MiB) is a bounded ceiling that still leaves headroom under 64 MiB alongside the other terms.
     max_prepared: 2,
+    // The exact byte budget is OFF by default (#958): edge-tiny already fits via the lowered count cap
+    // above, so the byte budget stays a purely opt-in tightening an operator may add.
+    max_prepared_bytes: 0,
 };
 
 /// The `balanced` preset: THE default, and EXACTLY the compiled-in `DEFAULT_*` constant set, so a
@@ -746,6 +753,8 @@ const BALANCED_PRESET: ProfilePreset = ProfilePreset {
     // `balanced` IS the default knob set, so it keeps the shipped prepared cap (with the guard off, its
     // ~1 TiB worst case is not charged against any ceiling).
     max_prepared: DEFAULT_MAX_PREPARED,
+    // Byte budget OFF (#958): `balanced` is the zero-config default, so only the count cap binds.
+    max_prepared_bytes: 0,
 };
 
 /// The `throughput` preset: `docs/CONFIG.md` section 6, wide buffers for a multi-core hub. 256 MiB
@@ -772,6 +781,8 @@ const THROUGHPUT_PRESET: ProfilePreset = ProfilePreset {
     dedup_max_producers: DEFAULT_DEDUP_MAX_PRODUCERS,
     // A hub sizes RAM out of band (guard off), so it keeps the shipped default prepared cap.
     max_prepared: DEFAULT_MAX_PREPARED,
+    // Byte budget OFF (#958): a hub sizes RAM out of band, so only the count cap binds.
+    max_prepared_bytes: 0,
 };
 
 /// The smallest segment size cap `serve` accepts: below this, segments proliferate
@@ -2250,6 +2261,12 @@ struct ServeFlags {
     /// `edge-tiny`). Bounds the resident prepared-half-message RAM the refuse-to-boot guard charges
     /// under a `TxnPrepare` flood of distinct `txn_id`s.
     max_prepared: Option<usize>,
+    /// The OPTIONAL exact resident-byte budget for prepared half messages (#909 follow-up, #958);
+    /// `None` falls back to the profile preset (`0` = OFF everywhere by default, so only the count cap
+    /// `--max-prepared` binds). When set to a non-zero value the engine's per-prepare byte accounting
+    /// refuses any prepare that would push the resident sum past it, so the refuse-to-boot guard's
+    /// term-7 charge is the exact byte budget rather than the worst-case `max_prepared * maximal frame`.
+    max_prepared_bytes: Option<u64>,
     /// The durability LEVEL (#341, #379) selected by `--durability-level` / `IRONBUS_DURABILITY_LEVEL`.
     /// `None` resolves to the default `sync` (ack-implies-durable, I2, zero acked loss). An unknown
     /// name is a usage error.
@@ -2543,6 +2560,9 @@ fn collect_serve_flags(args: &[String]) -> Result<ServeFlags, CliError> {
             }
             "--max-prepared" => {
                 f.max_prepared = Some(take_number("--max-prepared", args, &mut i)?);
+            }
+            "--max-prepared-bytes" => {
+                f.max_prepared_bytes = Some(take_number("--max-prepared-bytes", args, &mut i)?);
             }
             "--disk-full-policy" => {
                 f.disk_full_policy = Some(take_value("--disk-full-policy", args, &mut i)?);
@@ -3123,6 +3143,14 @@ fn parse_serve_flags_with_env_and_reader(
                 f.max_prepared,
                 env,
                 preset.max_prepared,
+            )?,
+            // #958: the OPTIONAL exact byte budget takes its default from the profile preset (OFF = `0`
+            // everywhere), still overridable by env/flag — the byte-side sibling of `--max-prepared`.
+            max_prepared_bytes: resolve_number(
+                "--max-prepared-bytes",
+                f.max_prepared_bytes,
+                env,
+                preset.max_prepared_bytes,
             )?,
             // The durability level and its interval triggers (#341, #379). The level is resolved
             // above (flag > env > default `sync`); the interval triggers take their defaults when not
@@ -4653,6 +4681,10 @@ fn validate_ram_ceiling(config: &ServeConfig) -> Result<(), CliError> {
         // wire-supplied, so the count is bounded only by this cap, not the connection count. The engine
         // honors it via `Engine::set_txn_max_prepared`, so the charge is a true bound.
         max_prepared: u64::try_from(config.max_prepared).unwrap_or(u64::MAX),
+        // Term 7's OPTIONAL exact byte budget (#958): `0` = OFF (term 7 charges the worst-case count
+        // above); when set the engine's per-prepare byte accounting holds the resident sum under it, so
+        // the guard charges the exact budget — the txn sibling of `consumer_credit_bytes` on term 1.
+        max_prepared_bytes: config.max_prepared_bytes,
     };
     match ironbus_server::rss::fits_under_ram_ceiling(&footprint) {
         ironbus_server::rss::RamCeilingVerdict::Disabled
@@ -4862,6 +4894,13 @@ struct ServeConfig {
     /// LOWERS it (each slot is a maximal frame) so the guard fits its 64 MiB ceiling; floored to 1 by the
     /// engine.
     max_prepared: usize,
+    /// The OPTIONAL exact resident-byte budget for prepared half messages (#909 follow-up, #958): `0` =
+    /// OFF (only the count cap `max_prepared` binds); when non-zero the engine's per-prepare byte
+    /// accounting refuses any prepare that would push the resident sum past it, so the refuse-to-boot
+    /// guard's term-7 charge is the exact byte budget rather than the worst-case `max_prepared * maximal
+    /// frame` — the txn sibling of `consumer_credit_bytes`. Threaded into the engine via
+    /// `Engine::set_txn_max_prepared_bytes` (as `None` when `0`). Default `0` (OFF) on every preset.
+    max_prepared_bytes: u64,
     /// The DURABILITY LEVEL (#341, #379): how an ack relates to the covering `fdatasync`. Default
     /// [`DurabilityLevelArg::Sync`] (ack only after the covering fdatasync, I2, ZERO acked loss on a
     /// power cut), so a zero-config broker is power-loss safe. The relaxed levels weaken I2 by a
@@ -5026,6 +5065,8 @@ impl ServeConfig {
             dedup_max_producers: DEFAULT_DEDUP_MAX_PRODUCERS,
             // #909: the bench broker uses the shipped default prepared cap (the guard is off here).
             max_prepared: DEFAULT_MAX_PREPARED,
+            // #958: no exact byte budget by default (OFF), so only the count cap binds.
+            max_prepared_bytes: 0,
             // The bench broker runs the default durable level (#341): ack-implies-durable, the same
             // power-loss-safe guarantee the shipped `serve` default carries.
             durability_level: DurabilityLevelArg::Sync,
@@ -6286,7 +6327,7 @@ fn materialized_config_line(config: &ServeConfig, addr: &str, data_dir: Option<&
          max_retained_bytes={} max_age_ms={} max_messages={} health_liveness_window_ms={} \
          actor_watchdog_bound_ms={} \
          enable_admin={} ram_ceiling_bytes={} dedup_max_ids={} dedup_max_producers={} \
-         max_prepared={} \
+         max_prepared={} max_prepared_bytes={} \
          durability_level={durability_level} \
          power_loss_safe={power_loss_safe} compression={compression} flush_interval_ms={} \
          flush_max_bytes={} async_loss_ack={} wal_fsync_headroom_bytes={} storage={storage} \
@@ -6316,6 +6357,7 @@ fn materialized_config_line(config: &ServeConfig, addr: &str, data_dir: Option<&
         config.dedup_max_ids,
         config.dedup_max_producers,
         config.max_prepared,
+        config.max_prepared_bytes,
         config.flush_interval_ms,
         config.flush_max_bytes,
         config.async_loss_ack,
@@ -9242,6 +9284,14 @@ fn open_engine_with<F: Filesystem + Clone>(
     // like the compaction / key-shared config below; a broker whose txn store is created lazily on the
     // first `TxnPrepare` picks up the remembered value. `edge-tiny` lowers it so its ceiling fits.
     engine.set_txn_max_prepared(config.max_prepared);
+    // Wire the OPTIONAL exact byte budget (#958): `0` means OFF (only the count cap above binds), so
+    // pass `None`; a non-zero budget arms the engine's per-prepare byte accounting, making the guard's
+    // term-7 charge the exact byte ceiling. Server-side only, like the count cap above.
+    engine.set_txn_max_prepared_bytes(if config.max_prepared_bytes == 0 {
+        None
+    } else {
+        Some(config.max_prepared_bytes)
+    });
     // Enable OPT-IN key compaction (#337) when `--compact` was passed (OFF by default). It runs the
     // off-hot-path compactor after each produce-path reaper run; it never touches the active segment,
     // so it cannot block an append. A broker without `--compact` is byte-for-byte unchanged.
@@ -12830,6 +12880,7 @@ mod tests {
             dedup_max_producers: DEFAULT_DEDUP_MAX_PRODUCERS,
             // #909: the shipped default prepared cap (the guard is off unless a ceiling is set).
             max_prepared: DEFAULT_MAX_PREPARED,
+            max_prepared_bytes: 0,
             // The default durable level (#341): a test config that does not opt in stays power-loss
             // safe (ack-implies-durable), so an unrelated test never accidentally relaxes durability.
             durability_level: DurabilityLevelArg::Sync,
@@ -16260,6 +16311,7 @@ mod tests {
             dedup_max_producers: DEFAULT_DEDUP_MAX_PRODUCERS,
             // #909: the shipped default prepared cap (the guard is off unless a ceiling is set).
             max_prepared: DEFAULT_MAX_PREPARED,
+            max_prepared_bytes: 0,
             // The default durable level (#341): a test config that does not opt in stays power-loss
             // safe (ack-implies-durable), so an unrelated test never accidentally relaxes durability.
             durability_level: DurabilityLevelArg::Sync,

--- a/crates/ironbus-core/src/config.rs
+++ b/crates/ironbus-core/src/config.rs
@@ -395,6 +395,10 @@ pub const KEY_TABLE: &[KeySpec] = &[
         key: "delivery.max_prepared",
         kind: KeyKind::Integer,
     },
+    KeySpec {
+        key: "delivery.max_prepared_bytes",
+        kind: KeyKind::Integer,
+    },
     // [network]
     KeySpec {
         key: "network.listen",

--- a/crates/ironbus-core/src/txn.rs
+++ b/crates/ironbus-core/src/txn.rs
@@ -186,6 +186,16 @@ pub enum TxnError {
         /// The configured cap on concurrently-prepared transactions.
         cap: usize,
     },
+    /// A fresh prepare would push the resident prepared-payload byte sum past the optional
+    /// `--max-prepared-bytes` budget (#909 follow-up, #958). Like [`TxnError::TooManyPrepared`] a live
+    /// half message is NEVER evicted to make room — the new prepare is refused instead, so the
+    /// per-prepare byte accounting keeps the term-7 RAM under the exact configured ceiling rather than
+    /// the worst-case `max_prepared * maximal frame`. The producer retries after some in-flight txns
+    /// resolve and free bytes.
+    TooManyPreparedBytes {
+        /// The configured resident-byte budget the prepare would exceed.
+        budget: u64,
+    },
     /// The supplied `txn_id` exceeds [`MAX_TXN_ID_LEN`]. Rejected at the boundary before it is stored.
     TxnIdTooLong {
         /// The rejected id length.
@@ -215,6 +225,12 @@ impl core::fmt::Display for TxnError {
                 write!(
                     f,
                     "too many prepared transactions (cap {cap}); retry after some resolve"
+                )
+            }
+            TxnError::TooManyPreparedBytes { budget } => {
+                write!(
+                    f,
+                    "prepared transactions exceed the {budget}-byte budget; retry after some resolve"
                 )
             }
             TxnError::TxnIdTooLong { len } => {
@@ -486,6 +502,22 @@ impl TxnTable {
                 },
             );
             self.prepared_by_age.insert((now, txn_id.to_vec()));
+        }
+    }
+
+    /// Undoes a fresh prepare THIS call just recorded (a [`PrepareDecision::Prepared`]) whose caller then
+    /// declined to durably buffer it — the byte-budget refusal (#909 follow-up, #958). It removes the
+    /// `Prepared` entry and its age-index WITHOUT leaving a resolved tombstone, so the id is left FULLY
+    /// UNTRACKED and retryable, exactly as a [`TxnError::TooManyPrepared`] count refusal leaves it (that
+    /// refusal never records the id at all, because it rejects before the insert). This is the RIGHT
+    /// undo for a refusal taken AFTER the pure decision but BEFORE any durable effect: the opposite of
+    /// [`TxnTable::rollback`], which moves the id to a SPENT `Resolved(RolledBack)` tombstone (used when
+    /// a DURABLE half-append then fails, so the id is genuinely consumed). A no-op if `txn_id` is not
+    /// currently `Prepared`, so a double cancel is harmless.
+    pub fn cancel_prepared(&mut self, txn_id: &[u8]) {
+        if let Some(entry) = self.prepared.remove(txn_id) {
+            self.prepared_by_age
+                .remove(&(entry.instant, txn_id.to_vec()));
         }
     }
 
@@ -907,6 +939,32 @@ mod tests {
             Some(TxnState::Resolved(TxnOutcome::RolledBack))
         );
         assert_eq!(t.prepared_count(), 0);
+    }
+
+    #[test]
+    fn cancel_prepared_leaves_the_id_untracked_and_retryable_unlike_rollback() {
+        // #958: `cancel_prepared` undoes a fresh prepare WITHOUT leaving a spent tombstone (the byte-
+        // budget refusal path), so the id is fully UNTRACKED and can be re-prepared — unlike `rollback`,
+        // which moves it to a SPENT `Resolved(RolledBack)` tombstone that a re-prepare would reject as
+        // `TxnIdSpent`. This is the discriminating difference the byte-budget refusal relies on.
+        let mut t = table();
+        assert_eq!(t.prepare(b"tx1", 10), Ok(PrepareDecision::Prepared));
+        t.cancel_prepared(b"tx1");
+        assert_eq!(
+            t.state(b"tx1"),
+            None,
+            "cancel leaves NO tombstone (untracked)"
+        );
+        assert_eq!(t.prepared_count(), 0);
+        assert_eq!(t.resolved_tombstone_count(), 0);
+        // The id is retryable: a fresh prepare of the same id succeeds (a rollback would have made it
+        // `TxnIdSpent` here).
+        assert_eq!(t.prepare(b"tx1", 11), Ok(PrepareDecision::Prepared));
+        // And it does not leave a stale age-index entry: unresolved_before finds exactly the re-prepare.
+        assert_eq!(t.unresolved_before(u64::MAX), vec![(b"tx1".to_vec(), 11)]);
+        // A cancel of an unknown / already-cancelled id is a harmless no-op.
+        t.cancel_prepared(b"nope");
+        assert_eq!(t.prepared_count(), 1);
     }
 
     #[test]

--- a/crates/ironbus-server/src/engine.rs
+++ b/crates/ironbus-server/src/engine.rs
@@ -2697,6 +2697,14 @@ pub struct Engine<F: Filesystem, C: Clock> {
     /// (the txn sibling of the #878 dedup cap). Defaults to [`ironbus_core::txn::DEFAULT_MAX_PREPARED`]
     /// (`65_536`); an edge profile LOWERS it so the guard's term-7 charge fits its RAM ceiling.
     txn_max_prepared: usize,
+    /// The OPTIONAL exact resident-byte budget for the prepared half messages (#909 follow-up, #958):
+    /// `Some(budget)` meters each FRESH prepare against the running sum of buffered payload bytes (the
+    /// store's `prepared_bytes`) and REFUSES one that would push the sum past `budget`, so the term-7
+    /// RAM is bounded by the exact configured byte ceiling rather than the worst-case
+    /// `max_prepared * maximal frame`. `None` (the default) leaves only the count cap
+    /// (`txn_max_prepared`) in force. Applied at store open and whenever set via
+    /// [`Engine::set_txn_max_prepared_bytes`].
+    txn_max_prepared_bytes: Option<u64>,
     /// The per-STREAM default message TTL (V2-M4, #549): a record reached on the poll path whose
     /// EFFECTIVE TTL (the lower of this and the record's own per-message TTL) has passed against the
     /// WALL-clock seam (anchored to the record's durable producer `timestamp_ms`) is EXPIRED — skipped
@@ -3128,6 +3136,9 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
             // fits its ceiling). An eager-recovered txn store above opened with the default cap is
             // retuned to this value by the boot-time setter, exactly like `back_check_config`.
             txn_max_prepared: ironbus_core::txn::DEFAULT_MAX_PREPARED,
+            // No exact byte budget by default (#958): only the count cap binds until an operator sets
+            // `--max-prepared-bytes` via `set_txn_max_prepared_bytes`, matching the pre-#958 behavior.
+            txn_max_prepared_bytes: None,
             // Empty by default: no group is key_shared until an operator configures one (#64), so an
             // unconfigured engine is plain competing everywhere and unchanged.
             key_shared_groups: std::collections::BTreeSet::new(),
@@ -4233,6 +4244,9 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         listener_group: &[u8],
     ) -> Result<(), EngineError> {
         let now = self.log.now_monotonic();
+        // The optional exact byte budget (#958), read before the store borrow so the gate below is a
+        // plain local compare.
+        let max_prepared_bytes = self.txn_max_prepared_bytes;
         let back_check_timeout = {
             let store = self.ensure_txn_store()?;
             store.back_check().config().timeout
@@ -4253,6 +4267,33 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
                 Ok(())
             }
             ironbus_core::txn::PrepareDecision::Prepared => {
+                // Exact byte-budget gate (#909 follow-up, #958): if an operator set
+                // `--max-prepared-bytes`, meter this FRESH prepare's resident cost against the running
+                // sum and REFUSE it if buffering it would push the sum past the budget — the byte-side
+                // sibling of the `TooManyPrepared` count refusal, so the term-7 RAM stays under the
+                // exact configured ceiling. A live half message is never evicted to make room; we undo
+                // the in-memory prepare (nothing durable was written yet) and refuse. Metered only on a
+                // FRESH prepare: a benign duplicate (`AlreadyPrepared`) is already counted in the sum.
+                if let Some(budget) = max_prepared_bytes {
+                    let need = ironbus_storage::txn::prepared_resident_bytes(
+                        txn_id,
+                        stream,
+                        message.key,
+                        message.headers,
+                        message.payload,
+                    );
+                    if store.prepared_bytes().saturating_add(need) > budget {
+                        // Undo the in-memory prepare the pure table just recorded, leaving the id FULLY
+                        // UNTRACKED (not a spent tombstone) — the same "never recorded" state a
+                        // `TooManyPrepared` count refusal leaves, so the producer can RETRY the same
+                        // `txn_id` after some in-flight txns resolve and free bytes. No durable half
+                        // record exists yet, so nothing on disk needs undoing.
+                        store.table_mut().cancel_prepared(txn_id);
+                        return Err(EngineError::Txn(
+                            ironbus_core::txn::TxnError::TooManyPreparedBytes { budget },
+                        ));
+                    }
+                }
                 // Durably append + fsync the half record. If the durable write fails, ROLL BACK the
                 // in-memory prepared state so the table and the durable log stay consistent (the
                 // prepare did not happen), and surface the error.
@@ -4594,6 +4635,26 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
     #[must_use]
     pub fn txn_max_prepared(&self) -> usize {
         self.txn_max_prepared
+    }
+
+    /// Sets the OPTIONAL exact resident-byte budget for prepared half messages (#909 follow-up, #958):
+    /// `Some(budget)` meters each FRESH `TxnPrepare` against the running sum of buffered payload bytes
+    /// and refuses one that would push the sum past `budget`, so the term-7 RAM is bounded by the exact
+    /// configured byte ceiling rather than the worst-case `max_prepared * maximal frame`; `None`
+    /// disables the byte budget, leaving only the count cap. Server-side only (NOT on the wire), like
+    /// [`Engine::set_txn_max_prepared`]. Remembered for a later lazy open and applied to the running
+    /// meter immediately (the store already tracks `prepared_bytes`, so there is nothing to retune on
+    /// the store). Lowering it below the current resident sum never drops a live half message; it only
+    /// refuses further prepares until the backlog drains under the budget.
+    pub fn set_txn_max_prepared_bytes(&mut self, budget: Option<u64>) {
+        self.txn_max_prepared_bytes = budget;
+    }
+
+    /// The active exact resident-byte budget for prepared half messages (#958), or `None` when only the
+    /// count cap binds. For the refuse-to-boot guard's accounting and tests.
+    #[must_use]
+    pub fn txn_max_prepared_bytes(&self) -> Option<u64> {
+        self.txn_max_prepared_bytes
     }
 
     /// Registers (or re-registers, after a reconnect) producer connection `member` as the live listener
@@ -17157,6 +17218,43 @@ mod tests {
         assert_eq!(e.txn_prepared_count(), 1);
         e.txn_rollback(b"tx1").unwrap();
         assert_eq!(e.txn_prepared_count(), 0);
+    }
+
+    #[test]
+    fn set_txn_max_prepared_bytes_meters_the_exact_resident_byte_budget() {
+        // #958 HONESTY LINK: with the OPTIONAL exact byte budget set, the refuse-to-boot guard charges
+        // `max_prepared_bytes` for term 7 (not `max_prepared * a maximal frame`), so the engine MUST
+        // hold the resident prepared-payload sum under that budget — else the guard's tighter proof is a
+        // lie. Each half here costs `txn_id.len() + payload.len()` resident bytes (`txn_half` has an
+        // empty stream/key/headers): "tx1"/"tx2" (3) + a 10-byte payload = 13 bytes. A 20-byte budget
+        // admits ONE but REFUSES the second (13 + 13 = 26 > 20), and a resolve frees the bytes so a fresh
+        // prepare fits again.
+        let mut e = open(config(10, 5));
+        e.set_txn_max_prepared_bytes(Some(20));
+        assert_eq!(e.txn_max_prepared_bytes(), Some(20));
+        // First prepare (13 bytes) fits under the 20-byte budget.
+        e.txn_prepare(b"tx1", "", &txn_half(&[b'a'; 10]), b"")
+            .unwrap();
+        assert_eq!(e.txn_prepared_count(), 1);
+        // The second prepare would push the resident sum to 26 > 20: REFUSED on bytes, naming the budget.
+        match e.txn_prepare(b"tx2", "", &txn_half(&[b'b'; 10]), b"") {
+            Err(EngineError::Txn(ironbus_core::txn::TxnError::TooManyPreparedBytes { budget })) => {
+                assert_eq!(budget, 20, "the refusal names the configured byte budget");
+            }
+            other => panic!("a prepare past the byte budget must be refused, got {other:?}"),
+        }
+        // The refused txn left NO residue: the one prepared half is untouched and still resolvable.
+        assert_eq!(e.txn_prepared_count(), 1);
+        // Resolving tx1 releases its 13 bytes, so tx2 now fits under the budget.
+        e.txn_rollback(b"tx1").unwrap();
+        assert_eq!(e.txn_prepared_count(), 0);
+        e.txn_prepare(b"tx2", "", &txn_half(&[b'b'; 10]), b"")
+            .unwrap();
+        assert_eq!(
+            e.txn_prepared_count(),
+            1,
+            "the freed bytes let a fresh prepare fit again"
+        );
     }
 
     #[test]

--- a/crates/ironbus-server/src/rss.rs
+++ b/crates/ironbus-server/src/rss.rs
@@ -316,6 +316,14 @@ pub struct RamFootprintConfig {
     /// (term 7), exactly as it charges the dedup cap (#878) and `consumer_credit`, which likewise cost
     /// nothing until used. `0` is floored to 1 by the engine, so a `0` here charges one slot.
     pub max_prepared: u64,
+    /// `--max-prepared-bytes`: the OPTIONAL exact resident-byte budget for the prepared half messages
+    /// (#909 follow-up, #958). `0` = OFF (only the count cap `max_prepared` binds, so term 7 charges the
+    /// worst case `max_prepared * PREPARED_HALF_MESSAGE_BYTES`). When SET, the engine's per-prepare byte
+    /// accounting refuses any prepare that would push the resident sum past this budget, so it is the
+    /// FIRM byte bound on term 7 — exactly as `consumer_credit_bytes` is the firm byte bound on term 1
+    /// (a maximal-frame count charge otherwise). Lets an operator tune the prepared-payload RAM ceiling
+    /// precisely instead of paying a full maximal frame per slot.
+    pub max_prepared_bytes: u64,
 }
 
 /// The worst-case STEADY-STATE bounded-buffer footprint (in bytes) the configured caps imply,
@@ -372,7 +380,11 @@ pub struct RamFootprintConfig {
 ///   1 TiB) this refuses any small ceiling, so an edge profile MUST lower `--max-prepared` (the
 ///   `edge-tiny` preset does, to a handful of slots, since each slot is a full maximal frame). The
 ///   engine HONORS the lowered cap (`Engine::set_txn_max_prepared` retunes the txn table), so the
-///   charge is a true bound, not a paper one.
+///   charge is a true bound, not a paper one. With the OPTIONAL exact byte budget set
+///   (`--max-prepared-bytes`, #958) the engine's per-prepare byte accounting instead holds the resident
+///   sum under that budget, so term 7 charges `max_prepared_bytes` directly — the firm byte bound, the
+///   txn sibling of term 1's `consumer_credit_bytes`, letting an operator tune the ceiling precisely
+///   rather than paying a full maximal frame per slot.
 ///
 /// NOT counted here, and WHY (this is the honest boundary of what the guard can prove):
 ///
@@ -465,10 +477,18 @@ pub fn worst_case_buffer_bytes(config: &RamFootprintConfig) -> u64 {
     // Saturating, so an absurd cap refuses rather than wraps. `.max(1)` mirrors the engine's floor
     // (`Engine::set_txn_max_prepared` clamps to >= 1), so a configured `0` still charges the one slot
     // the engine will actually admit — matching the `max_prepared` doc.
-    let term7_prepared = config
-        .max_prepared
-        .max(1)
-        .saturating_mul(PREPARED_HALF_MESSAGE_BYTES);
+    // With the exact byte budget SET (#958), the engine's per-prepare accounting holds the resident sum
+    // under `max_prepared_bytes`, so that is the FIRM byte bound and term 7 charges it directly — the
+    // txn sibling of term 1's `consumer_credit_bytes`. With it OFF (`0`) only the count cap binds, so the
+    // provable worst case is every slot a maximal frame (`max_prepared * PREPARED_HALF_MESSAGE_BYTES`).
+    let term7_prepared = if config.max_prepared_bytes == 0 {
+        config
+            .max_prepared
+            .max(1)
+            .saturating_mul(PREPARED_HALF_MESSAGE_BYTES)
+    } else {
+        config.max_prepared_bytes
+    };
 
     term1
         .saturating_add(term3)
@@ -560,6 +580,8 @@ mod tests {
             // prepared slots fit under 64 MiB. 2 slots is ~32 MiB — the whole worst case lands just under
             // the ceiling. The shipped default (65_536) would imply ~1 TiB and refuse here.
             max_prepared: 2,
+            // The exact byte budget is OFF (#958): edge-tiny fits via the lowered count cap alone.
+            max_prepared_bytes: 0,
         }
     }
 
@@ -633,6 +655,7 @@ mod tests {
             dedup_max_producers: 64,
             dedup_max_ids: 1024,
             max_prepared: 2,
+            max_prepared_bytes: 0,
         };
         assert!(matches!(
             fits_under_ram_ceiling(&cfg),
@@ -660,6 +683,7 @@ mod tests {
             dedup_max_producers: 0, // dedup off: this test isolates the term-1 count charge
             dedup_max_ids: 0,
             max_prepared: 0, // prepared cap off (floored to 1 elsewhere): isolate the term-1 charge
+            max_prepared_bytes: 0, // byte budget OFF: isolate the term-1 charge
         };
         let worst = worst_case_buffer_bytes(&cfg);
         // Term 1 alone is `max_connections * consumer_credit * MAX_FRAME_LEN`; the whole worst case is
@@ -691,6 +715,7 @@ mod tests {
             dedup_max_producers: 64,
             dedup_max_ids: 1024,
             max_prepared: 2,
+            max_prepared_bytes: 0,
         };
         let high_count = RamFootprintConfig {
             consumer_credit: u64::from(ironbus_core::backpressure::DEFAULT_CREDIT_CEILING),
@@ -909,6 +934,40 @@ mod tests {
                 "a blown --max-prepared under a 64 MiB ceiling must be refused, got {other:?}"
             ),
         }
+    }
+
+    #[test]
+    fn the_exact_byte_budget_binds_term_seven_independent_of_the_count_cap() {
+        // #958 FIRM-BYTE-BOUND DRIFT TEST (the txn sibling of the term-1 `consumer_credit_bytes` test
+        // above). With the exact byte budget SET, term 7 is `max_prepared_bytes` NO MATTER how high the
+        // count cap is: two configs that differ ONLY in `max_prepared` but share the byte budget have the
+        // IDENTICAL worst case, because the engine's per-prepare accounting holds the resident sum under
+        // the byte budget. This pins the byte-budget branch so a change that reverts term 7 to the
+        // count charge (a silent ceiling loosening) FAILS here.
+        let low_count = RamFootprintConfig {
+            max_prepared_bytes: 8 * 1024 * 1024,
+            ..edge_tiny_footprint()
+        };
+        let high_count = RamFootprintConfig {
+            max_prepared: u64::try_from(ironbus_core::txn::DEFAULT_MAX_PREPARED).unwrap(),
+            ..low_count
+        };
+        assert_eq!(
+            worst_case_buffer_bytes(&low_count),
+            worst_case_buffer_bytes(&high_count),
+            "with a byte budget set, the count cap must not change the worst case (the byte budget is \
+             the firm term-7 RAM bound)"
+        );
+        // And the byte budget is ACTUALLY charged: with it set, term 7 is exactly the budget, strictly
+        // smaller than the count charge the same slots would otherwise cost (2 * a maximal frame).
+        let count_charged = RamFootprintConfig {
+            max_prepared_bytes: 0,
+            ..low_count
+        };
+        assert!(
+            worst_case_buffer_bytes(&low_count) < worst_case_buffer_bytes(&count_charged),
+            "the exact byte budget (8 MiB) must charge less than 2 maximal frames of count charge"
+        );
     }
 
     #[test]

--- a/crates/ironbus-storage/src/txn.rs
+++ b/crates/ironbus-storage/src/txn.rs
@@ -101,6 +101,45 @@ pub struct HalfMessage {
     pub flags: RecordFlags,
 }
 
+impl HalfMessage {
+    /// The RESIDENT heap bytes this buffered half message costs (#958), via [`prepared_resident_bytes`]
+    /// over its producer-controlled parts. The per-prepare charge the byte budget meters.
+    #[must_use]
+    pub fn resident_bytes(&self) -> u64 {
+        prepared_resident_bytes(
+            &self.txn_id,
+            &self.stream,
+            &self.key,
+            &self.headers,
+            &self.payload,
+        )
+    }
+}
+
+/// The RESIDENT heap bytes one buffered prepared half message costs (#958): the sum of its
+/// variable-length, producer-controlled parts (`txn_id` + `stream` + `key` + `headers` + `payload`),
+/// which is the RAM a `TxnPrepare` pins while the txn stays `Prepared`. This is the exact per-prepare
+/// charge the optional byte budget (`--max-prepared-bytes`, #909 follow-up) meters and the refuse-to-
+/// boot guard's term 7 bounds when the budget is set — the honest analog of the worst-case
+/// `PREPARED_HALF_MESSAGE_BYTES` count-charge. The small fixed per-entry struct/`HashMap` overhead is
+/// not counted, exactly as term 1's `consumer_credit_bytes` charges payload bytes, not the slot
+/// bookkeeping; each `len` is a bounded (`u16`-framed) wire quantity, but the adds SATURATE so the
+/// measure can never wrap.
+#[must_use]
+pub fn prepared_resident_bytes(
+    txn_id: &[u8],
+    stream: &str,
+    key: &[u8],
+    headers: &[u8],
+    payload: &[u8],
+) -> u64 {
+    (txn_id.len() as u64)
+        .saturating_add(stream.len() as u64)
+        .saturating_add(key.len() as u64)
+        .saturating_add(headers.len() as u64)
+        .saturating_add(payload.len() as u64)
+}
+
 /// The fixed-size prefix of a HALF record's metadata blob: `magic`(4) + `version`(1) +
 /// `txn_id_len`(2) + `stream_len`(2) + `orig_headers_len`(2) + `orig_flags`(1).
 const HALF_FIXED_LEN: usize = 4 + 1 + 2 + 2 + 2 + 1;
@@ -377,6 +416,12 @@ pub struct TxnStore<F: Filesystem, C: Clock> {
     /// fresh prepare and removed on resolve (commit OR rollback). Bounded by the table's
     /// `max_prepared` cap (a prepare over the cap is refused), so this never grows without bound.
     prepared_payloads: HashMap<Vec<u8>, HalfMessage>,
+    /// The running sum of [`prepared_resident_bytes`] over every CURRENTLY-buffered prepared payload
+    /// (#958): kept in lockstep with `prepared_payloads` (added on a fresh half buffer, subtracted on
+    /// resolve, recomputed on replay). The engine meters a fresh prepare against the optional
+    /// `--max-prepared-bytes` budget using this sum, so the byte budget is an EXACT charge rather than
+    /// the worst-case `max_prepared * maximal frame`. Zero whenever no txn is prepared.
+    prepared_bytes: u64,
     /// The number of half records durably written across this store's lifetime (for observability).
     half_records: u64,
     /// The number of op markers durably written across this store's lifetime (for observability).
@@ -459,6 +504,7 @@ impl<F: Filesystem, C: Clock> TxnStore<F, C> {
             table: TxnTable::new(txn_config),
             back_check: BackCheckBook::new(back_check_config),
             prepared_payloads: HashMap::new(),
+            prepared_bytes: 0,
             half_records: 0,
             op_records: 0,
             back_records: 0,
@@ -490,6 +536,7 @@ impl<F: Filesystem, C: Clock> TxnStore<F, C> {
         self.table = TxnTable::new(self.table.config());
         self.back_check = BackCheckBook::new(self.back_check.config());
         self.prepared_payloads.clear();
+        self.prepared_bytes = 0;
         self.half_records = 0;
         self.op_records = 0;
         self.back_records = 0;
@@ -585,6 +632,15 @@ impl<F: Filesystem, C: Clock> TxnStore<F, C> {
             let attempts = restored_attempts.get(&txn_id).copied().unwrap_or(0);
             self.back_check.restore(&txn_id, attempts, 0);
         }
+        // Rebuild the resident-byte sum (#958) from the recovered buffered payloads. Replay never
+        // ENFORCES the byte budget — a durable prepared payload is undelivered data that must survive a
+        // restart even if the operator later lowered `--max-prepared-bytes` below the recovered total,
+        // exactly as replay bypasses the `max_prepared` count cap via `TxnTable::restore` (the budget
+        // only refuses FURTHER prepares until the backlog drains).
+        self.prepared_bytes = self
+            .prepared_payloads
+            .values()
+            .fold(0u64, |acc, h| acc.saturating_add(h.resident_bytes()));
         Ok(())
     }
 
@@ -663,19 +719,31 @@ impl<F: Filesystem, C: Clock> TxnStore<F, C> {
         // fsync the half record BEFORE returning: a prepared half message is never lost.
         self.log.sync()?;
         self.half_records = self.half_records.saturating_add(1);
-        self.prepared_payloads.insert(
-            txn_id.to_vec(),
-            HalfMessage {
-                txn_id: txn_id.to_vec(),
-                stream: stream.to_string(),
-                timestamp_ms: message.timestamp_ms,
-                key: message.key.to_vec(),
-                headers: message.headers.to_vec(),
-                payload: message.payload.to_vec(),
-                flags: message.flags,
-            },
-        );
+        let half = HalfMessage {
+            txn_id: txn_id.to_vec(),
+            stream: stream.to_string(),
+            timestamp_ms: message.timestamp_ms,
+            key: message.key.to_vec(),
+            headers: message.headers.to_vec(),
+            payload: message.payload.to_vec(),
+            flags: message.flags,
+        };
+        // Track the resident-byte sum (#958) in lockstep with the buffer insert. The caller (the
+        // engine) has ALREADY metered this fresh prepare against the optional `--max-prepared-bytes`
+        // budget before reaching here (a re-prepare of a still-prepared id never calls this), so the
+        // sum stays under the budget by construction.
+        self.prepared_bytes = self.prepared_bytes.saturating_add(half.resident_bytes());
+        self.prepared_payloads.insert(txn_id.to_vec(), half);
         Ok(())
+    }
+
+    /// The running sum of the buffered prepared payloads' [`prepared_resident_bytes`] (#958), the RAM a
+    /// `TxnPrepare` flood currently pins. The engine meters a fresh prepare against the optional
+    /// `--max-prepared-bytes` budget with this, and it is a true bound on the term-7 RAM the refuse-to-
+    /// boot guard charges (`docs/RAM_BUDGET.md` term 7).
+    #[must_use]
+    pub fn prepared_bytes(&self) -> u64 {
+        self.prepared_bytes
     }
 
     /// Durably appends a COMMITTED op-marker for `txn_id` (recording the `real_offset` the payload
@@ -722,7 +790,12 @@ impl<F: Filesystem, C: Clock> TxnStore<F, C> {
         // fsync the op marker BEFORE returning: a resolution, once acked, survives a restart.
         self.log.sync()?;
         self.op_records = self.op_records.saturating_add(1);
-        self.prepared_payloads.remove(txn_id);
+        // Drop the buffered payload and release its resident-byte charge (#958), keeping the sum in
+        // lockstep with the buffer. A resolve of an id with no buffered payload (an idempotent
+        // re-resolve reaching the store, or a payload already dropped) subtracts nothing.
+        if let Some(half) = self.prepared_payloads.remove(txn_id) {
+            self.prepared_bytes = self.prepared_bytes.saturating_sub(half.resident_bytes());
+        }
         Ok(())
     }
 
@@ -959,6 +1032,50 @@ mod tests {
         assert_eq!(hm.key, b"k");
         assert_eq!(hm.headers, b"orig-hdr");
         assert_eq!(reopened.table().state(b"tx1"), Some(TxnState::Prepared));
+    }
+
+    #[test]
+    fn prepared_bytes_tracks_the_buffer_and_is_rebuilt_on_replay() {
+        // #958: the running resident-byte sum is kept in lockstep with the buffered payloads (added on a
+        // fresh half buffer, released on resolve) and RECOMPUTED on replay, so it is a true bound on the
+        // term-7 RAM the refuse-to-boot guard charges under the exact byte budget.
+        let fs = InMemoryFs::new();
+        let tx1_bytes = prepared_resident_bytes(b"tx1", "orders", b"k", b"orig-hdr", b"hello");
+        let tx2_bytes = prepared_resident_bytes(b"tx2", "orders", b"k", b"orig-hdr", b"worldwide");
+        {
+            let mut s = store(&fs);
+            assert_eq!(s.prepared_bytes(), 0, "empty store charges nothing");
+            s.table_mut().prepare(b"tx1", 1).unwrap();
+            s.append_half(b"tx1", "orders", &half(b"hello")).unwrap();
+            assert_eq!(
+                s.prepared_bytes(),
+                tx1_bytes,
+                "one buffered half's resident bytes"
+            );
+            s.table_mut().prepare(b"tx2", 2).unwrap();
+            s.append_half(b"tx2", "orders", &half(b"worldwide"))
+                .unwrap();
+            assert_eq!(
+                s.prepared_bytes(),
+                tx1_bytes + tx2_bytes,
+                "both halves summed"
+            );
+            // Resolving tx1 releases exactly its bytes; tx2's charge remains.
+            s.table_mut().commit(b"tx1", 3).unwrap();
+            s.mark_committed(b"tx1", 99).unwrap();
+            assert_eq!(
+                s.prepared_bytes(),
+                tx2_bytes,
+                "commit frees exactly tx1's bytes"
+            );
+        }
+        // Replay rebuilds the sum from the recovered buffered payloads (only tx2 is still Prepared).
+        let reopened = store(&fs);
+        assert_eq!(
+            reopened.prepared_bytes(),
+            tx2_bytes,
+            "replay rebuilds the resident-byte sum from the recovered prepared payloads"
+        );
     }
 
     #[test]


### PR DESCRIPTION
[low/follow-up] #958: self-filed follow-up from the milestone-#30 audit; implemented at the real production site, mutation-verified where behavioral, whole-workspace green (cargo check --workspace). Reviewed across 3 adversarial lenses.

Closes #958

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>