### PR TITLE
fix(codes): assign the stable retryable ERR_NOT_ENOUGH_ISR code to the ISR-rejected produce Err (#965)

### DIFF
--- a/crates/ironbus-proto/src/err.rs
+++ b/crates/ironbus-proto/src/err.rs
@@ -40,6 +40,10 @@ pub enum ServerErrorCode {
     /// `ERR_AT_CAPACITY`: the durable log is at its byte cap (the drop-new shed) — a benign,
     /// retryable backpressure signal, NOT a permanent reject.
     AtCapacity,
+    /// `ERR_NOT_ENOUGH_ISR`: a clustered `C2-fsync` produce could not be quorum-committed because the
+    /// partition's parked-ack backlog is at its cap (not enough in-sync replicas) — a RETRYABLE
+    /// unavailable-over-unsafe signal, NOT a permanent reject: retry once the ISR recovers.
+    NotEnoughIsr,
     /// `ERR_STORAGE`: a generic storage fault.
     Storage,
     /// `ERR_PRODUCER_FENCED`: a produce presented a stale producer epoch (a zombie session).
@@ -94,6 +98,7 @@ impl ServerErrorCode {
     pub fn from_token(token: &str) -> Option<Self> {
         let code = match token {
             "ERR_AT_CAPACITY" => Self::AtCapacity,
+            "ERR_NOT_ENOUGH_ISR" => Self::NotEnoughIsr,
             "ERR_STORAGE" => Self::Storage,
             "ERR_PRODUCER_FENCED" => Self::ProducerFenced,
             "ERR_OUT_OF_ORDER_SEQUENCE" => Self::OutOfOrderSequence,
@@ -126,6 +131,7 @@ impl ServerErrorCode {
     pub fn as_token(self) -> &'static str {
         match self {
             Self::AtCapacity => "ERR_AT_CAPACITY",
+            Self::NotEnoughIsr => "ERR_NOT_ENOUGH_ISR",
             Self::Storage => "ERR_STORAGE",
             Self::ProducerFenced => "ERR_PRODUCER_FENCED",
             Self::OutOfOrderSequence => "ERR_OUT_OF_ORDER_SEQUENCE",
@@ -266,6 +272,7 @@ mod tests {
     fn every_variant_round_trips_through_its_token() {
         for code in [
             ServerErrorCode::AtCapacity,
+            ServerErrorCode::NotEnoughIsr,
             ServerErrorCode::Storage,
             ServerErrorCode::ProducerFenced,
             ServerErrorCode::OutOfOrderSequence,

--- a/crates/ironbus-server/src/codes.rs
+++ b/crates/ironbus-server/src/codes.rs
@@ -158,6 +158,15 @@ impl ErrorCode {
     /// at-capacity [`EngineError::Storage`].
     pub const ERR_AT_CAPACITY: ErrorCode = ErrorCode("ERR_AT_CAPACITY");
 
+    /// A clustered `C2-fsync` produce could not be quorum-committed because the partition's parked-ack
+    /// backlog is at its cap (#864/#883): an unsatisfiable ISR is already withholding the cap's worth of
+    /// acks, so the data plane refused to park another (the honest unavailable-over-unsafe signal) rather
+    /// than grow toward OOM or ack a record durable only on the leader. A genuinely RETRYABLE condition —
+    /// the producer backs off and retries once the ISR recovers. Not an `EngineError` and not an
+    /// `AppendOutcome`: it is the [`AckDisposition::Rejected`](crate::cluster::dataplane::AckDisposition)
+    /// gate outcome, tagged directly at its reply site. The contract's `ERR_NOT_ENOUGH_ISR`.
+    pub const ERR_NOT_ENOUGH_ISR: ErrorCode = ErrorCode("ERR_NOT_ENOUGH_ISR");
+
     /// The lease generation space is exhausted (unreachable in practice). Maps
     /// [`EngineError::GenerationExhausted`].
     pub const ERR_GENERATION_EXHAUSTED: ErrorCode = ErrorCode("ERR_GENERATION_EXHAUSTED");
@@ -244,7 +253,8 @@ mod tests {
     // crate's `from_token` map (the client cannot depend on this crate); this test PINS the two together
     // so a rename here that the proto map misses fails CI. Every code the server places on an `Err`
     // frame — the `EngineError` rejections plus the `AppendOutcome` signals (`ERR_AT_CAPACITY`,
-    // `ERR_PRODUCER_FENCED`, `ERR_OUT_OF_ORDER_SEQUENCE`) — must round-trip through the proto enum.
+    // `ERR_PRODUCER_FENCED`, `ERR_OUT_OF_ORDER_SEQUENCE`) plus the `AckDisposition` gate reject
+    // (`ERR_NOT_ENOUGH_ISR`) — must round-trip through the proto enum.
     fn every_wire_code_is_recognized_by_the_proto_decoder() {
         use ironbus_proto::err::ServerErrorCode;
         let wire_codes = [
@@ -269,6 +279,7 @@ mod tests {
             ErrorCode::ERR_TXN,
             ErrorCode::ERR_TXN_CHECK_UNAUTHORIZED,
             ErrorCode::ERR_AT_CAPACITY,
+            ErrorCode::ERR_NOT_ENOUGH_ISR,
             ErrorCode::ERR_PRODUCER_FENCED,
             ErrorCode::ERR_OUT_OF_ORDER_SEQUENCE,
         ];
@@ -289,6 +300,7 @@ mod tests {
             "ERR_CUMULATIVE_ACK_NOT_ALLOWED"
         );
         assert_eq!(ErrorCode::ERR_ACK_NOT_OWNED.as_str(), "ERR_ACK_NOT_OWNED");
+        assert_eq!(ErrorCode::ERR_NOT_ENOUGH_ISR.as_str(), "ERR_NOT_ENOUGH_ISR");
         assert_eq!(ErrorCode::OFFSET_TRIMMED.as_str(), "OFFSET_TRIMMED");
         assert_eq!(ErrorCode::OFFSET_COMPACTED.as_str(), "OFFSET_COMPACTED");
         assert_eq!(

--- a/crates/ironbus-server/src/session.rs
+++ b/crates/ironbus-server/src/session.rs
@@ -4441,7 +4441,11 @@ fn write_pub_reply_gated<
             // record is durable on the leader but is NOT quorum-fsync'd, so acking it would be a lie).
             // The connection stays open; the producer can retry once the ISR recovers.
             Some(crate::cluster::dataplane::AckDisposition::Rejected) => {
-                reply_err(out, "not enough in-sync replicas to quorum-commit; retry");
+                reply_err_coded(
+                    out,
+                    crate::codes::ErrorCode::ERR_NOT_ENOUGH_ISR.as_str(),
+                    "not enough in-sync replicas to quorum-commit; retry",
+                );
             }
         }
         return Ok(());
@@ -7306,6 +7310,78 @@ mod tests {
         assert!(
             out.is_empty(),
             "a fire-and-forget dedup hit must send no frame: {out:?}"
+        );
+    }
+
+    /// A mock whose fresh produce clears the actor (`Appended`) but whose cluster ack gate REJECTS the
+    /// quorum-commit (the parked-ack backlog is at its cap under an unsatisfiable ISR): the reply site
+    /// must emit the RETRYABLE `ERR_NOT_ENOUGH_ISR`-coded Err, not a `PubAck`. For #965.
+    struct IsrRejectingEngine;
+    impl crate::actor::EngineAccess<InMemoryFs, ManualClock> for IsrRejectingEngine {
+        fn produce(
+            &self,
+            _append: crate::actor::OwnedAppend,
+        ) -> Result<ProduceOutcome, crate::actor::ActorGone> {
+            Ok(ProduceOutcome::Appended(Offset::new(7)))
+        }
+        fn with<R, J>(&self, _job: J) -> Result<R, crate::actor::ActorGone>
+        where
+            R: Send + 'static,
+            J: FnOnce(&mut Engine<InMemoryFs, ManualClock>) -> R + Send + 'static,
+        {
+            Err(crate::actor::ActorGone)
+        }
+        fn now_monotonic_nanos(&self) -> u64 {
+            0
+        }
+        fn consumer_credit_caps(&self) -> (u32, u64) {
+            (64, 0)
+        }
+        fn has_client_ack_gate(&self) -> bool {
+            true
+        }
+        fn client_ack_disposition(
+            &self,
+            _member: MemberId,
+            _offset: u64,
+            _reply_bytes: Vec<u8>,
+        ) -> Option<crate::cluster::dataplane::AckDisposition> {
+            Some(crate::cluster::dataplane::AckDisposition::Rejected)
+        }
+    }
+
+    #[test]
+    fn an_isr_rejected_produce_carries_the_stable_retryable_code() {
+        // #965: the ISR-rejected quorum-commit (`AckDisposition::Rejected`) is a genuinely RETRYABLE
+        // condition. It must reply with an Err carrying the STABLE `ERR_NOT_ENOUGH_ISR` code in front of
+        // the human message, so a client branches on the code (retry) instead of substring-matching prose
+        // — never a PubAck (the record is durable only on the leader, so acking it would be a lie).
+        let mut s = Session::new();
+        let mut out = Vec::new();
+        s.process(
+            &IsrRejectingEngine,
+            &frame(FrameType::Connect, b""),
+            &mut out,
+        )
+        .unwrap();
+        out.clear();
+        connect_and_pub(&mut s, &IsrRejectingEngine, &mut out);
+
+        let (ty, body) = one_response(&out);
+        assert_eq!(
+            ty,
+            FrameType::Err,
+            "an ISR reject must be an Err, not a PubAck"
+        );
+        let decoded = ironbus_proto::err::decode_err_body(&body);
+        assert_eq!(
+            decoded.code,
+            Some(ironbus_proto::err::ServerErrorCode::NotEnoughIsr),
+            "the ISR reject must carry the stable retryable code",
+        );
+        assert_eq!(
+            decoded.message, "not enough in-sync replicas to quorum-commit; retry",
+            "the human message is preserved verbatim",
         );
     }
 


### PR DESCRIPTION
[low/follow-up] #965: self-filed follow-up from the milestone-#30 audit; implemented at the real production site, mutation-verified where behavioral, whole-workspace green (cargo check --workspace). Reviewed across 3 adversarial lenses.

Closes #965

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>