### PR TITLE
fix(bench): --no-fsync runs the spawned broker at interval durability; DEFAULT_FETCH_BATCH 2048 (#1027)

### DIFF
--- a/crates/ironbus-cli/src/bench.rs
+++ b/crates/ironbus-cli/src/bench.rs
@@ -25,10 +25,12 @@
 //!
 //! FLASH-ENDURANCE. A run MUST be bounded: exactly one of `--duration` or `--count` is required, so
 //! there is no unbounded default that burns edge flash write endurance. A `--no-fsync` dry-run mode
-//! batches the bench-spawned broker's cursor checkpoints instead of forcing one durable cursor write
-//! per ack, cutting the bench's own flash writes for a quick capacity probe; in that mode the
-//! reported fsync cost is flagged not-measured, because the honest fsync number requires the
-//! per-ack durable path.
+//! runs the bench-spawned broker at `interval` durability (ack on the page-cache write, a
+//! bounded-loss forced-fdatasync window — the honest "relaxed" tier a real
+//! `serve --durability-level interval` broker runs, #1027) and batches its cursor checkpoints
+//! instead of forcing one durable cursor write per ack, cutting the bench's own flash writes for a
+//! quick capacity probe; in that mode the reported fsync cost is flagged not-measured, because the
+//! honest fsync number requires the per-ack durable path.
 //!
 //! # Why this lives in `ironbus-cli`, not the `ironbus-bench` crate
 //!
@@ -251,8 +253,11 @@ pub struct BenchConfig {
     /// populated when the operator passed `--i-understand-this-is-live` (the parse-time guard), so
     /// its presence alone means a deliberately-acknowledged live run.
     pub live_addr: Option<String>,
-    /// Dry-run: batch the bench broker's cursor checkpoints instead of one durable write per ack,
-    /// to spare edge flash. In this mode the fsync cost is not measured.
+    /// Dry-run (#1027): run the spawned isolated broker at `interval` durability (ack on the
+    /// page-cache write, bounded-loss forced-fdatasync window — the honest "relaxed" tier a real
+    /// `serve --durability-level interval` runs) AND batch its cursor checkpoints instead of one
+    /// durable write per ack, to spare edge flash. In this mode the fsync cost is not measured
+    /// (the per-ack durable path is not exercised).
     pub no_fsync: bool,
     /// The pipelined publish window (#450): how many un-acked PUBs the publisher keeps in flight
     /// per produce call. `1` (the default) is the historical one-awaited-ack-per-publish path;
@@ -321,7 +326,8 @@ impl BenchConfig {
     /// Whether the run measures the HONEST per-op fsync cost (#445): only on the DISK backend
     /// (the in-memory engine issues NO fsync at all, so there is no durable-write cost to
     /// attribute; reporting one would be dishonest) and only outside the `--no-fsync` dry run
-    /// (which batches the cursor checkpoints, so the per-ack durable path is not exercised).
+    /// (which runs the spawned broker at `interval` durability and batches the cursor
+    /// checkpoints, #1027, so the per-ack durable path is not exercised).
     /// The callers live in `bench_run.rs` behind `cfg(unix)` (the bench broker is the real
     /// `serve` path, Unix-only in v1), so on a non-unix build this method is otherwise dead
     /// code and `-D warnings` refuses the build (the Windows CI lane caught exactly that).
@@ -919,6 +925,19 @@ pub fn write_human<W: Write + ?Sized>(
         write_latency_line(out, "ack p999", report.ack_p999_us)?;
         write_latency_line(out, "ack max", report.ack_max_us)?;
     }
+    write_fsync_cost_line(cfg, report, out)?;
+    Ok(())
+}
+
+/// Writes the fsync-cost line with the tier-honest wording for every non-measured case (#445,
+/// #1027): measured -> the per-ack cost; memory -> no fsync exists; --no-fsync isolated -> the
+/// spawned broker really ran INTERVAL durability; --no-fsync live -> no tier claim; otherwise ->
+/// overlapped publishes make per-op attribution dishonest (and no dry run may be claimed).
+fn write_fsync_cost_line<W: Write + ?Sized>(
+    cfg: &BenchConfig,
+    report: &BenchReport,
+    out: &mut W,
+) -> Result<(), CliError> {
     if report.fsync_measured {
         write_latency_line(out, "fsync cost", report.fsync_cost_us)?;
     } else if cfg.storage == StorageArg::Memory {
@@ -930,11 +949,31 @@ pub fn write_human<W: Write + ?Sized>(
             "fsync cost:     not measured (--storage memory: the in-memory engine issues no \
              fsync, so there is no durable-write cost to attribute)"
         )?;
-    } else {
+    } else if cfg.no_fsync && cfg.is_isolated() {
+        // The #1027 dry-run wording: the SPAWNED broker really ran the interval tier, so the
+        // reader knows the numbers above are bounded-loss page-cache acks, not the sync tier.
+        writeln!(
+            out,
+            "fsync cost:     not measured (--no-fsync dry run: the spawned broker ran INTERVAL \
+             durability — bounded-loss page-cache acks, not the power-loss-safe sync tier; the \
+             honest fsync number needs the per-ack durable path)"
+        )?;
+    } else if cfg.no_fsync {
+        // LIVE mode never spawns (or reconfigures) a broker, so no tier claim may be made; the
+        // flag only withholds the fsync attribution.
         writeln!(
             out,
             "fsync cost:     not measured (--no-fsync dry run; the honest fsync number needs the \
              per-ack durable path)"
+        )?;
+    } else {
+        // Overlapped disk paths without --no-fsync (windowed/stream/autopipe/faf): the durable
+        // cost EXISTS but no single produce owns a covering fsync, so per-op attribution would be
+        // dishonest. Never claim a dry run that was not requested (#1027).
+        writeln!(
+            out,
+            "fsync cost:     not attributed (overlapped publishes share covering fsyncs; use \
+             --pubwindow 1 for the honest per-ack cost)"
         )?;
     }
     Ok(())
@@ -1089,8 +1128,17 @@ pub const ROUND_TRIP_TOKEN_LEN: usize = 16;
 /// The default per-message payload size.
 const DEFAULT_PAYLOAD_BYTES: usize = 256;
 
-/// The default receiver fetch credit window.
-const DEFAULT_FETCH_BATCH: u32 = 256;
+/// The default receiver fetch credit window (`--fetch-batch`), shared by the Tier-W work-queue
+/// fetch and the Tier-S streaming window. 2048, not 256 (#1027): at 256 the streaming drain is
+/// round-trip-latency-bound (~700 fetch RTTs/s of ~1.4 ms each, zero CPU hotspots — 128 B records
+/// drained at ~180k msg/s on the baseline rig), while 2048 reaches the ~1M rec/s per-record
+/// plateau there (969k-1217k msg/s at 128 B; 8192 measured 931k, so a larger window buys nothing —
+/// the ~0.5 us/record cost is the real ceiling). 2048 is also PEER-COMPARABLE consumer sizing (a
+/// stock Kafka consumer fetches ~50 MB / 500+ records per poll, so a 256-record default is not a
+/// fair head-to-head) and exactly the broker's default per-consumer credit ceiling
+/// (`DEFAULT_CONSUMER_CREDIT` = 2048), which every fetch is capped at anyway. `--fetch-batch`
+/// still overrides.
+const DEFAULT_FETCH_BATCH: u32 = 2048;
 
 /// Fills `payload` with the chosen shape AFTER the round-trip token, leaving `payload[..token_len]`
 /// untouched for the caller to stamp. `realistic` writes a repetitive, codec-friendly pattern (so
@@ -1227,6 +1275,20 @@ mod tests {
         // The default group is a fresh synthetic namespace.
         assert!(cfg.group.starts_with(BENCH_NAMESPACE_PREFIX));
         assert_eq!(cfg.group, "ironbus-bench-deadbeef");
+    }
+
+    #[test]
+    fn the_default_fetch_batch_is_pinned_at_2048_and_the_flag_still_overrides() {
+        // #1027 PIN: 2048 is peer-comparable consumer sizing (a stock Kafka consumer pulls 500+
+        // records per poll) and the measured ~1M rec/s plateau point of the streaming drain; 256
+        // was round-trip-latency-bound (~180k msg/s at 128 B). This FAILS if the default drifts.
+        let cfg = parse(&["--count", "1"]).unwrap();
+        assert_eq!(
+            cfg.fetch_batch, 2048,
+            "the default fetch window is pinned at the 2048 plateau point (#1027)"
+        );
+        let cfg = parse(&["--count", "1", "--fetch-batch", "256"]).unwrap();
+        assert_eq!(cfg.fetch_batch, 256, "--fetch-batch still overrides");
     }
 
     #[test]

--- a/crates/ironbus-cli/src/bench_run.rs
+++ b/crates/ironbus-cli/src/bench_run.rs
@@ -13,7 +13,10 @@ use crate::bench::{
     fill_payload, percentiles_us, AckMode, BenchConfig, BenchReport, Bound, ConsumeTier, Mode,
     BENCH_NAMESPACE_PREFIX, ROUND_TRIP_TOKEN_LEN,
 };
-use crate::{open_disk_engine, open_memory_engine, CliError, ServeConfig, StorageArg};
+use crate::{
+    materialized_config_line, open_disk_engine, open_memory_engine, CliError, DurabilityLevelArg,
+    ServeConfig, StorageArg,
+};
 use ironbus_client::{Client, ClientConfig, ClientError, StreamConsumerConfig};
 use ironbus_core::clock::Clock; // the monotonic seam the serve loop's liveness beacon (#95) reads
 use ironbus_proto::message::{ConsumeTier as ProtoConsumeTier, PubBody};
@@ -63,6 +66,7 @@ fn execute_isolated(cfg: &BenchConfig) -> Result<BenchReport, CliError> {
         StorageArg::Disk => execute_isolated_disk(cfg, &config),
         StorageArg::Memory => {
             let broker = IsolatedBroker::spawn_memory(&config)?;
+            log_spawned_config(&config, broker.addr(), None);
             let result = drive_load(cfg, broker.addr());
             broker.shutdown();
             result
@@ -84,6 +88,7 @@ fn execute_isolated_disk(cfg: &BenchConfig, config: &ServeConfig) -> Result<Benc
     let mut dir_guard = DataDirGuard::arm(data_dir.clone());
 
     let broker = IsolatedBroker::spawn_disk(&data_dir, config)?;
+    log_spawned_config(config, broker.addr(), Some(&data_dir));
     let run_result = drive_load(cfg, broker.addr());
     // Tear the broker down BEFORE deleting the directory, so no writer races the cleanup.
     broker.shutdown();
@@ -307,20 +312,44 @@ const BENCH_MEMORY_CAP_BYTES: u64 = 256 * 1024 * 1024;
 
 /// Builds the `ServeConfig` for the isolated bench broker: the compiled defaults, except the
 /// checkpoint interval, which is `1` (durable cursor write per ack, honest fsync) normally and a
-/// large batch under `--no-fsync` (spare flash, fsync cost not measured). Under
-/// `--storage memory` (#445) it carries the memory backend plus the two boot-gate requirements
-/// the real serve path enforces: the explicit ephemeral consent (bench's synthetic broker and its
-/// data are disposable by design, so bench supplies the consent the way it already owns the
-/// auto-delete of its synthetic disk dir) and the default in-RAM byte cap above.
+/// large batch under `--no-fsync` (spare flash, fsync cost not measured). `--no-fsync` (#1027)
+/// ALSO relaxes the spawned broker's PRODUCE durability to `interval` (ack on the page-cache
+/// write, a bounded-loss forced-fdatasync window — the honest "relaxed / page-cache" tier a real
+/// `serve --durability-level interval` runs): before #1027 only the checkpoint interval was
+/// raised, so the "page-cache dry run" silently still measured the per-ack `sync` fsync tier.
+/// Under `--storage memory` (#445) it carries the memory backend plus the two boot-gate
+/// requirements the real serve path enforces: the explicit ephemeral consent (bench's synthetic
+/// broker and its data are disposable by design, so bench supplies the consent the way it already
+/// owns the auto-delete of its synthetic disk dir) and the default in-RAM byte cap above.
 fn bench_serve_config(cfg: &BenchConfig) -> ServeConfig {
     let mut config = ServeConfig::bench_default();
     config.checkpoint_interval = if cfg.no_fsync { 1_000_000 } else { 1 };
+    if cfg.no_fsync {
+        // The dry run's produce path must ALSO leave the per-ack fsync tier (#1027): `interval`
+        // is the bounded-loss page-cache level (the default flush window still forces periodic
+        // fdatasyncs, so the loss stays bounded exactly as a real relaxed broker's would). The
+        // `sync` default is kept for every honest run, so `fsync_measured` claims stay true.
+        config.durability_level = DurabilityLevelArg::Interval;
+    }
     if cfg.storage == StorageArg::Memory {
         config.storage = StorageArg::Memory;
         config.ephemeral_loss_ack = true;
         config.max_total_bytes = BENCH_MEMORY_CAP_BYTES;
     }
     config
+}
+
+/// Writes the spawned isolated broker's MATERIALIZED-CONFIG line (#87) to stderr, exactly the
+/// audit surface `serve` emits at startup (#1027): one structured `key=value` line with every
+/// resolved knob, so an operator (or a probe) reads the EFFECTIVE durability tier the bench broker
+/// really ran — `durability_level=interval` under `--no-fsync`, `durability_level=sync` otherwise —
+/// straight off the run's stderr, never inferring it from the flag. stderr, not stdout, so the
+/// `--json` single-object stdout contract is untouched.
+fn log_spawned_config(config: &ServeConfig, addr: &str, data_dir: Option<&Path>) {
+    eprintln!(
+        "bench: {}",
+        materialized_config_line(config, addr, data_dir)
+    );
 }
 
 /// Drives the load against the broker at `addr` and returns the measured report. Dispatches on the
@@ -1419,6 +1448,43 @@ mod tests {
             ack_max < e2e_max,
             "the ack RTT ({ack_max}) is the produce leg only, strictly below the e2e delivery \
              tail ({e2e_max}) here"
+        );
+    }
+
+    #[test]
+    fn no_fsync_spawns_an_interval_durability_broker_and_the_default_stays_sync() {
+        // #1027 DISCRIMINATOR: `--no-fsync` must relax the spawned broker's PRODUCE durability to
+        // `interval` (the bounded-loss page-cache tier) IN ADDITION to batching the cursor
+        // checkpoints. This FAILS on the pre-#1027 code, where only the checkpoint interval moved
+        // and the "page-cache dry run" silently measured the per-ack `sync` fsync tier.
+        let dry = bench_serve_config(&cfg_of(&["--count", "10", "--no-fsync"]));
+        assert_eq!(
+            dry.durability_level,
+            DurabilityLevelArg::Interval,
+            "--no-fsync must materialize interval durability on the spawned broker"
+        );
+        assert_eq!(
+            dry.checkpoint_interval, 1_000_000,
+            "the checkpoint relaxation is kept alongside the durability relaxation"
+        );
+        // The relaxed level must still pass the REAL serve boot gates (interval needs at least one
+        // positive flush trigger and is not `--async-loss-ack`-gated), or the spawn would refuse.
+        crate::validate_serve_config(&dry).expect("the --no-fsync bench config boots");
+        // And the audit surface says so: the materialized-config line the run logs names the tier.
+        let line = materialized_config_line(&dry, "127.0.0.1:0", None);
+        assert!(
+            line.contains("durability_level=interval") && line.contains("power_loss_safe=false"),
+            "the materialized-config line must name the interval tier: {line}"
+        );
+        // WITHOUT the flag the honest default is untouched: per-ack sync durability, per-ack
+        // checkpoint, and the line says so.
+        let honest = bench_serve_config(&cfg_of(&["--count", "10"]));
+        assert_eq!(honest.durability_level, DurabilityLevelArg::Sync);
+        assert_eq!(honest.checkpoint_interval, 1);
+        let line = materialized_config_line(&honest, "127.0.0.1:0", None);
+        assert!(
+            line.contains("durability_level=sync") && line.contains("power_loss_safe=true"),
+            "the default bench broker stays on the power-loss-safe sync tier: {line}"
         );
     }
 

--- a/crates/ironbus-cli/src/main.rs
+++ b/crates/ironbus-cli/src/main.rs
@@ -1168,7 +1168,10 @@ Notes:
     instead of n (#450). Every ack keeps its fsynced-durable meaning; only WHEN the publisher
     awaits changes. 1 is the historical one-awaited-ack-per-publish path.
     <secs> or --count <n> is REQUIRED (no unbounded default), and --no-fsync is a dry run that
-    batches the bench broker's cursor checkpoints (the fsync cost is then reported as not measured).
+    runs the spawned isolated broker at INTERVAL durability (bounded-loss page-cache acks, the
+    honest relaxed tier a real serve --durability-level interval runs, #1027) and batches its
+    cursor checkpoints (the fsync cost is then reported as not measured); the spawned broker's
+    materialized-config line on stderr names the effective tier either way.
     round-trip mode (the default) measures producer-to-consumer latency through the real durable
     path, so the fsync-cost number is honest. Payloads are realistic (compressible, codec-friendly)
     by default; --payload-shape random uses incompressible noise. bench --storage memory spawns the

--- a/crates/ironbus-cli/tests/bench.rs
+++ b/crates/ironbus-cli/tests/bench.rs
@@ -286,17 +286,40 @@ fn round_trip_reports_ack_percentiles_from_the_awaited_producer_leg() {
 fn no_fsync_dry_run_flags_the_cost_not_measured() {
     let out = run_bench(&["--count", "100", "--no-fsync", "--json"]);
     let stdout = String::from_utf8_lossy(&out.stdout);
-    assert!(
-        out.status.success(),
-        "stderr: {}",
-        String::from_utf8_lossy(&out.stderr)
-    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(out.status.success(), "stderr: {stderr}");
     assert!(stdout.contains("\"no_fsync\":true"), "json: {stdout}");
     assert!(
         stdout.contains("\"fsync_measured\":false"),
         "json: {stdout}"
     );
     assert!(stdout.contains("\"fsync_cost_us\":null"), "json: {stdout}");
+    // #1027 TEETH: the spawned broker must MATERIALIZE the relaxed tier, not just batch the
+    // checkpoints — the stderr materialized-config line names the effective durability level the
+    // dry run really measured. This FAILS on the pre-#1027 code (which stayed on `sync` and
+    // emitted no materialized-config line at all).
+    assert!(
+        stderr.contains("materialized-config")
+            && stderr.contains("durability_level=interval")
+            && stderr.contains("power_loss_safe=false"),
+        "the --no-fsync spawned broker must run (and report) interval durability; stderr: {stderr}"
+    );
+}
+
+#[test]
+fn the_default_spawned_broker_reports_the_sync_tier_on_its_materialized_config_line() {
+    // The #1027 counterpart: WITHOUT --no-fsync the spawned broker stays on the power-loss-safe
+    // per-ack sync tier, and its stderr materialized-config line says so, so an honest run's
+    // numbers are auditable as sync-tier numbers.
+    let out = run_bench(&["--count", "50", "--mode", "publish", "--json"]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(out.status.success(), "stderr: {stderr}");
+    assert!(
+        stderr.contains("materialized-config")
+            && stderr.contains("durability_level=sync")
+            && stderr.contains("power_loss_safe=true"),
+        "the default spawned broker must run (and report) sync durability; stderr: {stderr}"
+    );
 }
 
 #[test]

--- a/crates/ironbus-client-async/src/lib.rs
+++ b/crates/ironbus-client-async/src/lib.rs
@@ -1862,6 +1862,20 @@ mod tests {
     use super::*;
 
     #[test]
+    fn the_default_streaming_fetch_window_is_pinned_at_2048() {
+        // #1027 PIN (async port): the re-exported sync-client default is the peer-comparable 2048
+        // window (the measured ~1M rec/s streaming-drain plateau point, and the broker's default
+        // per-consumer credit ceiling); 256 left a tight drain loop round-trip-latency-bound. This
+        // FAILS if the re-export drifts from the pinned sizing.
+        assert_eq!(DEFAULT_STREAM_FETCH_RECORDS, 2048);
+        assert_eq!(
+            StreamConsumerConfig::default().max_records,
+            DEFAULT_STREAM_FETCH_RECORDS,
+            "the config default rides the pinned constant"
+        );
+    }
+
+    #[test]
     fn ingest_delivery_caps_the_aggregate_decompressed_bytes() {
         // #879 (async port): the running aggregate of materialized payload bytes is bounded across a
         // fetch window, not just per-record. Once the running total would exceed the ceiling the batch

--- a/crates/ironbus-client/src/lib.rs
+++ b/crates/ironbus-client/src/lib.rs
@@ -622,11 +622,16 @@ const STREAM_FLUSH_BYTES: usize = 32 * 1024;
 pub const DEFAULT_PIPELINE_WINDOW: usize = 64;
 
 /// The default streaming-consumer fetch window (Tier-S, #550): the `max_records` a
-/// [`StreamingConsumer`]'s [`StreamingConsumer::next_batch`] pulls per `StreamFetch`. Sized to
-/// amortize the per-round-trip cost across a healthy batch while staying within a typical negotiated
-/// per-consumer credit (the actual pull is capped at the negotiated credit, #292). Configurable via
+/// [`StreamingConsumer`]'s [`StreamingConsumer::next_batch`] pulls per `StreamFetch`. 2048, not
+/// 256 (#1027): at 256 a tight drain loop is round-trip-latency-bound (~700 fetch RTTs/s of
+/// ~1.4 ms each drained 128 B records at ~180k msg/s on the baseline rig, even with read-ahead),
+/// while 2048 reaches the ~1M rec/s per-record plateau there (969k-1217k msg/s at 128 B; 8192
+/// measured 931k, no further gain). 2048 is PEER-COMPARABLE consumer sizing (a stock Kafka
+/// consumer fetches ~50 MB / 500+ records per poll) and exactly the broker's default per-consumer
+/// credit ceiling, which the actual pull is capped at anyway (the negotiated credit, #292), so the
+/// default never over-asks a default broker. Configurable via
 /// [`StreamConsumerConfig::max_records`].
-pub const DEFAULT_STREAM_FETCH_RECORDS: u32 = 256;
+pub const DEFAULT_STREAM_FETCH_RECORDS: u32 = 2048;
 
 /// The default periodic-commit cadence (Tier-S, #550): a [`StreamingConsumer`] auto-commits its
 /// cumulative offset once every this-many fetched windows (and always when the stream drains or the
@@ -3667,6 +3672,20 @@ pub struct FlushSummary {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn the_default_streaming_fetch_window_is_pinned_at_2048() {
+        // #1027 PIN: 2048 is peer-comparable consumer sizing (a stock Kafka consumer pulls 500+
+        // records / ~50 MB per poll), the measured ~1M rec/s streaming-drain plateau point, and
+        // exactly the broker's default per-consumer credit ceiling the pull is capped at; 256 left
+        // a tight drain loop round-trip-latency-bound. This FAILS if the default drifts.
+        assert_eq!(DEFAULT_STREAM_FETCH_RECORDS, 2048);
+        assert_eq!(
+            StreamConsumerConfig::default().max_records,
+            DEFAULT_STREAM_FETCH_RECORDS,
+            "the config default rides the pinned constant"
+        );
+    }
 
     #[test]
     fn client_error_source_chain_exposes_the_wrapped_inner_cause() {


### PR DESCRIPTION
Implements #1027 (bench-driver only). (1) `--no-fsync` now genuinely relaxes the SPAWNED isolated broker to interval durability (bounded-loss page-cache; materialized-config line proves it) — previously it only raised checkpoint_interval and the broker stayed Sync, so the published 'page-cache' P3 row measured the fsync tier (226 msg/s → 35.3k at 1KiB with the fix, stock engine). (2) Streaming-consume DEFAULT_FETCH_BATCH 256 → 2048 (= the broker's DEFAULT_CREDIT_CEILING; fb 256 was round-trip-latency-bound at ~180k msg/s vs 969k-1217k at 2048 — peer-comparable consumer sizing; --fetch-batch override honored). Post-review fix: the fsync-cost wording is now gated on `cfg.no_fsync` (the overlapped disk paths get an honest 'not attributed' line instead of a false dry-run claim), extracted to `write_fsync_cost_line`.

fmt/clippy(pedantic)/541 tests green. Reviewed across 2 adversarial lenses (HONESTY initially BLOCKed on the wording gate — fixed as above; REGRESS: SHIP_WITH_NITS).

Closes #1027

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>