### PR TITLE
feat(cluster/873): Phase 2 — loss-free reconcile-on-adopt truncation of a divergent uncommitted tail

### DIFF
--- a/crates/ironbus-server/src/cluster/dataplane.rs
+++ b/crates/ironbus-server/src/cluster/dataplane.rs
@@ -1093,6 +1093,109 @@ impl<F: Filesystem, C: Clock> DataPlaneController<F, C> {
         }
     }
 
+    /// The leader epochs the follower of `partition` has learned (its epoch-cache boundary epochs, in
+    /// cache order), so the follower fetch loop can pre-collect the leader's `OffsetForLeaderEpoch`
+    /// answers OFF the server lock before driving a divergence heal (#873 Phase 2). Follower-only;
+    /// `None` otherwise. It is EMPTY in the common case (a follower learns epoch boundaries only over an
+    /// epoch-aware fetch path), which makes [`heal_divergent_follower`](Self::heal_divergent_follower)
+    /// fall back to the committed-HW truncation.
+    #[must_use]
+    pub fn follower_epochs(&self, partition: u64) -> Option<Vec<LeaderEpoch>> {
+        match self.roles.get(&partition) {
+            Some(PartitionRole::Follower { follower }) => Some(
+                lock_follower(follower)
+                    .epochs()
+                    .entries()
+                    .iter()
+                    .map(|e| e.epoch)
+                    .collect(),
+            ),
+            _ => None,
+        }
+    }
+
+    /// SELF-HEAL a divergent follower of `partition` on the PRODUCTION adopt path (#873 Phase 2): when
+    /// the follower holds an uncommitted tail ABOVE its own quorum-committed frontier `committed_hw`
+    /// (the replicated `CheckpointCommittedHw` bar — NEVER the leader's flush HW) after a leader change,
+    /// drop the divergent/uncommitted suffix and KEEP the committed prefix; the caller then re-fetches
+    /// the clean lineage forward.
+    ///
+    /// ## Fail-closed leader-behind guard
+    ///
+    /// `leader_end_hw` is the adopted leader's advertised end frontier (its flushed HW). If it is BELOW
+    /// `committed_hw` the adopted leader does not even hold all the committed data this heal must be able
+    /// to restore, so truncating the follower's tail and re-fetching from it would risk dropping
+    /// committed data the leader cannot serve back. FAIL CLOSED with
+    /// [`ReplicationError::ResyncLeaderBehind`] BEFORE any truncation, leaving the (still-complete)
+    /// follower untouched for a retry against a complete leader — the same defense-in-depth guard the
+    /// full auto-resync uses (#798).
+    ///
+    /// ## Truncation
+    ///
+    /// It first runs the KIP-101 epoch reconcile
+    /// ([`reconcile_follower`](Self::reconcile_follower)): if the follower has learned the leader's
+    /// epoch boundaries it truncates to the PRECISE divergence point (which may keep shared-lineage
+    /// records above the committed HW). If that resolves nothing — the common case, the follower's
+    /// epoch cache is empty — yet the follower still holds a tail above `committed_hw`, it truncates
+    /// that unverifiable suffix down to `committed_hw` via
+    /// [`EpochAwareFollower::truncate_to_committed`]. Either path NEVER drops below `committed_hw`, so
+    /// committed data (quorum-fsync'd, #691) is never dropped. Returns the typed
+    /// [`DivergenceTruncation`] (a clean no-op only when nothing above the committed frontier existed).
+    /// It is IDEMPOTENT: a retry after a clean heal finds no tail above `committed_hw` and reports a
+    /// no-op. Follower-only.
+    ///
+    /// `leader_end_offset` answers the leader's end-offset for a queried epoch — in production a map of
+    /// the leader's `OffsetForLeaderEpoch` answers pre-collected off the wire (only consulted when the
+    /// follower's cache is non-empty); in a test it calls the leader's
+    /// [`serve_epoch_query`](Self::serve_epoch_query) directly.
+    ///
+    /// # Errors
+    /// [`DataPlaneError::WrongRole`] on a leader; [`DataPlaneError::UnknownPartition`] if absent;
+    /// [`DataPlaneError::Replication`] with [`ReplicationError::ResyncLeaderBehind`] if the leader is
+    /// behind the committed frontier, or on a truncation / epoch-cache fault.
+    pub fn heal_divergent_follower<L>(
+        &mut self,
+        partition: u64,
+        committed_hw: Offset,
+        leader_end_hw: u64,
+        leader_end_offset: L,
+    ) -> Result<DivergenceTruncation, DataPlaneError>
+    where
+        L: FnMut(LeaderEpoch) -> LeaderEpochEndOffset,
+    {
+        // FAIL CLOSED before touching durable bytes: never truncate to re-fetch from a leader that does
+        // not even hold the committed frontier this heal must preserve (#798 leader-behind guard).
+        if leader_end_hw < committed_hw.get() {
+            return Err(DataPlaneError::Replication(
+                ReplicationError::ResyncLeaderBehind {
+                    leader_hw: leader_end_hw,
+                    committed_hw: committed_hw.get(),
+                },
+            ));
+        }
+        let healed = self.reconcile_follower(partition, committed_hw, leader_end_offset)?;
+        if !healed.is_no_op() {
+            return Ok(healed);
+        }
+        // The epoch reconcile resolved nothing (an empty / prefix epoch cache). If the follower still
+        // holds an uncommitted tail above the committed frontier, truncate it down to the committed HW.
+        match self.roles.get(&partition) {
+            Some(PartitionRole::Follower { follower }) => {
+                let mut guard = lock_follower(follower);
+                if guard.follower().next_fetch_offset().get() > committed_hw.get() {
+                    Ok(guard.truncate_to_committed(committed_hw)?)
+                } else {
+                    Ok(healed)
+                }
+            }
+            Some(PartitionRole::Leader { .. }) => Err(DataPlaneError::WrongRole {
+                partition,
+                needed: "follower",
+            }),
+            None => Err(DataPlaneError::UnknownPartition { partition }),
+        }
+    }
+
     /// The follower's current visible high-watermark for `partition` (`min(its durable prefix, the
     /// leader's last-observed HW)`) — only committed-and-replicated data is visible below it.
     /// Follower-only; `None` otherwise.
@@ -2275,6 +2378,353 @@ mod tests {
                 assert_replicated_byte_identical(log, &new_leader_log, new_served);
             })
             .unwrap();
+    }
+
+    // ---- #873 Phase 2: reconcile-on-adopt truncation (empty-epoch-cache fallback) -----------------
+
+    /// The shared committed-prefix record content (both a divergent follower and a clean new leader hold
+    /// byte-identical records here) — 6 bytes, so a small segment cap rolls identically on both.
+    fn shared_rec(i: u32) -> String {
+        format!("rec-{i:02}")
+    }
+    /// The DIVERGENT new-lineage record content (same 6-byte width so segment rolls stay aligned).
+    fn new_rec(i: u32) -> String {
+        format!("new-{i:02}")
+    }
+
+    fn min1() -> IsrConfig {
+        IsrConfig {
+            min_isr: 1,
+            max_lag_records: 0,
+        }
+    }
+
+    /// Build a FOLLOWER (node 2, EMPTY epoch cache — the common post-failover shape) that fully
+    /// replicated a throwaway old leader's `old_len`-record `shared_rec` lineage over the read-plane
+    /// serve path; it now holds `[0, old_served)` fsynced with NO learned epoch boundaries. `fs` backs
+    /// the follower log so a caller can reopen it (crash-recovery model). Returns the follower + the
+    /// old leader's sealed-served end (the follower's frontier).
+    fn divergent_follower_holding(
+        partition: u64,
+        fs: InMemoryFs,
+        old_len: u32,
+    ) -> (DataPlaneController<InMemoryFs, ManualClock>, u64) {
+        let mut old_leader_log = open_log(InMemoryFs::new(), small_config());
+        for i in 0..old_len {
+            old_leader_log
+                .append(&rec(shared_rec(i).as_bytes()))
+                .unwrap();
+        }
+        old_leader_log.sync().unwrap();
+        let old_plane = leader_plane(&old_leader_log);
+        let old_served = plane_served_end(&old_plane);
+        let mut old_leader = DataPlaneController::<InMemoryFs, ManualClock>::new(1);
+        old_leader.start_leader(
+            partition,
+            Arc::clone(&old_plane),
+            EpochCache::new(),
+            &[1, 2],
+            min1(),
+        );
+        let mut follower = DataPlaneController::<InMemoryFs, ManualClock>::new(2);
+        follower.start_follower(partition, open_log(fs, small_config()));
+        for _ in 0..40 {
+            if follower.follower_high_watermark(partition).unwrap() >= old_served {
+                break;
+            }
+            let req = follower.make_fetch_request(partition, 8, 4096).unwrap();
+            let resp = old_leader.serve_fetch(partition, &req).unwrap();
+            follower.apply_fetch_response(partition, &resp).unwrap();
+        }
+        assert!(
+            old_served >= 8,
+            "old leader must seal a usable prefix (got {old_served})"
+        );
+        assert_eq!(
+            follower
+                .with_follower_log(partition, |log| log.next_offset().get())
+                .unwrap(),
+            old_served,
+            "the follower holds the full old prefix as its uncommitted tail"
+        );
+        (follower, old_served)
+    }
+
+    /// Build a NEW leader (node 1) whose lineage shares `[0, floor)` with the followers (`shared_rec`)
+    /// and DIVERGES over `[floor, total)` (`new_rec`). Returns the leader, its owned log, and its
+    /// sealed-served end.
+    fn new_divergent_leader(
+        partition: u64,
+        floor: u32,
+        total: u32,
+    ) -> (
+        DataPlaneController<InMemoryFs, ManualClock>,
+        Log<InMemoryFs, ManualClock>,
+        u64,
+    ) {
+        let mut log = open_log(InMemoryFs::new(), small_config());
+        for i in 0..floor {
+            log.append(&rec(shared_rec(i).as_bytes())).unwrap();
+        }
+        for i in floor..total {
+            log.append(&rec(new_rec(i).as_bytes())).unwrap();
+        }
+        log.sync().unwrap();
+        let plane = leader_plane(&log);
+        let served = plane_served_end(&plane);
+        let mut leader = DataPlaneController::<InMemoryFs, ManualClock>::new(1);
+        leader.start_leader(
+            partition,
+            Arc::clone(&plane),
+            EpochCache::new(),
+            &[1, 2],
+            min1(),
+        );
+        (leader, log, served)
+    }
+
+    /// An epoch-answer closure that must never be consulted (an empty follower epoch cache locates no
+    /// divergence point, so the heal falls back to the committed-HW truncation without any query).
+    fn no_query(_epoch: LeaderEpoch) -> LeaderEpochEndOffset {
+        panic!("an empty follower epoch cache must never query the leader");
+    }
+
+    #[test]
+    fn heal_truncates_a_divergent_uncommitted_tail_down_to_the_committed_floor() {
+        const P: u64 = 0;
+        const FLOOR: u64 = 6;
+        let (mut follower, old_served) = divergent_follower_holding(P, InMemoryFs::new(), 18);
+        assert!(
+            old_served > FLOOR,
+            "the follower must hold a tail above the floor"
+        );
+
+        // The new leader's lineage diverges after the committed floor; its frontier is at/above FLOOR,
+        // so the leader-behind guard passes and the heal truncates the unverifiable tail to FLOOR.
+        let (new_leader, new_leader_log, new_served) =
+            new_divergent_leader(P, u32::try_from(FLOOR).unwrap(), 20);
+        let healed = follower
+            .heal_divergent_follower(P, Offset::new(FLOOR), new_served, no_query)
+            .expect("the follower self-heals to the committed floor");
+        assert!(
+            !healed.is_no_op(),
+            "the divergent uncommitted tail was truncated"
+        );
+        assert_eq!(
+            healed.divergence_point.truncate_to.get(),
+            FLOOR,
+            "it truncated to EXACTLY the committed floor, never below"
+        );
+        assert_eq!(
+            follower
+                .with_follower_log(P, |log| log.next_offset().get())
+                .unwrap(),
+            FLOOR,
+            "the follower's frontier is now the committed floor — the uncommitted tail is gone"
+        );
+
+        // Re-fetch the CLEAN new lineage forward; the follower converges byte-identical (its kept
+        // [0,FLOOR) committed prefix + the new [FLOOR,new_served) lineage).
+        for _ in 0..40 {
+            if follower.follower_high_watermark(P).unwrap() >= new_served {
+                break;
+            }
+            let req = follower.make_fetch_request(P, 8, 4096).unwrap();
+            let resp = new_leader.serve_fetch(P, &req).unwrap();
+            follower.apply_fetch_response(P, &resp).unwrap();
+        }
+        follower
+            .with_follower_log(P, |log| {
+                assert_replicated_byte_identical(log, &new_leader_log, new_served);
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn heal_refuses_when_the_new_leader_is_behind_the_committed_floor() {
+        const P: u64 = 0;
+        const FLOOR: u64 = 10;
+        let (mut follower, old_served) = divergent_follower_holding(P, InMemoryFs::new(), 18);
+
+        // The adopted leader's frontier is BELOW the committed floor: it cannot restore the committed
+        // data a truncation would drop. The heal FAILS CLOSED and leaves the follower UNTOUCHED.
+        let leader_behind_hw = FLOOR - 1;
+        let err = follower
+            .heal_divergent_follower(P, Offset::new(FLOOR), leader_behind_hw, no_query)
+            .expect_err("a leader behind the committed floor must be refused");
+        match err {
+            DataPlaneError::Replication(ReplicationError::ResyncLeaderBehind {
+                leader_hw,
+                committed_hw,
+            }) => {
+                assert_eq!(leader_hw, leader_behind_hw);
+                assert_eq!(committed_hw, FLOOR);
+            }
+            other => panic!("expected ResyncLeaderBehind, got {other:?}"),
+        }
+        assert_eq!(
+            follower
+                .with_follower_log(P, |log| log.next_offset().get())
+                .unwrap(),
+            old_served,
+            "REFUSED heals never truncate: the follower's log is untouched for a retry"
+        );
+    }
+
+    #[test]
+    fn heal_never_drops_a_committed_record_and_preserves_the_prefix_byte_for_byte() {
+        const P: u64 = 0;
+        const FLOOR: u64 = 8;
+        let fs = InMemoryFs::new();
+        let (mut follower, old_served) = divergent_follower_holding(P, fs, 18);
+        assert!(old_served > FLOOR);
+
+        // Snapshot the committed-prefix bytes [0, FLOOR) BEFORE the heal (the segment files wholly below
+        // the floor), so we can prove the heal drops ONLY the suffix and never a committed record.
+        let prefix_before: std::collections::BTreeMap<String, Vec<u8>> = follower
+            .with_follower_log(P, dump_segments)
+            .unwrap()
+            .into_iter()
+            .collect();
+
+        // A leader with a frontier well above the floor: the heal truncates to exactly FLOOR.
+        follower
+            .heal_divergent_follower(P, Offset::new(FLOOR), old_served, no_query)
+            .expect("heals to the floor");
+        assert_eq!(
+            follower
+                .with_follower_log(P, |log| log.next_offset().get())
+                .unwrap(),
+            FLOOR
+        );
+
+        // Every surviving follower segment file is a byte-identical PREFIX of the pre-heal file of the
+        // same name (a wholly-below-floor segment is byte-for-byte unchanged; the segment straddling the
+        // floor is a truncated prefix). No committed record below the floor was altered or dropped.
+        let after = follower.with_follower_log(P, dump_segments).unwrap();
+        for (name, bytes) in after {
+            let before = prefix_before
+                .get(&name)
+                .unwrap_or_else(|| panic!("heal fabricated a new segment file {name}"));
+            assert!(
+                before.starts_with(&bytes),
+                "surviving segment {name} is not a byte-identical prefix of its pre-heal bytes"
+            );
+        }
+
+        // A DECODE of the survivor confirms records [0, FLOOR) are intact and unmodified.
+        follower
+            .with_follower_log(P, |log| {
+                let records = log
+                    .read_from(Offset::new(0), usize::try_from(FLOOR).unwrap())
+                    .expect("committed prefix reads back");
+                assert_eq!(records.len(), usize::try_from(FLOOR).unwrap());
+                for (i, got) in records.iter().enumerate() {
+                    assert_eq!(
+                        got.payload.as_ref(),
+                        shared_rec(u32::try_from(i).unwrap()).as_bytes(),
+                        "committed record {i} was altered by the heal"
+                    );
+                }
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn heal_is_idempotent_on_retry() {
+        const P: u64 = 0;
+        const FLOOR: u64 = 6;
+        let (mut follower, old_served) = divergent_follower_holding(P, InMemoryFs::new(), 18);
+
+        let first = follower
+            .heal_divergent_follower(P, Offset::new(FLOOR), old_served, no_query)
+            .expect("first heal truncates");
+        assert!(!first.is_no_op(), "the first heal drops the divergent tail");
+        assert_eq!(
+            follower
+                .with_follower_log(P, |log| log.next_offset().get())
+                .unwrap(),
+            FLOOR
+        );
+
+        // A RETRY (e.g. after a reconnect) finds nothing above the floor: a clean no-op that drops
+        // nothing. Idempotent — re-running the heal never double-truncates or errors.
+        let second = follower
+            .heal_divergent_follower(P, Offset::new(FLOOR), old_served, no_query)
+            .expect("retry is a clean no-op");
+        assert!(second.is_no_op(), "the retry truncates nothing");
+        assert_eq!(
+            follower
+                .with_follower_log(P, |log| log.next_offset().get())
+                .unwrap(),
+            FLOOR,
+            "the frontier is unchanged after the idempotent retry"
+        );
+    }
+
+    #[test]
+    fn heal_survives_a_reopen_recovering_to_the_truncated_prefix() {
+        const P: u64 = 0;
+        const FLOOR: u64 = 6;
+        // A SHARED fs (Arc-backed) so a fresh Log::open after the heal recovers from the SAME durable
+        // bytes — the crash-consistency model: recovery is a pure function of the post-truncate bytes.
+        let fs = InMemoryFs::new();
+        let (mut follower, old_served) = divergent_follower_holding(P, fs.clone(), 18);
+        follower
+            .heal_divergent_follower(P, Offset::new(FLOOR), old_served, no_query)
+            .expect("heals to the floor");
+        // The truncate fsync'd (set_len + sync_all + sync_dir); a reopen from the shared durable store
+        // must recover EXACTLY the truncated prefix — never the dropped suffix, never short of the floor.
+        let reopened = open_log(fs, small_config());
+        assert_eq!(
+            reopened.next_offset().get(),
+            FLOOR,
+            "recovery after the heal lands on exactly the truncated committed prefix"
+        );
+        let records = reopened
+            .read_from(Offset::new(0), usize::try_from(FLOOR).unwrap())
+            .expect("prefix reads back after reopen");
+        assert_eq!(records.len(), usize::try_from(FLOOR).unwrap());
+        for (i, got) in records.iter().enumerate() {
+            assert_eq!(
+                got.payload.as_ref(),
+                shared_rec(u32::try_from(i).unwrap()).as_bytes()
+            );
+        }
+    }
+
+    #[test]
+    fn two_replicas_heal_to_the_same_prefix_deterministically() {
+        const P: u64 = 0;
+        const FLOOR: u64 = 7;
+        let (mut a, a_served) = divergent_follower_holding(P, InMemoryFs::new(), 18);
+        let (mut b, b_served) = divergent_follower_holding(P, InMemoryFs::new(), 18);
+        assert_eq!(a_served, b_served, "identical setups replicate identically");
+
+        a.heal_divergent_follower(P, Offset::new(FLOOR), a_served, no_query)
+            .expect("A heals");
+        b.heal_divergent_follower(P, Offset::new(FLOOR), b_served, no_query)
+            .expect("B heals");
+
+        let a_bytes: std::collections::BTreeMap<String, Vec<u8>> = a
+            .with_follower_log(P, dump_segments)
+            .unwrap()
+            .into_iter()
+            .collect();
+        let b_bytes: std::collections::BTreeMap<String, Vec<u8>> = b
+            .with_follower_log(P, dump_segments)
+            .unwrap()
+            .into_iter()
+            .collect();
+        assert_eq!(
+            a_bytes, b_bytes,
+            "two replicas healing to the same committed floor produce byte-identical prefixes"
+        );
+        assert_eq!(
+            a.with_follower_log(P, |log| log.next_offset().get())
+                .unwrap(),
+            FLOOR
+        );
     }
 
     // ---- single-node / single-replica = the local-fsync ack, byte-identical ----------------------

--- a/crates/ironbus-server/src/cluster/replication.rs
+++ b/crates/ironbus-server/src/cluster/replication.rs
@@ -1167,6 +1167,36 @@ impl<F: Filesystem, C: Clock> EpochAwareFollower<F, C> {
             truncation,
         })
     }
+
+    /// Truncate the follower's log DOWN to the committed high-watermark `committed_hw` — the
+    /// NO-EPOCH-INFO divergence self-heal (#873 Phase 2). When a follower holds an uncommitted tail
+    /// ABOVE the leader's committed frontier after a leader change but has NOT learned the leader's
+    /// epoch boundaries (so [`reconcile_with_leader`](Self::reconcile_with_leader) cannot locate a
+    /// shared-epoch divergence point — its epoch cache is empty), the uncommitted suffix is
+    /// unverifiable: drop it down to the committed frontier and re-fetch the clean lineage forward.
+    /// It NEVER drops below `committed_hw` (committed data is fsync'd on a quorum, #691), so this is
+    /// loss-free for committed data by construction. Mirrors the truncation in the epoch cache and
+    /// resets the observed leader HW, exactly as [`reconcile_with_leader`](Self::reconcile_with_leader)
+    /// does after an epoch-based truncation, and reports the same typed [`DivergenceTruncation`] (never
+    /// a silent drop).
+    ///
+    /// # Errors
+    /// [`ReplicationError::Storage`] if the underlying [`Log::truncate_to`] fails.
+    pub fn truncate_to_committed(
+        &mut self,
+        committed_hw: Offset,
+    ) -> Result<DivergenceTruncation, ReplicationError> {
+        let truncation = self.follower.log.truncate_to(committed_hw)?;
+        self.epochs.truncate_to(committed_hw);
+        self.follower.leader_high_watermark = committed_hw.get();
+        Ok(DivergenceTruncation {
+            divergence_point: DivergencePoint {
+                truncate_to: committed_hw,
+                diverged_at_epoch: LeaderEpoch::GENESIS,
+            },
+            truncation,
+        })
+    }
 }
 
 /// A bidirectional REPLICATION peer link over any byte stream (`Read + Write`): a real `TcpStream`

--- a/crates/ironbus-server/src/cluster/serve.rs
+++ b/crates/ironbus-server/src/cluster/serve.rs
@@ -105,8 +105,9 @@ use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
 use ironbus_core::clock::Clock;
-use ironbus_core::epoch_cache::EpochCache;
+use ironbus_core::epoch_cache::{EpochCache, LeaderEpochEndOffset};
 use ironbus_core::leader_lease::LeaderEpoch;
+use ironbus_core::types::Offset;
 use ironbus_proto::frame::{
     decode_frame_with_cap, encode_frame, FrameDecode, FrameError, FrameType, MAX_FRAME_LEN,
 };
@@ -122,7 +123,9 @@ use super::dataplane::{
 };
 use super::divergence::{empty_run_above_leader_frontier, suspect_uncommitted_tail};
 use super::isr::IsrConfig;
-use super::replication::{FetchRecordsBody, FetchResponseBody};
+use super::replication::{
+    FetchRecordsBody, FetchResponseBody, OffsetForLeaderEpochBody, ReplicationError,
+};
 use super::rereplication::{
     FetchBudget, ReReplicationThrottle, FULL_CATCHUP_BYTES, FULL_CATCHUP_RECORDS,
 };
@@ -1643,6 +1646,227 @@ fn note_suspected_uncommitted_tail(
     true
 }
 
+/// The outcome of a #873 Phase 2 reconcile-on-adopt heal driven over the live leader link.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum AdoptHeal {
+    /// A divergent uncommitted tail was TRUNCATED down to the committed floor (a durable, loss-free
+    /// self-heal). The caller re-fetches the clean lineage forward.
+    Healed,
+    /// Nothing to heal (a clean no-op reconcile), or the wire / role failed. The caller reconnects and
+    /// re-fetches rather than hot-looping.
+    NoneOrFailed,
+    /// FAIL CLOSED: the adopted leader is BEHIND the follower's committed floor (the `ResyncLeaderBehind`
+    /// guard). The follower was left UNTOUCHED (never truncated) for a retry against a complete leader.
+    Refused,
+}
+
+/// #873 Phase 2 RECONCILE-ON-ADOPT (the adopt seam). Run ONCE at the top of the follower fetch loop —
+/// BEFORE the first forward fetch could apply anything — probe the newly-adopted leader and, if this
+/// follower holds a divergent uncommitted tail (the Phase 1 detector fires against the follower's OWN
+/// quorum-committed floor, `ClusterStatus::last_committed_hw` — NEVER `resp.high_watermark`), TRUNCATE
+/// that tail away down to (never below) the committed floor. This closes the silent-stitch hazard: with
+/// the stale uncommitted bytes gone, no forward fetch can graft the new leader's lineage onto them.
+///
+/// It is PURE DETECTION until it acts: the probe response is NEVER applied to the log (a divergent
+/// follower's probe is by construction an empty run above the leader frontier), so "before the first
+/// forward fetch" holds. A refusal (`ResyncLeaderBehind`) leaves the follower untouched — the safe,
+/// fail-closed outcome. On any wire / role failure it simply returns; the caller reconnects.
+fn reconcile_on_adopt<S, F, C>(
+    partition: u64,
+    link: &mut DataPlaneLink<S>,
+    server: &Arc<Mutex<DataPlaneServer<F, C>>>,
+    status: Option<&Arc<Mutex<ClusterStatus>>>,
+    divergence: &FollowerDivergenceMetrics,
+) where
+    S: Read + Write,
+    F: Filesystem + Send + Sync + 'static,
+    C: Clock + Send + 'static,
+{
+    // Build a PROBE fetch from the follower's current frontier under a short lock (never held across
+    // the wire). Its `from_offset` IS the follower's next offset — the LEO the detector compares.
+    let req = {
+        let Ok(srv) = server.lock() else {
+            return; // poisoned: tearing down
+        };
+        match srv.seam().controller().make_fetch_request(
+            partition,
+            FULL_CATCHUP_RECORDS,
+            FULL_CATCHUP_BYTES,
+        ) {
+            Ok(req) => req,
+            Err(_) => return, // not a follower of this partition
+        }
+    };
+    let follower_next_offset = req.from_offset;
+    // Send the probe and read exactly one response. A wire failure / stray frame aborts the adopt
+    // reconcile; the caller reconnects and retries (idempotent — a fresh adopt re-probes).
+    if link
+        .send(partition, &DataPlaneFrame::FetchRequest(req))
+        .is_err()
+    {
+        return;
+    }
+    let resp = match link.recv() {
+        Ok(Some((p, DataPlaneFrame::FetchResponse(resp)))) if p == partition => resp,
+        _ => return,
+    };
+    // Read the follower's OWN quorum-committed floor from the replicated metadata snapshot. It is
+    // AUTHORITATIVE only once the metadata group has published a `CheckpointCommittedHw` for this
+    // partition; before that the map has NO entry for it. We MUST distinguish an ABSENT floor from a
+    // genuine committed HW of `0`: the pre-fix code resolved the floor as `.unwrap_or(0)`, which
+    // CONFLATED the two — on a leader change BEFORE the first checkpoint it would truncate the WHOLE
+    // follower log (committed prefix INCLUDED) down to `0`, and a crash mid-heal would leave it empty
+    // (the `ResyncLeaderBehind` guard is vacuous at floor `0`). NEVER `resp.high_watermark` (the
+    // leader's flush HW). Resolve it as an `Option` and FAIL CLOSED on the absent case below.
+    let committed_floor: Option<u64> = status.and_then(|s| {
+        s.lock()
+            .ok()
+            .and_then(|st| st.last_committed_hw.get(&partition).copied())
+    });
+    let Some(committed_floor) = committed_floor else {
+        // ABSENT authoritative floor: the committed prefix length is UNKNOWN, so ANY truncation could
+        // durably drop committed data. If the follower nonetheless LOOKS divergent (an empty run above
+        // the leader frontier over a non-empty log — exactly what `suspect_uncommitted_tail` would have
+        // flagged against a bogus floor of `0`), REFUSE the heal entirely: leave the log UNTOUCHED,
+        // bump the heal-refused metric, and WARN. A retry once the metadata group publishes the floor
+        // heals normally. A caught-up / empty follower is not divergent and stays silent (no spam).
+        if empty_run_above_leader_frontier(follower_next_offset, &resp) && follower_next_offset > 0
+        {
+            divergence.record_uncommitted_tail_heal_refused();
+            tracing::warn!(
+                partition,
+                follower_next_offset,
+                leader_high_watermark = resp.high_watermark,
+                "data plane: reconcile-on-adopt REFUSED (#873 Phase 2) — no authoritative committed \
+                 floor yet (the metadata group has not published a CheckpointCommittedHw for this \
+                 partition), so the committed prefix length is UNKNOWN and any truncation could drop \
+                 committed data. FAIL CLOSED: refusing to truncate — the follower log is left \
+                 untouched. Retrying after the floor is published heals normally."
+            );
+        }
+        return;
+    };
+    // Only act on a SUSPECTED uncommitted-tail divergence (the empty-run-above-frontier discriminator).
+    // A caught-up / healthy follower short-circuits here and enters the steady loop untouched.
+    if !suspect_uncommitted_tail(follower_next_offset, committed_floor, &resp) {
+        return;
+    }
+    let leader_hw = resp.high_watermark;
+    match heal_divergent_follower_on_link(partition, committed_floor, leader_hw, link, server) {
+        AdoptHeal::Healed => {
+            divergence.record_uncommitted_tail_healed();
+            tracing::warn!(
+                partition,
+                follower_next_offset,
+                committed_floor,
+                leader_high_watermark = leader_hw,
+                "data plane: RECONCILED-ON-ADOPT (#873 Phase 2) — truncated a divergent uncommitted \
+                 tail down to the quorum-committed floor before the first forward fetch, so the new \
+                 leader lineage cannot stitch onto stale uncommitted bytes. Committed data was never \
+                 dropped (the truncation floor is the replicated committed HW). Re-fetching the clean \
+                 lineage forward."
+            );
+        }
+        AdoptHeal::Refused => {
+            divergence.record_uncommitted_tail_heal_refused();
+            tracing::warn!(
+                partition,
+                follower_next_offset,
+                committed_floor,
+                leader_high_watermark = leader_hw,
+                "data plane: reconcile-on-adopt REFUSED (#873 Phase 2, ResyncLeaderBehind) — the \
+                 adopted leader's frontier is BELOW this follower's committed floor, so it cannot \
+                 restore the committed data a truncation would drop. FAIL CLOSED: the follower is \
+                 left untouched for a retry against a complete leader."
+            );
+        }
+        AdoptHeal::NoneOrFailed => {}
+    }
+}
+
+/// #873 Phase 2: drive the divergence heal for `partition` over the live leader `link`. Pre-collects
+/// the follower's learned leader epochs OFF the server lock, queries the leader's `OffsetForLeaderEpoch`
+/// end-offset for each over the SAME link (none in the common case — an empty epoch cache), then drives
+/// the controller's [`DataPlaneController::heal_divergent_follower`] to truncate the divergent suffix
+/// down to `committed_hw` (never below). `leader_hw` is the adopted leader's advertised frontier; the
+/// controller FAILS CLOSED with `ResyncLeaderBehind` if it is below `committed_hw`. No wire I/O ever
+/// happens under the server lock: the epoch answers are collected off-lock first, then the heal runs
+/// under a short lock with a PURE closure over them.
+fn heal_divergent_follower_on_link<S, F, C>(
+    partition: u64,
+    committed_hw: u64,
+    leader_hw: u64,
+    link: &mut DataPlaneLink<S>,
+    server: &Arc<Mutex<DataPlaneServer<F, C>>>,
+) -> AdoptHeal
+where
+    S: Read + Write,
+    F: Filesystem + Send + Sync + 'static,
+    C: Clock + Send + 'static,
+{
+    // Pre-collect the follower's learned leader epochs under a SHORT lock, released before any wire I/O.
+    let epochs = {
+        let Ok(srv) = server.lock() else {
+            return AdoptHeal::NoneOrFailed; // poisoned: tearing down
+        };
+        match srv.seam().controller().follower_epochs(partition) {
+            Some(epochs) => epochs,
+            None => return AdoptHeal::NoneOrFailed, // no longer a follower of this partition
+        }
+    };
+    // Query the leader for each learned epoch's end-offset over the SAME link, OFF the server lock. A
+    // wire failure aborts the heal (reconnect); a missing answer maps to the committed-HW floor below
+    // so the reconcile never truncates on an answer it did not receive.
+    let mut answers: BTreeMap<u64, LeaderEpochEndOffset> = BTreeMap::new();
+    for epoch in epochs {
+        if link
+            .send(
+                partition,
+                &DataPlaneFrame::EpochQuery(OffsetForLeaderEpochBody { epoch }),
+            )
+            .is_err()
+        {
+            return AdoptHeal::NoneOrFailed;
+        }
+        match link.recv() {
+            Ok(Some((p, DataPlaneFrame::EpochResponse(resp)))) if p == partition => {
+                answers.insert(epoch.get(), resp.end_offset);
+            }
+            _ => return AdoptHeal::NoneOrFailed,
+        }
+    }
+    // Drive the heal under a SHORT lock with a PURE closure over the pre-collected answers (no wire I/O
+    // under the lock). A queried epoch with no answer falls back to the committed-HW floor.
+    let committed = Offset::new(committed_hw);
+    let Ok(mut srv) = server.lock() else {
+        return AdoptHeal::NoneOrFailed;
+    };
+    let outcome = srv.seam_mut().controller_mut().heal_divergent_follower(
+        partition,
+        committed,
+        leader_hw,
+        |epoch: LeaderEpoch| {
+            answers
+                .get(&epoch.get())
+                .copied()
+                .unwrap_or(LeaderEpochEndOffset {
+                    requested_epoch: epoch,
+                    answered_epoch: epoch,
+                    end_offset: committed,
+                })
+        },
+    );
+    match outcome {
+        Ok(truncation) if !truncation.is_no_op() => AdoptHeal::Healed,
+        Err(DataPlaneError::Replication(ReplicationError::ResyncLeaderBehind { .. })) => {
+            AdoptHeal::Refused
+        }
+        // A clean no-op reconcile, or any other truncation / epoch-cache fault: nothing was healed;
+        // the caller reconnects and re-fetches rather than hot-looping.
+        Ok(_) | Err(_) => AdoptHeal::NoneOrFailed,
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn follower_fetch_loop<F, C>(
     partition: u64,
@@ -1671,6 +1895,15 @@ fn follower_fetch_loop<F, C>(
             None => return, // not a follower of this partition
         }
     };
+    // #873 Phase 2 RECONCILE-ON-ADOPT: at the adopt seam — BEFORE the first forward fetch below — probe
+    // the newly-adopted leader once and, on a detected divergent uncommitted tail, TRUNCATE it away down
+    // to the follower's own quorum-committed floor. This runs per fetch-link session (a fresh adopt is a
+    // new session); it is idempotent (a clean follower / an already-healed one no-ops) and never applies
+    // the probe response, so the steady loop below always fetches a clean lineage forward.
+    if shutdown.load(Ordering::Acquire) {
+        return;
+    }
+    reconcile_on_adopt(partition, link, server, status, divergence);
     // The budget the throttle decided for the NEXT fetch. Seeded full-rate: the first fetch of a
     // freshly-dialed link runs at full budget (the backlog is not known until the first response), and
     // the throttle shapes every subsequent fetch from the observed backlog + service delay.
@@ -2120,6 +2353,299 @@ mod tests {
         ) -> Result<Log<InMemoryFs, ManualClock>, String> {
             Ok(open_log())
         }
+    }
+
+    // ============================================================================================
+    //  #873 Phase 2 SERVE-SEAM wiring: `reconcile_on_adopt` / `heal_divergent_follower_on_link` driven
+    //  over an IN-MEMORY link (no socket, no thread — fully deterministic, InMemoryFs + ManualClock).
+    //  The review flagged these seam functions as having ZERO direct coverage. Each test scripts the
+    //  adopt handshake — a single probe (FetchRequest -> an empty-run FetchResponse above the leader
+    //  frontier) with an EMPTY follower epoch cache, so the whole reconcile runs off ONE response — and
+    //  asserts the CRITICAL fix: an ABSENT authoritative committed floor REFUSES (log untouched), a
+    //  PRESENT floor + a divergent tail TRUNCATES to the floor, and a PRESENT floor with the leader
+    //  behind REFUSES (`ResyncLeaderBehind`).
+    // ============================================================================================
+
+    fn min_isr1() -> IsrConfig {
+        IsrConfig {
+            min_isr: 1,
+            max_lag_records: 0,
+        }
+    }
+
+    /// A synchronous IN-MEMORY duplex stream for a [`DataPlaneLink`]: `recv` reads pre-scripted leader
+    /// response bytes out of `inbound`; `send` captures the follower's outbound frames in `outbound`
+    /// (inspectable, though these tests only assert on the log + metrics). Single-threaded and fully
+    /// deterministic — no socket, no clock. Reading past the scripted bytes returns `0` (a clean EOF),
+    /// which the link surfaces as a benign end-of-stream the reconcile treats as "nothing more to do".
+    struct ScriptedStream {
+        inbound: Vec<u8>,
+        read_pos: usize,
+        outbound: Vec<u8>,
+    }
+    impl ScriptedStream {
+        fn new(inbound: Vec<u8>) -> Self {
+            Self {
+                inbound,
+                read_pos: 0,
+                outbound: Vec::new(),
+            }
+        }
+    }
+    impl std::io::Read for ScriptedStream {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            let n = (self.inbound.len() - self.read_pos).min(buf.len());
+            buf[..n].copy_from_slice(&self.inbound[self.read_pos..self.read_pos + n]);
+            self.read_pos += n;
+            Ok(n)
+        }
+    }
+    impl std::io::Write for ScriptedStream {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.outbound.extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// Build a FOLLOWER `DataPlaneServer` (node 2, EMPTY epoch cache — the common post-failover shape)
+    /// that fully replicated a throwaway old leader's `old_len`-record shared lineage over the read-plane
+    /// serve path, so it now holds `[0, frontier)` fsynced with NO learned epoch boundaries. Returns the
+    /// server behind the `Arc<Mutex>` the seam wiring takes, plus the follower's frontier offset (its
+    /// over-extended, mostly-uncommitted tail).
+    fn divergent_follower_server(
+        partition: u64,
+        old_len: u32,
+    ) -> (Arc<Mutex<DataPlaneServer<InMemoryFs, ManualClock>>>, u64) {
+        let mut old_leader_log = open_log();
+        for i in 0..old_len {
+            old_leader_log
+                .append(&rec(format!("rec-{i:02}").as_bytes()))
+                .unwrap();
+        }
+        old_leader_log.sync().unwrap();
+        let old_plane = leader_plane(&old_leader_log);
+        let old_served = plane_served_end(&old_plane);
+        let mut old_leader: DataPlaneController<InMemoryFs, ManualClock> =
+            DataPlaneController::new(1);
+        old_leader.start_leader(partition, old_plane, EpochCache::new(), &[1, 2], min_isr1());
+        let mut follower: DataPlaneController<InMemoryFs, ManualClock> =
+            DataPlaneController::new(2);
+        follower.start_follower(partition, open_log());
+        for _ in 0..80 {
+            if follower.follower_high_watermark(partition).unwrap() >= old_served {
+                break;
+            }
+            let req = follower.make_fetch_request(partition, 8, 4096).unwrap();
+            let resp = old_leader.serve_fetch(partition, &req).unwrap();
+            follower.apply_fetch_response(partition, &resp).unwrap();
+        }
+        let frontier = follower
+            .with_follower_log(partition, |log| log.next_offset().get())
+            .unwrap();
+        assert_eq!(
+            frontier, old_served,
+            "the follower holds the full old prefix as its uncommitted tail"
+        );
+        assert!(
+            frontier >= 8,
+            "the follower holds a usable tail (got {frontier})"
+        );
+        (
+            Arc::new(Mutex::new(DataPlaneServer::new(
+                2,
+                ProduceAckSeam::new(follower),
+            ))),
+            frontier,
+        )
+    }
+
+    /// A SHORTER new leader (node 1, `new_len` records of the SAME shared lineage) whose served frontier
+    /// sits BELOW a divergent follower's over-extended tail, so a probe from the follower's frontier is
+    /// an empty run above the leader frontier — exactly the Phase-1 uncommitted-tail discriminator. The
+    /// backing log is leaked so the `Arc`-shared read plane keeps serving. Returns the leader controller
+    /// and its served frontier (the leader's advertised HW to the probe).
+    fn short_new_leader(
+        partition: u64,
+        new_len: u32,
+    ) -> (DataPlaneController<InMemoryFs, ManualClock>, u64) {
+        let mut log = open_log();
+        for i in 0..new_len {
+            log.append(&rec(format!("rec-{i:02}").as_bytes())).unwrap();
+        }
+        log.sync().unwrap();
+        let log: &'static Log<InMemoryFs, ManualClock> = Box::leak(Box::new(log));
+        let plane = leader_plane(log);
+        let served = plane_served_end(&plane);
+        let mut leader: DataPlaneController<InMemoryFs, ManualClock> = DataPlaneController::new(1);
+        leader.start_leader(partition, plane, EpochCache::new(), &[1, 2], min_isr1());
+        (leader, served)
+    }
+
+    /// Script the adopt PROBE: serve the follower's exact probe fetch (same `FULL_CATCHUP_*` params
+    /// `reconcile_on_adopt` uses) on the short leader, assert it is an empty run above the leader
+    /// frontier, and return the encoded `FetchResponse` frame + the follower frontier + the leader HW.
+    fn scripted_probe(
+        partition: u64,
+        server: &Arc<Mutex<DataPlaneServer<InMemoryFs, ManualClock>>>,
+        leader: &DataPlaneController<InMemoryFs, ManualClock>,
+    ) -> (Vec<u8>, u64, u64) {
+        let probe = server
+            .lock()
+            .unwrap()
+            .seam()
+            .controller()
+            .make_fetch_request(partition, FULL_CATCHUP_RECORDS, FULL_CATCHUP_BYTES)
+            .unwrap();
+        let frontier = probe.from_offset;
+        let resp = leader.serve_fetch(partition, &probe).unwrap();
+        assert!(
+            empty_run_above_leader_frontier(frontier, &resp),
+            "the probe from the divergent follower is an empty run above the leader frontier"
+        );
+        let leader_hw = resp.high_watermark;
+        assert!(
+            leader_hw < frontier,
+            "the leader HW ({leader_hw}) is below the follower's tail ({frontier})"
+        );
+        let bytes =
+            encode_dataplane_peer_frame(partition, &DataPlaneFrame::FetchResponse(resp)).unwrap();
+        (bytes, frontier, leader_hw)
+    }
+
+    fn follower_frontier(
+        partition: u64,
+        server: &Arc<Mutex<DataPlaneServer<InMemoryFs, ManualClock>>>,
+    ) -> u64 {
+        server
+            .lock()
+            .unwrap()
+            .seam()
+            .controller()
+            .with_follower_log(partition, |log| log.next_offset().get())
+            .unwrap()
+    }
+
+    #[test]
+    fn adopt_reconcile_refuses_when_the_committed_floor_is_absent() {
+        // THE FIX: with NO `ClusterStatus::last_committed_hw` entry for the partition (the metadata group
+        // has not yet published a committed HW), the committed-prefix length is UNKNOWN. The pre-fix code
+        // resolved the floor as `.unwrap_or(0)` and would have durably truncated the WHOLE follower log
+        // (committed prefix INCLUDED) down to 0. The fix FAILS CLOSED: the log is left UNTOUCHED and the
+        // heal-refused metric is bumped.
+        const P: u64 = 0;
+        let (server, frontier) = divergent_follower_server(P, 45);
+        let (leader, _served) = short_new_leader(P, 18);
+        let (probe, _frontier, _hw) = scripted_probe(P, &server, &leader);
+        let mut link = DataPlaneLink::new(ScriptedStream::new(probe));
+
+        // An EMPTY cluster status: no committed HW published for P → the floor is ABSENT.
+        let status = Arc::new(Mutex::new(ClusterStatus::default()));
+        let divergence = FollowerDivergenceMetrics::default();
+
+        reconcile_on_adopt(P, &mut link, &server, Some(&status), &divergence);
+
+        assert_eq!(
+            follower_frontier(P, &server),
+            frontier,
+            "an absent floor must leave the follower log UNTOUCHED (never truncated to 0)"
+        );
+        assert_eq!(
+            divergence.uncommitted_tail_heal_refused_total(),
+            1,
+            "the absent-floor refusal bumps the heal-refused metric"
+        );
+        assert_eq!(
+            divergence.uncommitted_tail_healed_total(),
+            0,
+            "no heal was performed on an absent floor"
+        );
+    }
+
+    #[test]
+    fn adopt_reconcile_truncates_a_divergent_tail_down_to_the_present_floor() {
+        // The traced two-node scenario over an in-memory link: a follower holds a divergent uncommitted
+        // tail; an AUTHORITATIVE committed floor is present and the adopted leader's frontier is at/above
+        // it. probe -> suspect_uncommitted_tail -> heal: the tail is truncated down to EXACTLY the floor.
+        const P: u64 = 0;
+        let (server, frontier) = divergent_follower_server(P, 45);
+        let (leader, _served) = short_new_leader(P, 18);
+        let (probe, _frontier, leader_hw) = scripted_probe(P, &server, &leader);
+        let mut link = DataPlaneLink::new(ScriptedStream::new(probe));
+
+        // A genuine committed floor STRICTLY below both the leader HW (so the leader-behind guard passes)
+        // and the follower's tail (so the tail is above the floor and the heal fires).
+        let floor = leader_hw / 2;
+        assert!(
+            floor > 0 && floor < leader_hw && floor < frontier,
+            "the floor is a genuine committed bar below the leader HW and the tail"
+        );
+        let mut status = ClusterStatus::default();
+        status.last_committed_hw.insert(P, floor);
+        let status = Arc::new(Mutex::new(status));
+        let divergence = FollowerDivergenceMetrics::default();
+
+        reconcile_on_adopt(P, &mut link, &server, Some(&status), &divergence);
+
+        assert_eq!(
+            follower_frontier(P, &server),
+            floor,
+            "the divergent uncommitted tail was truncated down to EXACTLY the committed floor"
+        );
+        assert_eq!(
+            divergence.uncommitted_tail_healed_total(),
+            1,
+            "a divergent adopt-seam heal bumps the healed metric"
+        );
+        assert_eq!(
+            divergence.uncommitted_tail_heal_refused_total(),
+            0,
+            "a healed adopt is never a refusal"
+        );
+    }
+
+    #[test]
+    fn adopt_reconcile_refuses_when_the_present_floor_is_above_the_leader() {
+        // A PRESENT floor, but the adopted leader's frontier is BELOW it: the leader cannot restore the
+        // committed data a truncation would drop. The `ResyncLeaderBehind` guard FAILS CLOSED — the
+        // follower log is left untouched and the heal-refused metric is bumped.
+        const P: u64 = 0;
+        let (server, frontier) = divergent_follower_server(P, 45);
+        let (leader, _served) = short_new_leader(P, 18);
+        let (probe, _frontier, leader_hw) = scripted_probe(P, &server, &leader);
+        let mut link = DataPlaneLink::new(ScriptedStream::new(probe));
+
+        // A floor ABOVE the leader HW but still below the follower tail (so the divergence is suspected
+        // and the heal is attempted, then refused by the leader-behind guard).
+        let floor = leader_hw + (frontier - leader_hw) / 2;
+        assert!(
+            floor > leader_hw && floor < frontier,
+            "the floor sits above the leader HW (guard refuses) yet below the tail (suspected)"
+        );
+        let mut status = ClusterStatus::default();
+        status.last_committed_hw.insert(P, floor);
+        let status = Arc::new(Mutex::new(status));
+        let divergence = FollowerDivergenceMetrics::default();
+
+        reconcile_on_adopt(P, &mut link, &server, Some(&status), &divergence);
+
+        assert_eq!(
+            follower_frontier(P, &server),
+            frontier,
+            "a leader-behind refusal never truncates: the follower log is untouched"
+        );
+        assert_eq!(
+            divergence.uncommitted_tail_heal_refused_total(),
+            1,
+            "the ResyncLeaderBehind refusal bumps the heal-refused metric"
+        );
+        assert_eq!(
+            divergence.uncommitted_tail_healed_total(),
+            0,
+            "a refused adopt performs no heal"
+        );
     }
 
     // ============================================================================================

--- a/crates/ironbus-server/src/registry.rs
+++ b/crates/ironbus-server/src/registry.rs
@@ -55,6 +55,10 @@ use std::sync::atomic::{AtomicU64, Ordering};
 /// metric label), so no adversarial or buggy input can grow this block. Nothing here ever touches the
 /// durable log, the wire format, or any behavior — it is pure observation.
 #[derive(Debug, Default)]
+// The shared `uncommitted_tail_` prefix is deliberate: every counter names one lifecycle stage of the
+// SAME #873 uncommitted-tail hazard (suspected -> healed / heal-refused), so the prefix is the domain,
+// not incidental repetition; dropping it would make the field names ambiguous in isolation.
+#[allow(clippy::struct_field_names)]
 pub struct FollowerDivergenceMetrics {
     /// `ironbus_follower_uncommitted_tail_suspected_total`: the number of times a follower fetch loop
     /// SUSPECTED (detection only — never acted) that it holds an fsynced UNCOMMITTED tail above its own
@@ -63,6 +67,17 @@ pub struct FollowerDivergenceMetrics {
     /// latches it), so a wedged follower that empty-no-op loops does not inflate the counter — it stays
     /// a bounded, once-per-episode operator signal, not a per-poll spam.
     uncommitted_tail_suspected: AtomicU64,
+    /// `ironbus_follower_uncommitted_tail_healed_total`: the number of times a follower fetch loop
+    /// RECONCILED-ON-ADOPT (#873 Phase 2) — truncated a divergent uncommitted tail down to its own
+    /// quorum-committed floor before the first forward fetch could stitch a new lineage onto the stale
+    /// bytes. A durable, loss-free self-heal actually performed. Incremented once per divergent
+    /// adopt-seam heal (a clean no-op reconcile does NOT bump it).
+    uncommitted_tail_healed: AtomicU64,
+    /// `ironbus_follower_uncommitted_tail_heal_refused_total`: the number of times a reconcile-on-adopt
+    /// heal FAILED CLOSED because the adopted leader was BEHIND the follower's quorum-committed floor
+    /// (the `ResyncLeaderBehind` guard) — the follower was left untouched (never truncated) for a retry
+    /// against a complete leader. A refusal is the safe outcome, never a data loss.
+    uncommitted_tail_heal_refused: AtomicU64,
 }
 
 impl FollowerDivergenceMetrics {
@@ -78,6 +93,33 @@ impl FollowerDivergenceMetrics {
     #[must_use]
     pub fn uncommitted_tail_suspected_total(&self) -> u64 {
         self.uncommitted_tail_suspected.load(Ordering::Relaxed)
+    }
+
+    /// Records one reconcile-on-adopt HEAL (#873 Phase 2): a divergent uncommitted tail was truncated
+    /// down to the committed floor. Lock-free; callable from any data-plane follower thread.
+    pub fn record_uncommitted_tail_healed(&self) {
+        self.uncommitted_tail_healed.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// The cumulative count of reconcile-on-adopt heals performed
+    /// (`ironbus_follower_uncommitted_tail_healed_total`).
+    #[must_use]
+    pub fn uncommitted_tail_healed_total(&self) -> u64 {
+        self.uncommitted_tail_healed.load(Ordering::Relaxed)
+    }
+
+    /// Records one reconcile-on-adopt heal REFUSED by the leader-behind guard (#873 Phase 2): the
+    /// follower was left untouched. Lock-free; callable from any data-plane follower thread.
+    pub fn record_uncommitted_tail_heal_refused(&self) {
+        self.uncommitted_tail_heal_refused
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// The cumulative count of reconcile-on-adopt heals refused by the leader-behind guard
+    /// (`ironbus_follower_uncommitted_tail_heal_refused_total`).
+    #[must_use]
+    pub fn uncommitted_tail_heal_refused_total(&self) -> u64 {
+        self.uncommitted_tail_heal_refused.load(Ordering::Relaxed)
     }
 }
 


### PR DESCRIPTION
**#873 Phase 2 of the reconcile-on-adopt roadmap** (does NOT close the epic — Phase 3 C4 content-mismatch + Phase 5 hardening remain).

Turns Phase 1's detection into a LOSS-FREE self-heal: at the adopt seam (top of `follower_fetch_loop`, before the first forward fetch), a follower that suspects a post-failover uncommitted-tail divergence **truncates that stale tail down to its own quorum-committed floor** (or fail-closes), so no forward fetch can stitch a new lineage onto dead-leader bytes.

**Loss-free by construction (proven + adversarially verified across 5+3 lenses):**
- Floor = `ClusterStatus::last_committed_hw` (the replicated `CheckpointCommittedHw` bar), resolved as `Option` — **never** `resp.high_watermark`. Proven to never be stale-HIGH (monotone max of values each ≤ the true committed frontier at proposal).
- **Absent floor FAILS CLOSED** (`let Some(floor) = … else { refuse + heal_refused metric + WARN; leave the log untouched }`) — the review caught that the first cut's `unwrap_or(0)` would have wiped the whole committed log to 0 before the metadata group published a committed HW; truncation is now reachable only from the `Some` branch.
- `ResyncLeaderBehind` fail-closed guard (leader behind the committed floor → refuse); the `Log::truncate_to` storage backstop refuses cutting into compacted/committed segments; the promotion path only elects a successor holding the full committed lineage. So a wrong/stale/zero floor causes under-truncate-then-refetch or a refusal — a quorum-committed record is never permanently dropped.
- Crash-consistent (truncate fsync ordering is valid-prefix-recoverable; reopen lands at exactly the committed floor) and idempotent on retry; deterministic (two replicas heal to a byte-identical prefix).

**Tests:** 6 controller heal tests + 3 serve-seam wiring tests (absent-floor refuses / present-floor truncates-to-floor / leader-behind refuses), mutation-verified. Whole-workspace fmt+clippy(pedantic) clean; server+storage suites + conformance byte-identity + determinism all green.

Scope: heals the empty-run-above-frontier (uncommitted-tail) case; the below-frontier content-mismatch case is Phase 3 (C4 fingerprints), by design.

Part of #873

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>