### PR TITLE
feat(storage,engine): prep API for the pipelined sync tier — Arc'd writer, staged async barrier, async-commit seam (#1040, 1/2)

### DIFF
--- a/crates/ironbus-bench/src/inproc.rs
+++ b/crates/ironbus-bench/src/inproc.rs
@@ -105,6 +105,7 @@ fn engine_config_with_credit(consumer_credit: u32, max_in_flight: u32) -> Engine
         fire_and_forget_refill_ms: 0,
         egress_limit: 0,
         wal_fsync_headroom_bytes: 0,
+        sync_max_dirty_bytes: 0,
         // Compression OFF (#430): the in-process self-test proves the open-loop latency harness,
         // not the codec, and its recorded baselines predate the wiring (decision 2026-06-10).
         compression: ironbus_core::compress::Codec::None,

--- a/crates/ironbus-cli/src/admin.rs
+++ b/crates/ironbus-cli/src/admin.rs
@@ -700,6 +700,7 @@ mod tests {
                 fire_and_forget_refill_ms: 0,
                 egress_limit: 0,
                 wal_fsync_headroom_bytes: 0,
+                sync_max_dirty_bytes: 0,
                 // Compression OFF (#430): the admin tests pin the historical byte-identical image.
                 compression: ironbus_core::compress::Codec::None,
                 // V2-M4 routing richness defaults to inert here (#549/#551): no message TTL, no

--- a/crates/ironbus-cli/src/main.rs
+++ b/crates/ironbus-cli/src/main.rs
@@ -9284,6 +9284,11 @@ fn open_engine_with<F: Filesystem + Clone>(
             // drain under `sync` / the interval window under a relaxed level), so a zero-config
             // broker is unchanged; a non-zero value is the opt-in tight RAM / loss-window bound.
             wal_fsync_headroom_bytes: config.wal_fsync_headroom_bytes,
+            // The pipelined sync tier's dirty-byte bound (#1040) at its shipped default (16 MiB).
+            // PLUMBING ONLY today — nothing enforces it until the pipelined actor loop lands, so
+            // a zero-config broker is byte-for-byte unchanged; the `--sync-max-dirty-bytes` flag
+            // arrives with that activation PR.
+            sync_max_dirty_bytes: ironbus_server::engine::DEFAULT_SYNC_MAX_DIRTY_BYTES,
             // The per-record write-path compression codec (#430, ADR-0003), wired from
             // `--compression` (default `lz4`). `none` stores every record raw, byte-for-byte the
             // historical layout; `zstd` was already rejected at parse on this build, so the two
@@ -14818,6 +14823,7 @@ mod tests {
                 fire_and_forget_refill_ms: 0,
                 egress_limit: 0,
                 wal_fsync_headroom_bytes: 0,
+                sync_max_dirty_bytes: 0,
                 // V2-M4 routing richness defaults to inert here (#549/#551): no message TTL, no
                 // dead-letter exchange (the existing fixed-DLQ behavior) — back-compat byte-identical.
                 default_message_ttl_ms: 0,
@@ -15765,6 +15771,7 @@ mod tests {
                 fire_and_forget_refill_ms: 0,
                 egress_limit: 0,
                 wal_fsync_headroom_bytes: 0,
+                sync_max_dirty_bytes: 0,
                 // V2-M4 routing richness defaults to inert here (#549/#551): no message TTL, no
                 // dead-letter exchange (the existing fixed-DLQ behavior) — back-compat byte-identical.
                 default_message_ttl_ms: 0,
@@ -15850,6 +15857,7 @@ mod tests {
                 fire_and_forget_refill_ms: 0,
                 egress_limit: 0,
                 wal_fsync_headroom_bytes: 0,
+                sync_max_dirty_bytes: 0,
                 // V2-M4 routing richness defaults to inert here (#549/#551): no message TTL, no
                 // dead-letter exchange (the existing fixed-DLQ behavior) — back-compat byte-identical.
                 default_message_ttl_ms: 0,
@@ -19556,6 +19564,7 @@ mod tests {
                 fire_and_forget_refill_ms: 0,
                 egress_limit: 0,
                 wal_fsync_headroom_bytes: 0,
+                sync_max_dirty_bytes: 0,
                 // V2-M4 routing richness defaults to inert here (#549/#551): no message TTL, no
                 // dead-letter exchange (the existing fixed-DLQ behavior) — back-compat byte-identical.
                 default_message_ttl_ms: 0,
@@ -19640,6 +19649,7 @@ mod tests {
                 fire_and_forget_refill_ms: 0,
                 egress_limit: 0,
                 wal_fsync_headroom_bytes: 0,
+                sync_max_dirty_bytes: 0,
                 // V2-M4 routing richness defaults to inert here (#549/#551): no message TTL, no
                 // dead-letter exchange (the existing fixed-DLQ behavior) — back-compat byte-identical.
                 default_message_ttl_ms: 0,

--- a/crates/ironbus-client-async/tests/roundtrip.rs
+++ b/crates/ironbus-client-async/tests/roundtrip.rs
@@ -63,6 +63,7 @@ fn start_server() -> (SocketAddr, Arc<AtomicBool>, JoinHandle<()>) {
             fire_and_forget_refill_ms: 0,
             egress_limit: 0,
             wal_fsync_headroom_bytes: 0,
+            sync_max_dirty_bytes: 0,
             compression: ironbus_core::compress::Codec::None,
             default_message_ttl_ms: 0,
             dead_letter_exchange: None,

--- a/crates/ironbus-client/src/lib.rs
+++ b/crates/ironbus-client/src/lib.rs
@@ -4017,6 +4017,7 @@ mod tests {
                 fire_and_forget_refill_ms: 0,
                 egress_limit: 0,
                 wal_fsync_headroom_bytes: 0,
+                sync_max_dirty_bytes: 0,
                 // The write-path codec under test (#430): `None` for every historical test
                 // (byte-identical broker), `Lz4` for the transparency end-to-end test.
                 compression,
@@ -4077,6 +4078,7 @@ mod tests {
                 fire_and_forget_refill_ms: 0,
                 egress_limit: 0,
                 wal_fsync_headroom_bytes: 0,
+                sync_max_dirty_bytes: 0,
                 compression: ironbus_core::compress::Codec::None,
                 default_message_ttl_ms: 0,
                 dead_letter_exchange: None,
@@ -7663,6 +7665,7 @@ mod tests {
                 fire_and_forget_refill_ms: 0,
                 egress_limit: 0,
                 wal_fsync_headroom_bytes: 0,
+                sync_max_dirty_bytes: 0,
                 compression: ironbus_core::compress::Codec::None,
                 default_message_ttl_ms: 0,
                 dead_letter_exchange: None,
@@ -7983,6 +7986,7 @@ mod tests {
             fire_and_forget_refill_ms: 0,
             egress_limit: 0,
             wal_fsync_headroom_bytes: 0,
+            sync_max_dirty_bytes: 0,
             compression: ironbus_core::compress::Codec::None,
             default_message_ttl_ms: 0,
             dead_letter_exchange: None,

--- a/crates/ironbus-server/src/actor.rs
+++ b/crates/ironbus-server/src/actor.rs
@@ -2127,6 +2127,7 @@ mod tests {
             fire_and_forget_refill_ms: 0,
             egress_limit: 0,
             wal_fsync_headroom_bytes: 0,
+            sync_max_dirty_bytes: 0,
             // Compression OFF (#430): the actor tests pin the historical byte-identical image;
             // the engine compression tests cover the lz4 path.
             compression: ironbus_core::compress::Codec::None,

--- a/crates/ironbus-server/src/engine.rs
+++ b/crates/ironbus-server/src/engine.rs
@@ -48,13 +48,14 @@ use ironbus_storage::checkpoint::{
 };
 use ironbus_storage::dlq::{DeadLetterReason, DlqSink, DLQ_SUBDIR};
 use ironbus_storage::fs::Filesystem;
-use ironbus_storage::log::{Append, Log, LogConfig, RetentionBounds};
+use ironbus_storage::log::{Append, Log, LogConfig, RetentionBounds, SyncTicket};
 use ironbus_storage::loss::LossReport;
 use ironbus_storage::naming::MAX_STREAM_NAME_LEN;
 use ironbus_storage::segment::{OwnedRecord, RawByteRun, StorageError};
 use ironbus_storage::streamset::{CommitOutcome, StreamError, StreamId, StreamSet};
 use ironbus_storage::txn::{TxnStore, TxnStoreError};
 use std::collections::BTreeMap;
+use std::sync::Arc;
 
 /// What the engine does with a produce that would exceed the durable-log byte cap
 /// ([`LogConfig::max_total_bytes`]): the overflow policy (#82). The default, [`DiskFullPolicy::DropNew`],
@@ -511,6 +512,20 @@ pub struct EngineConfig {
     /// empty backlog always admits the next record). See [`ironbus_core::backpressure::FsyncHeadroom`]
     /// and `docs/BACKPRESSURE.md`.
     pub wal_fsync_headroom_bytes: u64,
+    /// The PIPELINED sync tier's dirty-byte admission bound (#1040): once the append actor's
+    /// pipelined branch decouples the covering `fdatasync` from the append path, this bounds the
+    /// UNSYNCED record bytes ([`Engine::unsynced_bytes`], the log's own meter — no shadow state)
+    /// that may accumulate behind the one in-flight barrier before a new produce is THROTTLED
+    /// (block for one completion; dispatch-before-block, never shed — today's sync-tier
+    /// semantics), with the one-record floor so an oversized produce never wedges. Distinct from
+    /// [`EngineConfig::wal_fsync_headroom_bytes`] (#378), which keeps its drain-then-admit
+    /// semantics unchanged.
+    ///
+    /// The default is [`DEFAULT_SYNC_MAX_DIRTY_BYTES`] (16 MiB); `0` DISABLES the bound. CONFIG
+    /// PLUMBING ONLY in this change: the value is snapshotted at spawn by the pipelined actor
+    /// branch (the #1040 activation PR) and NOTHING enforces it until then, so any value is inert
+    /// today and a zero-config broker is byte-for-byte unchanged.
+    pub sync_max_dirty_bytes: u64,
     /// The PER-RECORD payload compression codec for NEW writes (#430, refs #387, #12, #75; ADR-0003):
     /// the produce path compresses each record's payload into the self-describing stored object
     /// (the 9-byte descriptor then the codec stream) behind [`RecordFlags::COMPRESSED`], applied at
@@ -553,6 +568,29 @@ pub struct EngineConfig {
     /// is configured; with no DLX an expired message is always reclaimed by retention.
     pub dead_letter_expired: bool,
 }
+
+/// One PIPELINED async commit in flight (#1040): the engine-level pairing of the storage
+/// [`SyncTicket`] staged by [`Engine::begin_async_commit`] with the #570 produce->ack window
+/// stamp taken at dispatch. The append actor's pipelined branch carries it OPAQUELY across the
+/// flusher's `fdatasync` and hands it back to [`Engine::complete_async_commit`] once the barrier
+/// has RETURNED successfully — never before (I2: an ack must imply durable). On a FAILED barrier
+/// it is dropped and [`Engine::fail_async_commit`] freezes the writer instead.
+#[derive(Clone, Copy, Debug)]
+pub struct AsyncCommit {
+    /// The staged storage-barrier snapshot ([`ironbus_storage::log::SyncTicket`]), applied
+    /// all-or-nothing by the log on completion (a stale ticket is a FULL no-op).
+    pub(crate) ticket: SyncTicket,
+    /// The clock-seam instant [`Engine::begin_async_commit`] stamped, so the produce->ack
+    /// histogram's window includes the barrier's queueing, the flight, AND the completion
+    /// delivery — the honest producer-visible ack latency on this tier (#570 semantics).
+    produce_ack_start: u64,
+}
+
+/// What [`Engine::begin_async_commit`] stages for a DIRTIED log (#1040): the SHARED
+/// active-segment fd the flusher's `fdatasync` runs on, paired with the opaque [`AsyncCommit`]
+/// to hand back on completion. `None` = the log is CLEAN (no barrier owed) — distinct by
+/// construction from a FROZEN writer, which is an `Err`, never a clean `None`.
+pub type StagedAsyncCommit<F> = Option<(Arc<F>, AsyncCommit)>;
 
 /// An error from the engine.
 #[derive(Debug)]
@@ -1916,6 +1954,16 @@ pub const DEFAULT_CONSUMER_CREDIT: u32 = ironbus_core::backpressure::DEFAULT_CRE
 /// guard). See [`EngineConfig::consumer_credit_bytes`].
 pub const DEFAULT_CONSUMER_CREDIT_BYTES: u64 = 8 * 1024 * 1024;
 
+/// The default pipelined-sync-tier dirty-byte admission bound (#1040): the most UNSYNCED record
+/// bytes the append actor's pipelined branch lets accumulate behind an in-flight `fdatasync`
+/// before it throttles new produces (block for one completion, never shed). 16 MiB: deep enough
+/// that a healthy disk's one-flight window (a few ms of appends) never touches it, small enough
+/// to bound both the actor-side parked-ack memory and a producer's worst-case unacked exposure on
+/// a wedged disk. `0` disables the bound. CONFIG PLUMBING ONLY today: the value is carried and
+/// exposed ([`Engine::sync_max_dirty_bytes`]) but NOTHING enforces it until the pipelined actor
+/// loop lands (the #1040 activation PR). See [`EngineConfig::sync_max_dirty_bytes`].
+pub const DEFAULT_SYNC_MAX_DIRTY_BYTES: u64 = 16 * 1024 * 1024;
+
 /// The default cap on the number of live work-groups per engine, INCLUDING the durable default
 /// (refs #240, #9, #10): bounds total consumer-state memory once the wire can name groups, so an
 /// unauthenticated client cannot exhaust memory by naming endless groups. A non-zero, defensible
@@ -2778,6 +2826,11 @@ pub struct Engine<F: Filesystem, C: Clock> {
     /// `commit_batch` forces an `fdatasync`. `0` disables the byte trigger. Only consulted under
     /// [`DurabilityLevel::Interval`]. See [`EngineConfig::flush_max_bytes`].
     flush_max_bytes: u64,
+    /// The pipelined sync tier's dirty-byte admission bound (#1040), carried from
+    /// [`EngineConfig::sync_max_dirty_bytes`] so the append actor's pipelined branch can snapshot
+    /// it at spawn ([`Engine::sync_max_dirty_bytes`]). `0` disables. PLUMBING ONLY today: nothing
+    /// in the engine enforces it (the throttle lives in the #1040 activation PR's actor loop).
+    sync_max_dirty_bytes: u64,
     /// The monotonic-clock instant (nanoseconds, via the clock seam, never a raw `Instant::now`) of
     /// the LAST completed `fdatasync` under a relaxed level, the time-window anchor for `interval`
     /// (#341). Seeded to the engine's open instant (a fresh broker's first record is at most one
@@ -3166,6 +3219,9 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
             durability_level: config.durability_level,
             flush_interval_nanos: config.flush_interval_ms.saturating_mul(1_000_000),
             flush_max_bytes: config.flush_max_bytes,
+            // The pipelined tier's dirty-byte bound (#1040): carried for the actor's spawn-time
+            // snapshot; nothing enforces it until the pipelined actor loop lands.
+            sync_max_dirty_bytes: config.sync_max_dirty_bytes,
             last_sync_monotonic_nanos: opened_at,
             last_fsync_nanos: 0,
             // The runtime backpressure controllers (#68, #69), prebuilt above. Held outside the
@@ -6115,6 +6171,141 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         }
     }
 
+    /// BEGINS a pipelined async commit (#1040): stages the log's covering barrier
+    /// ([`Log::prepare_async_sync`] — pending bytes into the file, NEITHER head advanced) and
+    /// returns the shared fd handle for the flusher's off-actor `fdatasync` plus the opaque
+    /// [`AsyncCommit`] to hand back to [`Engine::complete_async_commit`] once that barrier has
+    /// RETURNED successfully. `Ok(None)` means the log is CLEAN (no barrier owed) — distinct by
+    /// construction from a FROZEN writer, which is an `Err` (fatal for the caller's reply
+    /// fan-out), never a clean `None`.
+    ///
+    /// The #570 produce->ack window stamp is taken here, BEFORE the barrier is dispatched,
+    /// exactly where [`Engine::commit_batch`] stamps before its inline barrier — so on this tier
+    /// the recorded window honestly includes the flight and the completion delivery.
+    ///
+    /// # Errors
+    /// Returns the fatal [`StorageError::WriterFrozen`] if the writer is frozen (or froze while
+    /// staging), or the raw transient error from a deferred-roll retry (#867), exactly as the
+    /// inline `commit_batch` barrier surfaces them.
+    pub fn begin_async_commit(&mut self) -> Result<StagedAsyncCommit<F::File>, EngineError> {
+        let produce_ack_start = self.log.now_monotonic();
+        let staged = self.log.prepare_async_sync()?;
+        Ok(staged.map(|(file, ticket)| {
+            (
+                file,
+                AsyncCommit {
+                    ticket,
+                    produce_ack_start,
+                },
+            )
+        }))
+    }
+
+    /// Step 1 of completing a pipelined async commit (#1040), run on the actor the moment the
+    /// flusher reports the barrier RETURNED `Ok`: applies the staged ticket to the log (both
+    /// heads to the snapshotted target, byte meter, seek index, read-plane frontier — with the
+    /// log's all-or-nothing staleness guard, so a stale completion touches NOTHING) and records
+    /// the barrier into the fsync / append-latency / produce->ack histograms, exactly the
+    /// bookkeeping [`Engine::commit_batch`] does inline for a real barrier. `fsync_nanos` is the
+    /// flusher's measured wall-clock barrier duration (the sim never runs the flusher thread).
+    /// Also re-anchors the `interval` window ([`Engine::commit_durability_barrier`]'s
+    /// `last_sync_monotonic_nanos`) to this completed barrier, keeping the anchor coherent with
+    /// "the last completed fdatasync".
+    ///
+    /// Cheap and infallible; the caller dispatches the NEXT barrier and releases the covered
+    /// acks before running the heavier [`Engine::commit_tail_after_async_completion`].
+    pub fn complete_async_commit(&mut self, commit: &AsyncCommit, fsync_nanos: u64) {
+        self.log.complete_async_sync(&commit.ticket);
+        // A real fsync covered this window: record it exactly as `commit_batch` records an
+        // inline barrier (one sample per barrier into each histogram, allocation-free).
+        self.last_fsync_nanos = fsync_nanos;
+        self.fsync.observe(fsync_nanos);
+        self.registry.observe_fsync_nanos(fsync_nanos);
+        self.registry.observe_append_nanos(fsync_nanos);
+        // The produce->ack window (#570): from the dispatch stamp to NOW, so it includes the
+        // flight and the completion delivery — the honest producer-visible ack latency.
+        let now = self.log.now_monotonic();
+        self.registry
+            .observe_produce_ack_nanos(now.saturating_sub(commit.produce_ack_start));
+        // Interval-anchor coherence: the next window measures from the last COMPLETED barrier.
+        self.last_sync_monotonic_nanos = now;
+    }
+
+    /// Step 2 of completing a pipelined async commit (#1040), run AFTER the caller dispatched
+    /// the next barrier and released the covered acks (bookkeeping must never idle the disk or
+    /// the producers): the once-per-commit tail of [`Engine::commit_batch`], split out verbatim —
+    /// the consumer-safe retention reap, the idle-group sweep, and the L2 confirm-timeout sweep.
+    ///
+    /// # Errors
+    /// Propagates a storage error from the retention reap or the idle-group sweep, exactly as
+    /// `commit_batch` does; the caller treats it as fatal (freeze + fan out), noting the acks
+    /// already released were covered by a RETURNED barrier, so I2 still holds.
+    pub fn commit_tail_after_async_completion(&mut self) -> Result<(), EngineError> {
+        // Consumer-safe retention (refs #13, #80): reclaim disk once per completed barrier (the
+        // pipelined tier's once-per-group-commit cadence), never a segment a consumer needs.
+        self.reap_for_retention()?;
+        // Idle named-group eviction sweep (#277) on the same deterministic produce-seam tick.
+        let now = self.log.now_monotonic();
+        self.sweep_idle_groups(now)?;
+        // The Level-2 confirm-timeout sweep (#497), riding the same tick.
+        self.sweep_l2_confirm_timeouts();
+        Ok(())
+    }
+
+    /// The pipelined async commit's barrier FAILED on the flusher (#1040): freeze the writer
+    /// into the exact terminal state a failed inline [`Log::sync`] leaves (fatal, never retried,
+    /// un-resurrectable), and return the fatal error for the caller's reply fan-out. After this,
+    /// every later append/sync/stage surfaces [`StorageError::WriterFrozen`], no new barrier can
+    /// ever be staged ([`Engine::begin_async_commit`] errors), and no ack is ever released past
+    /// the failed barrier. Idempotent.
+    #[must_use]
+    pub fn fail_async_commit(&mut self) -> EngineError {
+        self.log.freeze_after_external_sync_failure();
+        EngineError::Storage(StorageError::WriterFrozen)
+    }
+
+    /// Whether the log has appended records not yet covered by a RETURNED `fdatasync` (#1040):
+    /// the pipelined dispatch gate — a dirtied log owes a barrier. A FROZEN writer reports
+    /// `false` (it can never be made durable), so a dispatch seam must distinguish frozen from
+    /// clean via [`Engine::begin_async_commit`]'s `Err`, never via this predicate alone.
+    #[must_use]
+    pub fn has_unsynced_records(&self) -> bool {
+        self.log.has_unsynced_records()
+    }
+
+    /// Whether the log's writer is still LIVE (not permanently frozen by a failed durability
+    /// barrier) (#1040): the freeze-reconcile predicate the pipelined actor branch consults at
+    /// its reconcile points. A transiently-deferred roll (#867) reports `true` (resumable).
+    #[must_use]
+    pub fn log_is_writable(&self) -> bool {
+        self.log.is_writable()
+    }
+
+    /// The DURABLE head: the first offset NOT yet covered by a RETURNED `fdatasync`
+    /// ([`Log::synced_offset`]) (#1040). The pipelined ack rule releases a parked produce reply
+    /// only once its covering target is at or below this head (ack-implies-durable, I2).
+    #[must_use]
+    pub fn durable_offset(&self) -> Offset {
+        self.log.synced_offset()
+    }
+
+    /// The APPENDED head: the offset the NEXT appended record will receive
+    /// ([`Log::next_offset`]) (#1040). The pipelined branch stamps each parked produce reply
+    /// with this head AFTER its append — the reply's covering target.
+    #[must_use]
+    pub fn append_head(&self) -> Offset {
+        self.log.next_offset()
+    }
+
+    /// The configured pipelined-tier dirty-byte admission bound (#1040):
+    /// [`EngineConfig::sync_max_dirty_bytes`], for the append actor's spawn-time snapshot. `0`
+    /// means DISABLED. Fixed for the engine's life (not live-reloadable). PLUMBING ONLY today:
+    /// nothing enforces it until the pipelined actor loop lands.
+    #[must_use]
+    pub fn sync_max_dirty_bytes(&self) -> u64 {
+        self.sync_max_dirty_bytes
+    }
+
     /// Whether the `interval` level's flush window is DUE this commit (#341): true when the time
     /// window has elapsed since the last completed `fdatasync` OR the accumulated unsynced record
     /// bytes have reached the byte budget. A trigger of `0` is DISABLED (that dimension never fires),
@@ -8700,6 +8891,7 @@ mod tests {
             fire_and_forget_refill_ms: 0,
             egress_limit: 0,
             wal_fsync_headroom_bytes: 0,
+            sync_max_dirty_bytes: 0,
             // Compression OFF in the shared test config (#430), so every existing test's disk
             // image stays byte-identical to the pre-compression broker; the compression tests
             // build a config with `Codec::Lz4` explicitly.
@@ -8740,6 +8932,137 @@ mod tests {
             Poll::Message(d) => d,
             other => panic!("expected a message, got {other:?}"),
         }
+    }
+
+    // --- The pipelined async-commit API (#1040): begin/complete/tail/fail + passthroughs ---
+
+    #[test]
+    fn an_async_commit_cycle_stages_completes_and_advances_the_durable_head() {
+        use ironbus_storage::io::RandomAccessFile as _;
+        let mut e = open(config(10, 5));
+        e.append_no_sync(&Append {
+            timestamp_ms: 0,
+            flags: RecordFlags::EMPTY,
+            key: b"",
+            headers: b"",
+            payload: b"record",
+        })
+        .unwrap();
+        // Appended but not committed: the passthroughs report one barrier owed.
+        assert!(e.has_unsynced_records());
+        assert!(e.log_is_writable());
+        assert_eq!(e.durable_offset(), Offset::ZERO);
+        assert_eq!(e.append_head(), Offset::new(1));
+
+        let fsyncs_before = e.fsync_histogram().count();
+        let (file, commit) = e.begin_async_commit().unwrap().expect("one barrier owed");
+        // Staging touches NEITHER head and records no histogram sample: nothing is durable (or
+        // visible) until the external barrier RETURNS.
+        assert_eq!(e.durable_offset(), Offset::ZERO);
+        assert_eq!(e.flushed_offset(), Offset::ZERO);
+        assert_eq!(e.fsync_histogram().count(), fsyncs_before);
+
+        // The flusher's half: the covering fdatasync on the shared handle, then the completion.
+        file.sync_data().unwrap();
+        e.complete_async_commit(&commit, 1_234);
+        assert_eq!(e.durable_offset(), Offset::new(1));
+        assert_eq!(e.flushed_offset(), Offset::new(1));
+        assert!(!e.has_unsynced_records());
+        assert_eq!(e.unsynced_bytes(), 0);
+        // Exactly ONE real barrier was recorded, with the flusher's measured duration.
+        assert_eq!(e.fsync_histogram().count(), fsyncs_before + 1);
+        // The split-out commit tail (reap + sweeps) runs cleanly after the completion.
+        e.commit_tail_after_async_completion().unwrap();
+        // Clean now: no further barrier owed.
+        assert!(e.begin_async_commit().unwrap().is_none());
+    }
+
+    #[test]
+    fn begin_async_commit_on_a_clean_engine_is_none() {
+        let mut e = open(config(10, 5));
+        // A fresh engine owes no barrier...
+        assert!(e.begin_async_commit().unwrap().is_none());
+        // ...and one whose produce committed inline (the synchronous path) owes none either.
+        produce(&mut e, b"a");
+        assert!(!e.has_unsynced_records());
+        assert!(e.begin_async_commit().unwrap().is_none());
+    }
+
+    #[test]
+    fn fail_async_commit_freezes_the_writer_and_begin_becomes_an_error() {
+        let mut e = open(config(10, 5));
+        e.append_no_sync(&Append {
+            timestamp_ms: 0,
+            flags: RecordFlags::EMPTY,
+            key: b"",
+            headers: b"",
+            payload: b"doomed",
+        })
+        .unwrap();
+        // The barrier failed on the flusher: the engine freezes the writer and hands back the
+        // fatal error for the reply fan-out.
+        let err = e.fail_async_commit();
+        assert!(
+            err.is_fatal(),
+            "a failed external barrier is the fatal class"
+        );
+        assert!(!e.log_is_writable());
+        // Frozen is an ERROR at the dispatch seam, never a clean None (the L1 conflation): the
+        // pipeline can never re-arm against the frozen writer.
+        assert!(e.begin_async_commit().is_err());
+        // A frozen writer reports no unsynced records — which is exactly why the dispatch seam
+        // must use `begin_async_commit`'s Err, never this predicate alone.
+        assert!(!e.has_unsynced_records());
+        // Idempotent.
+        let again = e.fail_async_commit();
+        assert!(again.is_fatal());
+    }
+
+    #[test]
+    fn a_stale_async_completion_after_an_inline_commit_is_a_full_no_op() {
+        let mut e = open(config(10, 5));
+        e.append_no_sync(&Append {
+            timestamp_ms: 0,
+            flags: RecordFlags::EMPTY,
+            key: b"",
+            headers: b"",
+            payload: b"first",
+        })
+        .unwrap();
+        let (_file, stale) = e.begin_async_commit().unwrap().expect("one barrier owed");
+        // An INLINE barrier (a Run job's commit_batch, a quiesce) overtakes the flight and
+        // covers everything, including a record appended after the stage.
+        e.append_no_sync(&Append {
+            timestamp_ms: 0,
+            flags: RecordFlags::EMPTY,
+            key: b"",
+            headers: b"",
+            payload: b"second",
+        })
+        .unwrap();
+        e.commit_batch().unwrap();
+        assert_eq!(e.durable_offset(), Offset::new(2));
+        // The late completion must not rewind the durable head or disturb the byte meter (the
+        // log-level all-or-nothing guard, INV-6, observed through the engine seam).
+        e.complete_async_commit(&stale, 42);
+        assert_eq!(e.durable_offset(), Offset::new(2), "no rewind");
+        assert_eq!(e.flushed_offset(), Offset::new(2));
+        assert_eq!(e.unsynced_bytes(), 0);
+    }
+
+    #[test]
+    fn sync_max_dirty_bytes_is_plumbed_from_config_and_defaults_to_16_mib() {
+        // Config plumbing only (#1040): the value is carried to the spawn-time snapshot seam and
+        // nothing else — the enforcement lands with the pipelined actor loop.
+        assert_eq!(DEFAULT_SYNC_MAX_DIRTY_BYTES, 16 * 1024 * 1024);
+        let e = open(EngineConfig {
+            sync_max_dirty_bytes: 123,
+            ..config(10, 5)
+        });
+        assert_eq!(e.sync_max_dirty_bytes(), 123);
+        // The shared test config keeps it disabled (0), the inert value.
+        let off = open(config(10, 5));
+        assert_eq!(off.sync_max_dirty_bytes(), 0);
     }
 
     #[test]

--- a/crates/ironbus-server/src/health.rs
+++ b/crates/ironbus-server/src/health.rs
@@ -2595,6 +2595,7 @@ mod tests {
             fire_and_forget_refill_ms: 0,
             egress_limit: 0,
             wal_fsync_headroom_bytes: 0,
+            sync_max_dirty_bytes: 0,
             // V2-M4 routing richness defaults to inert here (#549/#551): no message TTL, no
             // dead-letter exchange (the existing fixed-DLQ behavior) — back-compat byte-identical.
             default_message_ttl_ms: 0,
@@ -3024,6 +3025,7 @@ mod tests {
                 fire_and_forget_refill_ms: 0,
                 egress_limit: 0,
                 wal_fsync_headroom_bytes: 0,
+                sync_max_dirty_bytes: 0,
                 // V2-M4 routing richness defaults to inert here (#549/#551): no message TTL, no
                 // dead-letter exchange (the existing fixed-DLQ behavior) — back-compat byte-identical.
                 default_message_ttl_ms: 0,
@@ -3677,6 +3679,7 @@ mod tests {
                 fire_and_forget_refill_ms: 0,
                 egress_limit: 0,
                 wal_fsync_headroom_bytes: 0,
+                sync_max_dirty_bytes: 0,
                 // V2-M4 routing richness defaults to inert here (#549/#551): no message TTL, no
                 // dead-letter exchange (the existing fixed-DLQ behavior) — back-compat byte-identical.
                 default_message_ttl_ms: 0,
@@ -3823,6 +3826,7 @@ mod tests {
                 fire_and_forget_refill_ms: 0,
                 egress_limit: 0,
                 wal_fsync_headroom_bytes: 0,
+                sync_max_dirty_bytes: 0,
                 // V2-M4 routing richness defaults to inert here (#549/#551): no message TTL, no
                 // dead-letter exchange (the existing fixed-DLQ behavior) — back-compat byte-identical.
                 default_message_ttl_ms: 0,
@@ -3901,6 +3905,7 @@ mod tests {
                 fire_and_forget_refill_ms: 0,
                 egress_limit: 0,
                 wal_fsync_headroom_bytes: 0,
+                sync_max_dirty_bytes: 0,
                 // V2-M4 routing richness defaults to inert here (#549/#551): no message TTL, no
                 // dead-letter exchange (the existing fixed-DLQ behavior) — back-compat byte-identical.
                 default_message_ttl_ms: 0,
@@ -4178,6 +4183,7 @@ mod tests {
                     fire_and_forget_refill_ms: 0,
                     egress_limit: 0,
                     wal_fsync_headroom_bytes: 0,
+                    sync_max_dirty_bytes: 0,
                     // V2-M4 routing richness defaults to inert here (#549/#551): no message TTL, no
                     // dead-letter exchange (the existing fixed-DLQ behavior) — back-compat byte-identical.
                     default_message_ttl_ms: 0,
@@ -4235,6 +4241,7 @@ mod tests {
                 fire_and_forget_refill_ms: 0,
                 egress_limit: 0,
                 wal_fsync_headroom_bytes: 0,
+                sync_max_dirty_bytes: 0,
                 // V2-M4 routing richness defaults to inert here (#549/#551): no message TTL, no
                 // dead-letter exchange (the existing fixed-DLQ behavior) — back-compat byte-identical.
                 default_message_ttl_ms: 0,
@@ -4395,6 +4402,7 @@ mod tests {
                 fire_and_forget_refill_ms: 0,
                 egress_limit: 0,
                 wal_fsync_headroom_bytes: 0,
+                sync_max_dirty_bytes: 0,
                 // V2-M4 routing richness defaults to inert here (#549/#551): no message TTL, no
                 // dead-letter exchange (the existing fixed-DLQ behavior) — back-compat byte-identical.
                 default_message_ttl_ms: 0,
@@ -4535,6 +4543,7 @@ mod tests {
                 fire_and_forget_refill_ms: 0,
                 egress_limit: 0,
                 wal_fsync_headroom_bytes: 0,
+                sync_max_dirty_bytes: 0,
                 // V2-M4 routing richness defaults to inert here (#549/#551): no message TTL, no
                 // dead-letter exchange (the existing fixed-DLQ behavior) — back-compat byte-identical.
                 default_message_ttl_ms: 0,
@@ -4752,6 +4761,7 @@ mod tests {
                 fire_and_forget_refill_ms: 0,
                 egress_limit: 0,
                 wal_fsync_headroom_bytes: 0,
+                sync_max_dirty_bytes: 0,
                 // V2-M4 routing richness defaults to inert here (#549/#551): no message TTL, no
                 // dead-letter exchange (the existing fixed-DLQ behavior) — back-compat byte-identical.
                 default_message_ttl_ms: 0,
@@ -5796,6 +5806,7 @@ mod tests {
                 fire_and_forget_refill_ms: 0,
                 egress_limit: 0,
                 wal_fsync_headroom_bytes: 0,
+                sync_max_dirty_bytes: 0,
                 // V2-M4 routing richness defaults to inert here (#549/#551): no message TTL, no
                 // dead-letter exchange (the existing fixed-DLQ behavior) — back-compat byte-identical.
                 default_message_ttl_ms: 0,
@@ -6008,6 +6019,7 @@ mod tests {
                 fire_and_forget_refill_ms: 0,
                 egress_limit: 0,
                 wal_fsync_headroom_bytes: 0,
+                sync_max_dirty_bytes: 0,
                 // V2-M4 routing richness defaults to inert here (#549/#551): no message TTL, no
                 // dead-letter exchange (the existing fixed-DLQ behavior) — back-compat byte-identical.
                 default_message_ttl_ms: 0,
@@ -6226,6 +6238,7 @@ mod tests {
                 fire_and_forget_refill_ms: 0,
                 egress_limit: 0,
                 wal_fsync_headroom_bytes: 0,
+                sync_max_dirty_bytes: 0,
                 // V2-M4 routing richness defaults to inert here (#549/#551): no message TTL, no
                 // dead-letter exchange (the existing fixed-DLQ behavior) — back-compat byte-identical.
                 default_message_ttl_ms: 0,
@@ -6538,6 +6551,7 @@ mod tests {
                 fire_and_forget_refill_ms: 0,
                 egress_limit: 0,
                 wal_fsync_headroom_bytes: 0,
+                sync_max_dirty_bytes: 0,
                 default_message_ttl_ms: 0,
                 dead_letter_exchange: None,
                 dead_letter_expired: false,

--- a/crates/ironbus-server/src/server.rs
+++ b/crates/ironbus-server/src/server.rs
@@ -724,6 +724,7 @@ mod tests {
             fire_and_forget_refill_ms: 0,
             egress_limit: 0,
             wal_fsync_headroom_bytes: 0,
+            sync_max_dirty_bytes: 0,
             // Compression OFF (#430): the server tests pin the historical byte-identical image.
             compression: ironbus_core::compress::Codec::None,
             // V2-M4 routing richness defaults to inert here (#549/#551): no message TTL, no

--- a/crates/ironbus-server/src/session.rs
+++ b/crates/ironbus-server/src/session.rs
@@ -4630,6 +4630,7 @@ mod tests {
             fire_and_forget_refill_ms: 0,
             egress_limit: 0,
             wal_fsync_headroom_bytes: 0,
+            sync_max_dirty_bytes: 0,
             // V2-M4 routing richness defaults to inert here (#549/#551): no message TTL, no
             // dead-letter exchange (the existing fixed-DLQ behavior) — back-compat byte-identical.
             default_message_ttl_ms: 0,
@@ -4733,6 +4734,7 @@ mod tests {
                 fire_and_forget_refill_ms: 0,
                 egress_limit: 0,
                 wal_fsync_headroom_bytes: 0,
+                sync_max_dirty_bytes: 0,
                 // V2-M4 routing richness defaults to inert here (#549/#551): no message TTL, no
                 // dead-letter exchange (the existing fixed-DLQ behavior) — back-compat byte-identical.
                 default_message_ttl_ms: 0,
@@ -4792,6 +4794,7 @@ mod tests {
                 fire_and_forget_refill_ms: 0,
                 egress_limit: 0,
                 wal_fsync_headroom_bytes: 0,
+                sync_max_dirty_bytes: 0,
                 // V2-M4 routing richness defaults to inert here (#549/#551): no message TTL, no
                 // dead-letter exchange (the existing fixed-DLQ behavior) — back-compat byte-identical.
                 default_message_ttl_ms: 0,
@@ -5106,6 +5109,7 @@ mod tests {
                 fire_and_forget_refill_ms: 0,
                 egress_limit: 0,
                 wal_fsync_headroom_bytes: 0,
+                sync_max_dirty_bytes: 0,
                 // V2-M4 routing richness defaults to inert here (#549/#551): no message TTL, no
                 // dead-letter exchange (the existing fixed-DLQ behavior) — back-compat byte-identical.
                 default_message_ttl_ms: 0,
@@ -7043,6 +7047,7 @@ mod tests {
                 fire_and_forget_refill_ms: 0,
                 egress_limit: 0,
                 wal_fsync_headroom_bytes: 0,
+                sync_max_dirty_bytes: 0,
                 // V2-M4 routing richness defaults to inert here (#549/#551): no message TTL, no
                 // dead-letter exchange (the existing fixed-DLQ behavior) — back-compat byte-identical.
                 default_message_ttl_ms: 0,
@@ -8235,6 +8240,7 @@ mod tests {
                     fire_and_forget_refill_ms: 0,
                     egress_limit: 0,
                     wal_fsync_headroom_bytes: 0,
+                    sync_max_dirty_bytes: 0,
                     // V2-M4 routing richness defaults to inert here (#549/#551): no message TTL, no
                     // dead-letter exchange (the existing fixed-DLQ behavior) — back-compat byte-identical.
                     default_message_ttl_ms: 0,
@@ -8639,6 +8645,7 @@ mod tests {
                 fire_and_forget_refill_ms: 0,
                 egress_limit: 0,
                 wal_fsync_headroom_bytes: 0,
+                sync_max_dirty_bytes: 0,
                 // V2-M4 routing richness defaults to inert here (#549/#551): no message TTL, no
                 // dead-letter exchange (the existing fixed-DLQ behavior) — back-compat byte-identical.
                 default_message_ttl_ms: 0,
@@ -8697,6 +8704,7 @@ mod tests {
                 fire_and_forget_refill_ms: 0,
                 egress_limit: 0,
                 wal_fsync_headroom_bytes: 0,
+                sync_max_dirty_bytes: 0,
                 // V2-M4 routing richness defaults to inert here (#549/#551): no message TTL, no
                 // dead-letter exchange (the existing fixed-DLQ behavior) — back-compat byte-identical.
                 default_message_ttl_ms: 0,
@@ -8908,6 +8916,7 @@ mod tests {
                 fire_and_forget_refill_ms: 0,
                 egress_limit: 0,
                 wal_fsync_headroom_bytes: 0,
+                sync_max_dirty_bytes: 0,
                 // V2-M4 routing richness defaults to inert here (#549/#551): no message TTL, no
                 // dead-letter exchange (the existing fixed-DLQ behavior) — back-compat byte-identical.
                 default_message_ttl_ms: 0,
@@ -9802,6 +9811,7 @@ mod tests {
                 fire_and_forget_refill_ms: 0,
                 egress_limit: 0,
                 wal_fsync_headroom_bytes: 0,
+                sync_max_dirty_bytes: 0,
                 // V2-M4 routing richness defaults to inert here (#549/#551): no message TTL, no
                 // dead-letter exchange (the existing fixed-DLQ behavior) — back-compat byte-identical.
                 default_message_ttl_ms: 0,

--- a/crates/ironbus-server/tests/conformance_vectors.rs
+++ b/crates/ironbus-server/tests/conformance_vectors.rs
@@ -679,6 +679,7 @@ fn build_config(setup: &Setup) -> EngineConfig {
         fire_and_forget_refill_ms: 0,
         egress_limit: 0,
         wal_fsync_headroom_bytes: 0,
+        sync_max_dirty_bytes: 0,
         // Compression OFF (#430): the frozen conformance vectors pin the uncompressed layout.
         compression: ironbus_core::compress::Codec::None,
         // V2-M4 routing richness defaults to inert here (#549/#551): no message TTL, no

--- a/crates/ironbus-server/tests/determinism.rs
+++ b/crates/ironbus-server/tests/determinism.rs
@@ -57,6 +57,7 @@ fn config() -> EngineConfig {
         fire_and_forget_refill_ms: 0,
         egress_limit: 0,
         wal_fsync_headroom_bytes: 0,
+        sync_max_dirty_bytes: 0,
         // Compression OFF (#430): the determinism image is unchanged by the new compression
         // field; the lz4 determinism case builds its config explicitly.
         compression: ironbus_core::compress::Codec::None,

--- a/crates/ironbus-storage/src/log.rs
+++ b/crates/ironbus-storage/src/log.rs
@@ -25,6 +25,7 @@ use ironbus_core::format::{
 };
 use ironbus_core::segment::SegmentHeader;
 use ironbus_core::types::{Offset, RecordFlags, Seq};
+use std::sync::Arc;
 
 /// The id of the first segment in a fresh log.
 const FIRST_SEGMENT_ID: u64 = 0;
@@ -870,6 +871,40 @@ struct PendingRoll {
     /// Its base offset (continues the sealed predecessor's run).
     base_offset: Offset,
 }
+
+/// A STAGED, not-yet-covered durability barrier for the pipelined sync tier (#1040): the snapshot
+/// [`Log::prepare_async_sync`] takes at the dirty-at-sync-start boundary, applied by
+/// [`Log::complete_async_sync`] once the EXTERNAL `fdatasync` on the shared file handle has
+/// RETURNED successfully. Everything appended AFTER the stage is deliberately outside this
+/// ticket: it stays in the unsynced window and is covered by the NEXT barrier, which is what lets
+/// the caller overlap one in-flight fdatasync with further appends on the same fd without ever
+/// advertising an uncovered byte as durable. Opaque outside this module: the engine and the
+/// append actor carry it between `prepare` and `complete` without reading it.
+#[derive(Clone, Copy, Debug)]
+pub struct SyncTicket {
+    /// The offset the durable head advances TO when this barrier completes: `next_offset` at
+    /// stage time. Bytes appended during the flight are never credited to this ticket.
+    target: Offset,
+    /// The active segment id at stage time: guards the resident seek-index raise across a roll
+    /// (a completion must never touch a DIFFERENT segment's index; after a roll the seal already
+    /// raised the sealed index to its full prefix).
+    segment_id: u64,
+    /// The resident active index `valid_end` at stage time, AFTER the stage's flush put every
+    /// staged byte in the file (#537): the exact in-file prefix this barrier covers, so the
+    /// completion raises the index's `flushed_end` to THIS snapshot — never the then-current
+    /// `valid_end`, whose tail may still sit in the writer's pending buffer.
+    staged_valid_end: u64,
+    /// The unsynced record-byte exposure at stage time: exactly the bytes this barrier covers,
+    /// subtracted (saturating) from the live meter on completion so records appended during the
+    /// flight keep their at-risk accounting until their own barrier returns.
+    covered_bytes: u64,
+}
+
+/// What [`Log::prepare_async_sync`] stages for a DIRTIED log (#1040): the SHARED active-segment
+/// fd the external `fdatasync` runs on, paired with the [`SyncTicket`] to apply on completion.
+/// `None` = the log is CLEAN (no barrier owed) — distinct by construction from a FROZEN writer,
+/// which is an `Err`, never a clean `None`.
+pub type StagedSync<F> = Option<(Arc<F>, SyncTicket)>;
 
 /// The bounds of a single [`Log::read_range`] pass, threaded to the per-segment read helpers so
 /// they share one definition of the start, the durable end, and the record/byte caps (#538).
@@ -3062,6 +3097,149 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
         self.publish_flushed_frontier();
     }
 
+    /// STAGES the covering durability barrier for the PIPELINED sync tier (#1040) without issuing
+    /// it: the third sibling of the #564 split-barrier family. It drains the writer's pending
+    /// buffer to the file (page cache) so the appended bytes are all IN the file, then returns a
+    /// SHARED handle to the active segment's fd plus a [`SyncTicket`] snapshotting the
+    /// dirty-at-sync-start boundary. The caller issues `sync_data` on the handle OFF this thread
+    /// (the flusher) and, once that external fdatasync has RETURNED successfully, applies the
+    /// ticket with [`Log::complete_async_sync`] — never before, preserving I2 exactly as
+    /// [`Log::advance_synced_offset_after_external_sync`]'s contract demands.
+    ///
+    /// Deliberately touches NEITHER head: contrast [`Log::flush_no_sync`], which raises the
+    /// VISIBLE head — reusing it here would leak not-yet-durable records to readers (and to the
+    /// cluster leader frontier) before the covering barrier returned, breaking
+    /// visible-equals-durable on this tier. Bytes appended AFTER this call are NOT covered by the
+    /// returned ticket (they stay in the unsynced window for the NEXT barrier), which is what
+    /// makes an in-flight barrier safe to overlap with further appends on the same fd.
+    ///
+    /// The three outcomes are DISTINCT by design (the false-ack conflation this API kills):
+    /// - **frozen** writer => `Err(WriterFrozen)`, NEVER a clean `None` — a frozen writer also
+    ///   reports `has_unsynced_records() == false`, so the frozen check precedes the clean check;
+    /// - **clean** log (nothing unsynced) => `Ok(None)`, no barrier owed;
+    /// - **dirtied** log => `Ok(Some((file, ticket)))`, one barrier owed.
+    ///
+    /// # Errors
+    /// Returns [`StorageError::WriterFrozen`] if the writer is frozen (or if staging the pending
+    /// bytes fails, which freezes it — the same fatal class as in [`Log::flush_no_sync`]), or the
+    /// raw transient error from a deferred-roll retry (#867), exactly as [`Log::sync`] surfaces it.
+    pub fn prepare_async_sync(&mut self) -> Result<StagedSync<F::File>, StorageError> {
+        // Finish a transient-fault-deferred roll first (#867), exactly as `sync` does, so the
+        // barrier is staged against a fully installed active segment.
+        self.ensure_writable()?;
+        // FROZEN IS AN ERROR, NEVER A CLEAN None: `has_unsynced_records` reports `false` for a
+        // frozen writer, so this check MUST come first or a dead writer would be
+        // indistinguishable from a clean log and its parked producers would never be fataled.
+        if self.active.is_none() {
+            return Err(StorageError::WriterFrozen);
+        }
+        // CLEAN: nothing appended since the last covering barrier, no barrier owed. Distinct
+        // from frozen by construction (the writer is live here).
+        if !self.has_unsynced_records() {
+            return Ok(None);
+        }
+        // Stage the writer's pending bytes into the file so the external fdatasync covers every
+        // appended byte (the same flush-before-barrier ordering `sync` uses). A flush failure is
+        // the fatal frozen-writer class, exactly as in `flush_no_sync`; clear the pending roll
+        // too so `ensure_writable` can never resurrect a frozen writer.
+        let Some(w) = self.active.as_mut() else {
+            return Err(StorageError::WriterFrozen);
+        };
+        if w.flush_pending().is_err() {
+            self.active = None;
+            self.pending_roll = None;
+            return Err(StorageError::WriterFrozen);
+        }
+        let file = w.shared_file();
+        let write_pos = w.write_pos();
+        // The staged in-file prefix (#537): the resident active index's `valid_end`, which now —
+        // post-flush — equals the writer's write position. Snapshotted so the completion raises
+        // the index's flushed bound to exactly what THIS barrier covered, never to a later
+        // (possibly still-pending) prefix. Defensive fallback to the writer's position if the
+        // active index were ever absent (it never is on this path).
+        let staged_valid_end = self
+            .segment_indexes
+            .borrow()
+            .get(&self.active_id)
+            .map_or(write_pos, |idx| idx.valid_end);
+        Ok(Some((
+            file,
+            SyncTicket {
+                target: self.next_offset,
+                segment_id: self.active_id,
+                staged_valid_end,
+                covered_bytes: self.unsynced_record_bytes,
+            },
+        )))
+    }
+
+    /// Applies a RETURNED, SUCCESSFUL external barrier staged by [`Log::prepare_async_sync`]:
+    /// generalizes [`Log::advance_synced_offset_after_external_sync`] from "advance to
+    /// `next_offset`" to "advance to the SNAPSHOTTED ticket target", so bytes appended while the
+    /// barrier was in flight are never advertised durable by it (they belong to the next ticket).
+    ///
+    /// ALL-OR-NOTHING staleness guard: a completion that arrives after the writer FROZE, or after
+    /// an intervening covering barrier (a roll's seal, an inline [`Log::sync`]) already advanced
+    /// the durable head at or past this ticket's target, is a FULL no-op — heads, unsynced byte
+    /// meter, seek index, read-plane frontier, ALL untouched. Half-applying a stale ticket is
+    /// exactly the byte-meter-undercount / index-corruption class this guard exists to kill (a
+    /// roll's seal already advanced the heads and ZEROED the meter; subtracting the stale ticket's
+    /// covered bytes on top would undercount the new segment's live exposure).
+    ///
+    /// Staleness is BINARY under the caller's depth-1 dispatch discipline: any intervening barrier
+    /// advanced `synced_offset` to a then-current `next_offset >= ticket.target`, so a PARTIAL
+    /// overlap (guard passed but the ticket straddles a barrier) is unreachable; reaching the body
+    /// means no barrier ran since the stage.
+    pub fn complete_async_sync(&mut self, ticket: &SyncTicket) {
+        if !self.is_writable() || self.synced_offset >= ticket.target {
+            return;
+        }
+        // Monotone by construction (offsets are never rewound): a ticket's target can never
+        // exceed the appended head. An op that REWINDS offsets must quiesce the pipeline first.
+        debug_assert!(
+            ticket.target <= self.next_offset,
+            "a staged ticket's target must never exceed the appended head (#1040)"
+        );
+        // The external fdatasync covered exactly the staged prefix: advance BOTH heads to the
+        // ticket's target. Bytes appended during the flight stay unsynced and unadvertised
+        // (visible == durable on this tier). `max` keeps the visible head monotone even if a
+        // relaxed-level `flush_no_sync` ran it ahead (not a pipelined-tier flow; defensive).
+        self.flushed_offset = self.flushed_offset.max(ticket.target);
+        self.synced_offset = ticket.target;
+        // Retire the covered bytes from the at-risk meter — SUBTRACT the snapshot, never zero
+        // it: the meter kept accumulating for records appended during the flight, and those are
+        // still at risk until their own barrier returns. Saturating, like every meter update.
+        self.unsynced_record_bytes = self
+            .unsynced_record_bytes
+            .saturating_sub(ticket.covered_bytes);
+        // Raise the ACTIVE index's flushed read bound to the SNAPSHOTTED staged prefix (#537) —
+        // never the current `valid_end`, whose tail may still be in the writer's pending buffer
+        // (not yet in the file). Only if the staged segment is still the active one: after a
+        // roll the seal already raised the sealed index to its full prefix.
+        if ticket.segment_id == self.active_id {
+            if let Some(idx) = self.segment_indexes.borrow_mut().get_mut(&self.active_id) {
+                idx.flushed_end = idx.flushed_end.max(ticket.staged_valid_end);
+            }
+        }
+        // Publish the new flushed frontier to the off-actor read plane (#539): the LAST step, so
+        // a reader that observes the frontier also observes every prior store, and the caller
+        // releases producer acks only after readers can already serve the acked records.
+        self.publish_flushed_frontier();
+    }
+
+    /// FREEZES the writer after an EXTERNALLY-issued covering barrier (a flusher's `sync_data` on
+    /// the [`Log::prepare_async_sync`] handle) FAILED: the exact terminal state a failed
+    /// [`Log::sync`] leaves — `active` dropped so every later append/sync surfaces the fatal,
+    /// never-retried [`StorageError::WriterFrozen`], and `pending_roll` cleared so
+    /// [`ensure_writable`](Log::ensure_writable) can never resurrect the writer after the freeze
+    /// (matching the roll-boundary freeze discipline in `create_or_defer_segment`). Reads keep
+    /// serving the durable prefix, and a health check sees the degraded state, exactly as after
+    /// any other fatal barrier. Idempotent.
+    pub fn freeze_after_external_sync_failure(&mut self) {
+        self.active = None;
+        self.pending_roll = None;
+    }
+
     /// Whether this log has appended records not yet covered by a returned `fdatasync` — i.e. it is
     /// DIRTIED and owes the next commit tick a durability barrier (#564). The exact gate the
     /// cross-stream `CommitCoordinator` uses to pick which streams a tick must sync: a stream whose
@@ -3073,8 +3251,13 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
     /// A frozen writer (`active` is `None`) reports `false`: it can no longer be made durable, so
     /// the coordinator must not pick it for a barrier (it would only re-surface `WriterFrozen`); its
     /// acked-but-now-lost tail is a recovery/loss concern, not a commit-tick concern.
+    ///
+    /// `pub` (widened from `pub(crate)`, #1040): the engine's pipelined-tier dispatch gate reads
+    /// the same predicate to decide whether a barrier is owed. NOTE the frozen-reports-`false`
+    /// caveat above — a dispatch seam must distinguish frozen from clean via
+    /// [`Log::prepare_async_sync`]'s `Err`, never via this predicate alone.
     #[must_use]
-    pub(crate) fn has_unsynced_records(&self) -> bool {
+    pub fn has_unsynced_records(&self) -> bool {
         self.is_writable() && self.synced_offset != self.next_offset
     }
 
@@ -7607,6 +7790,268 @@ mod tests {
         // The only fsync attempt was the roll's, and it faulted, so nothing became durable:
         // the flush mark is unchanged at the start.
         assert_eq!(log.flushed_offset(), Offset::ZERO);
+    }
+
+    // --- The pipelined-sync-tier staging API (#1040): prepare/complete/freeze ---
+
+    #[test]
+    fn prepare_async_sync_on_a_frozen_writer_is_an_error_never_a_clean_none() {
+        use crate::fault::FaultFs;
+        // Freeze the writer through a REAL failed barrier (the exact state a dead disk leaves).
+        let (fs, control) = FaultFs::new(InMemoryFs::new());
+        let mut log = Log::open(fs, ManualClock::new(), LogConfig::default()).unwrap();
+        log.append(&rec(b"unsynced")).unwrap();
+        control.set_fail_sync(true);
+        assert!(matches!(log.sync(), Err(StorageError::WriterFrozen)));
+        assert!(!log.is_writable());
+        // The L1 conflation this API kills: a frozen writer also reports
+        // `has_unsynced_records() == false`, so a clean-check-first implementation would return
+        // `Ok(None)` here and the caller would treat a dead writer as a clean log — its parked
+        // producers would never be fataled. Frozen MUST be a DISTINCT error outcome.
+        assert!(!log.has_unsynced_records());
+        assert!(
+            matches!(log.prepare_async_sync(), Err(StorageError::WriterFrozen)),
+            "a frozen writer must be Err, never a clean Ok(None)"
+        );
+        // The external-failure freeze reaches the same terminal state and stays an error too.
+        log.freeze_after_external_sync_failure();
+        assert!(matches!(
+            log.prepare_async_sync(),
+            Err(StorageError::WriterFrozen)
+        ));
+    }
+
+    #[test]
+    fn prepare_async_sync_on_a_clean_log_is_none() {
+        let mut log = open_mem(LogConfig::default());
+        // A fresh, never-appended log owes no barrier.
+        assert!(log.prepare_async_sync().unwrap().is_none());
+        // A fully-synced log owes no barrier either (clean, NOT frozen: the writer is live).
+        log.append(&rec(b"payload")).unwrap();
+        log.sync().unwrap();
+        assert!(log.is_writable());
+        assert!(log.prepare_async_sync().unwrap().is_none());
+        // And a dirtied log owes exactly one: the three outcomes are distinct.
+        log.append(&rec(b"more")).unwrap();
+        assert!(log.prepare_async_sync().unwrap().is_some());
+    }
+
+    #[test]
+    fn stage_then_complete_advances_both_heads_to_the_target_and_publishes_the_frontier() {
+        let mut log = open_mem(LogConfig::default());
+        // Build the off-actor read plane FIRST so the completion's frontier publish is observable.
+        let plane = log.read_plane().unwrap();
+        log.append(&rec(b"aaaa")).unwrap();
+        log.append(&rec(b"bbbb")).unwrap();
+        let meter_before = log.unsynced_bytes();
+        assert_eq!(meter_before, 8, "two 4-byte payloads are at risk");
+
+        let (file, ticket) = log.prepare_async_sync().unwrap().unwrap();
+        // Staging touches NEITHER head (contrast `flush_no_sync`): nothing is visible or durable
+        // until the external barrier RETURNS, and the byte meter still carries the exposure.
+        assert_eq!(log.flushed_offset(), Offset::ZERO);
+        assert_eq!(log.synced_offset(), Offset::ZERO);
+        assert_eq!(log.unsynced_bytes(), meter_before);
+        assert!(log.has_unsynced_records());
+        assert_eq!(plane.flushed(), 0, "no frontier before the barrier returns");
+        assert!(log.read_from(Offset::ZERO, 10).unwrap().is_empty());
+
+        // The external covering barrier (what the flusher thread does), then the completion.
+        file.sync_data().unwrap();
+        log.complete_async_sync(&ticket);
+
+        // Both heads advance EXACTLY to the snapshotted target, the meter retires the covered
+        // bytes, the frontier is published, and the records are readable.
+        assert_eq!(log.flushed_offset(), Offset::new(2));
+        assert_eq!(log.synced_offset(), Offset::new(2));
+        assert_eq!(log.unsynced_bytes(), 0);
+        assert!(!log.has_unsynced_records());
+        assert_eq!(
+            plane.flushed(),
+            2,
+            "completion publishes the flushed frontier"
+        );
+        assert_eq!(log.read_from(Offset::ZERO, 10).unwrap().len(), 2);
+        // Nothing further owed: the next prepare is a clean None.
+        assert!(log.prepare_async_sync().unwrap().is_none());
+    }
+
+    #[test]
+    fn the_byte_meter_stays_exact_across_overlapping_stage_complete_cycles() {
+        let mut log = open_mem(LogConfig::default());
+        // Cycle 1 stages record A (7 logical bytes)...
+        log.append(&rec(b"aaaaaaa")).unwrap();
+        assert_eq!(log.unsynced_bytes(), 7);
+        let (_file1, t1) = log.prepare_async_sync().unwrap().unwrap();
+        // ...record B (11 bytes) lands DURING the flight: the meter keeps accumulating and B is
+        // outside t1's snapshot (dirty-at-sync-start).
+        log.append(&rec(b"bbbbbbbbbbb")).unwrap();
+        assert_eq!(log.unsynced_bytes(), 18);
+        log.complete_async_sync(&t1);
+        // t1 retires EXACTLY its own 7 covered bytes: B's 11 stay at risk until ITS barrier.
+        assert_eq!(log.unsynced_bytes(), 11);
+        assert_eq!(log.synced_offset(), Offset::new(1));
+        assert_eq!(log.flushed_offset(), Offset::new(1));
+        assert!(log.has_unsynced_records(), "B is still unsynced");
+        // Cycle 2 covers B; after its completion the meter is exactly zero — no drift in either
+        // direction across the overlapped cycles.
+        let (_file2, t2) = log.prepare_async_sync().unwrap().unwrap();
+        log.complete_async_sync(&t2);
+        assert_eq!(log.unsynced_bytes(), 0);
+        assert_eq!(log.synced_offset(), Offset::new(2));
+        assert!(!log.has_unsynced_records());
+    }
+
+    #[test]
+    fn a_stale_completion_after_an_intervening_inline_sync_is_a_full_no_op() {
+        let mut log = open_mem(LogConfig::default());
+        log.append(&rec(b"aaaa")).unwrap();
+        let (_file, stale) = log.prepare_async_sync().unwrap().unwrap();
+        // An INLINE barrier (a Run job's `commit_batch`, a quiesce) overtakes the flight: it
+        // covers everything, including a record appended after the stage.
+        log.append(&rec(b"bbbb")).unwrap();
+        log.sync().unwrap();
+        assert_eq!(log.synced_offset(), Offset::new(2));
+        assert_eq!(log.unsynced_bytes(), 0);
+        // The late completion is a FULL no-op — applying it would REWIND the durable head to the
+        // stale target and rewind is exactly what the all-or-nothing guard forbids.
+        log.complete_async_sync(&stale);
+        assert_eq!(log.synced_offset(), Offset::new(2), "no rewind");
+        assert_eq!(log.flushed_offset(), Offset::new(2));
+        assert_eq!(log.unsynced_bytes(), 0);
+    }
+
+    #[test]
+    fn a_stale_completion_after_an_intervening_roll_is_a_full_no_op_including_the_byte_meter() {
+        // The L2 regression: a mid-flight roll's seal is itself a covering barrier that advances
+        // the heads and ZEROES the meter; the stale completion must then touch NOTHING — a
+        // half-applied ticket subtracting its covered bytes on top would UNDERCOUNT the new
+        // segment's live exposure forever.
+        let mut log = open_mem(small_config());
+        log.append(&rec(b"first")).unwrap();
+        let (file, stale) = log.prepare_async_sync().unwrap().unwrap();
+        // Force rolls while the barrier is "in flight": the 128-byte cap rolls within a few
+        // 20-byte records, and each roll's seal advances both heads past the stale target.
+        for i in 0..10u8 {
+            log.append(&rec(&[i; 20])).unwrap();
+        }
+        assert!(
+            log.synced_offset() > Offset::new(1),
+            "a roll's seal advanced the durable head past the stale target"
+        );
+        let synced_after_rolls = log.synced_offset();
+        let flushed_after_rolls = log.flushed_offset();
+        let meter_after_rolls = log.unsynced_bytes();
+        assert!(
+            meter_after_rolls > 0,
+            "the new active segment carries live unsynced exposure the stale ticket must not touch"
+        );
+        let index_flushed_end = log
+            .segment_indexes
+            .borrow()
+            .get(&log.active_id)
+            .unwrap()
+            .flushed_end;
+        // The stray fdatasync on the SEALED old fd is harmless (the Arc kept it alive)...
+        file.sync_data().unwrap();
+        // ...and its completion is a FULL no-op: heads, byte meter, and index all untouched.
+        log.complete_async_sync(&stale);
+        assert_eq!(log.synced_offset(), synced_after_rolls);
+        assert_eq!(log.flushed_offset(), flushed_after_rolls);
+        assert_eq!(
+            log.unsynced_bytes(),
+            meter_after_rolls,
+            "the meter must keep the NEW segment's exposure intact (no stale subtract)"
+        );
+        assert_eq!(
+            log.segment_indexes
+                .borrow()
+                .get(&log.active_id)
+                .unwrap()
+                .flushed_end,
+            index_flushed_end,
+            "the new active index's flushed bound is untouched by the stale completion"
+        );
+        // The log is fully live afterwards: appends and real barriers keep working.
+        log.append(&rec(b"after")).unwrap();
+        log.sync().unwrap();
+        assert_eq!(log.unsynced_bytes(), 0);
+    }
+
+    #[test]
+    fn a_completion_on_a_frozen_writer_is_a_full_no_op() {
+        let mut log = open_mem(LogConfig::default());
+        log.append(&rec(b"payload")).unwrap();
+        let (_file, ticket) = log.prepare_async_sync().unwrap().unwrap();
+        let meter_before = log.unsynced_bytes();
+        // The barrier FAILED on the flusher: the caller freezes the writer, then (in a race) the
+        // completion for an earlier Ok could still arrive — it must be a full no-op, because no
+        // ack may ever be released past a failed barrier and a frozen writer's heads are final.
+        log.freeze_after_external_sync_failure();
+        assert!(!log.is_writable());
+        log.complete_async_sync(&ticket);
+        assert_eq!(log.synced_offset(), Offset::ZERO);
+        assert_eq!(log.flushed_offset(), Offset::ZERO);
+        assert_eq!(log.unsynced_bytes(), meter_before);
+        // And the pipeline can never re-arm against the frozen writer.
+        assert!(matches!(
+            log.prepare_async_sync(),
+            Err(StorageError::WriterFrozen)
+        ));
+    }
+
+    #[test]
+    fn a_ticket_with_a_mismatched_segment_id_skips_the_index_raise() {
+        // The release-mode defensive arm of the completion's index raise: a ticket staged against
+        // a DIFFERENT segment id must never touch the current active segment's resident index
+        // (the heads/meter half still applies under the guard — this pins ONLY the index skip).
+        let mut log = open_mem(LogConfig::default());
+        log.append(&rec(b"aaaa")).unwrap();
+        log.append(&rec(b"bbbb")).unwrap();
+        let (_file, ticket) = log.prepare_async_sync().unwrap().unwrap();
+        let mut mismatched = ticket;
+        mismatched.segment_id = ticket.segment_id + 1;
+        let index_flushed_end_before = log
+            .segment_indexes
+            .borrow()
+            .get(&log.active_id)
+            .unwrap()
+            .flushed_end;
+        log.complete_async_sync(&mismatched);
+        // Heads and meter applied (the ticket is not stale)...
+        assert_eq!(log.synced_offset(), Offset::new(2));
+        assert_eq!(log.unsynced_bytes(), 0);
+        // ...but the active index's flushed bound was NOT raised by a foreign-segment ticket.
+        assert_eq!(
+            log.segment_indexes
+                .borrow()
+                .get(&log.active_id)
+                .unwrap()
+                .flushed_end,
+            index_flushed_end_before
+        );
+    }
+
+    #[test]
+    fn a_shared_file_handle_held_across_rolls_and_a_freeze_stays_harmless() {
+        // The Arc'd-writer property the flusher relies on (#1040): a staged handle that outlives
+        // the segment it was staged against (rolled away mid-flight) still accepts a barrier
+        // call, never resurrects the writer, and never disturbs the successor segment.
+        let mut log = open_mem(small_config());
+        log.append(&rec(b"first")).unwrap();
+        let (file, _ticket) = log.prepare_async_sync().unwrap().unwrap();
+        for i in 0..10u8 {
+            log.append(&rec(&[i; 20])).unwrap();
+        }
+        // The clone still points at the (long-sealed) old fd: a stray barrier is a no-op Ok.
+        file.sync_data().unwrap();
+        // The log keeps operating normally on the successor segments.
+        log.append(&rec(b"tail")).unwrap();
+        log.sync().unwrap();
+        assert!(log.is_writable());
+        assert_eq!(log.unsynced_bytes(), 0);
+        let total = log.read_from(Offset::ZERO, 100).unwrap().len();
+        assert_eq!(total, 12);
     }
 
     #[test]

--- a/crates/ironbus-storage/src/segment.rs
+++ b/crates/ironbus-storage/src/segment.rs
@@ -18,6 +18,7 @@ use ironbus_core::format::{
 use ironbus_core::segment::{CompactionMeta, SegmentError, SegmentFooter, SegmentHeader};
 use ironbus_core::types::{Offset, RecordFlags, Seq};
 use std::io;
+use std::sync::Arc;
 
 /// An error from the segment storage layer.
 #[derive(Debug)]
@@ -432,7 +433,17 @@ impl OwnedRecord {
 /// and rolls to a new segment by size or age.
 #[derive(Debug)]
 pub struct SegmentWriter<F: RandomAccessFile> {
-    file: F,
+    /// The segment's backing file, behind an `Arc` so an EXTERNAL durability barrier can hold a
+    /// shared handle to the SAME kernel fd (#1040: the pipelined sync tier's flusher thread issues
+    /// the covering `fdatasync` off the single-writer thread via [`SegmentWriter::shared_file`]).
+    /// Every writer-side use is a `&self` call on the file (`write_all_at` / `sync_data` /
+    /// `sync_all`), so the wrapper is transparent to the write paths and the on-disk bytes are
+    /// identical. A clone held across a [`SegmentWriter::seal`] (or a retention reap) merely delays
+    /// the fd close by the holder's lifetime — a stray fdatasync on a sealed or unlinked file is a
+    /// harmless no-op barrier. `Arc`, not `try_clone`: no new trait surface, no per-cycle
+    /// dup(2)/close, and a fault-injection backend that gates syncs gates the shared handle's syncs
+    /// identically (the shared object IS the gated object).
+    file: Arc<F>,
     header: SegmentHeader,
     write_pos: u64,
     record_count: u32,
@@ -478,7 +489,9 @@ impl<F: RandomAccessFile> SegmentWriter<F> {
     pub fn create(file: F, header: SegmentHeader) -> Result<SegmentWriter<F>, StorageError> {
         file.write_all_at(&header.encode(), 0)?;
         Ok(SegmentWriter {
-            file,
+            // Wrapped internally (#1040): callers keep passing a bare `F`; the `Arc` exists only
+            // so `shared_file` can hand the flusher a co-owned handle to the same fd.
+            file: Arc::new(file),
             header,
             write_pos: SEGMENT_HEADER_LEN as u64,
             record_count: 0,
@@ -509,7 +522,8 @@ impl<F: RandomAccessFile> SegmentWriter<F> {
         max_timestamp_ms: u64,
     ) -> SegmentWriter<F> {
         SegmentWriter {
-            file,
+            // Wrapped internally (#1040), exactly as in `create`.
+            file: Arc::new(file),
             header,
             write_pos,
             record_count,
@@ -540,7 +554,8 @@ impl<F: RandomAccessFile> SegmentWriter<F> {
         );
         file.write_all_at(&header.encode(), 0)?;
         Ok(SegmentWriter {
-            file,
+            // Wrapped internally (#1040), exactly as in `create`.
+            file: Arc::new(file),
             header,
             write_pos: SEGMENT_HEADER_LEN as u64,
             record_count: 0,
@@ -894,6 +909,19 @@ impl<F: RandomAccessFile> SegmentWriter<F> {
         self.pending_base = self.write_pos;
         self.pending.clear();
         Ok(())
+    }
+
+    /// A SHARED handle to the segment's backing file — the SAME kernel fd the writer stages into —
+    /// for an EXTERNAL durability barrier (#1040): the pipelined sync tier hands this to its
+    /// flusher thread, which calls `sync_data` (`&self`, the trait is `Send + Sync`) off the
+    /// single-writer thread while the writer keeps appending. The caller MUST have already drained
+    /// the pending buffer to the file ([`SegmentWriter::flush_pending`]) for the external barrier
+    /// to cover what it believes it covers, exactly the [`SegmentWriter::sync_data_only`] contract.
+    /// A handle that outlives a [`SegmentWriter::seal`] or a retention reap is harmless: a stray
+    /// fdatasync on a sealed or unlinked file is a no-op barrier, and the co-owned fd merely closes
+    /// a little later.
+    pub(crate) fn shared_file(&self) -> Arc<F> {
+        Arc::clone(&self.file)
     }
 
     /// Seals the segment by writing the footer and a full fsync, consuming the writer
@@ -2293,6 +2321,34 @@ mod tests {
         assert_eq!(footer.record_count, 2);
         assert_eq!(footer.last_seq, Seq::new(1));
 
+        let scan = SegmentReader::open(Arc::clone(&file))
+            .unwrap()
+            .scan()
+            .unwrap();
+        assert!(scan.clean);
+        assert_eq!(scan.footer, Some(footer));
+        assert_eq!(scan.records.len(), 2);
+    }
+
+    #[test]
+    fn a_shared_file_clone_held_across_a_seal_stays_harmless() {
+        // The #1040 Arc'd-writer property: the flusher's shared handle points at the SAME kernel
+        // fd the writer stages into, and a clone that outlives the writer's `seal(mut self)` is
+        // harmless — a stray barrier on the sealed file is a no-op Ok, and the sealed bytes are
+        // byte-identical to a seal with no outstanding clone.
+        let file = Arc::new(InMemoryFile::new());
+        let mut w = SegmentWriter::create(Arc::clone(&file), header()).unwrap();
+        w.append(&rec(0, b"a")).unwrap();
+        let shared = w.shared_file();
+        // The shared handle observes the writer's flushes: staging puts the frame in the file,
+        // and a barrier issued through the CLONE (the flusher's call shape) succeeds.
+        w.flush_pending().unwrap();
+        shared.sync_data().unwrap();
+        w.append(&rec(1, b"b")).unwrap();
+        let footer = w.seal().unwrap();
+        assert_eq!(footer.record_count, 2);
+        // The clone outlived the seal: a late (stale-flight) barrier is still a harmless no-op.
+        shared.sync_data().unwrap();
         let scan = SegmentReader::open(Arc::clone(&file))
             .unwrap()
             .scan()


### PR DESCRIPTION
Refs #1040 (prep 1 of 2 — the API seam; the actor activation PR follows).

## What

The **pure-additive prep layer** for the pipelined sync tier (#1040): the storage/engine API that lets a later actor change run fdatasync on a side thread and complete acks off a durable watermark. **Zero behavior change** — nothing calls this API yet; `commit_batch` and `commit_durability_barrier` are byte-untouched (the sim, `produce_once`, non-fsync tiers, and quiesce keep the synchronous path).

## Pieces

- **`segment.rs`**: `SegmentWriter.file: F → Arc<F>` (wrapped inside constructors, zero caller churn — every use was `&self`) + `shared_file()`, so a flusher thread can hold the fd across the actor's appends.
- **`log.rs`**: `SyncTicket` (opaque snapshot: target, segment_id, staged_valid_end, covered_bytes) + `prepare_async_sync` (stages pending bytes; touches NEITHER head — contrast `flush_no_sync`; **frozen ⇒ `Err(WriterFrozen)`, NEVER `Ok(None)`**; clean ⇒ `Ok(None)`) + `complete_async_sync` (all-or-nothing staleness guard: full no-op if frozen or already past target; advances both heads to the snapshotted target; raises the active index to the SNAPSHOTTED `staged_valid_end`; publishes the flushed frontier last) + `freeze_after_external_sync_failure`.
- **`engine.rs`**: `AsyncCommit` + `begin_async_commit` / `complete_async_commit` / `commit_tail_after_async_completion` / `fail_async_commit` + passthroughs + `EngineConfig.sync_max_dirty_bytes` (default 16 MiB, plumbing only — enforcement is the activation PR).

## Review

Design ran a 3-design/2-critic panel (spec committed in the study docs). Notably, the spec's own pseudocode carried the "clean-check-before-frozen-check" conflation its own contract forbids — the implementation deviates in the direction the contract demands, pinned by a real-failed-barrier FaultFs test that a clean-check-first implementation cannot pass.

Two adversarial verify lenses, both SHIP:
- **Spec fidelity**: every early return of `prepare_async_sync` enumerated (frozen can never yield `Ok(None)`); staleness guard is the first statement of `complete_async_sync`; no unsynced leak to readers (prepare touches neither `flushed_offset` nor the frontier); index raise uses the snapshot, never current `valid_end`.
- **Mutation testing**: 12/16 mutants killed, including all safety-critical ones (guard removal, frozen-Ok(None), advance-past-target, meter zeroing). The 4 survivors are telemetry/bookkeeping in dormant code, with tests directed for the activation PR (spill-during-flight `staged_valid_end`, produce-ack + registry histograms, retention-observable commit-tail).

## Gates

fmt ✓ clippy pedantic (workspace, all-targets, all-features) ✓ storage 453 + server 1018 + core 469 unit tests ✓ conformance byte-identity ✓ determinism ✓ crash_recovery 28 ✓ corruption_corpus 23 ✓ `cargo check --workspace` ✓. 14 new unit tests.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
