### PR TITLE
feat(cli/1024): report produce-ack RTT percentiles for awaited window=1 publishes

### DIFF
--- a/crates/ironbus-cli/src/bench.rs
+++ b/crates/ironbus-cli/src/bench.rs
@@ -330,6 +330,20 @@ impl BenchConfig {
     pub fn fsync_is_measured(&self) -> bool {
         !self.no_fsync && self.storage == StorageArg::Disk
     }
+
+    /// Whether PUBLISH mode awaits EVERY produce individually (#1024): the plain half-duplex path,
+    /// `--pubwindow 1` without `--stream`, `--autopipe`, or `--faf`. Only then is each per-produce
+    /// sample an honest produce-to-ack RTT, the number the cross-broker study compares against a
+    /// Kafka/NATS synchronous publish. The pipelined paths (window > 1, stream, autopipe) amortize
+    /// a flush across many messages, so a per-op share would be dishonest, and fire-and-forget
+    /// awaits nothing at all. INDEPENDENT of the storage backend: an ack RTT is honest on the
+    /// memory engine too (it is just not a durable-write cost), unlike [`Self::fsync_is_measured`].
+    /// Unix-gated callers, exactly like [`Self::fsync_is_measured`].
+    #[cfg_attr(not(unix), allow(dead_code))]
+    #[must_use]
+    pub fn publish_acks_are_awaited(&self) -> bool {
+        self.pub_window == 1 && !self.stream && !self.auto_pipeline && !self.fire_and_forget
+    }
 }
 
 /// A bench run's measured result, independent of how it is rendered. The latency fields are present
@@ -356,6 +370,18 @@ pub struct BenchReport {
     pub p999_us: Option<f64>,
     /// Max observed latency, microseconds (latency modes only).
     pub max_us: Option<f64>,
+    /// p50 produce-to-ack RTT, microseconds (#1024): present ONLY when every produce was
+    /// individually awaited (plain `--pubwindow 1` publish, or the round-trip producer leg),
+    /// regardless of storage backend. `None` on the pipelined/fire-and-forget paths, where a
+    /// per-op attribution would be amortized and dishonest.
+    pub ack_p50_us: Option<f64>,
+    /// p99 produce-to-ack RTT, microseconds (#1024). Same presence rule as [`Self::ack_p50_us`].
+    pub ack_p99_us: Option<f64>,
+    /// p999 produce-to-ack RTT, microseconds (#1024). Same presence rule as [`Self::ack_p50_us`].
+    pub ack_p999_us: Option<f64>,
+    /// Max observed produce-to-ack RTT, microseconds (#1024). Same presence rule as
+    /// [`Self::ack_p50_us`].
+    pub ack_max_us: Option<f64>,
     /// Mean per-op fsync cost, microseconds, attributed from the round-trip latency through the
     /// real durable path (latency modes only, and only when `fsync_measured`).
     pub fsync_cost_us: Option<f64>,
@@ -884,6 +910,15 @@ pub fn write_human<W: Write + ?Sized>(
         write_latency_line(out, "latency p999", report.p999_us)?;
         write_latency_line(out, "latency max", report.max_us)?;
     }
+    // The produce-to-ack RTT percentiles (#1024): printed only when the run awaited every produce
+    // individually (plain `--pubwindow 1` publish, or the round-trip producer leg), so a reader
+    // never sees an amortized pipelined number dressed up as a per-op ack RTT.
+    if report.ack_p50_us.is_some() {
+        write_latency_line(out, "ack p50", report.ack_p50_us)?;
+        write_latency_line(out, "ack p99", report.ack_p99_us)?;
+        write_latency_line(out, "ack p999", report.ack_p999_us)?;
+        write_latency_line(out, "ack max", report.ack_max_us)?;
+    }
     if report.fsync_measured {
         write_latency_line(out, "fsync cost", report.fsync_cost_us)?;
     } else if cfg.storage == StorageArg::Memory {
@@ -923,7 +958,9 @@ fn write_latency_line<W: Write + ?Sized>(
 /// `latency_p999_us`, `latency_max_us`), null when the mode does not measure them. The `storage`
 /// field (#445) is ADDITIVE (schema version unchanged, the #439 `payload_entropy` precedent), so
 /// a recorded run self-describes which backend it measured and a RAM-path number is never
-/// mistaken for a disk number. Written to `out`.
+/// mistaken for a disk number. The produce-to-ack RTT percentile fields (#1024,
+/// `ack_p50_us`/`ack_p99_us`/`ack_p999_us`/`ack_max_us`) are likewise ADDITIVE, null unless every
+/// produce was individually awaited. Written to `out`.
 ///
 /// # Errors
 /// Returns [`CliError`] if writing to `out` fails.
@@ -951,6 +988,7 @@ pub fn bench_json(cfg: &BenchConfig, report: &BenchReport) -> String {
          \"produced\":{},\"recorded\":{},\"elapsed_secs\":{},\"msgs_per_sec\":{},\
          \"mb_per_sec\":{},\"bytes_per_op\":{},\
          \"latency_p50_us\":{},\"latency_p99_us\":{},\"latency_p999_us\":{},\"latency_max_us\":{},\
+         \"ack_p50_us\":{},\"ack_p99_us\":{},\"ack_p999_us\":{},\"ack_max_us\":{},\
          \"fsync_cost_us\":{},\"fsync_measured\":{}}}}}",
         BENCH_JSON_SCHEMA_VERSION,
         cfg.mode.as_str(),
@@ -979,6 +1017,10 @@ pub fn bench_json(cfg: &BenchConfig, report: &BenchReport) -> String {
         opt_f64_json(report.p99_us),
         opt_f64_json(report.p999_us),
         opt_f64_json(report.max_us),
+        opt_f64_json(report.ack_p50_us),
+        opt_f64_json(report.ack_p99_us),
+        opt_f64_json(report.ack_p999_us),
+        opt_f64_json(report.ack_max_us),
         opt_f64_json(report.fsync_cost_us),
         report.fsync_measured,
     );
@@ -1278,6 +1320,10 @@ mod tests {
             p99_us: Some(800.0),
             p999_us: Some(2500.0),
             max_us: Some(3000.0),
+            ack_p50_us: Some(880.0),
+            ack_p99_us: Some(1500.0),
+            ack_p999_us: Some(1900.0),
+            ack_max_us: Some(2100.0),
             fsync_cost_us: Some(900.0),
             fsync_measured: true,
         };
@@ -1289,6 +1335,11 @@ mod tests {
         assert!(json.contains("\"latency_p99_us\":800"), "json: {json}");
         assert!(json.contains("\"latency_p999_us\":2500"), "json: {json}");
         assert!(json.contains("\"latency_max_us\":3000"), "json: {json}");
+        // The ADDITIVE produce-to-ack RTT percentile fields (#1024), explicitly named.
+        assert!(json.contains("\"ack_p50_us\":880"), "json: {json}");
+        assert!(json.contains("\"ack_p99_us\":1500"), "json: {json}");
+        assert!(json.contains("\"ack_p999_us\":1900"), "json: {json}");
+        assert!(json.contains("\"ack_max_us\":2100"), "json: {json}");
         // fsync cost present and flagged honest.
         assert!(json.contains("\"fsync_cost_us\":900"), "json: {json}");
         assert!(json.contains("\"fsync_measured\":true"), "json: {json}");
@@ -1312,6 +1363,111 @@ mod tests {
         let json = bench_json(&cfg, &report);
         assert!(json.contains("\"latency_p50_us\":null"), "json: {json}");
         assert!(json.contains("\"latency_p999_us\":null"), "json: {json}");
+    }
+
+    #[test]
+    fn ack_rtt_is_claimed_only_on_the_awaited_per_produce_publish_path() {
+        // The #1024 gating condition, pinned: a per-produce ack RTT is honest ONLY when every
+        // produce is individually awaited — the plain half-duplex `--pubwindow 1` publish. This
+        // test FAILS if any amortized path (window > 1, --stream, --autopipe) or the un-awaited
+        // --faf path starts claiming ack percentiles, or if the plain path stops claiming them.
+        let plain = parse(&["--count", "10", "--mode", "publish"]).unwrap();
+        assert!(
+            plain.publish_acks_are_awaited(),
+            "plain --pubwindow 1 publish awaits every produce"
+        );
+        // MUTATION TEETH for `pub_window == 1`: an explicit window of exactly 1 stays awaited,
+        // while ANY window above 1 is amortized.
+        let window_one =
+            parse(&["--count", "10", "--mode", "publish", "--pubwindow", "1"]).unwrap();
+        assert!(window_one.publish_acks_are_awaited());
+        let windowed = parse(&["--count", "10", "--mode", "publish", "--pubwindow", "2"]).unwrap();
+        assert!(
+            !windowed.publish_acks_are_awaited(),
+            "a pipelined window amortizes; no per-op ack RTT may be claimed"
+        );
+        let stream = parse(&[
+            "--count",
+            "10",
+            "--mode",
+            "publish",
+            "--stream",
+            "--pubwindow",
+            "8",
+        ])
+        .unwrap();
+        assert!(!stream.publish_acks_are_awaited(), "full-duplex overlap");
+        let autopipe = parse(&["--count", "10", "--mode", "publish", "--autopipe"]).unwrap();
+        assert!(
+            !autopipe.publish_acks_are_awaited(),
+            "auto-pipelined flushes"
+        );
+        let faf = parse(&["--count", "10", "--mode", "publish", "--faf"]).unwrap();
+        assert!(!faf.publish_acks_are_awaited(), "no ack is awaited at all");
+        // STORAGE-INDEPENDENT (unlike the fsync cost): an ack RTT is honest on memory too.
+        let memory = parse(&["--count", "10", "--mode", "publish", "--storage", "memory"]).unwrap();
+        assert!(
+            memory.publish_acks_are_awaited(),
+            "ack RTT is backend-agnostic"
+        );
+        assert!(!memory.fsync_is_measured(), "but the fsync cost is not");
+    }
+
+    #[test]
+    fn ack_percentiles_land_in_the_json_and_null_when_not_awaited() {
+        // Present: the four ADDITIVE #1024 fields carry numbers when the report has them.
+        let cfg = parse(&["--count", "5", "--mode", "publish"]).unwrap();
+        let report = BenchReport {
+            produced: 5,
+            elapsed_secs: 1.0,
+            ack_p50_us: Some(150.0),
+            ack_p99_us: Some(400.0),
+            ack_p999_us: Some(650.0),
+            ack_max_us: Some(700.0),
+            ..BenchReport::default()
+        };
+        let json = bench_json(&cfg, &report);
+        assert!(json.contains("\"ack_p50_us\":150"), "json: {json}");
+        assert!(json.contains("\"ack_max_us\":700"), "json: {json}");
+        // Absent (an amortized/un-awaited path): the same fields are null, never omitted.
+        let json = bench_json(&cfg, &BenchReport::default());
+        for field in [
+            "\"ack_p50_us\":null",
+            "\"ack_p99_us\":null",
+            "\"ack_p999_us\":null",
+            "\"ack_max_us\":null",
+        ] {
+            assert!(json.contains(field), "missing {field} in json: {json}");
+        }
+    }
+
+    #[test]
+    fn human_view_prints_ack_percentiles_only_when_present() {
+        let cfg = parse(&["--count", "5", "--mode", "publish"]).unwrap();
+        let report = BenchReport {
+            produced: 5,
+            elapsed_secs: 1.0,
+            ack_p50_us: Some(150.0),
+            ack_p99_us: Some(400.0),
+            ack_p999_us: Some(650.0),
+            ack_max_us: Some(700.0),
+            fsync_measured: true,
+            ..BenchReport::default()
+        };
+        let mut human = Vec::new();
+        write_human(&cfg, &report, &mut human).unwrap();
+        let human = String::from_utf8(human).unwrap();
+        assert!(human.contains("ack p50:     150.0 us"), "human: {human}");
+        assert!(human.contains("ack p99:     400.0 us"), "human: {human}");
+        assert!(human.contains("ack p999:     650.0 us"), "human: {human}");
+        assert!(human.contains("ack max:     700.0 us"), "human: {human}");
+        // An un-awaited run prints NO ack lines at all (no noisy n/a rows for a metric the mode
+        // cannot honestly measure).
+        let mut human = Vec::new();
+        write_human(&cfg, &BenchReport::default(), &mut human).unwrap();
+        let human = String::from_utf8(human).unwrap();
+        assert!(!human.contains("ack p"), "human: {human}");
+        assert!(!human.contains("ack max"), "human: {human}");
     }
 
     #[test]

--- a/crates/ironbus-cli/src/bench_run.rs
+++ b/crates/ironbus-cli/src/bench_run.rs
@@ -457,6 +457,7 @@ fn run_publish_autopipe(cfg: &BenchConfig, addr: &str) -> Result<BenchReport, Cl
         Err(e) => return Err(classify(addr, "flushing the auto-pipelined tail to", &e)),
     }
     let elapsed = started.elapsed();
+    // The flush attribution is amortized across the window, so no per-op ack RTT is claimed.
     Ok(finish_report(
         cfg,
         produced,
@@ -464,7 +465,10 @@ fn run_publish_autopipe(cfg: &BenchConfig, addr: &str) -> Result<BenchReport, Cl
         &[],
         &fsync_samples,
         elapsed,
-        cfg.fsync_is_measured(),
+        SampleAttribution {
+            fsync_measured: cfg.fsync_is_measured(),
+            acks_awaited: false,
+        },
     ))
 }
 
@@ -529,7 +533,8 @@ fn run_publish_stream(
     let produced = summary.acked;
     let elapsed = started.elapsed();
     // No per-produce fsync attribution: the overlap makes a per-message share dishonest, so
-    // the histogram stays empty and the report's fsync_measured flag is forced off.
+    // the histogram stays empty, the report's fsync_measured flag is forced off, and no per-op
+    // ack RTT is claimed either.
     Ok(finish_report(
         cfg,
         produced,
@@ -537,7 +542,10 @@ fn run_publish_stream(
         &[],
         &[],
         elapsed,
-        false,
+        SampleAttribution {
+            fsync_measured: false,
+            acks_awaited: false,
+        },
     ))
 }
 
@@ -591,8 +599,9 @@ fn run_publish_faf(cfg: &BenchConfig, addr: &str) -> Result<BenchReport, CliErro
         .flush()
         .map_err(|e| classify(addr, "fire-and-forget producing to", &e))?;
     let elapsed = started.elapsed();
-    // At-most-once: no ack and no read-back, so no latency and no durable-write cost to attribute
-    // (the broker may even have shed sends under its token bucket). fsync is forced not-measured.
+    // At-most-once: no ack and no read-back, so no latency, no durable-write cost to attribute
+    // (the broker may even have shed sends under its token bucket), and certainly no ack RTT.
+    // fsync is forced not-measured.
     Ok(finish_report(
         cfg,
         produced,
@@ -600,7 +609,10 @@ fn run_publish_faf(cfg: &BenchConfig, addr: &str) -> Result<BenchReport, CliErro
         &[],
         &[],
         elapsed,
-        false,
+        SampleAttribution {
+            fsync_measured: false,
+            acks_awaited: false,
+        },
     ))
 }
 
@@ -689,7 +701,9 @@ fn run_publish(cfg: &BenchConfig, addr: &str) -> Result<BenchReport, CliError> {
     let elapsed = started.elapsed();
     // Publish has no read-back, so no end-to-end latency; but the per-produce durable cost IS
     // measured (the produce call returns after the fdatasync), so the fsync cost is honest unless
-    // --no-fsync batched the checkpoints.
+    // --no-fsync batched the checkpoints. The ack RTT percentiles (#1024) are claimed only on the
+    // plain awaited-per-produce path (`--pubwindow 1`), never from the windowed loop's amortized
+    // per-op shares.
     Ok(finish_report(
         cfg,
         produced,
@@ -697,7 +711,10 @@ fn run_publish(cfg: &BenchConfig, addr: &str) -> Result<BenchReport, CliError> {
         &[],
         &fsync_samples,
         elapsed,
-        cfg.fsync_is_measured(),
+        SampleAttribution {
+            fsync_measured: cfg.fsync_is_measured(),
+            acks_awaited: cfg.publish_acks_are_awaited(),
+        },
     ))
 }
 
@@ -763,7 +780,10 @@ fn run_subscribe(cfg: &BenchConfig, addr: &str) -> Result<BenchReport, CliError>
         &latencies,
         &[],
         drain_start.elapsed(),
-        false,
+        SampleAttribution {
+            fsync_measured: false,
+            acks_awaited: false,
+        },
     ))
 }
 
@@ -840,7 +860,9 @@ fn run_round_trip(cfg: &BenchConfig, addr: &str) -> Result<BenchReport, CliError
     };
 
     // The honest fsync cost is the median produce-call latency (ack-after-fsync, I2), measured only
-    // when the durable path was exercised per produce, i.e. NOT in the --no-fsync dry run.
+    // when the durable path was exercised per produce, i.e. NOT in the --no-fsync dry run. The
+    // producer leg awaits EVERY produce individually, so the same samples are honest produce-to-ack
+    // RTTs (#1024) on any backend.
     Ok(finish_report(
         cfg,
         produced,
@@ -848,7 +870,10 @@ fn run_round_trip(cfg: &BenchConfig, addr: &str) -> Result<BenchReport, CliError
         &latencies,
         &fsync_samples,
         elapsed,
-        cfg.fsync_is_measured(),
+        SampleAttribution {
+            fsync_measured: cfg.fsync_is_measured(),
+            acks_awaited: true,
+        },
     ))
 }
 
@@ -1037,12 +1062,29 @@ fn drain_streaming(
     Ok((recorded, latencies))
 }
 
+/// How the per-produce-call samples (`fsync_samples`) may honestly be attributed in the report.
+/// The two flags are ORTHOGONAL: a plain awaited publish on the memory backend has an honest ack
+/// RTT (`acks_awaited`) but no durable-write cost (`fsync_measured` off), while a `--pubwindow 8`
+/// disk publish has an honest amortized fsync cost but NO per-op ack RTT.
+#[derive(Clone, Copy)]
+struct SampleAttribution {
+    /// The per-op DURABLE path was exercised (disk backend, not the `--no-fsync` dry run), so the
+    /// median sample is an honest per-op fsync cost ([`BenchConfig::fsync_is_measured`]).
+    fsync_measured: bool,
+    /// EVERY produce was individually awaited (plain `--pubwindow 1` publish, or the round-trip
+    /// producer leg), so the samples are honest produce-to-ack RTTs REGARDLESS of storage backend
+    /// (#1024). Off on the pipelined/fire-and-forget paths, whose per-op shares are amortized.
+    acks_awaited: bool,
+}
+
 /// Assembles a [`BenchReport`] from the run tallies, the end-to-end LATENCY samples (read-back, in
 /// the latency modes), and the per-produce-call samples (`fsync_samples`). The reported fsync cost
 /// is the MEDIAN produce-call latency, not the round-trip p50: a `Pub` returns its `PubAck` only
 /// after the covering group-commit `fdatasync` (invariant I2), so the produce-call median isolates
 /// the durable-write cost from the queue-wait that inflates round-trip latency. It is reported only
-/// when `fsync_measured` (not in the `--no-fsync` dry run, which batches cursor checkpoints).
+/// when `fsync_measured` (not in the `--no-fsync` dry run, which batches cursor checkpoints). The
+/// same samples yield the produce-to-ack RTT percentiles (#1024) — but only when `acks_awaited`
+/// (every produce individually awaited), and then on ANY backend.
 fn finish_report(
     cfg: &BenchConfig,
     produced: u64,
@@ -1050,7 +1092,7 @@ fn finish_report(
     latencies: &[u64],
     fsync_samples: &[u64],
     elapsed: Duration,
-    fsync_measured: bool,
+    attribution: SampleAttribution,
 ) -> BenchReport {
     let elapsed_secs = elapsed.as_secs_f64().max(f64::MIN_POSITIVE);
     // Throughput counts the messages the MEASURED side moved: recorded for a latency mode, produced
@@ -1075,7 +1117,7 @@ fn finish_report(
         msgs_per_sec,
         mb_per_sec,
         bytes_per_op,
-        fsync_measured,
+        fsync_measured: attribution.fsync_measured,
         ..BenchReport::default()
     };
     if let Some((p50, p99, p999, max)) = percentiles_us(latencies) {
@@ -1084,10 +1126,21 @@ fn finish_report(
         report.p999_us = Some(p999);
         report.max_us = Some(max);
     }
+    // The produce-to-ack RTT percentiles (#1024): honest only when EVERY produce was individually
+    // awaited (each sample is one full produce-call round trip), and then on any backend — an ack
+    // RTT on the memory engine is a real RTT, it is just not a durable-write cost.
+    if attribution.acks_awaited {
+        if let Some((p50, p99, p999, max)) = percentiles_us(fsync_samples) {
+            report.ack_p50_us = Some(p50);
+            report.ack_p99_us = Some(p99);
+            report.ack_p999_us = Some(p999);
+            report.ack_max_us = Some(max);
+        }
+    }
     // The honest per-op fsync cost: the median produce-call latency, which an ack-after-fsync broker
     // (I2) cannot return before the durable write completes. Reported only when measured through the
     // per-produce durable path.
-    if fsync_measured {
+    if attribution.fsync_measured {
         if let Some((fsync_p50, _, _, _)) = percentiles_us(fsync_samples) {
             report.fsync_cost_us = Some(fsync_p50);
         }
@@ -1240,6 +1293,134 @@ fn stamp_send_time(payload: &mut [u8], started: Instant) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Parses a bench arg list with the deterministic test suffix, mirroring `bench.rs`'s helper.
+    fn cfg_of(args: &[&str]) -> BenchConfig {
+        let owned: Vec<String> = args.iter().map(|s| (*s).to_string()).collect();
+        crate::bench::parse_bench(&owned, "deadbeef").expect("valid bench args")
+    }
+
+    /// 1000 per-produce samples of 1..=1000 us (in nanoseconds), so the expected percentiles are
+    /// known exactly: max = 1000 us and p50 <= p99 <= p999 <= max.
+    fn awaited_samples() -> Vec<u64> {
+        (1..=1000u64).map(|us| us * 1_000).collect()
+    }
+
+    #[test]
+    fn awaited_publish_samples_yield_ack_percentiles_on_disk_and_memory() {
+        let samples = awaited_samples();
+        // DISK, plain --pubwindow 1 publish: BOTH the #1024 ack RTT percentiles and the honest
+        // fsync cost come from the same awaited per-produce samples, so the ack p50 must equal
+        // the reported fsync cost exactly.
+        let disk = cfg_of(&["--count", "1000", "--mode", "publish"]);
+        let report = finish_report(
+            &disk,
+            1000,
+            1000,
+            &[],
+            &samples,
+            Duration::from_secs(1),
+            SampleAttribution {
+                fsync_measured: disk.fsync_is_measured(),
+                acks_awaited: disk.publish_acks_are_awaited(),
+            },
+        );
+        let p50 = report.ack_p50_us.expect("disk ack p50");
+        let p99 = report.ack_p99_us.expect("disk ack p99");
+        let p999 = report.ack_p999_us.expect("disk ack p999");
+        let max = report.ack_max_us.expect("disk ack max");
+        assert!(p50 <= p99 && p99 <= p999 && p999 <= max, "ordered tail");
+        assert!((max - 1000.0).abs() < 1e-9, "max is the 1000 us sample");
+        let fsync = report.fsync_cost_us.expect("disk fsync cost");
+        assert!(
+            (fsync - p50).abs() < 1e-9,
+            "same samples, same median: fsync {fsync} vs ack p50 {p50}"
+        );
+        // MEMORY, same plain publish: the ack RTT is STILL honest (#1024, backend-agnostic), but
+        // no fsync cost may be claimed (the in-memory engine issues no fsync).
+        let memory = cfg_of(&[
+            "--count",
+            "1000",
+            "--mode",
+            "publish",
+            "--storage",
+            "memory",
+        ]);
+        let report = finish_report(
+            &memory,
+            1000,
+            1000,
+            &[],
+            &samples,
+            Duration::from_secs(1),
+            SampleAttribution {
+                fsync_measured: memory.fsync_is_measured(),
+                acks_awaited: memory.publish_acks_are_awaited(),
+            },
+        );
+        assert!(report.ack_p50_us.is_some(), "memory ack p50 is honest");
+        assert!(report.ack_max_us.is_some(), "memory ack max is honest");
+        assert!(!report.fsync_measured, "no fsync exists in memory mode");
+        assert!(report.fsync_cost_us.is_none(), "so none may be claimed");
+    }
+
+    #[test]
+    fn amortized_publish_never_claims_ack_percentiles() {
+        // A windowed publish's per-op shares are amortized (one flush covers the window), so the
+        // #1024 gate holds them out of the ack fields — even though the amortized fsync cost is
+        // still honestly attributed on disk. This FAILS if the awaited-only gate is dropped.
+        let cfg = cfg_of(&["--count", "1000", "--mode", "publish", "--pubwindow", "8"]);
+        let samples = awaited_samples();
+        let report = finish_report(
+            &cfg,
+            1000,
+            1000,
+            &[],
+            &samples,
+            Duration::from_secs(1),
+            SampleAttribution {
+                fsync_measured: cfg.fsync_is_measured(),
+                acks_awaited: cfg.publish_acks_are_awaited(),
+            },
+        );
+        assert!(report.ack_p50_us.is_none(), "amortized: no ack p50");
+        assert!(report.ack_p99_us.is_none(), "amortized: no ack p99");
+        assert!(report.ack_p999_us.is_none(), "amortized: no ack p999");
+        assert!(report.ack_max_us.is_none(), "amortized: no ack max");
+        assert!(
+            report.fsync_cost_us.is_some(),
+            "the amortized disk fsync cost is still reported"
+        );
+    }
+
+    #[test]
+    fn round_trip_producer_leg_populates_ack_percentiles() {
+        // The round-trip producer leg awaits every produce (produce_one), so its samples carry the
+        // #1024 ack percentiles alongside — and independent of — the e2e delivery percentiles.
+        let cfg = cfg_of(&["--count", "1000", "--mode", "round-trip"]);
+        let latencies: Vec<u64> = (1..=1000u64).map(|us| us * 5_000).collect(); // 5..5000 us e2e
+        let samples = awaited_samples();
+        let report = finish_report(
+            &cfg,
+            1000,
+            1000,
+            &latencies,
+            &samples,
+            Duration::from_secs(1),
+            SampleAttribution {
+                fsync_measured: cfg.fsync_is_measured(),
+                acks_awaited: true,
+            },
+        );
+        let ack_max = report.ack_max_us.expect("round-trip ack max");
+        let e2e_max = report.max_us.expect("round-trip e2e max");
+        assert!(report.ack_p50_us.is_some(), "round-trip ack p50");
+        assert!(
+            ack_max < e2e_max,
+            "the ack RTT ({ack_max}) is the produce leg only, strictly below the e2e delivery \
+             tail ({e2e_max}) here"
+        );
+    }
 
     #[test]
     fn drain_stops_on_full_count_and_on_shed_but_not_before_caught_up() {

--- a/crates/ironbus-cli/tests/bench.rs
+++ b/crates/ironbus-cli/tests/bench.rs
@@ -180,6 +180,109 @@ fn publish_mode_run_nulls_latency_and_still_cleans_up() {
 }
 
 #[test]
+fn awaited_publish_reports_ack_percentiles_on_disk_and_memory_but_windowed_does_not() {
+    // #1024 ACCEPTANCE: a plain `--mode publish --pubwindow 1` run awaits every produce, so the
+    // additive ack RTT percentile fields are POPULATED — on the disk backend AND on the memory
+    // backend (an ack RTT is honest without an fsync; it is just not a durable-write cost) — while
+    // a pipelined window (>1) amortizes its flushes and must emit null for all four.
+    let tmp = PrivateTmp::new();
+    let out = run_bench_in(&tmp, &["--count", "200", "--mode", "publish", "--json"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    for field in ["ack_p50_us", "ack_p99_us", "ack_p999_us", "ack_max_us"] {
+        assert!(
+            json_number(&stdout, field).is_some(),
+            "{field} should be measured for an awaited disk publish: {stdout}"
+        );
+    }
+    // The ack tail is ordered, and on disk the ack p50 IS the produce-call median the fsync cost
+    // reports (same awaited samples).
+    let ack_p50 = json_number(&stdout, "ack_p50_us").expect("ack_p50_us");
+    let ack_max = json_number(&stdout, "ack_max_us").expect("ack_max_us");
+    let fsync_cost = json_number(&stdout, "fsync_cost_us").expect("fsync_cost_us");
+    assert!(ack_p50 <= ack_max, "ordered: {stdout}");
+    assert!(
+        (ack_p50 - fsync_cost).abs() < f64::EPSILON,
+        "disk window=1: ack p50 ({ack_p50}) and fsync cost ({fsync_cost}) share the samples"
+    );
+    // MEMORY: ack percentiles populated, fsync cost honestly null.
+    let out = run_bench_in(
+        &tmp,
+        &[
+            "--count",
+            "200",
+            "--mode",
+            "publish",
+            "--storage",
+            "memory",
+            "--json",
+        ],
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        json_number(&stdout, "ack_p50_us").is_some(),
+        "memory ack p50 should be measured: {stdout}"
+    );
+    assert!(stdout.contains("\"fsync_cost_us\":null"), "json: {stdout}");
+    // WINDOWED (>1): amortized attribution, so every ack field is null.
+    let out = run_bench_in(
+        &tmp,
+        &[
+            "--count",
+            "200",
+            "--mode",
+            "publish",
+            "--pubwindow",
+            "8",
+            "--json",
+        ],
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    for field in [
+        "\"ack_p50_us\":null",
+        "\"ack_p99_us\":null",
+        "\"ack_p999_us\":null",
+        "\"ack_max_us\":null",
+    ] {
+        assert!(stdout.contains(field), "missing {field} in json: {stdout}");
+    }
+}
+
+#[test]
+fn round_trip_reports_ack_percentiles_from_the_awaited_producer_leg() {
+    // #1024: round-trip's producer leg awaits every produce, so the ack RTT percentiles are
+    // populated alongside the (strictly harder) e2e delivery percentiles.
+    let tmp = PrivateTmp::new();
+    let out = run_bench_in(&tmp, &["--count", "300", "--mode", "round-trip", "--json"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    for field in ["ack_p50_us", "ack_p99_us", "ack_p999_us", "ack_max_us"] {
+        assert!(
+            json_number(&stdout, field).is_some(),
+            "{field} should be measured for a round trip: {stdout}"
+        );
+    }
+}
+
+#[test]
 fn no_fsync_dry_run_flags_the_cost_not_measured() {
     let out = run_bench(&["--count", "100", "--no-fsync", "--json"]);
     let stdout = String::from_utf8_lossy(&out.stdout);


### PR DESCRIPTION
Implements #1024 (needed by the cross-broker study #1023): `ironbus bench` now reports **produce→ACK RTT percentiles** (`ack_p50_us/ack_p99_us/ack_p999_us/ack_max_us`) as additive, null-when-unmeasured JSON fields + matching human-view lines.

**Honest-attribution gating** (the core of the change): populated ONLY where every produce is individually awaited — plain `--mode publish --pubwindow 1` (ANY storage backend, memory included: an ack RTT is honest there, it's just not a durable-write cost) and the round-trip producer leg. Never on window>1 / `--stream` / `--autopipe` / fire-and-forget (amortized attribution stays honestly absent). `fsync_cost_us` byte-identical semantics (disk-only p50). Gate exposed as `BenchConfig::publish_acks_are_awaited`; `finish_report` takes `SampleAttribution{fsync_measured, acks_awaited}` (orthogonal flags, all six call sites updated).

**Envelope compat**: the frozen ironbus.cli.v1 envelope pins only the envelope shape, not the bench payload; the bench payload is its own versioned object (schema_version 1) and the four fields follow the documented additive precedent (#445/#439) — always-present keys, null when unmeasured. No vector regeneration needed. In-repo JSON consumers parse by key and are unaffected.

Mutation-verified (window==1 → >=1 gate mutation killed by two independent tests); 8 new/updated tests incl. live disk+memory integration; fmt/clippy(pedantic)/450 unit + 9 integration suites green. Reviewed across 2 adversarial lenses (honesty + compat).

Closes #1024

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>