### PR TITLE
feat(cluster/873): Phase 1 — detect + surface the follower uncommitted-tail divergence (observation only)

### DIFF
--- a/crates/ironbus-server/src/cluster/divergence.rs
+++ b/crates/ironbus-server/src/cluster/divergence.rs
@@ -106,7 +106,86 @@ use ironbus_storage::loss::{LossEvent, ReasonCode};
 use ironbus_storage::quarantine::QuarantineStore;
 use ironbus_storage::segment::StorageError;
 
-use crate::cluster::replication::{Follower, ReplicationError, ReplicationLeader};
+use crate::cluster::replication::{
+    FetchResponseBody, Follower, ReplicationError, ReplicationLeader,
+};
+
+// ---- #873 Phase 1: FETCH-SEAM uncommitted-tail divergence DETECTION (observation only) ----------
+//
+// This is a DISTINCT, complementary detector to the C4 SEGMENT-FINGERPRINT compare above. C4 catches
+// silent BODY drift between replicas that SHARE a lineage (same offsets, different bytes) by comparing
+// durable segment hashes. THIS predicate catches the #873 hazard at the FOLLOWER FETCH SEAM: a follower
+// that fsynced an UNCOMMITTED tail from a DEAD leader's epoch and, on failover, is about to (or has)
+// stitched the NEW leader's forward run onto that divergent tail — a permanently divergent replica that
+// passes every offset-contiguity check and never self-heals. Detection here is PURE OBSERVATION: it
+// mutates nothing (no truncate, no ISR change, no wire change), emits only an operator WARN + a bounded
+// metric, and a conservative MISS is by design safe (never data loss) since nothing acts on it yet.
+
+/// Does this follower hold an fsynced UNCOMMITTED tail that the INCOMING leader lineage EXCLUDES — the
+/// #873 silent post-failover stitch hazard? A PURE, side-effect-free predicate (Phase 1 = detection
+/// only); the caller emits the operator WARN + metric.
+///
+/// # The three-clause discriminator (false-positive-free by construction)
+///
+/// It fires ONLY when ALL hold:
+/// 1. **The leader served an EMPTY run** (`record_count == 0` and no frame bytes): the leader has
+///    NOTHING at the follower's fetch offset. A NON-empty run is ordinary forward catch-up, never this.
+/// 2. **The follower's LEO strictly EXCEEDS the leader's advertised frontier**
+///    (`follower_next_offset > resp_high_watermark`): the follower holds records ABOVE what the current
+///    leader has. This is THE discriminator versus a fully-caught-up follower, whose LEO EQUALS the
+///    leader's frontier (the empty run is then a benign steady-state poll). `resp_high_watermark` is the
+///    leader's advertised FLUSH frontier ([`FetchResponseBody::high_watermark`]) and is used ONLY as
+///    that positional signal — it is EXPLICITLY NOT the committed floor (see the ban below).
+/// 3. **That excess tail is genuinely ABOVE the follower's OWN quorum-committed floor**
+///    (`follower_next_offset > committed_floor`): the tail is truly UNCOMMITTED (not merely a lagging
+///    checkpoint of already-committed data). A fresh / empty follower (`LEO == floor == 0`) never fires.
+///
+/// # BANNED: `resp.high_watermark` is NEVER the floor
+///
+/// `committed_floor` MUST be the follower's OWN quorum-committed floor — the replicated
+/// `CheckpointCommittedHw` bar (`ClusterStatus::last_committed_hw`), a value applied from replicated
+/// metadata. It MUST NOT be `resp.high_watermark`, which is the leader's LOCAL flush frontier
+/// (`Log::flushed_offset`) and can sit ARBITRARILY relative to the follower's own committed state.
+///
+/// # Why the floor's freshness is not safety-critical for DETECTION
+///
+/// Clause 2 (LEO > leader frontier on an empty run) is the safety-critical gate and is INDEPENDENT of
+/// `committed_floor`. A STALE-LOW floor only makes clause 3 easier, but clause 2 still gates, so it
+/// cannot manufacture a false positive; a STALE-HIGH floor only makes the detector MORE conservative
+/// (a missed signal — safe, since nothing acts on it). So even an imperfect / not-fresh-across-restart
+/// `last_committed_hw` keeps this detector false-positive-free.
+///
+/// # In scope / out of scope
+///
+/// This catches the UNCOMMITTED-TAIL case where the leader has NOT yet advanced its flush frontier past
+/// the follower's LEO (the leader serves nothing at the follower's offset). It deliberately does NOT try
+/// to catch the below-frontier CONTENT-mismatch case (the leader already advanced past the divergent
+/// tail and serves a NON-empty conflicting run) — that is the C4 fingerprint compare's job (a later
+/// phase). A miss there is a conservative, by-design gap, never data loss.
+/// The floor-INDEPENDENT, lock-free gate of [`suspect_uncommitted_tail`] (clauses 1-2): the leader
+/// served nothing at the follower's offset (an empty run) AND the follower's LEO sits strictly above the
+/// leader's advertised frontier. This is the safety-critical discriminator and needs no committed floor,
+/// so a caller can evaluate it BEFORE paying for the shared-status lock that yields the floor (the hot
+/// streaming path — a non-empty run — then short-circuits without touching the mutex).
+#[must_use]
+pub fn empty_run_above_leader_frontier(
+    follower_next_offset: u64,
+    resp: &FetchResponseBody,
+) -> bool {
+    resp.record_count == 0
+        && resp.frame_bytes.is_empty()
+        && follower_next_offset > resp.high_watermark
+}
+
+#[must_use]
+pub fn suspect_uncommitted_tail(
+    follower_next_offset: u64,
+    committed_floor: u64,
+    resp: &FetchResponseBody,
+) -> bool {
+    empty_run_above_leader_frontier(follower_next_offset, resp)
+        && follower_next_offset > committed_floor
+}
 
 /// The hard maximum number of per-segment fingerprints a single advertisement may carry. Bounds the
 /// untrusted peer bytes the decode path will buffer and trust: a replica with more sealed segments
@@ -1123,6 +1202,95 @@ mod tests {
         }
         log.sync().unwrap();
         log
+    }
+
+    // ===== #873 Phase 1: FETCH-SEAM uncommitted-tail DETECTION (observation only) =====
+
+    #[test]
+    fn phase1_uncommitted_tail_detector_discriminates_divergence_from_lag() {
+        // A DEAD leader's uncommitted tail: this follower fsynced 12 records, but only the first 8 ever
+        // quorum-committed. The NEW leader's lineage reaches only offset 8 (it never held 8..12). This
+        // is the #873 silent-stitch setup, staged on real InMemoryFs/ManualClock logs.
+        let follower_log = log_with(&[
+            b"0", b"1", b"2", b"3", b"4", b"5", b"6", b"7", b"8", b"9", b"10", b"11",
+        ]);
+        let follower = Follower::new(follower_log);
+        // The follower's OWN quorum-committed floor (the replicated `CheckpointCommittedHw` bar) — NOT
+        // the leader flush HW. Only [0,8) was ever committed; [8,12) is the dead leader's uncommitted tail.
+        let committed_floor = 8u64;
+
+        // The NEW leader has only the 8 committed records.
+        let new_leader = log_with(&[b"0", b"1", b"2", b"3", b"4", b"5", b"6", b"7"]);
+        let leader = ReplicationLeader::new(&new_leader);
+
+        // --- (A) FIRES: the divergent uncommitted tail. A fetch from the follower's LEO (12) serves an
+        //     EMPTY run advertising HW=8 < LEO=12 — the leader's lineage excludes the follower's tail. ---
+        let leo = follower.next_fetch_offset().get();
+        assert_eq!(leo, 12, "the follower fsynced a 12-record log");
+        let resp = leader
+            .serve_fetch(&follower.fetch_request(64, 0))
+            .expect("leader serves an empty run above its HW");
+        assert_eq!(
+            resp.record_count, 0,
+            "the leader has nothing at the follower's ahead LEO"
+        );
+        assert!(
+            suspect_uncommitted_tail(leo, committed_floor, &resp),
+            "the divergent uncommitted tail (LEO {leo} > leader HW {} and > committed floor \
+             {committed_floor}) MUST be detected",
+            resp.high_watermark
+        );
+        // Mutation check on the BANNED floor: had we (wrongly) used resp.high_watermark AS the floor, the
+        // clause-3 comparison would be `LEO > resp.high_watermark` — still true here — so this positive
+        // case alone cannot catch the ban violation; the (B2) stale-floor case below is what pins it.
+
+        // --- (B) does NOT fire on a fully-caught-up follower (clean catch-up): its LEO EQUALS the
+        //     leader frontier, so the empty run is a benign steady-state poll, not divergence. ---
+        let caught_up = Follower::new(log_with(&[b"0", b"1", b"2", b"3", b"4", b"5", b"6", b"7"]));
+        let cu_leo = caught_up.next_fetch_offset().get();
+        assert_eq!(cu_leo, 8);
+        let cu_resp = leader
+            .serve_fetch(&caught_up.fetch_request(64, 0))
+            .expect("serve");
+        assert_eq!(cu_resp.record_count, 0);
+        assert!(
+            !suspect_uncommitted_tail(cu_leo, committed_floor, &cu_resp),
+            "a fully-caught-up follower (LEO == leader HW) must NOT be flagged (no false positive)"
+        );
+
+        // --- (B2) stale checkpoint: a caught-up follower whose committed floor LAGS its (committed) LEO
+        //     STILL does not fire — clause 2 (LEO > leader HW) gates independently of the floor, so a
+        //     stale-LOW `last_committed_hw` can never manufacture a false positive. This is the Q1
+        //     robustness guarantee: the detector is sound even if the floor is not fresh across restart. ---
+        assert!(
+            !suspect_uncommitted_tail(cu_leo, 5, &cu_resp),
+            "a stale-low committed floor must not cause a false positive on a caught-up follower"
+        );
+
+        // --- (C) does NOT fire on a simply-BEHIND follower (normal replication lag): the leader serves a
+        //     NON-empty forward run — ordinary catch-up, never the divergence signal. ---
+        let behind = Follower::new(log_with(&[b"0", b"1", b"2", b"3"]));
+        let behind_resp = leader
+            .serve_fetch(&behind.fetch_request(64, 0))
+            .expect("serve a forward run");
+        assert!(
+            behind_resp.record_count > 0,
+            "the leader serves the lagging follower forward records"
+        );
+        assert!(
+            !suspect_uncommitted_tail(behind.next_fetch_offset().get(), 0, &behind_resp),
+            "a follower that is simply behind must NOT be flagged"
+        );
+
+        // --- (D) does NOT fire on a fresh / empty follower (LEO 0). ---
+        let empty_follower = Follower::new(open_log(InMemoryFs::new()));
+        let empty_resp = leader
+            .serve_fetch(&empty_follower.fetch_request(64, 0))
+            .expect("serve");
+        assert!(
+            !suspect_uncommitted_tail(empty_follower.next_fetch_offset().get(), 0, &empty_resp),
+            "a fresh/empty follower must NOT be flagged"
+        );
     }
 
     // ===== C4-I1 DETECTION =====

--- a/crates/ironbus-server/src/cluster/serve.rs
+++ b/crates/ironbus-server/src/cluster/serve.rs
@@ -114,15 +114,19 @@ use ironbus_storage::fs::Filesystem;
 use ironbus_storage::log::Log;
 use ironbus_storage::read_plane::ReadPlane;
 
+use crate::registry::FollowerDivergenceMetrics;
+
 use super::dataplane::{
     decode_dataplane_frame, role_for_placement, DataPlaneAction, DataPlaneController,
     DataPlaneError, DataPlaneFrame, PlacementRole, ProduceAckSeam,
 };
+use super::divergence::{empty_run_above_leader_frontier, suspect_uncommitted_tail};
 use super::isr::IsrConfig;
 use super::replication::{FetchRecordsBody, FetchResponseBody};
 use super::rereplication::{
     FetchBudget, ReReplicationThrottle, FULL_CATCHUP_BYTES, FULL_CATCHUP_RECORDS,
 };
+use super::runtime::ClusterStatus;
 use super::state_machine::Placement;
 
 /// The hard maximum size, in bytes, of a single inbound DATA-plane peer frame (the partition prefix
@@ -922,6 +926,11 @@ pub struct DataPlaneRuntime<F: Filesystem, C: Clock> {
     listener: Option<JoinHandle<()>>,
     /// One FOLLOWER fetch thread per followed partition (dials the leader, fetch + apply + report).
     followers: Vec<JoinHandle<()>>,
+    /// The #873 Phase 1 follower-divergence telemetry (`Arc`-shared with every follower fetch thread):
+    /// a bounded, lock-free counter block the fetch loops bump on a SUSPECTED uncommitted-tail divergence
+    /// (detection only — no mutation). Exposed via [`Self::follower_divergence_metrics`] for the metrics
+    /// scrape to read, mirroring how the connz / health-shed off-engine signals are surfaced.
+    follower_divergence: Arc<FollowerDivergenceMetrics>,
 }
 
 /// How a leader-side data-plane reader RELEASES a quorum-fsync'd produce ack from a follower's
@@ -1094,6 +1103,14 @@ where
             effective_dataplane_reader_cap(dataplane_reader_cap, server.led_inbound_link_count());
         let server = Arc::new(Mutex::new(server));
         let shutdown = Arc::new(AtomicBool::new(false));
+        // #873 Phase 1: the shared committed-HW status snapshot (the follower's OWN quorum-committed
+        // floor source — the replicated `CheckpointCommittedHw` bar in `ClusterStatus::last_committed_hw`)
+        // and the bounded divergence telemetry, both cloned into every follower fetch thread below for
+        // OBSERVATION only. The status is cloned OUT of `client_cfg` before it is moved into the gate.
+        // Both are `None`/empty-safe: a runtime started without a status handle detects on clause 2 alone
+        // (the leader-frontier comparison), which is the safety-critical gate.
+        let follower_status = client_cfg.as_ref().and_then(|cfg| cfg.status.clone());
+        let follower_divergence = Arc::new(FollowerDivergenceMetrics::default());
         // Build the client produce-ack gate around the SAME server Arc when a config was given (#719/#735).
         // The gate and every leader-side reader share this one Arc, so the seam's parked state is one
         // source of truth. The #735 wiring (the `NOT_LEADER` leader-hint advertise map + the follower-read
@@ -1156,10 +1173,19 @@ where
             };
             let shutdown_f = Arc::clone(&shutdown);
             let server_f = Arc::clone(&server);
+            let status_f = follower_status.clone();
+            let divergence_f = Arc::clone(&follower_divergence);
             let handle = std::thread::Builder::new()
                 .name(format!("ib-dataplane-fetch-{partition}"))
                 .spawn(move || {
-                    run_follower_fetch(partition, leader_addr, server_f, &shutdown_f);
+                    run_follower_fetch(
+                        partition,
+                        leader_addr,
+                        server_f,
+                        &shutdown_f,
+                        status_f.as_ref(),
+                        &divergence_f,
+                    );
                 })
                 .expect("spawn data-plane follower fetch thread");
             followers.push(handle);
@@ -1171,6 +1197,7 @@ where
             shutdown,
             listener: Some(listener_handle),
             followers,
+            follower_divergence,
         })
     }
 
@@ -1187,6 +1214,15 @@ where
     #[must_use]
     pub fn client_gate(&self) -> Option<&Arc<super::client_ack::ClientAckGate<F, C>>> {
         self.client_gate.as_ref()
+    }
+
+    /// The #873 Phase 1 follower-divergence telemetry this runtime's fetch threads bump (the bounded
+    /// `ironbus_follower_uncommitted_tail_suspected_total` counter). The metrics scrape reads it to
+    /// surface the suspected-divergence signal alongside the operator WARN log. Detection only — reading
+    /// or incrementing it never mutates any durable / cluster state.
+    #[must_use]
+    pub fn follower_divergence_metrics(&self) -> &Arc<FollowerDivergenceMetrics> {
+        &self.follower_divergence
     }
 
     /// Signal shutdown and join every data-plane thread. Idempotent. Called by the broker's serve teardown
@@ -1503,6 +1539,8 @@ fn run_follower_fetch<F, C>(
     leader_addr: SocketAddr,
     server: Arc<Mutex<DataPlaneServer<F, C>>>,
     shutdown: &AtomicBool,
+    status: Option<&Arc<Mutex<ClusterStatus>>>,
+    divergence: &FollowerDivergenceMetrics,
 ) where
     F: Filesystem + Send + Sync + 'static,
     C: Clock + Send + 'static,
@@ -1527,6 +1565,8 @@ fn run_follower_fetch<F, C>(
                     shutdown,
                     &mut throttle,
                     origin,
+                    status,
+                    divergence,
                 );
             }
             Err(_) => {
@@ -1558,6 +1598,52 @@ fn run_follower_fetch<F, C>(
 /// untouched). The budget floors at [`MIN_CATCHUP_RECORDS`] and the backoff is capped, so the catch-up
 /// always makes forward progress and converges. `origin` is the monotonic instant the partition's
 /// throttle clock is measured from.
+/// #873 Phase 1: check the just-received fetch response for a SUSPECTED uncommitted-tail divergence
+/// and, on detection, emit the operator WARN + bump the bounded metric. Returns `true` iff it fired, so
+/// the caller LATCHES it to once per fetch-link session.
+///
+/// PURE OBSERVATION: it reads the follower's OWN quorum-committed floor from the replicated metadata
+/// snapshot (`ClusterStatus::last_committed_hw`, NEVER `resp.high_watermark`) and the fetch response,
+/// and mutates nothing durable — no truncation, no ISR change, no wire change. With no status handle the
+/// floor is `0` and detection rests on the leader-frontier comparison alone (the safety-critical gate).
+fn note_suspected_uncommitted_tail(
+    partition: u64,
+    follower_next_offset: u64,
+    resp: &FetchResponseBody,
+    status: Option<&Arc<Mutex<ClusterStatus>>>,
+    divergence: &FollowerDivergenceMetrics,
+) -> bool {
+    // Cheap, lock-free gate (clauses 1-2, the safety-critical leader-frontier discriminator) BEFORE
+    // paying for the shared-status lock that yields the committed floor: the hot streaming path (a
+    // non-empty run) short-circuits here without ever touching the `ClusterStatus` mutex.
+    if !empty_run_above_leader_frontier(follower_next_offset, resp) {
+        return false;
+    }
+    let committed_floor = status
+        .and_then(|s| {
+            s.lock()
+                .ok()
+                .and_then(|st| st.last_committed_hw.get(&partition).copied())
+        })
+        .unwrap_or(0);
+    if !suspect_uncommitted_tail(follower_next_offset, committed_floor, resp) {
+        return false;
+    }
+    divergence.record_uncommitted_tail_suspected();
+    tracing::warn!(
+        partition,
+        follower_next_offset,
+        leader_high_watermark = resp.high_watermark,
+        committed_floor,
+        "data plane: SUSPECTED uncommitted-tail divergence (#873) — this follower holds fsynced \
+         records above its committed floor that the incoming leader lineage excludes; the leader \
+         serves nothing at the follower's offset. DETECTION ONLY (no truncation / no self-heal in \
+         this phase). Investigate a post-failover divergent replica."
+    );
+    true
+}
+
+#[allow(clippy::too_many_arguments)]
 fn follower_fetch_loop<F, C>(
     partition: u64,
     link: &mut DataPlaneLink<TcpStream>,
@@ -1565,6 +1651,8 @@ fn follower_fetch_loop<F, C>(
     shutdown: &AtomicBool,
     throttle: &mut ReReplicationThrottle,
     origin: Instant,
+    status: Option<&Arc<Mutex<ClusterStatus>>>,
+    divergence: &FollowerDivergenceMetrics,
 ) where
     F: Filesystem + Send + Sync + 'static,
     C: Clock + Send + 'static,
@@ -1590,6 +1678,11 @@ fn follower_fetch_loop<F, C>(
         max_records: FULL_CATCHUP_RECORDS,
         max_bytes: FULL_CATCHUP_BYTES,
     };
+    // #873 Phase 1: latch the suspected-uncommitted-tail signal to ONCE per fetch-link session. A
+    // divergent follower wedges on empty no-op fetches (the bug), so an un-latched WARN + metric bump
+    // would fire every poll — an unbounded log/metric-volume vector. One signal per session keeps it a
+    // bounded, actionable operator event; a fresh adopt (reconnect) is a new session and may re-fire.
+    let mut divergence_suspected = false;
     while !shutdown.load(Ordering::Acquire) {
         // Build the next fetch request under a short lock (the follower's current frontier + the
         // throttle's current budget — capped below the historical full budget only while catching up
@@ -1658,6 +1751,20 @@ fn follower_fetch_loop<F, C>(
                     {
                         return;
                     }
+                }
+                // #873 Phase 1 DETECTION (observation only). Latch the first suspected uncommitted-tail
+                // signal of this fetch-link session; the helper reads the committed floor + predicate and
+                // emits the operator WARN + bumps the bounded metric. Nothing durable is mutated.
+                if !divergence_suspected
+                    && note_suspected_uncommitted_tail(
+                        partition,
+                        next_offset,
+                        &resp,
+                        status,
+                        divergence,
+                    )
+                {
+                    divergence_suspected = true;
                 }
                 // Drive the throttle from this fetch's NETWORK round-trip + the follower's backlog. The
                 // throttle internally treats a near-the-head backlog as steady-state (full-rate, no

--- a/crates/ironbus-server/src/registry.rs
+++ b/crates/ironbus-server/src/registry.rs
@@ -41,6 +41,45 @@
 
 use ironbus_proto::message::AckLevel;
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// The cross-thread, bounded CLUSTER-follower divergence telemetry (#873 Phase 1): a fixed set of
+/// process-lifetime monotonic counters the data-plane FOLLOWER fetch threads bump and the metrics
+/// scrape reads. It is a separate `Arc`-shared atomic block (the SAME shape the connz / health-shed
+/// signals use) rather than a field of [`MetricRegistry`], because the follower fetch loops run on
+/// their own data-plane threads with no access to the single-threaded engine-owned registry — a
+/// lock-free atomic counter is the only sound bridge from those threads to the scrape.
+///
+/// It is BOUNDED by construction: a FIXED, tiny set of `u64` counters with NO per-partition / per-label
+/// cardinality (a divergence event names its partition + offsets in the operator WARN LOG, not in a
+/// metric label), so no adversarial or buggy input can grow this block. Nothing here ever touches the
+/// durable log, the wire format, or any behavior — it is pure observation.
+#[derive(Debug, Default)]
+pub struct FollowerDivergenceMetrics {
+    /// `ironbus_follower_uncommitted_tail_suspected_total`: the number of times a follower fetch loop
+    /// SUSPECTED (detection only — never acted) that it holds an fsynced UNCOMMITTED tail above its own
+    /// quorum-committed floor that the incoming leader lineage excludes (the #873 silent post-failover
+    /// stitch hazard). Incremented at most ONCE per divergent fetch-link session (the follower loop
+    /// latches it), so a wedged follower that empty-no-op loops does not inflate the counter — it stays
+    /// a bounded, once-per-episode operator signal, not a per-poll spam.
+    uncommitted_tail_suspected: AtomicU64,
+}
+
+impl FollowerDivergenceMetrics {
+    /// Records one SUSPECTED uncommitted-tail divergence episode (#873 Phase 1). Lock-free; callable
+    /// from any data-plane follower thread.
+    pub fn record_uncommitted_tail_suspected(&self) {
+        self.uncommitted_tail_suspected
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// The cumulative count of suspected uncommitted-tail divergence episodes
+    /// (`ironbus_follower_uncommitted_tail_suspected_total`).
+    #[must_use]
+    pub fn uncommitted_tail_suspected_total(&self) -> u64 {
+        self.uncommitted_tail_suspected.load(Ordering::Relaxed)
+    }
+}
 
 /// The frozen registry-histogram bucket upper bounds, in NANOSECONDS, ascending, matching the
 /// fixed second-valued set the issue pins: `{0.0005, 0.001, 0.002, 0.005, 0.01, 0.02, 0.05,
@@ -1027,6 +1066,26 @@ pub fn registry_memory_ceiling_bytes() -> usize {
 mod tests {
     use super::*;
     use std::alloc::{GlobalAlloc, Layout, System};
+
+    #[test]
+    fn follower_divergence_counter_starts_zero_and_increments_once_per_episode() {
+        // #873 Phase 1: the bounded suspected-uncommitted-tail counter is monotonic and starts at zero.
+        let m = FollowerDivergenceMetrics::default();
+        assert_eq!(
+            m.uncommitted_tail_suspected_total(),
+            0,
+            "a fresh telemetry block reports the honest zero"
+        );
+        m.record_uncommitted_tail_suspected();
+        assert_eq!(
+            m.uncommitted_tail_suspected_total(),
+            1,
+            "recording a suspected episode increments the counter (mutation check)"
+        );
+        m.record_uncommitted_tail_suspected();
+        m.record_uncommitted_tail_suspected();
+        assert_eq!(m.uncommitted_tail_suspected_total(), 3);
+    }
 
     // -- The allocation-counting global allocator (scoped so it never makes unrelated tests flaky).
     //


### PR DESCRIPTION
**#873 Phase 1 of the reconcile-on-adopt roadmap** (does NOT close the epic — Phases 2-5 remain).

Makes the currently-SILENT post-failover follower divergent-stitch VISIBLE: adds adopt/fetch-time DETECTION + telemetry with **zero durable mutation** — no truncation, no ISR-membership change, no wire-format change, no behavior change beyond a new operator WARN log + one bounded metric.

- **Predicate** (`divergence::suspect_uncommitted_tail`, pure + unit-tested): empty run (leader served nothing at the follower's offset) AND follower LEO strictly above the leader's advertised frontier AND follower LEO above its own committed floor. Split out `empty_run_above_leader_frontier` as the floor-independent, lock-free gate so the hot streaming path short-circuits before touching the shared `ClusterStatus` mutex.
- **Floor** = the follower's OWN quorum-committed bar `ClusterStatus::last_committed_hw` (the replicated `CheckpointCommittedHw`), **never** `resp.high_watermark` (the leader flush HW — that was the earlier branch's bug). Detection soundness is independent of the floor's cross-restart freshness (the leader-frontier clause gates), so it is false-positive-free by construction (verified at the storage level: `read_range_raw` returns empty at/above `flushed_offset`, so a same-lineage follower can never out-run the leader frontier).
- **Telemetry**: `ironbus_follower_uncommitted_tail_suspected_total` (fixed-cardinality Arc-shared AtomicU64) + a WARN naming partition/offsets/floor, latched once per fetch-link session. (/metrics text exposition is a follow-up, same staging as the connz/cluster-ack counters.)

Mutation-verified two-sided; whole-workspace fmt+clippy(pedantic) clean; 988 server-lib tests + conformance byte-identity + determinism all green. Reviewed across 3 adversarial lenses (a 4th died on a 529 infra error; its floor-authority check is covered by the other 3).

Part of #873

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>