### PR TITLE
test(cluster/873): Phase 5 — crash-window + adopt-seam idempotency hardening

### DIFF
--- a/crates/ironbus-server/src/cluster/dataplane.rs
+++ b/crates/ironbus-server/src/cluster/dataplane.rs
@@ -2727,6 +2727,88 @@ mod tests {
         );
     }
 
+    /// Fetch forward from `leader` into `follower` until the follower's HW covers `target` (the shared
+    /// in-process serve->apply loop the other reconcile tests use). Deterministic: bounded, no clock.
+    fn converge_follower(
+        follower: &mut DataPlaneController<InMemoryFs, ManualClock>,
+        leader: &DataPlaneController<InMemoryFs, ManualClock>,
+        partition: u64,
+        target: u64,
+    ) {
+        for _ in 0..80 {
+            if follower.follower_high_watermark(partition).unwrap() >= target {
+                break;
+            }
+            let req = follower.make_fetch_request(partition, 8, 4096).unwrap();
+            let resp = leader.serve_fetch(partition, &req).unwrap();
+            follower.apply_fetch_response(partition, &resp).unwrap();
+        }
+    }
+
+    #[test]
+    fn a_healed_replica_image_is_byte_identical_to_a_clean_from_scratch_replica() {
+        // #873 Phase 5 gap (iv): the DETERMINISM/byte-identity apex — a replica that DIVERGED and then
+        // self-healed (truncate the uncommitted tail to the committed floor + re-fetch the new lineage
+        // forward) must end BYTE-FOR-BYTE identical to a replica that only ever replicated the clean new
+        // lineage from scratch. The heal path is a pure, retryable function of durable state: it leaves
+        // no seam artifact (no stale segment, no off-by-one seal boundary, no divergent tail residue).
+        const P: u64 = 0;
+        const FLOOR: u64 = 6;
+
+        // The HEALED replica: it fsynced an old divergent lineage [0, old_served), heals down to the
+        // committed floor against the new leader, then converges forward over the clean new lineage.
+        let (mut healed, old_served) = divergent_follower_holding(P, InMemoryFs::new(), 18);
+        assert!(
+            old_served > FLOOR,
+            "the healed replica held a divergent tail"
+        );
+        let (new_leader, _new_log, new_served) =
+            new_divergent_leader(P, u32::try_from(FLOOR).unwrap(), 20);
+        healed
+            .heal_divergent_follower(P, Offset::new(FLOOR), new_served, no_query)
+            .expect("the divergent replica self-heals to the committed floor");
+        converge_follower(&mut healed, &new_leader, P, new_served);
+
+        // The CLEAN replica: an independent node that only ever replicated the SAME new lineage from an
+        // empty log — never diverged, never healed. Its leader is an independent build of the identical
+        // lineage (deterministic bytes), so any difference is a real heal-path artifact, not input skew.
+        let (clean_leader, _clean_log, clean_served) =
+            new_divergent_leader(P, u32::try_from(FLOOR).unwrap(), 20);
+        assert_eq!(
+            new_served, clean_served,
+            "the two independent leaders build the identical lineage bytes"
+        );
+        let mut clean = DataPlaneController::<InMemoryFs, ManualClock>::new(2);
+        clean.start_follower(P, open_log(InMemoryFs::new(), small_config()));
+        converge_follower(&mut clean, &clean_leader, P, clean_served);
+
+        // Both converged to the same frontier, and their on-disk images are byte-for-byte identical.
+        assert_eq!(
+            healed
+                .with_follower_log(P, |log| log.next_offset().get())
+                .unwrap(),
+            clean
+                .with_follower_log(P, |log| log.next_offset().get())
+                .unwrap(),
+            "both replicas converged to the same frontier"
+        );
+        let healed_img: std::collections::BTreeMap<String, Vec<u8>> = healed
+            .with_follower_log(P, dump_segments)
+            .unwrap()
+            .into_iter()
+            .collect();
+        let clean_img: std::collections::BTreeMap<String, Vec<u8>> = clean
+            .with_follower_log(P, dump_segments)
+            .unwrap()
+            .into_iter()
+            .collect();
+        assert_eq!(
+            healed_img, clean_img,
+            "a healed replica image is byte-identical to a clean from-scratch replica (the heal leaves \
+             no seam artifact)"
+        );
+    }
+
     // ---- single-node / single-replica = the local-fsync ack, byte-identical ----------------------
 
     #[test]

--- a/crates/ironbus-server/src/cluster/serve.rs
+++ b/crates/ironbus-server/src/cluster/serve.rs
@@ -3027,6 +3027,293 @@ mod tests {
     }
 
     // ============================================================================================
+    //  #873 Phase 5: crash-window + adopt-seam idempotency HARDENING. Prove the whole adopt-seam
+    //  reconcile is a PURE, RETRYABLE function of durable state: re-running it after a clean heal
+    //  touches nothing (idempotency), and a crash AFTER the truncate but BEFORE the forward fetch
+    //  resumes reopens to the truncated committed prefix and RE-ADOPTS as a no-op (no double-heal, no
+    //  loss) — for BOTH the P2 uncommitted-tail path AND the P3 below-frontier content-mismatch path.
+    //  A shared-Arc `InMemoryFs` durable store models the crash: drop the in-memory handles, reopen a
+    //  fresh follower `Log` from the surviving bytes, and re-drive `reconcile_on_adopt`.
+    // ============================================================================================
+
+    /// Serve the follower's CURRENT probe fetch on `leader` and return the encoded `FetchResponse`
+    /// frame bytes — a re-adopt probe from wherever the follower's frontier now sits (unlike
+    /// [`scripted_probe`], which asserts the divergent empty-run shape a first adopt sees).
+    fn serve_probe_bytes(
+        partition: u64,
+        server: &Arc<Mutex<DataPlaneServer<InMemoryFs, ManualClock>>>,
+        leader: &DataPlaneController<InMemoryFs, ManualClock>,
+    ) -> Vec<u8> {
+        let req = server
+            .lock()
+            .unwrap()
+            .seam()
+            .controller()
+            .make_fetch_request(partition, FULL_CATCHUP_RECORDS, FULL_CATCHUP_BYTES)
+            .unwrap();
+        let resp = leader.serve_fetch(partition, &req).unwrap();
+        encode_dataplane_peer_frame(partition, &DataPlaneFrame::FetchResponse(resp)).unwrap()
+    }
+
+    /// The shared-Arc `InMemoryFs` backing the follower's partition log — cloning it shares the SAME
+    /// durable store, so a fresh `Log::open` after a "crash" (dropping the server) recovers from the
+    /// exact post-truncate bytes.
+    fn follower_fs(
+        partition: u64,
+        server: &Arc<Mutex<DataPlaneServer<InMemoryFs, ManualClock>>>,
+    ) -> InMemoryFs {
+        server
+            .lock()
+            .unwrap()
+            .seam()
+            .controller()
+            .with_follower_log(partition, |log| log.filesystem().clone())
+            .unwrap()
+    }
+
+    /// Reopen a FOLLOWER `DataPlaneServer` (node 2, empty epoch cache) over the durable bytes in `fs` —
+    /// the post-crash recovery: a fresh `Log::open` re-derives the follower state as a pure function of
+    /// the surviving durable bytes.
+    fn reopened_follower_server(
+        partition: u64,
+        fs: InMemoryFs,
+    ) -> Arc<Mutex<DataPlaneServer<InMemoryFs, ManualClock>>> {
+        let log = Log::open(fs, ManualClock::new(), small_config()).expect("follower log reopens");
+        let mut follower: DataPlaneController<InMemoryFs, ManualClock> =
+            DataPlaneController::new(2);
+        follower.start_follower(partition, log);
+        Arc::new(Mutex::new(DataPlaneServer::new(
+            2,
+            ProduceAckSeam::new(follower),
+        )))
+    }
+
+    #[test]
+    fn adopt_seam_p2_reconcile_is_idempotent_after_a_clean_heal() {
+        // Gap (iii), P2 path: after the adopt seam truncates a divergent uncommitted tail to the floor, a
+        // SECOND adopt (a reconnect re-probe) against the same present floor must touch NOTHING — no
+        // second truncation, no metric bump. The heal is idempotent on the adopt seam, not just on the
+        // controller (`heal_is_idempotent_on_retry` covers the controller in isolation).
+        const P: u64 = 0;
+        let (server, frontier) = divergent_follower_server(P, 45);
+        let (leader, _served) = short_new_leader(P, 18);
+        let (probe, _frontier, leader_hw) = scripted_probe(P, &server, &leader);
+        let mut link = DataPlaneLink::new(ScriptedStream::new(probe));
+
+        let floor = leader_hw / 2;
+        assert!(floor > 0 && floor < leader_hw && floor < frontier);
+        let mut status = ClusterStatus::default();
+        status.last_committed_hw.insert(P, floor);
+        let status = Arc::new(Mutex::new(status));
+        let divergence = FollowerDivergenceMetrics::default();
+
+        // First adopt: heals down to the floor.
+        reconcile_on_adopt(P, &mut link, &server, Some(&status), &divergence);
+        assert_eq!(
+            follower_frontier(P, &server),
+            floor,
+            "first adopt heals to the floor"
+        );
+        assert_eq!(divergence.uncommitted_tail_healed_total(), 1);
+
+        // Second adopt (same process, a reconnect re-probe from the now-healed frontier): a genuine
+        // no-op. The follower's LEO now equals the floor, so nothing sits above it to truncate.
+        let probe2 = serve_probe_bytes(P, &server, &leader);
+        let mut link2 = DataPlaneLink::new(ScriptedStream::new(probe2));
+        reconcile_on_adopt(P, &mut link2, &server, Some(&status), &divergence);
+
+        assert_eq!(
+            follower_frontier(P, &server),
+            floor,
+            "the idempotent re-adopt truncates nothing (the frontier is unchanged)"
+        );
+        assert_eq!(
+            divergence.uncommitted_tail_healed_total(),
+            1,
+            "the re-adopt performs NO second heal (the healed counter is unchanged)"
+        );
+        assert_eq!(
+            divergence.uncommitted_tail_heal_refused_total(),
+            0,
+            "the idempotent re-adopt is not a refusal either"
+        );
+    }
+
+    #[test]
+    fn adopt_seam_p3_reconcile_is_idempotent_after_a_clean_heal() {
+        // Gap (iii), P3 path: the same adopt-seam idempotency for the below-frontier CONTENT-mismatch
+        // heal. After it truncates the content-divergent tail to the floor, a second adopt touches
+        // nothing (the follower LEO == floor, so the content-mismatch path returns before it even probes).
+        const P: u64 = 0;
+        let (server, frontier) = divergent_follower_server(P, 45);
+        let floor = 20u64;
+        let (leader, served) = content_divergent_leader(P, u32::try_from(floor).unwrap(), 60);
+        assert!(served > frontier);
+        let (probe, _leo, _hw) = scripted_content_probe(P, &server, &leader, floor);
+        let mut link = DataPlaneLink::new(ScriptedStream::new(probe));
+
+        let mut status = ClusterStatus::default();
+        status.last_committed_hw.insert(P, floor);
+        let status = Arc::new(Mutex::new(status));
+        let divergence = FollowerDivergenceMetrics::default();
+
+        // First adopt: the Phase 3 content-mismatch heal truncates down to the floor.
+        reconcile_on_adopt(P, &mut link, &server, Some(&status), &divergence);
+        assert_eq!(
+            follower_frontier(P, &server),
+            floor,
+            "first adopt heals to the floor"
+        );
+        assert_eq!(divergence.content_mismatch_healed_total(), 1);
+
+        // Second adopt from the healed frontier: a no-op (nothing above the floor to reconcile).
+        let probe2 = serve_probe_bytes(P, &server, &leader);
+        let mut link2 = DataPlaneLink::new(ScriptedStream::new(probe2));
+        reconcile_on_adopt(P, &mut link2, &server, Some(&status), &divergence);
+
+        assert_eq!(
+            follower_frontier(P, &server),
+            floor,
+            "the idempotent P3 re-adopt truncates nothing"
+        );
+        assert_eq!(
+            divergence.content_mismatch_healed_total(),
+            1,
+            "the re-adopt performs NO second content-mismatch heal"
+        );
+        assert_eq!(
+            divergence.content_mismatch_critical_total(),
+            0,
+            "the re-adopt is never a CRITICAL below-committed violation"
+        );
+        assert_eq!(
+            divergence.content_mismatch_heal_refused_total(),
+            0,
+            "the re-adopt is not a refusal either"
+        );
+    }
+
+    #[test]
+    fn crash_after_a_p2_adopt_heal_reopens_to_the_floor_and_re_adopts_as_a_no_op() {
+        // Gap (ii), P2 path: crash AFTER the adopt-seam truncate but BEFORE the forward fetch resumes.
+        // The truncate fsync'd (set_len + sync_all + sync_dir), so a reopen from the shared durable store
+        // recovers EXACTLY the truncated committed prefix — no divergent tail residue, no committed loss.
+        // Re-adopting the reopened follower re-runs the whole reconcile as a no-op (no double-heal).
+        const P: u64 = 0;
+        let (server, frontier) = divergent_follower_server(P, 45);
+        let (leader, _served) = short_new_leader(P, 18);
+        let (probe, _frontier, leader_hw) = scripted_probe(P, &server, &leader);
+        let mut link = DataPlaneLink::new(ScriptedStream::new(probe));
+
+        let floor = leader_hw / 2;
+        assert!(floor > 0 && floor < leader_hw && floor < frontier);
+        let mut status = ClusterStatus::default();
+        status.last_committed_hw.insert(P, floor);
+        let status = Arc::new(Mutex::new(status));
+        let divergence = FollowerDivergenceMetrics::default();
+
+        reconcile_on_adopt(P, &mut link, &server, Some(&status), &divergence);
+        assert_eq!(
+            follower_frontier(P, &server),
+            floor,
+            "the adopt heal truncated to the floor"
+        );
+
+        // CRASH: capture the shared durable store, drop the server (all in-memory handles gone), reopen.
+        let fs = follower_fs(P, &server);
+        drop(server);
+        let reopened = reopened_follower_server(P, fs);
+        assert_eq!(
+            follower_frontier(P, &reopened),
+            floor,
+            "recovery after the crash lands on EXACTLY the truncated committed prefix (no loss, no \
+             torn tail)"
+        );
+
+        // RE-ADOPT the reopened follower: the whole reconcile re-runs as a no-op — no second heal, no
+        // refusal, no further truncation. The adopt seam converges across the crash window.
+        let probe2 = serve_probe_bytes(P, &reopened, &leader);
+        let mut link2 = DataPlaneLink::new(ScriptedStream::new(probe2));
+        let divergence2 = FollowerDivergenceMetrics::default();
+        reconcile_on_adopt(P, &mut link2, &reopened, Some(&status), &divergence2);
+
+        assert_eq!(
+            follower_frontier(P, &reopened),
+            floor,
+            "the post-crash re-adopt truncates nothing (the recovered frontier is unchanged)"
+        );
+        assert_eq!(
+            divergence2.uncommitted_tail_healed_total(),
+            0,
+            "the re-adopt after the crash performs NO heal (no double-heal across the crash window)"
+        );
+        assert_eq!(
+            divergence2.uncommitted_tail_heal_refused_total(),
+            0,
+            "the post-crash re-adopt is not a refusal either"
+        );
+    }
+
+    #[test]
+    fn crash_after_a_p3_adopt_heal_reopens_to_the_floor_and_re_adopts_as_a_no_op() {
+        // Gap (ii), P3 path: the same crash-window convergence for the below-frontier content-mismatch
+        // heal. Crash after the content-mismatch truncate, reopen from the durable bytes to exactly the
+        // floor, and re-adopt as a no-op.
+        const P: u64 = 0;
+        let (server, frontier) = divergent_follower_server(P, 45);
+        let floor = 20u64;
+        let (leader, served) = content_divergent_leader(P, u32::try_from(floor).unwrap(), 60);
+        assert!(served > frontier);
+        let (probe, _leo, _hw) = scripted_content_probe(P, &server, &leader, floor);
+        let mut link = DataPlaneLink::new(ScriptedStream::new(probe));
+
+        let mut status = ClusterStatus::default();
+        status.last_committed_hw.insert(P, floor);
+        let status = Arc::new(Mutex::new(status));
+        let divergence = FollowerDivergenceMetrics::default();
+
+        reconcile_on_adopt(P, &mut link, &server, Some(&status), &divergence);
+        assert_eq!(
+            follower_frontier(P, &server),
+            floor,
+            "the P3 adopt heal truncated to the floor"
+        );
+        assert_eq!(divergence.content_mismatch_healed_total(), 1);
+
+        // CRASH + reopen from the shared durable store.
+        let fs = follower_fs(P, &server);
+        drop(server);
+        let reopened = reopened_follower_server(P, fs);
+        assert_eq!(
+            follower_frontier(P, &reopened),
+            floor,
+            "recovery lands on exactly the content-heal truncated committed prefix"
+        );
+
+        // RE-ADOPT: a no-op across the crash window.
+        let probe2 = serve_probe_bytes(P, &reopened, &leader);
+        let mut link2 = DataPlaneLink::new(ScriptedStream::new(probe2));
+        let divergence2 = FollowerDivergenceMetrics::default();
+        reconcile_on_adopt(P, &mut link2, &reopened, Some(&status), &divergence2);
+
+        assert_eq!(
+            follower_frontier(P, &reopened),
+            floor,
+            "the post-crash P3 re-adopt truncates nothing"
+        );
+        assert_eq!(
+            divergence2.content_mismatch_healed_total(),
+            0,
+            "no double content-mismatch heal across the crash window"
+        );
+        assert_eq!(
+            divergence2.content_mismatch_critical_total(),
+            0,
+            "the post-crash re-adopt is never a CRITICAL below-committed violation"
+        );
+    }
+
+    // ============================================================================================
     //  Codec tests: the data-plane peer codec round-trips + stays bounded on untrusted input.
     // ============================================================================================
 

--- a/crates/ironbus-storage/src/fault.rs
+++ b/crates/ironbus-storage/src/fault.rs
@@ -101,6 +101,15 @@ pub struct FaultControl {
     /// The condvar-backed sync rendezvous used to PROVE the group-commit fdatasync fan-out (#823)
     /// runs its K per-fd barriers CONCURRENTLY rather than serially. See [`RendezvousGate`].
     rendezvous: Arc<RendezvousGate>,
+    /// A monotonic count of every `remove` (segment unlink) that ran, so a test can assert a
+    /// multi-segment unlink loop genuinely reached the Nth removal (no false pass).
+    remove_count: Arc<AtomicU64>,
+    /// While non-zero, the `remove` whose 1-based ordinal EQUALS this threshold fails with an
+    /// injected IO error WITHOUT unlinking; every other `remove` (before and after) succeeds. `0`
+    /// disables it. This models a real-FS crash mid-multi-segment unlink loop firing on one specific
+    /// removal, so a test can prove `truncate_to` unlinks its divergent tail HIGHEST-id-first — the
+    /// order that leaves a contiguous, always-openable prefix at every crash point (#873).
+    fail_remove_on: Arc<AtomicU64>,
 }
 
 /// A condvar-backed gate the sync path waits on while closed (#177): `open` starts open (syncs pass),
@@ -209,6 +218,36 @@ impl FaultControl {
         }
         let threshold = self.fail_sync_dir_after.load(Ordering::SeqCst);
         threshold != 0 && self.sync_dir_count.load(Ordering::SeqCst) >= threshold
+    }
+
+    /// Arms a single-shot `remove` (segment unlink) failure on the `ordinal`-th removal (#873): the
+    /// `ordinal`-th `remove` since arming fails WITHOUT unlinking, while every removal before and
+    /// after it succeeds. Used to crash a `truncate_to` (or `reap`) mid-multi-segment unlink loop on
+    /// one exact segment, so a test can prove the surviving segments are always a contiguous,
+    /// openable prefix. `0` disables it. Counts the CURRENT `remove_count` as the baseline, so call
+    /// it just before the pass under test.
+    pub fn fail_remove_on(&self, ordinal: u64) {
+        let base = self.remove_count.load(Ordering::SeqCst);
+        // Store the ABSOLUTE ordinal (baseline + relative), so the check below is a plain equality
+        // against the running count regardless of how many removals ran before arming.
+        self.fail_remove_on.store(
+            if ordinal == 0 { 0 } else { base + ordinal },
+            Ordering::SeqCst,
+        );
+    }
+
+    /// The number of `remove` (unlink) calls that have run, so a test can assert the unlink loop
+    /// genuinely reached the Nth removal and a crash injected there is not a false pass.
+    #[must_use]
+    pub fn remove_count(&self) -> u64 {
+        self.remove_count.load(Ordering::SeqCst)
+    }
+
+    fn remove_should_fail(&self) -> bool {
+        let target = self.fail_remove_on.load(Ordering::SeqCst);
+        // `remove_count` is bumped BEFORE this check (see the `remove` impl), so equality fires on
+        // exactly the target ordinal's own call.
+        target != 0 && self.remove_count.load(Ordering::SeqCst) == target
     }
 
     /// Arms a TRANSIENT `create_new` failure (#867): the next `count` calls to `create_new` fail with
@@ -683,6 +722,15 @@ impl<F: Filesystem> Filesystem for FaultFs<F> {
     }
 
     fn remove(&self, name: &str) -> io::Result<()> {
+        // Count the unlink BEFORE the fault check so a threshold arm fires on the exact Nth removal,
+        // then, if that ordinal is armed, fail WITHOUT unlinking — the mid-loop crash point a
+        // multi-segment `truncate_to`/`reap` unlink must degrade to a contiguous prefix across (#873).
+        self.control.remove_count.fetch_add(1, Ordering::SeqCst);
+        if self.control.remove_should_fail() {
+            return Err(io::Error::other(
+                "injected fault: remove (segment unlink) failed",
+            ));
+        }
         self.inner.remove(name)
     }
 

--- a/crates/ironbus-storage/src/log.rs
+++ b/crates/ironbus-storage/src/log.rs
@@ -3864,10 +3864,24 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
 
         // Unlink every WHOLE segment strictly ABOVE the kept one (its base_offset >= target, so its
         // entire range is in the divergent suffix). `split_off` keeps `[0, keep_idx]` and yields the
-        // tail to unlink. Unlink them (the iteration order does not matter — each is wholly dropped),
-        // then a single dir-sync below makes every removal durable together.
+        // tail to unlink. Iterate the tail HIGHEST-id-first (reverse order): the single trailing
+        // dir-sync below still batches every removal durable together, so under the InMemoryFs
+        // canonical crash model (durable reverts to the last sync barrier atomically) the final state
+        // is unchanged. On a REAL FS a crash MID-loop can leave only a PREFIX of the ISSUED unlink
+        // sequence durable — same-directory metadata ops complete in issue order under ordered
+        // journaling (the prefix-durability this storage layer already relies on), and the single
+        // trailing dir-sync batches the rest. Removing highest-first makes that surviving prefix
+        // `{highest, highest-1, ...}` drop the TOP of the chain, so the survivors are always a
+        // CONTIGUOUS prefix `[0, kept..k]` (never [kept, <gap>, higher]) — always openable, in the
+        // same spirit as `Log::reap`. A later reconcile then re-runs this truncation idempotently over
+        // the valid, over-long prefix. (Lowest-first could leave a durable low-unlink with a surviving
+        // higher segment -> a gap -> `scan_recover_chain` fails `SegmentChainBroken` -> an UNOPENABLE
+        // log. NOTE: under truly ARBITRARY unlink reorder highest-first alone would not suffice — that
+        // needs a per-unlink dir-sync as `Log::reap` does; here we rely on same-dir prefix-durability
+        // plus the trailing sync_dir.)
         let mut segments_dropped = 0u64;
-        for slot in self.segments.split_off(keep_idx + 1) {
+        let mut tail = self.segments.split_off(keep_idx + 1);
+        while let Some(slot) = tail.pop() {
             self.fs.remove(&segment_file_name(slot.id))?;
             self.evict_segment_index(slot.id);
             segments_dropped += 1;
@@ -9076,6 +9090,202 @@ mod tests {
         // It still works normally.
         log.append(&rec(b"still")).unwrap();
         assert_eq!(log.next_offset(), Offset::new(7));
+    }
+
+    #[test]
+    fn truncate_to_crash_mid_surgery_reopens_to_a_valid_prefix_never_torn() {
+        // #873 Phase 5 gap (i): a crash MID-`truncate_to` must reopen to a VALID, contiguous prefix —
+        // never a torn/gapped chain, never losing a record below the truncation target. The
+        // unlink-then-truncate order (whole tail segments unlinked FIRST, then the kept segment cut)
+        // keeps every intermediate durable state valid-prefix-recoverable; this proves it across the two
+        // interior crash windows, both reopened from the surviving durable bytes (a pure function, I4).
+        use crate::fault::FaultFs;
+
+        // WINDOW A: crash AFTER the whole tail segments are unlinked but BEFORE the kept segment's
+        // `set_len` — the exact "segments unlinked, set_len not completed" window. The kept segment's
+        // `record_byte_positions` read (which computes the cut boundary, run after the unlinks and before
+        // `set_len`) faults, aborting the surgery with the kept segment still holding records above the
+        // target.
+        let (fs, control) = FaultFs::new(InMemoryFs::new());
+        let durable = fs.inner().clone();
+        let mut log = Log::open(fs, ManualClock::new(), small_config()).unwrap();
+        for i in 0..30u32 {
+            log.append(&rec(format!("t{i:02}").as_bytes())).unwrap();
+        }
+        log.sync().unwrap();
+        assert!(
+            log.segment_count() >= 3,
+            "the log must span several segments so the truncate unlinks whole ones"
+        );
+        let files_before = durable.list().unwrap().len();
+
+        control.set_fail_read(true);
+        assert!(
+            log.truncate_to(Offset::new(13)).is_err(),
+            "the mid-surgery read fault aborts the truncate"
+        );
+        // Prove we are genuinely in the "unlinked but not yet set_len" window: the whole tail segments
+        // were already removed from the durable store before the read fault fired.
+        assert!(
+            durable.list().unwrap().len() < files_before,
+            "the divergent tail segments were unlinked before the mid-surgery fault"
+        );
+        drop(log); // crash: the in-memory handles are gone; only the durable bytes survive.
+
+        // Reopen from the surviving bytes (no fault): recovery reconstructs a valid prefix, never torn.
+        let reopened = Log::open(durable, ManualClock::new(), small_config()).unwrap();
+        let next = reopened.next_offset().get();
+        assert!(
+            (13..=30).contains(&next),
+            "reopen recovered a valid prefix in [target, original] (got {next}), never short of the \
+             target (no committed loss) and never a torn/over-long chain"
+        );
+        // The recovered prefix is DENSE and contiguous — no gap, no committed loss below the target, no
+        // fabricated bytes leaking from the dropped suffix.
+        let recs = reopened.read_from(Offset::ZERO, 100).unwrap();
+        assert_eq!(
+            recs.len() as u64,
+            next,
+            "the recovered prefix is dense and contiguous"
+        );
+        for (i, r) in recs.iter().enumerate() {
+            assert_eq!(
+                r.payload.as_ref(),
+                format!("t{i:02}").as_bytes(),
+                "record {i} survived the aborted surgery intact"
+            );
+        }
+        // The recovered log is fully writable: the aborted surgery left a clean state, not a frozen one.
+        let mut reopened = reopened;
+        reopened.append(&rec(b"afterA")).unwrap();
+        reopened.sync().unwrap();
+        assert_eq!(reopened.next_offset().get(), next + 1);
+
+        // WINDOW B: crash AFTER the kept segment's `set_len` but BEFORE the final directory `sync_dir`
+        // (the kept segment is already cut to the target on disk). Recovery lands on EXACTLY the target —
+        // the fully-formed truncated prefix, no torn tail.
+        let (fs, control) = FaultFs::new(InMemoryFs::new());
+        let durable = fs.inner().clone();
+        let mut log = Log::open(fs, ManualClock::new(), small_config()).unwrap();
+        for i in 0..30u32 {
+            log.append(&rec(format!("t{i:02}").as_bytes())).unwrap();
+        }
+        log.sync().unwrap();
+        // The kept segment's `sync_all` (issued immediately after its `set_len`) faults, aborting the
+        // surgery after the byte-cut is durable but before the directory publish.
+        control.set_fail_sync(true);
+        assert!(
+            log.truncate_to(Offset::new(13)).is_err(),
+            "the post-set_len sync fault aborts the truncate"
+        );
+        drop(log);
+        let reopened = Log::open(durable, ManualClock::new(), small_config()).unwrap();
+        let next = reopened.next_offset().get();
+        // The kept segment's byte-cut is already durable here (the fault fired on the sync AFTER the
+        // `set_len`), so recovery lands on EXACTLY the truncation target — not merely somewhere in the
+        // valid `[target, original]` band. (Tightened from a range check per review: this window's
+        // outcome is deterministic.)
+        assert_eq!(
+            next, 13,
+            "window B recovers to exactly the truncation target"
+        );
+        let recs = reopened.read_from(Offset::ZERO, 100).unwrap();
+        assert_eq!(recs.len() as u64, next, "window B is dense and contiguous");
+        for (i, r) in recs.iter().enumerate() {
+            assert_eq!(r.payload.as_ref(), format!("t{i:02}").as_bytes());
+        }
+    }
+
+    #[test]
+    fn truncate_to_crash_mid_multi_segment_unlink_reopens_to_a_contiguous_prefix() {
+        // #873 Phase 5 gap: the divergent-tail unlink loop removes MANY whole segments under a single
+        // trailing `sync_dir`. On a real FS, directory writeback can reorder unlinks across that fsync
+        // barrier, so a crash mid-loop can leave only SOME removals durable. `truncate_to` unlinks
+        // HIGHEST-id-first so whatever partial subset survives is always a CONTIGUOUS prefix
+        // `[0, kept..k]` — always openable — never `[kept, <gap>, higher]` (which `scan_recover_chain`
+        // rejects `SegmentChainBroken` -> an UNOPENABLE log). This models that exact reordered crash:
+        // FaultFs fails the SECOND unlink, then we reopen the LIVE (most-flushed) store — the stronger
+        // model than `simulate_power_loss` (which would revert the whole batch atomically and hide the
+        // ordering entirely) — and assert recovery SUCCEEDS to a dense, contiguous prefix.
+        //
+        // Mutation check: reverting the unlink to lowest-id-first makes the surviving set
+        // `[kept, <gap>, higher...]`, so `Log::open` below fails `SegmentChainBroken` and this test
+        // fails — the fix is load-bearing.
+        use crate::fault::FaultFs;
+
+        let (fs, control) = FaultFs::new(InMemoryFs::new());
+        // `durable` aliases the SAME in-memory disk (Arc-backed), so it observes every unlink the
+        // aborted truncate made durable — the live, most-flushed image, NOT a power-loss revert.
+        let durable = fs.inner().clone();
+        let mut log = Log::open(fs, ManualClock::new(), small_config()).unwrap();
+        for i in 0..30u32 {
+            log.append(&rec(format!("t{i:02}").as_bytes())).unwrap();
+        }
+        log.sync().unwrap();
+        // A low target keeps only the first segment(s), so the divergent tail is MANY (>=3) whole
+        // segments — enough that a SECOND unlink genuinely runs (the mid-loop crash point).
+        let seg_count = log.segment_count();
+        assert!(
+            seg_count >= 4,
+            "need a >=3-segment divergent tail so a second unlink runs (got {seg_count} segments)"
+        );
+        let files_before = durable.list().unwrap().len();
+
+        // Arm the crash on the SECOND unlink AFTER this point. `fail_remove_on` is RELATIVE to the
+        // current `remove_count` (segment rolls already issued their own unlinks during the appends),
+        // so this pins the second unlink of the truncate's own tail loop. Highest-first, that loop's
+        // 1st unlink drops the TOP segment durably; its 2nd faults, so the loop aborts with the
+        // surviving set still a contiguous prefix.
+        let removes_before = control.remove_count();
+        control.fail_remove_on(2);
+        assert!(
+            log.truncate_to(Offset::new(3)).is_err(),
+            "the mid-loop unlink fault aborts the truncate"
+        );
+        // Prove we genuinely reached the second removal (no false pass) and that exactly ONE segment
+        // was unlinked before the fault — the highest, leaving a contiguous prefix.
+        assert_eq!(
+            control.remove_count() - removes_before,
+            2,
+            "the truncate reached (and faulted on) the second unlink"
+        );
+        assert_eq!(
+            durable.list().unwrap().len(),
+            files_before - 1,
+            "exactly the top divergent segment was unlinked before the crash"
+        );
+        drop(log); // crash: only the durable/live bytes survive.
+
+        // Reopen the LIVE store: highest-first leaves `[0, kept..k-1]`, a valid contiguous prefix, so
+        // recovery SUCCEEDS. (Lowest-first would leave a gap here and this `unwrap` would panic.)
+        let reopened = Log::open(durable, ManualClock::new(), small_config()).unwrap();
+        let next = reopened.next_offset().get();
+        // No committed loss below the truncation target, and never an over-short chain: recovery lands
+        // in the valid `[target, original]` band (the kept segments were never cut, so the surviving
+        // prefix is over-long — a later reconcile re-truncates it idempotently).
+        assert!(
+            (3..=30).contains(&next),
+            "recovered a valid over-long prefix in [target, original] (got {next})"
+        );
+        let recs = reopened.read_from(Offset::ZERO, 100).unwrap();
+        assert_eq!(
+            recs.len() as u64,
+            next,
+            "the recovered prefix is dense and contiguous — no gap, no torn tail"
+        );
+        for (i, r) in recs.iter().enumerate() {
+            assert_eq!(
+                r.payload.as_ref(),
+                format!("t{i:02}").as_bytes(),
+                "record {i} survived the aborted multi-segment unlink intact"
+            );
+        }
+        // The recovered log is fully writable: the aborted surgery left a clean prefix, not a frozen
+        // or torn state.
+        let mut reopened = reopened;
+        reopened.append(&rec(b"after")).unwrap();
+        reopened.sync().unwrap();
+        assert_eq!(reopened.next_offset().get(), next + 1);
     }
 
     /// #822 discriminator for the OUTER cross-subtree recovery pool: [`par_recover_open`] MUST return


### PR DESCRIPTION
**#873 Phase 5** — crash-window + idempotency hardening (closing out the reconcile-on-adopt work; the correctness fix is P1-P3).

Proves the whole adopt-seam reconcile is a **pure, retryable function of durable state across every crash window**, and closes one latent storage crash-consistency gap:
- **Crash-window tests** (deterministic InMemoryFs/ManualClock/FaultFs): crash mid-`truncate_to` (both interior windows — unlinked-not-set_len, set_len-not-sync_dir) reopens to a valid prefix; crash mid-reconcile-handshake (after truncate, before forward fetch) reopens to exactly the committed floor and re-adopts as a no-op — for BOTH the P2 uncommitted-tail and P3 content-mismatch paths; adopt-seam idempotency (re-running after a clean heal touches nothing); a healed replica image is byte-identical to a from-scratch clean replica.
- **Storage hardening**: `Log::truncate_to` now unlinks the divergent tail **highest-id-first** (was lowest-first), so a crash mid-multi-segment-unlink always leaves a **contiguous, openable** prefix (never [kept, <gap>, higher] → `SegmentChainBroken`), matching `Log::reap`'s contiguous-removal safety. The final on-disk state is byte-identical (only crash-intermediate ordering changes); mutation-verified (reverting to lowest-first fails with `SegmentChainBroken`). New `FaultFs::fail_remove_on` + a covering test.

Test-only except the storage unlink-order hardening; whole-workspace fmt+clippy(pedantic) clean; storage 443 + server 1007 + all integration/determinism/conformance byte-identity suites green.

Part of #873 (closes out the correctness+hardening work; P4 live-KIP-101 remains an owner-gated wire-format follow-up).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>