### PR TITLE
perf(storage): logically extend preallocated active segments — fdatasync carries no i_size update (13µs/7% p50 per sync)

### DIFF
--- a/crates/ironbus-core/tests/conformance/mod.rs
+++ b/crates/ironbus-core/tests/conformance/mod.rs
@@ -95,8 +95,20 @@ pub enum Verdict {
     /// loss tuple is what recovery would emit when it truncates to the prior intact boundary.
     TornTruncate(LossTuple),
     /// `decode` returns a corruption error recovery turns into a skip-and-report with this
-    /// loss tuple (a mid-log single-bit flip, a zero-window tail, etc.).
+    /// loss tuple (a mid-log single-bit flip of real record bytes, etc.).
     SkipAndReport(LossTuple),
+    /// `decode` at `start` fails with a header-class error because every byte from `start` to
+    /// the file end is ZERO: the unwritten tail of a preallocated, logically-extended segment
+    /// (the shape every crashed preallocated active segment leaves). Recovery truncates the
+    /// all-zero span SILENTLY — a zero word is never a valid frame magic, so the span provably
+    /// never held a written frame, and reporting up to a roll size of never-written zeros as
+    /// loss (or quarantining them) on every boot would trip the bounded-loss caps for bytes
+    /// that were never acked data. Unlike [`Verdict::SkipAndReport`] there is NO loss tuple to
+    /// emit; the storage-side conformance gate asserts the silence.
+    UnwrittenZeroTailTruncate {
+        /// The byte offset within the fixture where the unwritten all-zero span begins.
+        start: u64,
+    },
     /// `decode` rejects the frame fail-closed (a newer-version record a v1 reader refuses).
     FailClosedReject(DecodeError),
 }
@@ -574,21 +586,23 @@ pub fn corpus() -> Vec<Fixture> {
     }
 
     // --- A zero-window (preallocated / zero-filled) tail. ---------------------------------
-    // The record region is entirely zero-filled, modelling a freshly preallocated segment whose
-    // records never landed. A zero word is not a valid record magic: decode at the region start
-    // -> BadMagic, recovery -> CorruptRecordHeader over the zeroed bytes (zero records recovered).
+    // The record region is entirely zero-filled: exactly the shape a preallocated, logically
+    // extended active segment leaves when its records never landed. A zero word is not a valid
+    // record magic, so decode at the region start -> BadMagic and the scan stops there (zero
+    // records recovered); recovery then truncates the provably-unwritten all-zero span SILENTLY
+    // (no loss report, nothing quarantined) — it never held a written frame, and production
+    // preallocates every active segment this way, so reporting it would claim a roll size of
+    // "loss" on every boot.
     {
         let mut bytes = corpus_segment_header().encode().to_vec();
         bytes.resize(SEGMENT_HEADER_LEN + 256, 0);
         out.push(Fixture {
             name: "segment_zero_window_tail",
             freeze: Freeze::RawBytes,
-            description: "Zero-window tail: a valid header then a zero-filled (preallocated) record region; no record decodes, recovery reports the zeroed span as a corrupt-header skip.",
-            verdict: Verdict::SkipAndReport(LossTuple {
-                reason: ReasonCode::CorruptRecordHeader,
+            description: "Zero-window tail: a valid header then an all-zero (preallocated, logically extended) record region; no record decodes, and recovery truncates the unwritten span silently (no loss report).",
+            verdict: Verdict::UnwrittenZeroTailTruncate {
                 start: SEGMENT_HEADER_LEN as u64,
-                end: bytes.len() as u64,
-            }),
+            },
             bytes,
         });
     }

--- a/crates/ironbus-core/tests/conformance_corpus.rs
+++ b/crates/ironbus-core/tests/conformance_corpus.rs
@@ -227,6 +227,7 @@ fn assert_fixture_verdict(f: &Fixture) {
         } => assert_intact_segment(f, records, *has_footer),
         Verdict::TornTruncate(loss) => assert_torn_truncate(f, loss),
         Verdict::SkipAndReport(loss) => assert_skip_and_report(f, loss),
+        Verdict::UnwrittenZeroTailTruncate { start } => assert_unwritten_zero_tail(f, *start),
         Verdict::FailClosedReject(expected_err) => {
             assert_eq!(
                 decode(&f.bytes),
@@ -353,6 +354,41 @@ fn assert_skip_and_report(f: &Fixture, loss: &conformance::LossTuple) {
     assert_eq!(
         stop as u64, loss.start,
         "{}: prefix ends at the corrupt head",
+        f.name
+    );
+}
+
+/// Asserts an unwritten-zero-tail fixture: every byte from `start` to EOF is zero (the tail is
+/// PROVABLY never-written space — the premise recovery's silent truncation stands on), decoding at
+/// `start` fails with a header-class error (a zero word is never a valid frame magic, so the scan
+/// stops there), and the valid prefix ends exactly at `start`. The recovery-level half of the
+/// contract — the span is truncated with NO loss report and nothing quarantined — is asserted by
+/// the storage-side gate (`ironbus-storage/tests/conformance_recovery.rs`), which drives these
+/// same bytes through `Log::open`.
+fn assert_unwritten_zero_tail(f: &Fixture, start: u64) {
+    let at = usize::try_from(start).expect("offset fits usize");
+    assert!(
+        f.bytes[at..].iter().all(|&b| b == 0),
+        "{}: the span is all zeros (provably unwritten)",
+        f.name
+    );
+    let err = decode(&f.bytes[at..]).expect_err("a zero word must not decode as a frame");
+    assert!(
+        matches!(
+            err,
+            DecodeError::BadMagic
+                | DecodeError::UnsupportedVersion(_)
+                | DecodeError::BadHeaderCrc
+                | DecodeError::Truncated
+        ),
+        "{}: header-class error at the zero window, got {err:?}",
+        f.name
+    );
+    // The valid prefix before the zero window decodes; its length is exactly `start`.
+    let (_, stop) = decode_segment_records(&f.bytes);
+    assert_eq!(
+        stop as u64, start,
+        "{}: prefix ends at the zero-window start",
         f.name
     );
 }

--- a/crates/ironbus-storage/src/admin.rs
+++ b/crates/ironbus-storage/src/admin.rs
@@ -1256,6 +1256,14 @@ where
 
     // Enumerate every file in the source tree (root + subdirs), reading its bytes. Excludes the LOCK
     // file at the root. This is the faithful copy: every committed artifact, by enumeration.
+    //
+    // TODO(perf/r5 follow-up): the ACTIVE segment is captured at its full preallocated LOGICAL
+    // length (`docs/PREALLOCATION.md`): the broker extends it to the roll size at create, so this
+    // verbatim copy reads and stores up to `max_segment_bytes` (64 MiB default) of mostly
+    // never-written zeros in EVERY backup. Correctness is unaffected (a restore + open recovers
+    // and silently truncates the zero tail), but the backup is bloated; a sparse-aware capture
+    // (bound the active segment's read at its recovered `valid_end`, recorded in the manifest) is
+    // deliberately NOT implemented in the preallocation change and is filed as a follow-up.
     let mut captured: Vec<(String, Vec<u8>)> = Vec::new();
     collect_tree(src, "", &mut captured)?;
 

--- a/crates/ironbus-storage/src/io.rs
+++ b/crates/ironbus-storage/src/io.rs
@@ -112,28 +112,41 @@ pub trait RandomAccessFile: Send + Sync {
     ///
     /// This is the cross-platform preallocation primitive (the four-primitive shim in
     /// `docs/PREALLOCATION.md`). It is a BEST-EFFORT optimization, never a correctness
-    /// requirement: it does not change the bytes a reader sees, it does not advance the
-    /// append cursor (the write position stays the logical length), and a backend that
-    /// cannot reserve blocks is free to do less. Two payoffs on the slow flash an edge node
-    /// runs on: the segment is placed as one contiguous extent (less fragmentation, faster
-    /// sequential scan), and the steady-state append writes into already-allocated space so
-    /// the per-commit `fdatasync` need not also persist a length-grow (less flash wear, lower
-    /// commit latency).
+    /// requirement: it does not change any byte that was ever written, it never SHRINKS the
+    /// file, it does not advance the append cursor (the writer's position is tracked by the
+    /// layers above, not derived from the file length), and a backend that cannot reserve
+    /// blocks is free to do less. The production [`StdFile`] does two things:
+    ///
+    /// 1. Reserves backing blocks (Linux `fallocate` with `FALLOC_FL_KEEP_SIZE`, macOS
+    ///    `fcntl(F_PREALLOCATE)`), so the segment is placed as one contiguous extent (less
+    ///    fragmentation, faster sequential scan) and appends never grow the block map.
+    /// 2. ADVANCES the LOGICAL length up to `len` (`set_len` up, never down), so every
+    ///    subsequent append lands INSIDE the logical size: the per-commit `fdatasync` no longer
+    ///    journals an inode-size (`i_size`) update on every commit. (It is NOT metadata-free:
+    ///    on ext4 the first append into each reserved-but-unwritten extent still journals that
+    ///    extent's one-time unwritten→written state conversion — both probe arms paid those —
+    ///    so what the extension eliminates is precisely the EVERY-COMMIT `i_size` update.
+    ///    Measured on the ext4/virtio bench VM: ~13us / 7% p50 and ~26us / 10% p99 saved per
+    ///    fdatasync versus the keep-size form whose every append grew `i_size`.)
+    ///
+    /// The logical extension makes the unwritten remainder READ BACK AS ZEROS, and a zero word
+    /// is never a valid record-frame magic, so recovery's torn-tail scan stops at the first
+    /// unwritten byte and truncates the unwritten tail (the zero-window end-of-data rule, the
+    /// frozen #45 fixture); recovery treats a provably all-zero tail as never-written space
+    /// (truncated silently, not reported as loss), and the seal path truncates the file back
+    /// down to the footer end (with the documented `set_len`-shrink-needs-`sync_all` pairing)
+    /// so a SEALED segment's on-disk image is byte-identical to a never-preallocated one and
+    /// footer discovery at the file end still works. A freshly preallocated, empty segment
+    /// (header then zeros) recovers as no records.
     ///
     /// The reservation is NOT the durability barrier: the ack-implies-durable guarantee is
-    /// always the commit `sync_data` (I2), independent of preallocation. A preallocated tail
-    /// reads back as ZEROS, and a zero word is never a valid record-frame magic, so recovery's
-    /// torn-tail scan stops at the first unwritten byte and truncates the unwritten tail
-    /// exactly as it truncates a torn one (the zero-window end-of-data rule, the frozen #45
-    /// fixture). A freshly preallocated, empty segment (header then zeros) therefore recovers
-    /// as no records.
+    /// always the commit `sync_data` (I2), independent of preallocation, and losing the
+    /// logical extension in a crash merely shortens the file back toward its data.
     ///
     /// The DEFAULT body is a no-op: a backend with no preallocation primitive degrades to
     /// today's grow-on-append, which is correct, only without the wear/latency benefit. The
-    /// production [`StdFile`] overrides it with the per-OS KEEP-SIZE reservation (Linux
-    /// `fallocate` with `FALLOC_FL_KEEP_SIZE`, macOS `fcntl(F_PREALLOCATE)`), which reserves
-    /// blocks WITHOUT advancing the logical length, falling back to grow-on-append on a
-    /// filesystem that supports none of them.
+    /// deterministic-simulation [`InMemoryFile`] deliberately only TRACKS the request (see its
+    /// docs); the ephemeral in-RAM backend keeps the no-op (it has no fsync cost to save).
     ///
     /// # Errors
     /// Propagates an underlying IO error (for example `ENOSPC`, which an implementation may
@@ -143,6 +156,46 @@ pub trait RandomAccessFile: Send + Sync {
         let _ = len;
         Ok(())
     }
+}
+
+/// Returns one past the LAST non-zero byte of `file` in `[start, end)`, or `start` when the
+/// whole region is zero. Scans BACKWARD in bounded 4 KiB chunks, so a roll-size region costs no
+/// large allocation (and, on a filesystem with unwritten-extent tracking, the zero portion costs
+/// no device IO: a preallocated hole reads back as zeros straight from the kernel).
+///
+/// This is the shared ZERO-TAIL BOUNDING rule for a preallocated, logically-extended active
+/// segment (`docs/PREALLOCATION.md`): the tail past the durable valid prefix may be up to a roll
+/// size of never-written zeros, so both recovery ([`Log::recover`](crate::log::Log)) and the
+/// offline inspector ([`OfflineReader`](crate::offline::OfflineReader)) bound what they REPORT
+/// (loss events, quarantine capture) at one past the tail's last non-zero byte — the end of the
+/// bytes that were ever plausibly written. An all-zero tail (`start` returned) is unwritten
+/// space, not loss. The bound can exclude trailing zero bytes of a genuinely torn frame (a frame
+/// whose last written bytes happen to be zero); that under-report of informationless zeros is
+/// deliberate and bounded, whereas reporting up to the FILE length would claim a roll size of
+/// "loss" per event, flood quarantine with near-all-zero blobs, and trip the I3 per-event cap on
+/// any segment size above it.
+///
+/// # Errors
+/// Propagates the underlying IO error from the positioned reads.
+pub(crate) fn last_nonzero_end<F: RandomAccessFile>(
+    file: &F,
+    start: u64,
+    end: u64,
+) -> io::Result<u64> {
+    let mut hi = end;
+    let mut buf = [0u8; 4096];
+    while hi > start {
+        let lo = hi.saturating_sub(buf.len() as u64).max(start);
+        // `hi - lo` is at most the 4 KiB buffer, so the conversion never truncates.
+        let want = usize::try_from(hi - lo).unwrap_or(buf.len());
+        let chunk = &mut buf[..want];
+        file.read_exact_at(chunk, lo)?;
+        if let Some(i) = chunk.iter().rposition(|&b| b != 0) {
+            return Ok(lo + i as u64 + 1);
+        }
+        hi = lo;
+    }
+    Ok(start)
 }
 
 fn invalid_input(msg: &'static str) -> io::Error {
@@ -228,12 +281,15 @@ pub struct InMemoryFile {
     syncs: AtomicU64,
     /// The highest `len` ever passed to [`preallocate`](RandomAccessFile::preallocate), or `0` if
     /// it was never called. The in-memory backend models preallocation as a TRACKED RESERVATION,
-    /// not a length change: a real `fallocate` reserves backing blocks without advancing the file's
-    /// logical length or its bytes, and the deterministic simulation must mirror that so a
-    /// preallocated active segment is byte-identical to a grow-on-append one (the determinism and
-    /// crash-recovery sweeps stay green, and recovery's truncated-tail accounting is unchanged).
-    /// A test reads this back via [`InMemoryFile::preallocated_to`] to assert the roll-size
-    /// reservation was requested.
+    /// not a length change. The production [`StdFile`] now ALSO advances the logical length up to
+    /// the reservation (so its per-commit fdatasync carries no `i_size` update), but mirroring that here
+    /// would materialize `max_segment_bytes` of zeros in RAM for every active segment across every
+    /// simulation and server test (and double again in the durable image), so the simulation keeps
+    /// the compact reservation-only model: a preallocated active segment stays byte-identical to a
+    /// grow-on-append one, the determinism and crash-recovery sweeps stay green, and the
+    /// extended-zero-tail recovery behavior is pinned by explicit tests and the frozen #45
+    /// zero-window fixture, which write the zero tail out for real. A test reads this back via
+    /// [`InMemoryFile::preallocated_to`] to assert the roll-size reservation was requested.
     preallocated_to: AtomicU64,
 }
 
@@ -462,10 +518,13 @@ impl RandomAccessFile for InMemoryFile {
     }
 
     fn preallocate(&self, len: u64) -> io::Result<()> {
-        // Model `fallocate`: RESERVE backing space without changing the file's bytes or its
-        // logical length, so a preallocated active segment is byte-identical to a grow-on-append
-        // one and the determinism / crash-recovery sweeps stay green. Only the requested reservation
-        // is recorded (a high-water mark a test can read via `preallocated_to`).
+        // Model the RESERVATION half only: record the request without changing the file's bytes or
+        // its logical length, so a preallocated active segment is byte-identical to a grow-on-append
+        // one and the determinism / crash-recovery sweeps stay green. The production `StdFile` also
+        // extends the logical length; the simulation deliberately does not (see the field docs on
+        // `preallocated_to` for why), and the zero-tail recovery behavior that extension creates is
+        // pinned by tests that write the zero tail explicitly. Only the requested reservation is
+        // recorded (a high-water mark a test can read via `preallocated_to`).
         self.preallocated_to.fetch_max(len, Ordering::SeqCst);
         Ok(())
     }
@@ -521,6 +580,32 @@ mod tests {
         f.write_all_at(b"G", 0).unwrap();
         f.sync_data().unwrap();
         assert_eq!(f.durable_snapshot(), b"GDBA\x00\x00FF");
+    }
+
+    #[test]
+    fn last_nonzero_end_bounds_a_zero_tail_at_the_last_written_byte() {
+        // The zero-tail bounding rule recovery and the offline inspector share: the returned
+        // end is one past the LAST non-zero byte of the region, `start` for an all-zero region,
+        // exact across the backward 4 KiB chunk boundaries.
+        let f = InMemoryFile::new();
+        // An all-zero region (a pure preallocated extension) bounds to `start`.
+        f.set_len(3 * 4096 + 17).unwrap();
+        assert_eq!(last_nonzero_end(&f, 100, f.len().unwrap()).unwrap(), 100);
+        // A single non-zero byte in the FIRST chunk of the region: found across the backward
+        // chunk walk (two full zero chunks are scanned and skipped first).
+        f.write_all_at(&[0xAB], 334).unwrap();
+        assert_eq!(last_nonzero_end(&f, 100, f.len().unwrap()).unwrap(), 335);
+        // A later non-zero byte wins (the LAST one bounds), including exactly on a chunk edge.
+        f.write_all_at(&[0x01], 2 * 4096 - 1).unwrap();
+        assert_eq!(
+            last_nonzero_end(&f, 100, f.len().unwrap()).unwrap(),
+            2 * 4096
+        );
+        // A non-zero byte at `start` itself is inside the region; one just below is not.
+        assert_eq!(last_nonzero_end(&f, 334, 4096).unwrap(), 335);
+        assert_eq!(last_nonzero_end(&f, 335, 4096).unwrap(), 335);
+        // An empty region is `start`.
+        assert_eq!(last_nonzero_end(&f, 42, 42).unwrap(), 42);
     }
 
     #[test]
@@ -1092,66 +1177,79 @@ impl RandomAccessFile for StdFile {
     }
 
     // Preallocation (the `docs/PREALLOCATION.md` shim). Reserve `len` backing blocks for the
-    // segment up front so the steady-state appends write into already-allocated space. This is a
-    // BEST-EFFORT optimization: the fallback ladder bottoms out at today's grow-on-append, which is
-    // correct, only without the wear/latency win. It never advances the append cursor and never
-    // changes a byte a reader sees; the preallocated tail is zeros that recovery's torn-tail scan
-    // truncates exactly as it would a torn tail (the frozen #45 zero-window fixture).
+    // segment up front AND advance the logical length to the reservation boundary, so the
+    // steady-state appends land inside already-allocated space AND inside the logical size: the
+    // per-commit `fdatasync` then carries no `i_size` update (first-touch unwritten→written
+    // extent-state conversions are still journaled; see the trait doc for the honest
+    // accounting). This is a BEST-EFFORT optimization: the fallback ladder bottoms out at today's
+    // grow-on-append, which is correct, only without the wear/latency win. It never advances the
+    // append cursor and never changes a byte that was written; the unwritten tail is zeros that
+    // recovery's torn-tail scan truncates (the frozen #45 zero-window fixture), and the seal path
+    // truncates the file back down to the footer end.
     fn preallocate(&self, len: u64) -> io::Result<()> {
         preallocate_file(&self.file, len)
     }
 }
 
-/// Reserves `len` backing blocks for `file`, with the per-OS reservation recipe and a fallback
-/// ladder that bottoms out at grow-on-append (the `docs/PREALLOCATION.md` shim, primitive (a)).
+/// Reserves `len` backing blocks for `file` AND advances its LOGICAL length up to `len`, with the
+/// per-OS reservation recipe and a fallback ladder that bottoms out at grow-on-append (the
+/// `docs/PREALLOCATION.md` shim, primitive (a)).
 ///
-/// CRUCIAL invariant: the reservation reserves blocks WITHOUT advancing the file's LOGICAL length.
-/// The append cursor is the logical end of data, and recovery and the offline scan tools find the
-/// end of data from `file.len()`; if preallocation grew the logical length to `len`, every reader
-/// would see a 64 MiB zero tail and (correctly but needlessly) report it as a torn/zero window. So
-/// each OS uses the keep-size form: Linux `fallocate` with `FALLOC_FL_KEEP_SIZE`, macOS
-/// `F_PREALLOCATE` alone (which never advances the size). The appends then extend the logical
-/// length the normal way (a positioned write past the current end), landing in already-reserved
-/// blocks.
+/// Two halves, deliberately paired (the Redpanda `segment_appender` recipe: `fallocate` then
+/// truncate UP to the preallocation boundary):
 ///
-/// - **Linux**: `fallocate(fd, FALLOC_FL_KEEP_SIZE, 0, len)` reserves real extents on ext4/f2fs/xfs
-///   (the edge targets) and keeps the apparent size. On `EOPNOTSUPP`/`ENOSYS` (a filesystem with no
-///   allocation support, e.g. some tmpfs) it falls back to grow-on-append.
-/// - **Apple**: `fcntl(fd, F_PREALLOCATE)` requesting contiguous blocks (`F_ALLOCATECONTIG`) then
-///   any blocks (`F_ALLOCATEALL`); it reserves blocks and never advances the logical size, so no
-///   `ftruncate` pairing is used. On `ENOTSUP` it falls back to grow-on-append.
-/// - **Any other Unix**: no portable keep-size reservation syscall, so it is grow-on-append (a
-///   no-op here).
+/// 1. **Block reservation** (keep-size form): Linux `fallocate(fd, FALLOC_FL_KEEP_SIZE, 0, len)`
+///    reserves real extents on ext4/f2fs/xfs (the edge targets); Apple
+///    `fcntl(fd, F_PREALLOCATE)` requests contiguous blocks (`F_ALLOCATECONTIG`) then any blocks
+///    (`F_ALLOCATEALL`). A filesystem with no allocation support
+///    (`EOPNOTSUPP`/`ENOSYS`/`ENOTSUP`) degrades to no reservation; any other Unix has no portable
+///    reservation syscall and skips this half.
+/// 2. **Logical extension**: `set_len` UP to `len` (never down — a file already longer is left
+///    alone). Every subsequent append then lands INSIDE the logical size, so the per-commit
+///    `fdatasync` no longer journals an `i_size` update per sync. It is NOT metadata-free: an
+///    append's first touch of a reserved-but-unwritten extent still journals that extent's
+///    one-time unwritten→written state conversion (both measurement arms paid those); the
+///    EVERY-COMMIT `i_size` update is what the extension eliminates. Measured on the
+///    ext4/virtio bench VM this saves ~13us (7%) p50 and ~26us (10%) p99 per fdatasync versus
+///    the keep-size-only form. The one-time size-grow metadata commit is paid by the first
+///    sync after this call.
 ///
-/// `len == 0` is a no-op (nothing to reserve). The reservation is never the durability barrier: the
-/// commit `sync_data` (I2) is, independent of this call. A genuine `ENOSPC` is surfaced so the
-/// caller can route a create-time out-of-space to the overflow path rather than discover it
+/// The extension is what the rest of the engine is built to absorb: the writer's append cursor is
+/// tracked by the layers above (never derived from `file.len()`), the unwritten tail reads back as
+/// zeros that recovery's zero-window rule truncates silently (never-written space, not loss), and
+/// the seal path truncates the file back down to the footer end so a sealed segment's image is
+/// byte-identical to a never-preallocated one.
+///
+/// `len == 0` is a no-op (nothing to reserve). The call is never the durability barrier: the
+/// commit `sync_data` (I2) is, independent of this call, and an extension lost to a crash merely
+/// leaves a shorter file that recovery handles like any other. A genuine `ENOSPC` is surfaced so
+/// the caller can route a create-time out-of-space to the overflow path rather than discover it
 /// mid-append.
 #[cfg(unix)]
 fn preallocate_file(file: &std::fs::File, len: u64) -> io::Result<()> {
     if len == 0 {
         return Ok(());
     }
+    // Half 1: reserve backing blocks (best-effort per OS; unsupported filesystems degrade inside).
     #[cfg(target_os = "linux")]
-    {
-        preallocate_linux(file, len)
-    }
+    preallocate_linux(file, len)?;
     #[cfg(target_vendor = "apple")]
-    {
-        preallocate_apple(file, len)
+    preallocate_apple(file, len)?;
+    // Half 2: advance the logical length up to the reservation boundary (never shrink). Done even
+    // when the reservation half degraded (or does not exist, on another Unix): a sparse extension
+    // still moves the size-grow metadata commit off the per-commit fdatasync path, which is the
+    // measured win; only the contiguity/wear benefit needs real reserved blocks.
+    if file.metadata()?.len() < len {
+        file.set_len(len)?;
     }
-    // Any other Unix (no portable keep-size reservation primitive): grow-on-append, the bottom rung.
-    #[cfg(not(any(target_os = "linux", target_vendor = "apple")))]
-    {
-        let _ = (file, len);
-        Ok(())
-    }
+    Ok(())
 }
 
 /// Linux: `fallocate(fd, FALLOC_FL_KEEP_SIZE, 0, len)` reserves real extents while KEEPING the
-/// apparent file size (so the logical length still grows only with appends). A filesystem that
-/// cannot allocate (`EOPNOTSUPP`/`ENOSYS`) degrades to grow-on-append; any other error (e.g.
-/// `ENOSPC`) is surfaced so a create-time out-of-space is not masked.
+/// apparent file size; the caller ([`preallocate_file`]) then advances the logical length with a
+/// single `ftruncate`-up, which together are equivalent to a mode-0 `fallocate` (reserve + size).
+/// A filesystem that cannot allocate (`EOPNOTSUPP`/`ENOSYS`) degrades to the extension alone; any
+/// other error (e.g. `ENOSPC`) is surfaced so a create-time out-of-space is not masked.
 #[cfg(target_os = "linux")]
 fn preallocate_linux(file: &std::fs::File, len: u64) -> io::Result<()> {
     use std::os::unix::io::AsRawFd;
@@ -1180,9 +1278,9 @@ fn preallocate_linux(file: &std::fs::File, len: u64) -> io::Result<()> {
 }
 
 /// Apple: `fcntl(fd, F_PREALLOCATE)` reserves blocks (contiguous if possible) WITHOUT advancing the
-/// logical size, which is exactly the keep-size reservation we want (no `ftruncate` pairing, so the
-/// logical length still grows only with appends). If `F_PREALLOCATE` is unsupported (`ENOTSUP`),
-/// fall back to grow-on-append.
+/// logical size; the caller ([`preallocate_file`]) then advances the logical length with a single
+/// `set_len`-up (the `ftruncate` pairing Apple's own docs describe for a full preallocation). If
+/// `F_PREALLOCATE` is unsupported (`ENOTSUP`), fall back to the extension alone.
 #[cfg(target_vendor = "apple")]
 fn preallocate_apple(file: &std::fs::File, len: u64) -> io::Result<()> {
     use std::os::unix::io::AsRawFd;
@@ -1376,41 +1474,73 @@ mod std_file_tests {
     }
 
     #[test]
-    fn preallocate_keeps_the_logical_length_and_appends_round_trip() {
-        // The keep-size reservation reserves blocks WITHOUT advancing the logical length: the
-        // header written at 0 is intact, the logical length stays at the written length (no zero
-        // tail a reader or the offline scan tools would see), and an append into the reserved range
-        // round-trips. This is the load-bearing property: the logical length grows only with
-        // appends, so recovery and the offline `dump`/`scrub` tools find the end of data unchanged.
+    fn preallocate_extends_the_logical_length_and_appends_land_inside() {
+        // The production preallocation reserves blocks AND advances the LOGICAL length up to the
+        // reservation boundary, so subsequent appends land inside the logical size and the
+        // per-commit fdatasync carries no i_size update. The unwritten remainder
+        // reads back as ZEROS (the zero-window end-of-data rule recovery relies on), the written
+        // header is intact, and an append inside the extension round-trips.
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("seg.log");
         let f = StdFile::create(&path).unwrap();
         f.write_all_at(b"HEADER", 0).unwrap();
-        f.preallocate(64 * 1024).unwrap();
+        let want: u64 = 64 * 1024;
+        f.preallocate(want).unwrap();
         f.sync_all().unwrap();
-        // The header is intact and the LOGICAL length is unchanged (the reservation grew no bytes).
+        // The header is intact and the LOGICAL length is the preallocation boundary.
         let mut hdr = [0u8; 6];
         f.read_exact_at(&mut hdr, 0).unwrap();
         assert_eq!(&hdr, b"HEADER");
         assert_eq!(
             f.len().unwrap(),
-            6,
-            "keep-size preallocation does not advance the logical length"
+            want,
+            "preallocation advances the logical length to the boundary"
         );
-        // A read past the logical end is a real EOF, exactly as before preallocation (no zero tail).
-        let mut buf = [0u8; 4];
-        assert_eq!(
-            f.read_at(&mut buf, 6).unwrap(),
-            0,
-            "no zero tail past the end"
+        // The unwritten tail reads back as zeros (never garbage): the zero-window rule's premise.
+        let mut tail = [0xFFu8; 32];
+        f.read_exact_at(&mut tail, 6).unwrap();
+        assert!(
+            tail.iter().all(|&b| b == 0),
+            "the unwritten extension reads back as zeros"
         );
-        // An append extends the logical length into the reserved range and round-trips.
+        // An append at the cursor (INSIDE the logical size) round-trips and does not grow the file.
         f.write_all_at(b"record", 6).unwrap();
         f.sync_data().unwrap();
-        assert_eq!(f.len().unwrap(), 12);
+        assert_eq!(
+            f.len().unwrap(),
+            want,
+            "an in-size append never grows i_size"
+        );
         let mut back = [0u8; 12];
         f.read_exact_at(&mut back, 0).unwrap();
         assert_eq!(&back, b"HEADERrecord");
+        // The seal-path shape: a shrink back to the true end (set_len + sync_all) works.
+        f.set_len(12).unwrap();
+        f.sync_all().unwrap();
+        assert_eq!(
+            f.len().unwrap(),
+            12,
+            "the seal truncates the zero tail away"
+        );
+    }
+
+    #[test]
+    fn preallocate_never_shrinks_a_longer_file() {
+        // A reservation smaller than the current length must never truncate data: the extension
+        // half is set_len UP only.
+        let dir = tempfile::tempdir().unwrap();
+        let f = StdFile::create(&dir.path().join("long.log")).unwrap();
+        let data = vec![7u8; 8192];
+        f.write_all_at(&data, 0).unwrap();
+        f.preallocate(4096).unwrap();
+        assert_eq!(
+            f.len().unwrap(),
+            8192,
+            "a smaller preallocation never shrinks the file"
+        );
+        let mut back = vec![0u8; 8192];
+        f.read_exact_at(&mut back, 0).unwrap();
+        assert_eq!(back, data);
     }
 
     #[test]

--- a/crates/ironbus-storage/src/log.rs
+++ b/crates/ironbus-storage/src/log.rs
@@ -737,8 +737,10 @@ pub struct Log<F: Filesystem, C: Clock> {
     /// scan. Exposed by [`Log::durable_record_count`].
     total_record_count: u64,
     /// Bytes dropped from a torn or unsynced active-segment tail at recovery: the silent
-    /// loss that recovery truncates to reach the last intact record. Zero for a fresh log
-    /// or a clean recovery.
+    /// loss that recovery truncates to reach the last intact record. Bounded at one past the
+    /// tail's last NON-ZERO byte (`crate::io::last_nonzero_end`): the never-written zeros of a
+    /// preallocated logical extension past that bound are truncated too but were never data, so
+    /// they are not counted. Zero for a fresh log, a clean recovery, or an all-zero tail.
     recovered_truncated_bytes: u64,
     /// The structured, versioned report of what recovery dropped (#120): the same loss as
     /// `recovered_truncated_bytes`, but as per-segment events carrying the byte span and the
@@ -1305,12 +1307,24 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
         if file_len <= header {
             return Ok(true);
         }
-        let mut pos = header;
+        Self::region_is_all_zero(file, header, file_len)
+    }
+
+    /// `true` if every byte of `file` in `[start, end)` is zero. Reads in bounded 4 KiB chunks so
+    /// a `max_segment_bytes`-long region costs no large allocation (and, on a filesystem with
+    /// unwritten-extent tracking, no device IO at all: a preallocated hole reads back as zeros
+    /// straight from the kernel). The #868 reap uses it via
+    /// [`segment_body_is_all_zero`](Log::segment_body_is_all_zero) to prove a bad-header trailing
+    /// segment is a genuinely-empty preallocated tail. (Recovery's zero-tail REPORTING rule uses
+    /// the sibling [`crate::io::last_nonzero_end`], which additionally bounds a non-zero tail at
+    /// one past its last written byte.)
+    fn region_is_all_zero(file: &F::File, start: u64, end: u64) -> Result<bool, StorageError> {
+        let mut pos = start;
         let mut buf = [0u8; 4096];
-        while pos < file_len {
+        while pos < end {
             let want = buf
                 .len()
-                .min(usize::try_from(file_len - pos).unwrap_or(usize::MAX));
+                .min(usize::try_from(end - pos).unwrap_or(usize::MAX));
             let chunk = &mut buf[..want];
             file.read_exact_at(chunk, pos)?;
             if chunk.iter().any(|&b| b != 0) {
@@ -1589,36 +1603,59 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
             let file = log.fs.open(&name)?;
             let len = file.len()?;
             if scan.valid_end < len {
-                // Record the silent loss before dropping it, so an operator can see that a
-                // torn or unsynced tail was discarded at recovery, both as a raw byte count
-                // and as a structured loss event carrying the span and the reason (#120). The
-                // records-lost estimate is a lower bound: the torn or corrupt span is, by
-                // definition, not fully parseable, but at least the frame at `valid_end` is gone.
-                log.recovered_truncated_bytes = len - scan.valid_end;
-                let reason = scan.tail_reason.unwrap_or(ReasonCode::TornTail);
-                let event = LossEvent::span(last_id, scan.valid_end, len, 1, reason);
-                log.loss_report.push(event);
-                // Quarantine the corrupt bytes BEFORE truncating them away, while `file` still holds
-                // the full image (#134). This is a COPY: it only ever reads `file`, and the
-                // truncation below is unchanged. It is best-effort and forensic, so any quarantine
-                // failure is swallowed and never affects the truncation or the open; a clean torn
-                // tail is not quarantined (see `quarantine::is_corruption_skip`).
-                if crate::quarantine::is_corruption_skip(reason) {
-                    let captured = crate::quarantine::quarantine_corrupt_span(
-                        &log.fs,
-                        &file,
-                        &event,
-                        log.config.max_quarantine_bytes,
-                    );
-                    // Reflect the new blob in the PERSISTED total (#315). A capture under a cap can
-                    // evict older blobs to make room, so re-derive the gauge from the true on-disk
-                    // footprint (the seeded scan plus this capture, net of any eviction) rather than
-                    // a naive add. The re-scan is read-only and best-effort, so it never affects the
-                    // truncation below or the open. The cheap `captured > 0` guard skips the re-scan
-                    // when nothing was captured (a cap skip or a best-effort give-up).
-                    if captured > 0 {
-                        log.quarantined_bytes = crate::quarantine::persisted_bytes(&log.fs);
+                // Distinguish DISCARDED DATA from the unwritten remainder of a preallocated,
+                // logically-extended active segment: the production `StdFile::preallocate` advances
+                // the logical length to the roll size up front, so even a clean kill leaves the
+                // active segment with a (possibly roll-size) all-zero tail past the last record.
+                // Zeros are provably not acked data — a zero word is never a valid frame magic, so
+                // no frame was ever written there — so everything REPORTED (the loss event, the
+                // quarantine capture, `recovered_truncated_bytes`) is bounded at one past the
+                // tail's LAST NON-ZERO byte, the end of the bytes that were ever plausibly
+                // written. An ALL-ZERO tail is truncated silently (the same I3-tripping non-loss
+                // #868 declined to record); reporting to the FILE length instead would claim (and
+                // quarantine) up to a whole roll size of never-written zeros for ONE torn byte,
+                // and would fail the boot on the I3 per-event cap whenever `max_segment_bytes`
+                // exceeds it. The FILE truncation below still cuts at `valid_end` as before.
+                let reported_end = crate::io::last_nonzero_end(&file, scan.valid_end, len)?;
+                if reported_end > scan.valid_end {
+                    // Record the silent loss before dropping it, so an operator can see that a
+                    // torn or unsynced tail was discarded at recovery, both as a raw byte count
+                    // and as a structured loss event carrying the span and the reason (#120). The
+                    // records-lost estimate is a lower bound: the torn or corrupt span is, by
+                    // definition, not fully parseable, but at least the frame at `valid_end` is gone.
+                    log.recovered_truncated_bytes = reported_end - scan.valid_end;
+                    let reason = scan.tail_reason.unwrap_or(ReasonCode::TornTail);
+                    let event = LossEvent::span(last_id, scan.valid_end, reported_end, 1, reason);
+                    log.loss_report.push(event);
+                    // Quarantine the corrupt bytes BEFORE truncating them away, while `file` still holds
+                    // the full image (#134). This is a COPY: it only ever reads `file`, and the
+                    // truncation below is unchanged. It is best-effort and forensic, so any quarantine
+                    // failure is swallowed and never affects the truncation or the open; a clean torn
+                    // tail is not quarantined (see `quarantine::is_corruption_skip`).
+                    if crate::quarantine::is_corruption_skip(reason) {
+                        let captured = crate::quarantine::quarantine_corrupt_span(
+                            &log.fs,
+                            &file,
+                            &event,
+                            log.config.max_quarantine_bytes,
+                        );
+                        // Reflect the new blob in the PERSISTED total (#315). A capture under a cap can
+                        // evict older blobs to make room, so re-derive the gauge from the true on-disk
+                        // footprint (the seeded scan plus this capture, net of any eviction) rather than
+                        // a naive add. The re-scan is read-only and best-effort, so it never affects the
+                        // truncation below or the open. The cheap `captured > 0` guard skips the re-scan
+                        // when nothing was captured (a cap skip or a best-effort give-up).
+                        if captured > 0 {
+                            log.quarantined_bytes = crate::quarantine::persisted_bytes(&log.fs);
+                        }
                     }
+                    // I3, enforced BEFORE the destructive truncate below: a cap-exceeding loss must
+                    // fail closed with the evidence still ON DISK (plus the forensic quarantine copy
+                    // just taken). Truncating first would destroy the over-cap bytes, so the NEXT
+                    // boot would open clean with an empty loss report — a fail-closed refusal that
+                    // scrubbed the very state the operator is being told to inspect. The end-of-open
+                    // check below stays as the backstop for the paths that push no event here.
+                    log.enforce_loss_caps(durable_bytes)?;
                 }
                 file.set_len(scan.valid_end)?;
                 file.sync_all()?;
@@ -1639,21 +1676,33 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
             ));
         }
 
-        // I3: fail closed if recovery would drop more than the bounded-loss caps allow (#120),
-        // rather than accept unbounded silent loss. The per-event cap is one segment or 64 MiB,
-        // whichever is smaller. The global cap is 1% of the durable bytes, FLOORED at the
-        // per-event cap so a single in-cap event (the normal torn tail, even on a tiny log whose
-        // 1% is under one byte) is always within bounds; without that floor the literal 1% would
-        // freeze a normal small-log recovery.
-        let per_event_cap = log
+        // I3 backstop: the torn-tail path above already enforced the caps BEFORE its truncate;
+        // this covers the no-event paths (a roll-forward pushes nothing) so every recovery exit
+        // is cap-checked exactly once against its final report.
+        log.enforce_loss_caps(durable_bytes)?;
+        Ok(log)
+    }
+
+    /// I3: fail closed if recovery would drop more than the bounded-loss caps allow (#120),
+    /// rather than accept unbounded silent loss. The per-event cap is one segment or 64 MiB,
+    /// whichever is smaller. The global cap is 1% of the durable bytes, FLOORED at the
+    /// per-event cap so a single in-cap event (the normal torn tail, even on a tiny log whose
+    /// 1% is under one byte) is always within bounds; without that floor the literal 1% would
+    /// freeze a normal small-log recovery.
+    ///
+    /// Both recovery paths call this at two points: right AFTER pushing the active-segment tail
+    /// loss event but BEFORE the truncate that would destroy the over-cap bytes (fail-closed must
+    /// leave the evidence on disk for the next boot and the offline inspector), and once more at
+    /// the end of the open as the backstop for the paths that push no tail event.
+    fn enforce_loss_caps(&self, durable_bytes: u64) -> Result<(), StorageError> {
+        let per_event_cap = self
             .config
             .max_segment_bytes
             .min(LossReport::PER_EVENT_BYTE_CAP);
         let global_cap = LossReport::global_loss_cap_bytes(durable_bytes).max(per_event_cap);
-        log.loss_report
+        self.loss_report
             .check_caps(per_event_cap, global_cap)
-            .map_err(StorageError::ExcessiveRecoveryLoss)?;
-        Ok(log)
+            .map_err(StorageError::ExcessiveRecoveryLoss)
     }
 
     /// Recovers a data directory that contains at least one COMPACTED (v2) segment (#337),
@@ -2085,20 +2134,34 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
                 let name = segment_file_name(a.id);
                 let file = log.fs.open(&name)?;
                 if a.valid_end < a.file_len {
-                    log.recovered_truncated_bytes = a.file_len - a.valid_end;
-                    let reason = a.tail_reason.unwrap_or(ReasonCode::TornTail);
-                    let event = LossEvent::span(a.id, a.valid_end, a.file_len, 1, reason);
-                    log.loss_report.push(event);
-                    if crate::quarantine::is_corruption_skip(reason) {
-                        let captured = crate::quarantine::quarantine_corrupt_span(
-                            &log.fs,
-                            &file,
-                            &event,
-                            log.config.max_quarantine_bytes,
-                        );
-                        if captured > 0 {
-                            log.quarantined_bytes = crate::quarantine::persisted_bytes(&log.fs);
+                    // As in the v1 recovery: the REPORTED span (loss event, quarantine capture,
+                    // `recovered_truncated_bytes`) is bounded at one past the tail's LAST NON-ZERO
+                    // byte — an all-zero tail is the unwritten remainder of the preallocated
+                    // logical extension (never acked data), truncated silently; a non-zero tail is
+                    // reported and quarantined over only the bytes that were ever plausibly
+                    // written, never the roll-size extension. The FILE truncation stays at
+                    // `valid_end`.
+                    let reported_end = crate::io::last_nonzero_end(&file, a.valid_end, a.file_len)?;
+                    if reported_end > a.valid_end {
+                        log.recovered_truncated_bytes = reported_end - a.valid_end;
+                        let reason = a.tail_reason.unwrap_or(ReasonCode::TornTail);
+                        let event = LossEvent::span(a.id, a.valid_end, reported_end, 1, reason);
+                        log.loss_report.push(event);
+                        if crate::quarantine::is_corruption_skip(reason) {
+                            let captured = crate::quarantine::quarantine_corrupt_span(
+                                &log.fs,
+                                &file,
+                                &event,
+                                log.config.max_quarantine_bytes,
+                            );
+                            if captured > 0 {
+                                log.quarantined_bytes = crate::quarantine::persisted_bytes(&log.fs);
+                            }
                         }
+                        // I3 BEFORE the destructive truncate, as in the v1 path: a cap-exceeding
+                        // report (this tail event, or the #836 corrupt-compacted events already
+                        // pushed above) must fail closed with the tail evidence still on disk.
+                        log.enforce_loss_caps(durable_bytes)?;
                     }
                     file.set_len(a.valid_end)?;
                     file.sync_all()?;
@@ -2139,18 +2202,12 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
 
         // I3 bounded-loss caps, identical to the v1 path: fail closed rather than accept unbounded
         // silent loss. The orphan/superseded reconciliation unlinks lose nothing (their data is
-        // present elsewhere), so the only loss events here are an active-segment torn tail and any
-        // #836 committed-but-corrupt compacted segment the reconciliation quarantined — the latter
-        // is exactly why the cap matters, so a cascade of corrupt compacted segments fails closed
+        // present elsewhere), so the only loss events here are an active-segment torn tail (already
+        // cap-checked BEFORE its truncate above) and any #836 committed-but-corrupt compacted
+        // segment the reconciliation quarantined — the latter is exactly why this backstop matters
+        // on the no-tail-event paths, so a cascade of corrupt compacted segments fails closed
         // rather than silently dropping every survivor they covered.
-        let per_event_cap = log
-            .config
-            .max_segment_bytes
-            .min(LossReport::PER_EVENT_BYTE_CAP);
-        let global_cap = LossReport::global_loss_cap_bytes(durable_bytes).max(per_event_cap);
-        log.loss_report
-            .check_caps(per_event_cap, global_cap)
-            .map_err(StorageError::ExcessiveRecoveryLoss)?;
+        log.enforce_loss_caps(durable_bytes)?;
         Ok(log)
     }
 
@@ -2170,17 +2227,23 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
             flags: 0,
         };
         let file = self.fs.create_new(&segment_file_name(id))?;
-        // Preallocate the new active segment to the full roll size BEFORE the first append, so the
-        // steady-state appends write into already-reserved space (`docs/PREALLOCATION.md`). This is
-        // a BEST-EFFORT optimization: a filesystem with no reservation primitive (or any preallocate
-        // error) degrades to today's grow-on-append, so the failure is SWALLOWED and never fails the
-        // create. The reserved tail is zeros that recovery's torn-tail scan truncates exactly as a
-        // torn tail (the frozen #45 zero-window fixture), so preallocation cannot break recovery: a
-        // freshly preallocated empty segment (header then zeros) recovers as no records, and a
-        // partially-written one recovers to its longest valid prefix. A genuine create-time
-        // out-of-space is therefore not surfaced here as a distinct fail-fast event; it falls back to
-        // grow-on-append and surfaces at the append/sync as it does today (the doc's ENOSPC-to-
-        // `AtCapacity` routing is a forward refinement, not required for correctness).
+        // Preallocate the new active segment to the full roll size BEFORE the first append: the
+        // production backend reserves the blocks AND advances the LOGICAL length to the roll size
+        // (`docs/PREALLOCATION.md`), so every steady-state append lands inside both the reserved
+        // space and the logical size and the per-commit fdatasync carries no i_size update (the
+        // one-time unwritten→written extent-state conversions are still journaled on first touch;
+        // `io.rs` has the honest accounting). This is a BEST-EFFORT optimization: a filesystem
+        // with no reservation primitive (or any preallocate error) degrades to today's
+        // grow-on-append, so the failure is SWALLOWED and never fails the create. The unwritten
+        // tail is zeros that recovery's torn-tail scan stops at (the frozen #45 zero-window
+        // fixture) and truncates SILENTLY (never-written space, not loss), and `seal` truncates
+        // the file down to the footer end, so preallocation cannot break recovery or footer
+        // discovery: a freshly preallocated empty segment (header then zeros) recovers as no
+        // records, and a partially-written one recovers to its longest valid prefix. A genuine
+        // create-time out-of-space is therefore not surfaced here as a distinct fail-fast event;
+        // it falls back to grow-on-append and surfaces at the append/sync as it does today (the
+        // doc's ENOSPC-to-`AtCapacity` routing is a forward refinement, not required for
+        // correctness).
         let _ = file.preallocate(self.config.max_segment_bytes);
         let mut writer = SegmentWriter::create(file, header)?;
         writer.sync()?; // the header is durable...
@@ -3555,10 +3618,17 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
             self.seek_in_segment(slot, seg_start, remaining)?
         else {
             // The index does not cover `seg_start` (the as-yet-unflushed active tail): fall back to a
-            // full scan for this segment — correct, only (rarely) slower, the same records.
-            let records = SegmentReader::open(self.fs.open(&segment_file_name(slot.id))?)?
-                .scan()?
-                .records;
+            // full scan for this segment — correct, only (rarely) slower, the same records. The
+            // ACTIVE segment's scan is bounded at the writer's `write_pos`: its preallocated logical
+            // extension makes the FILE roll-size long, and an unbounded fallback would eagerly
+            // allocate and read the whole zero tail (up to 64 MiB of zeros for the same records).
+            let mut reader = SegmentReader::open(self.fs.open(&segment_file_name(slot.id))?)?;
+            if slot.id == self.active_id {
+                if let Some(writer) = self.active.as_ref() {
+                    reader = reader.with_data_end(writer.write_pos());
+                }
+            }
+            let records = reader.scan()?.records;
             for record in records {
                 if record.offset.get() < bounds.start_v {
                     continue;
@@ -4042,6 +4112,15 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
             });
         }
 
+        // Capture the active writer's data end BEFORE dropping it: when the KEPT segment is the
+        // active one, its preallocated logical extension makes the file roll-size long, and the
+        // `record_byte_positions` walk below would otherwise eagerly allocate and read the whole
+        // zero tail. Bounding the reader at `write_pos` is byte-identical for the walk (zeros
+        // decode no frame) and leaves the truncate-down below untouched.
+        let keep_data_end = (keep_slot.id == self.active_id)
+            .then(|| self.active.as_ref().map(SegmentWriter::write_pos))
+            .flatten();
+
         // Drop the active writer before any file surgery: it is rebuilt from the recovered chain.
         self.active = None;
 
@@ -4076,7 +4155,10 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
         // offset (it held only surviving records), nothing inside it is cut beyond removing a sealed
         // footer — which unseals it into the active writer, matching a fresh log's shape.
         let keep_name = segment_file_name(keep_slot.id);
-        let reader = SegmentReader::open(self.fs.open(&keep_name)?)?;
+        let mut reader = SegmentReader::open(self.fs.open(&keep_name)?)?;
+        if let Some(end) = keep_data_end {
+            reader = reader.with_data_end(end);
+        }
         let (positions, body_end) = reader.record_byte_positions()?;
         let within = usize::try_from(target_v - keep_slot.base_offset)
             .map_err(|_| StorageError::SegmentFull)?;
@@ -5467,6 +5549,284 @@ mod tests {
         }
         // The recovered writer resumes cleanly at offset 5.
         assert_eq!(log.append(&rec(b"after")).unwrap(), Offset::new(5));
+    }
+
+    #[test]
+    fn a_preallocated_logical_extension_zero_tail_recovers_silently_with_no_loss_event() {
+        // The PRODUCTION preallocation (`StdFile`) advances the active segment's logical length to
+        // the roll size, so a crash — or even a clean kill — leaves header + records + a large
+        // all-zero tail (here a multi-MiB one, the hazard case: the scan must stop at the first
+        // zero word, never walk the span frame-by-frame, and never classify it as loss). Recovery
+        // must recover exactly the records and truncate the never-written zero tail SILENTLY: no
+        // loss event, no quarantine, no recovered_truncated_bytes — those zeros were never acked
+        // data, and reporting a roll-size span on every boot would trip the I3 caps for nothing.
+        // The in-memory backend models the reservation only, so the test writes the logical
+        // extension out for real with the same set_len-up the production preallocate performs.
+        let cfg = LogConfig {
+            max_segment_bytes: 8 * 1024 * 1024,
+            ..LogConfig::default()
+        };
+        let mut log = open_mem(cfg);
+        for i in 0..3u8 {
+            log.append(&rec(&[i; 8])).unwrap();
+        }
+        log.sync().unwrap();
+        let file = log.filesystem().open(&segment_file_name(0)).unwrap();
+        let valid_end = file.len().unwrap();
+        file.set_len(cfg.max_segment_bytes).unwrap();
+        file.sync_all().unwrap();
+        let fs = log.into_filesystem();
+
+        let mut log = Log::open(fs, ManualClock::new(), cfg).unwrap();
+        assert_eq!(log.next_offset(), Offset::new(3), "the records survive");
+        assert!(
+            log.loss_report().events.is_empty(),
+            "an all-zero preallocated tail is never-written space, not reported loss"
+        );
+        assert_eq!(
+            log.recovered_truncated_bytes(),
+            0,
+            "no data byte was discarded"
+        );
+        assert_eq!(
+            log.quarantined_bytes(),
+            0,
+            "never-written zeros are not forensic material"
+        );
+        assert_eq!(
+            log.filesystem()
+                .open(&segment_file_name(0))
+                .unwrap()
+                .len()
+                .unwrap(),
+            valid_end,
+            "recovery truncated the unwritten extension back to the durable prefix"
+        );
+        // The resumed writer appends cleanly at the next offset.
+        assert_eq!(log.append(&rec(b"after")).unwrap(), Offset::new(3));
+    }
+
+    #[test]
+    fn a_torn_tail_inside_a_preallocated_extension_is_reported_bounded_to_its_written_span() {
+        // Only a PROVABLY all-zero tail is silent. Any non-zero byte after the valid prefix means
+        // real written bytes are being discarded (a torn/corrupt frame that reached the disk), so
+        // the skip-and-report path runs — BOUNDED at one past the tail's last non-zero byte,
+        // never at the extended file length: the loss event, `recovered_truncated_bytes`, and the
+        // quarantined forensic blob all cover exactly the 3 written garbage bytes, not the
+        // ~64 KiB extension of never-written zeros behind them. (Unbounded, one torn byte would
+        // quarantine a near-all-zero roll-size blob — four such boots would evict every genuine
+        // forensic blob under the default 256 MiB store cap — and would fail the boot outright on
+        // the I3 per-event cap for any `max_segment_bytes` above 64 MiB.)
+        let cfg = LogConfig {
+            max_segment_bytes: 64 * 1024,
+            ..LogConfig::default()
+        };
+        let mut log = open_mem(cfg);
+        log.append(&rec(b"durable")).unwrap();
+        log.sync().unwrap();
+        let file = log.filesystem().open(&segment_file_name(0)).unwrap();
+        let valid_end = file.len().unwrap();
+        // Garbage (not a valid frame magic) directly after the prefix, then the zero extension.
+        file.write_all_at(&[0xAB, 0xCD, 0xEF], valid_end).unwrap();
+        file.set_len(cfg.max_segment_bytes).unwrap();
+        file.sync_all().unwrap();
+        let fs = log.into_filesystem();
+
+        let log = Log::open(fs, ManualClock::new(), cfg).unwrap();
+        assert_eq!(
+            log.next_offset(),
+            Offset::new(1),
+            "the durable record survives"
+        );
+        let events = &log.loss_report().events;
+        assert_eq!(events.len(), 1, "the discarded non-zero tail is reported");
+        let e = events[0];
+        assert_eq!(e.reason_code, ReasonCode::CorruptRecordHeader);
+        assert_eq!(e.byte_offset_start, valid_end);
+        assert_eq!(
+            e.byte_offset_end,
+            valid_end + 3,
+            "the span is the 3 written bytes, not the extension"
+        );
+        assert_eq!(e.bytes_skipped, 3);
+        assert_eq!(log.recovered_truncated_bytes(), 3);
+        assert_eq!(
+            log.quarantined_bytes(),
+            3,
+            "the forensic blob is the real span: bytes, not the roll size"
+        );
+        assert_eq!(
+            log.filesystem()
+                .open(&segment_file_name(0))
+                .unwrap()
+                .len()
+                .unwrap(),
+            valid_end,
+            "truncated back to the valid prefix"
+        );
+    }
+
+    #[test]
+    fn one_torn_byte_under_a_roll_size_beyond_the_per_event_cap_still_boots() {
+        // THE AVAILABILITY REGRESSION (perf/r5 review): with `max_segment_bytes` ABOVE the I3
+        // per-event cap (64 MiB), an UNBOUNDED torn-tail span [valid_end, file_len) on an
+        // extended active segment would be ~the roll size, exceed the cap, and fail Log::open
+        // with ExcessiveRecoveryLoss after a routine crash — one torn byte would take the broker
+        // down unrecoverably. Bounded at the last non-zero byte, the same boot succeeds and
+        // reports a ONE-BYTE loss event; the next boot is clean and consistent with it.
+        let cfg = LogConfig {
+            max_segment_bytes: 128 * 1024 * 1024, // 2x the 64 MiB per-event cap
+            ..LogConfig::default()
+        };
+        let mut log = open_mem(cfg);
+        log.append(&rec(b"durable")).unwrap();
+        log.sync().unwrap();
+        let file = log.filesystem().open(&segment_file_name(0)).unwrap();
+        let valid_end = file.len().unwrap();
+        // One non-zero torn byte at valid_end, then the roll-size logical extension (written out
+        // for real, as the production preallocate leaves it).
+        file.write_all_at(&[0xAB], valid_end).unwrap();
+        file.set_len(cfg.max_segment_bytes).unwrap();
+        file.sync_all().unwrap();
+        let fs = log.into_filesystem();
+
+        // Boot 1 SUCCEEDS: the reported span is one byte, far under the 64 MiB per-event cap.
+        let log = Log::open(fs, ManualClock::new(), cfg).unwrap();
+        let events = &log.loss_report().events;
+        assert_eq!(events.len(), 1);
+        let e = events[0];
+        assert_eq!(e.byte_offset_start, valid_end);
+        assert_eq!(e.byte_offset_end, valid_end + 1, "one byte, not ~128 MiB");
+        assert_eq!(e.bytes_skipped, 1);
+        assert_eq!(log.recovered_truncated_bytes(), 1);
+        assert_eq!(log.quarantined_bytes(), 1, "a one-byte forensic blob");
+        assert_eq!(log.next_offset(), Offset::new(1));
+
+        // Boot 2 is CLEAN and consistent with boot 1's report: the file was truncated to the
+        // valid prefix, so nothing is left to report (and the recovered records are unchanged).
+        let fs = log.into_filesystem();
+        let log = Log::open(fs, ManualClock::new(), cfg).unwrap();
+        assert!(
+            log.loss_report().events.is_empty(),
+            "boot 2 reports nothing new"
+        );
+        assert_eq!(log.recovered_truncated_bytes(), 0);
+        assert_eq!(log.next_offset(), Offset::new(1));
+        assert_eq!(read_back(log.filesystem(), 0).len(), 1);
+    }
+
+    #[test]
+    fn a_cap_exceeding_corrupt_tail_fails_closed_without_destroying_the_evidence() {
+        // THE EVIDENCE-DESTRUCTION REGRESSION (perf/r5 review; the ordering predates the branch):
+        // recovery used to run its set_len(valid_end) + sync_all BEFORE the I3 cap check, so a
+        // cap-failing boot TRUNCATED the over-cap corrupt bytes and the NEXT boot opened clean
+        // with an empty loss report — the fail-closed refusal scrubbed the very state the
+        // operator is told to inspect. The cap check now runs BEFORE the destructive truncate:
+        // every cap-failing boot leaves the file byte-identical, so boot 2 (and an offline
+        // inspector) still see the full evidence and fail the same way.
+        let config = LogConfig {
+            max_segment_bytes: 4096, // the per-event cap: min(4096, 64 MiB) = 4096
+            max_total_bytes: 0,
+            ..LogConfig::default()
+        };
+        let mut log = open_mem(config);
+        for i in 0..3u8 {
+            log.append(&rec(&[i; 8])).unwrap();
+        }
+        log.sync().unwrap();
+        let active = log.active_segment_id();
+        let fs = log.into_filesystem();
+
+        // 5000 bytes of 0xff garbage past the durable tail: GENUINE over-cap corruption (every
+        // byte non-zero, so the last-non-zero bound does not shrink it below the 4096 cap).
+        let file = fs.open(&segment_file_name(active)).unwrap();
+        let len_before = file.len().unwrap();
+        file.write_all_at(&[0xffu8; 5000], len_before).unwrap();
+        file.sync_data().unwrap();
+        let expected_len = len_before + 5000;
+
+        // Boot 1 fails closed...
+        let err = Log::open(fs.clone(), ManualClock::new(), config).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                StorageError::ExcessiveRecoveryLoss(crate::loss::CapViolation::PerEvent {
+                    cap: 4096,
+                    ..
+                })
+            ),
+            "expected a per-event cap violation, got {err:?}"
+        );
+        // ...WITHOUT truncating: the evidence is byte-for-byte on disk.
+        assert_eq!(
+            fs.open(&segment_file_name(active)).unwrap().len().unwrap(),
+            expected_len,
+            "a cap-failing boot must not destroy its own evidence"
+        );
+
+        // Boot 2 sees the SAME evidence and fails the SAME way (no silent clean open).
+        let err2 = Log::open(fs.clone(), ManualClock::new(), config).unwrap_err();
+        assert!(
+            matches!(
+                err2,
+                StorageError::ExcessiveRecoveryLoss(crate::loss::CapViolation::PerEvent { .. })
+            ),
+            "boot 2 must fail closed on the surviving evidence, got {err2:?}"
+        );
+        assert_eq!(
+            fs.open(&segment_file_name(active)).unwrap().len().unwrap(),
+            expected_len,
+            "the evidence survives every refused boot"
+        );
+    }
+
+    #[test]
+    fn a_roll_seals_an_extended_active_segment_down_to_its_footer_end() {
+        // Footer discovery reads the END of the file. If the active segment carries a preallocated
+        // logical extension when it rolls, `seal` must truncate the zero tail so the sealed image
+        // ends exactly at the footer — otherwise the seal would be invisible (zeros where the
+        // footer is expected) and a reopen would refuse the chain with UnsealedPredecessor.
+        let cfg = LogConfig {
+            max_segment_bytes: 256,
+            ..LogConfig::default()
+        };
+        let mut log = open_mem(cfg);
+        log.append(&rec(b"first")).unwrap();
+        log.sync().unwrap();
+        // Extend segment 0 as the production preallocate would have at create time.
+        log.filesystem()
+            .open(&segment_file_name(0))
+            .unwrap()
+            .set_len(cfg.max_segment_bytes * 4)
+            .unwrap();
+        // Append past the cap so the extended segment 0 is sealed by a roll.
+        for _ in 0..16 {
+            log.append(&rec(b"payload-payload")).unwrap();
+            log.sync().unwrap();
+        }
+        assert!(log.active_segment_id() >= 1, "the workload rolled");
+        let total = log.durable_record_count();
+        let seg0 = log.filesystem().open(&segment_file_name(0)).unwrap();
+        let len = seg0.len().unwrap();
+        assert!(
+            len < cfg.max_segment_bytes * 4,
+            "the extension was truncated at seal"
+        );
+        let scan = SegmentReader::open(seg0).unwrap().scan().unwrap();
+        assert!(
+            scan.footer.is_some(),
+            "the footer is discoverable at the file end"
+        );
+        assert_eq!(
+            scan.valid_end + SEGMENT_FOOTER_LEN as u64,
+            len,
+            "the sealed image ends exactly at the footer"
+        );
+        // A reopen recovers the sealed predecessor + the rest of the chain with no loss.
+        let fs = log.into_filesystem();
+        let log = Log::open(fs, ManualClock::new(), cfg).unwrap();
+        assert_eq!(log.durable_record_count(), total);
+        assert!(log.loss_report().events.is_empty());
     }
 
     /// A file whose `preallocate` always errors (an unsupported FS or an out-of-space reservation),
@@ -8302,6 +8662,57 @@ mod tests {
         assert_eq!(total, 9);
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn stdfs_preallocation_extends_the_active_segment_and_recovery_is_silent() {
+        // The PRODUCTION path end to end: `StdFile::preallocate` reserves blocks and advances the
+        // active segment's LOGICAL length to the roll size (so the per-commit fdatasync is a pure
+        // data flush), a kill + reopen recovers the records and truncates the unwritten zero tail
+        // SILENTLY (no loss event, nothing quarantined), and the log keeps working.
+        use crate::fs::StdFs;
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        let cfg = LogConfig {
+            max_segment_bytes: 64 * 1024,
+            ..LogConfig::default()
+        };
+        let mut log = Log::open(StdFs::new(root.clone()), ManualClock::new(), cfg).unwrap();
+        log.append(&rec(b"one")).unwrap();
+        log.append(&rec(b"two")).unwrap();
+        log.sync().unwrap();
+        let seg0_len = StdFs::new(root.clone())
+            .open(&segment_file_name(0))
+            .unwrap()
+            .len()
+            .unwrap();
+        assert_eq!(
+            seg0_len, cfg.max_segment_bytes,
+            "the active segment is logically extended to the roll size"
+        );
+        // A kill + reopen: the crash shape every preallocated broker leaves behind.
+        drop(log);
+        let mut log = Log::open(StdFs::new(root.clone()), ManualClock::new(), cfg).unwrap();
+        assert_eq!(log.next_offset(), Offset::new(2), "both records recovered");
+        assert!(
+            log.loss_report().events.is_empty(),
+            "the unwritten zero tail is not loss"
+        );
+        assert_eq!(log.recovered_truncated_bytes(), 0);
+        assert!(
+            StdFs::new(root.clone())
+                .open(&segment_file_name(0))
+                .unwrap()
+                .len()
+                .unwrap()
+                < cfg.max_segment_bytes,
+            "the zero tail was truncated at recovery"
+        );
+        // The resumed writer appends and syncs cleanly.
+        assert_eq!(log.append(&rec(b"three")).unwrap(), Offset::new(2));
+        log.sync().unwrap();
+        assert_eq!(read_back(log.filesystem(), 0).len(), 3);
+    }
+
     // Fills a small-segment log with `n` single-byte records (each `payload` byte `i`), synced,
     // and returns it rolled across several segments so the reaper has sealed predecessors.
     fn rolled_log(n: u8) -> Log<InMemoryFs, ManualClock> {
@@ -9396,6 +9807,56 @@ mod tests {
         log.append(&rec(b"new13")).unwrap();
         log.sync().unwrap();
         assert_eq!(log.next_offset(), Offset::new(14));
+    }
+
+    #[test]
+    fn truncate_to_inside_a_preallocated_extension_cuts_at_the_frame_boundary() {
+        // The admin truncate on an EXTENDED active segment (the production preallocate shape):
+        // the record-position walk is bounded at the writer's data end (never reading the
+        // roll-size zero tail eagerly), and the surgery still cuts exactly at the target's frame
+        // boundary — dropping both the divergent records AND the logical extension, exactly as a
+        // reopen-recovery would leave the file.
+        let cfg = LogConfig {
+            max_segment_bytes: 512 * 1024,
+            ..LogConfig::default()
+        };
+        let mut log = open_mem(cfg);
+        for i in 0..8u8 {
+            log.append(&rec(&[i; 16])).unwrap();
+        }
+        log.sync().unwrap();
+        // Write the logical extension out for real (the in-memory backend models the
+        // reservation only).
+        log.filesystem()
+            .open(&segment_file_name(0))
+            .unwrap()
+            .set_len(cfg.max_segment_bytes)
+            .unwrap();
+
+        let outcome = log.truncate_to(Offset::new(5)).unwrap();
+        assert_eq!(outcome.truncated_to, 5);
+        assert_eq!(outcome.records_dropped, 3);
+        assert_eq!(log.next_offset(), Offset::new(5));
+
+        // The surviving records are intact and the extension is gone (a truncate-down).
+        let recs = log.read_from(Offset::ZERO, 100).unwrap();
+        assert_eq!(recs.len(), 5);
+        for (i, r) in recs.iter().enumerate() {
+            assert_eq!(r.payload.as_ref(), &[u8::try_from(i).unwrap(); 16]);
+        }
+        assert!(
+            log.filesystem()
+                .open(&segment_file_name(0))
+                .unwrap()
+                .len()
+                .unwrap()
+                < cfg.max_segment_bytes,
+            "the truncate cut the extension off with the suffix"
+        );
+        // Appending resumes cleanly at the truncation point.
+        log.append(&rec(b"resumed")).unwrap();
+        log.sync().unwrap();
+        assert_eq!(log.next_offset(), Offset::new(6));
     }
 
     #[test]

--- a/crates/ironbus-storage/src/offline.rs
+++ b/crates/ironbus-storage/src/offline.rs
@@ -7,10 +7,14 @@
 //! it does not truncate a torn tail, roll a sealed segment forward, or create a new segment. It
 //! bounds every read to the durable high-water mark (the longest valid record prefix), so a
 //! torn or unsynced tail past that mark is reported as loss but never read as a record, even
-//! when the file is physically longer. It also does NOT fail closed on excessive loss (the I3
-//! cap that [`crate::log::Log`] recovery enforces): an inspector must be able to show a badly
-//! corrupted directory, not refuse to open it. This backs the offline `peek` / `dump` / `info`
-//! verbs (#92).
+//! when the file is physically longer. The report applies recovery's zero-tail rule
+//! (`docs/PREALLOCATION.md`): the active segment of every cleanly-stopped preallocating broker
+//! ends in a large all-zero logical extension, which is unwritten space (silent, not loss), and
+//! a non-zero tail's reported span is bounded at one past its last non-zero byte — so `verify`
+//! on a healthy stopped directory reports ZERO loss. It also does NOT fail closed on excessive
+//! loss (the I3 cap that [`crate::log::Log`] recovery enforces): an inspector must be able to
+//! show a badly corrupted directory, not refuse to open it. This backs the offline `peek` /
+//! `dump` / `info` verbs (#92).
 
 use crate::fs::Filesystem;
 use crate::io::RandomAccessFile;
@@ -103,11 +107,20 @@ impl<F: Filesystem> OfflineReader<F> {
                 .ok_or(StorageError::SegmentFull)?;
             // Only the active (final, unsealed) segment can carry a torn or corrupt tail past
             // its valid prefix; a sealed segment's `valid_end` is its footer start, with no
-            // loss. Record the dropped span exactly as recovery would, but without truncating
-            // it: the bytes stay on disk for an operator to inspect.
+            // loss. Record the dropped span exactly as recovery would — the same zero-tail rule
+            // ([`crate::io::last_nonzero_end`], `docs/PREALLOCATION.md`): an ALL-ZERO tail is the
+            // unwritten remainder of the preallocated logical extension (the NORMAL shape of
+            // EVERY cleanly-stopped broker's active segment, up to a roll size of never-written
+            // zeros), not loss, so it is not reported at all; a non-zero tail's span is bounded
+            // at one past its last non-zero byte. Unlike recovery, nothing is truncated: the
+            // bytes stay on disk for an operator to inspect.
             if is_last && scan.footer.is_none() && scan.valid_end < physical_len {
-                let reason = scan.tail_reason.unwrap_or(ReasonCode::TornTail);
-                loss_report.push(LossEvent::span(id, scan.valid_end, physical_len, 1, reason));
+                let reported_end =
+                    crate::io::last_nonzero_end(&fs.open(&name)?, scan.valid_end, physical_len)?;
+                if reported_end > scan.valid_end {
+                    let reason = scan.tail_reason.unwrap_or(ReasonCode::TornTail);
+                    loss_report.push(LossEvent::span(id, scan.valid_end, reported_end, 1, reason));
+                }
             }
         }
         // With no segments the range is empty; pin earliest to the head so `[earliest, head)` is
@@ -330,14 +343,16 @@ mod tests {
         assert_eq!(records[2].offset, Offset::new(2));
 
         // The dropped span is reported, exactly as recovery would: one torn-tail event in
-        // segment 0 ending at the physical (torn) length.
+        // segment 0. Its end is bounded at one past the tail's last NON-ZERO byte (the shared
+        // zero-tail rule), so it never claims past the physical (torn) length and may exclude
+        // trailing zero bytes of the torn frame.
         let report = reader.loss_report();
         assert_eq!(report.events.len(), 1);
         let e = report.events[0];
         assert_eq!(e.reason_code, ReasonCode::TornTail);
         assert_eq!(e.segment_id, 0);
-        assert_eq!(e.byte_offset_end, torn_len);
-        assert!(e.byte_offset_start < torn_len);
+        assert!(e.byte_offset_end <= torn_len);
+        assert!(e.byte_offset_start < e.byte_offset_end);
 
         // Read-only: the reader did NOT truncate the torn tail (online recovery would have).
         // The file is still its physically-torn length, proving the inspector never wrote.
@@ -351,5 +366,87 @@ mod tests {
             after_len, torn_len,
             "the offline reader must not mutate the file"
         );
+    }
+
+    #[test]
+    fn a_healthy_directory_with_a_preallocated_extension_reports_zero_loss() {
+        // THE `ironbus verify` REGRESSION (perf/r5 review): the production `StdFile::preallocate`
+        // extends the active segment's LOGICAL length to the roll size, so EVERY healthy,
+        // cleanly-stopped broker directory ends in a large all-zero tail. That tail is unwritten
+        // space, not loss: the offline reader (which backs `verify`/`info`/`scrub`) must report
+        // ZERO loss for it — an unbounded report would claim ~a roll size of "data loss" (a
+        // corrupt-header reason, exit 3) for every healthy directory. The in-memory backend
+        // models the reservation only, so the extension is written out for real here with the
+        // same set_len-up the production preallocate performs.
+        let cfg = LogConfig {
+            max_segment_bytes: 4 * 1024 * 1024,
+            ..LogConfig::default()
+        };
+        let mut log = Log::open(InMemoryFs::new(), ManualClock::new(), cfg).unwrap();
+        for i in 0..5u8 {
+            append(&mut log, &[i; 8]);
+        }
+        log.sync().unwrap(); // a clean shutdown: everything acked is synced
+        let head = log.flushed_offset();
+        let fs = log.into_filesystem();
+        let file = fs.open(&segment_file_name(0)).unwrap();
+        let valid_end = file.len().unwrap();
+        file.set_len(cfg.max_segment_bytes).unwrap();
+        file.sync_all().unwrap();
+
+        let reader = OfflineReader::open(fs).unwrap();
+        assert!(
+            reader.loss_report().is_empty(),
+            "a healthy stopped directory reports ZERO loss, got {:?}",
+            reader.loss_report().events
+        );
+        assert_eq!(reader.durable_head(), head);
+        assert_eq!(all_records(&reader).len(), 5);
+        // Read-only: the extension is still on disk, untouched.
+        assert_eq!(
+            reader
+                .into_filesystem()
+                .open(&segment_file_name(0))
+                .unwrap()
+                .len()
+                .unwrap(),
+            cfg.max_segment_bytes,
+            "the inspector never truncates"
+        );
+        assert!(valid_end < cfg.max_segment_bytes, "the tail existed");
+    }
+
+    #[test]
+    fn a_torn_byte_inside_a_preallocated_extension_is_reported_bounded_to_its_real_span() {
+        // A non-zero byte after the valid prefix of an EXTENDED active segment is real discarded
+        // data and must be reported — but bounded at one past the last non-zero byte, never to
+        // the roll-size file length (which would inflate one torn byte into megabytes of
+        // reported "loss").
+        let cfg = LogConfig {
+            max_segment_bytes: 4 * 1024 * 1024,
+            ..LogConfig::default()
+        };
+        let mut log = Log::open(InMemoryFs::new(), ManualClock::new(), cfg).unwrap();
+        append(&mut log, b"durable!");
+        log.sync().unwrap();
+        let fs = log.into_filesystem();
+        let file = fs.open(&segment_file_name(0)).unwrap();
+        let valid_end = file.len().unwrap();
+        file.write_all_at(&[0xAB], valid_end).unwrap();
+        file.set_len(cfg.max_segment_bytes).unwrap();
+        file.sync_all().unwrap();
+
+        let reader = OfflineReader::open(fs).unwrap();
+        assert_eq!(reader.durable_head(), Offset::new(1));
+        let report = reader.loss_report();
+        assert_eq!(report.events.len(), 1, "the torn byte is reported");
+        let e = report.events[0];
+        assert_eq!(e.byte_offset_start, valid_end);
+        assert_eq!(
+            e.byte_offset_end,
+            valid_end + 1,
+            "the span is the ONE written byte, not the extension"
+        );
+        assert_eq!(e.bytes_skipped, 1);
     }
 }

--- a/crates/ironbus-storage/src/segment.rs
+++ b/crates/ironbus-storage/src/segment.rs
@@ -658,6 +658,17 @@ impl<F: RandomAccessFile> SegmentWriter<F> {
         trailer[..SEGMENT_FOOTER_LEN].copy_from_slice(&footer.encode_v2());
         trailer[SEGMENT_FOOTER_LEN..].copy_from_slice(&meta.encode());
         self.file.write_all_at(&trailer, self.write_pos)?;
+        // As in `seal`: the v2 trailer is discovered by reading the END of the file, so a
+        // logically-extended (preallocated) file must be truncated down to the true trailer end
+        // before the same `sync_all` that commits the trailer. Compaction writers are not
+        // preallocated today, so this is normally a no-op guard kept local to the seal invariant.
+        let end = self
+            .write_pos
+            .checked_add((SEGMENT_FOOTER_LEN + COMPACTION_META_LEN) as u64)
+            .ok_or(StorageError::SegmentFull)?;
+        if self.file.len()? > end {
+            self.file.set_len(end)?;
+        }
         self.file.sync_all()?;
         Ok(())
     }
@@ -924,8 +935,17 @@ impl<F: RandomAccessFile> SegmentWriter<F> {
         Arc::clone(&self.file)
     }
 
-    /// Seals the segment by writing the footer and a full fsync, consuming the writer
-    /// and returning the footer.
+    /// Seals the segment by writing the footer, truncating any preallocated zero tail down to the
+    /// footer end, and issuing a full fsync, consuming the writer and returning the footer.
+    ///
+    /// The truncation is load-bearing with preallocation's LOGICAL extension (`StdFile::
+    /// preallocate` advances the file length to the roll size up front): footer discovery reads
+    /// the trailing 32 bytes of the FILE (`SegmentReader::scan` and every sibling), so a sealed
+    /// image must end exactly at the footer or the zero tail would hide the seal. The shrink is
+    /// metadata, made durable by the very `sync_all` the seal already issues (the documented
+    /// `set_len`-shrink-needs-`sync_all` pairing in `io.rs`), so a sealed segment's on-disk image
+    /// is byte-identical to a never-preallocated one. A never-extended file skips the `set_len`
+    /// (its length already equals the footer end).
     ///
     /// # Errors
     /// Propagates the underlying IO error.
@@ -938,6 +958,13 @@ impl<F: RandomAccessFile> SegmentWriter<F> {
             record_count: self.record_count,
         };
         self.file.write_all_at(&footer.encode(), self.write_pos)?;
+        let end = self
+            .write_pos
+            .checked_add(SEGMENT_FOOTER_LEN as u64)
+            .ok_or(StorageError::SegmentFull)?;
+        if self.file.len()? > end {
+            self.file.set_len(end)?;
+        }
         self.file.sync_all()?;
         Ok(footer)
     }
@@ -1122,6 +1149,26 @@ impl<F: RandomAccessFile> SegmentReader<F> {
     #[must_use]
     pub fn header(&self) -> &SegmentHeader {
         &self.header
+    }
+
+    /// Clamps this reader's view of the file to end at `end` (never grown past the real length,
+    /// never cut into the 64-byte header `open` validated).
+    ///
+    /// For the ACTIVE segment, whose preallocated LOGICAL EXTENSION (`docs/PREALLOCATION.md`)
+    /// makes `file.len()` the roll size rather than the data end, the caller (the log) knows the
+    /// true data end (the writer's `write_pos`); bounding the reader there keeps the eager
+    /// whole-region reads ([`scan`](SegmentReader::scan)'s body read,
+    /// [`record_byte_positions`](SegmentReader::record_byte_positions)'s walk) at O(data) instead
+    /// of O(roll size) — unbounded, a fallback scan of a nearly-empty extended segment would
+    /// allocate and read up to a whole roll size (64 MiB default) of zeros. Behavior is
+    /// byte-identical to scanning a file physically truncated at `end`: everything past the
+    /// writer's position is unwritten zeros, which no scan decodes a record or a footer from, so
+    /// the records, positions, and `valid_end` are unchanged. SEALED segments are truncated
+    /// exactly at their footer by `seal`, so they never need (and never get) this clamp.
+    #[must_use]
+    pub fn with_data_end(mut self, end: u64) -> SegmentReader<F> {
+        self.file_len = self.file_len.min(end.max(SEGMENT_HEADER_LEN as u64));
+        self
     }
 
     /// Reads `len` bytes starting at file byte position `start` into a FRESH shared [`Bytes`]
@@ -2359,6 +2406,40 @@ mod tests {
     }
 
     #[test]
+    fn seal_truncates_a_preallocated_logical_extension_down_to_the_footer_end() {
+        // The production preallocation logically EXTENDS the active file to the roll size, so at
+        // seal time the file may be much longer than the data. Footer discovery reads the trailing
+        // 32 bytes of the FILE, so `seal` must truncate the unwritten zero tail away: the sealed
+        // image ends exactly at the footer (byte-identical to a never-preallocated seal) and the
+        // footer is discoverable again.
+        let file = Arc::new(InMemoryFile::new());
+        let mut w = SegmentWriter::create(Arc::clone(&file), header()).unwrap();
+        w.append(&rec(0, b"a")).unwrap();
+        w.append(&rec(1, b"b")).unwrap();
+        w.sync().unwrap();
+        // Apply the logical extension the production preallocate performs (the in-memory backend
+        // models the reservation only, so write the zero tail out for real).
+        file.set_len(64 * 1024).unwrap();
+        let expected_end = w.write_pos() + SEGMENT_FOOTER_LEN as u64;
+        let footer = w.seal().unwrap();
+        assert_eq!(
+            file.len().unwrap(),
+            expected_end,
+            "the sealed image ends exactly at the footer, zero tail gone"
+        );
+        // The truncation is fsynced by the seal's sync_all: it survives a power loss.
+        file.simulate_power_loss();
+        assert_eq!(file.len().unwrap(), expected_end);
+        let scan = SegmentReader::open(Arc::clone(&file))
+            .unwrap()
+            .scan()
+            .unwrap();
+        assert!(scan.clean);
+        assert_eq!(scan.footer, Some(footer), "the seal is discoverable at EOF");
+        assert_eq!(scan.records.len(), 2);
+    }
+
+    #[test]
     fn empty_sealed_segment() {
         let file = Arc::new(InMemoryFile::new());
         let w = SegmentWriter::create(Arc::clone(&file), header()).unwrap();
@@ -2998,6 +3079,74 @@ mod tests {
         assert_eq!(scan.records.len(), 2);
         assert_eq!(scan.records[0].payload.as_ref(), b"keep1");
         assert_eq!(scan.records[1].payload.as_ref(), b"keep2");
+    }
+
+    #[test]
+    fn with_data_end_scans_an_extended_active_segment_byte_identically_and_bounded() {
+        // The active segment's preallocated LOGICAL EXTENSION makes file.len() the roll size, so
+        // an unbounded eager scan/walk reads the whole zero tail. `with_data_end(write_pos)`
+        // must be byte-identical to scanning the file as if it were physically truncated at the
+        // data end: same records, same valid_end, same positions — while the whole-file scan of
+        // the SAME extended image also agrees (zeros decode nothing), proving the clamp changes
+        // only the bytes read, never the result.
+        let file = Arc::new(InMemoryFile::new());
+        let mut w = SegmentWriter::create(Arc::clone(&file), header()).unwrap();
+        w.append(&rec(0, b"alpha")).unwrap();
+        w.append(&rec(1, b"beta")).unwrap();
+        w.append(&rec(2, b"gamma")).unwrap();
+        w.sync().unwrap();
+        let data_end = w.write_pos();
+        // The production preallocate shape: the logical length is far past the data end.
+        file.set_len(64 * 1024).unwrap();
+
+        let bounded = SegmentReader::open(Arc::clone(&file))
+            .unwrap()
+            .with_data_end(data_end);
+        assert_eq!(
+            bounded.file_len, data_end,
+            "the clamp bounds the reader's view at the data end"
+        );
+        let bounded_scan = bounded.scan().unwrap();
+        let full_scan = SegmentReader::open(Arc::clone(&file))
+            .unwrap()
+            .scan()
+            .unwrap();
+        assert_eq!(bounded_scan.valid_end, data_end);
+        assert_eq!(bounded_scan.valid_end, full_scan.valid_end);
+        assert_eq!(bounded_scan.records, full_scan.records);
+        assert_eq!(bounded_scan.records.len(), 3);
+        assert!(bounded_scan.footer.is_none() && full_scan.footer.is_none());
+        // The bounded view decoded the WHOLE region it saw (no zero tail inside it), while the
+        // full view necessarily stopped early at the zero tail.
+        assert!(bounded_scan.clean);
+        assert!(!full_scan.clean);
+
+        // The position walk agrees the same way (the truncate_to path).
+        let (bounded_pos, bounded_end) = SegmentReader::open(Arc::clone(&file))
+            .unwrap()
+            .with_data_end(data_end)
+            .record_byte_positions()
+            .unwrap();
+        let (full_pos, full_end) = SegmentReader::open(Arc::clone(&file))
+            .unwrap()
+            .record_byte_positions()
+            .unwrap();
+        assert_eq!(bounded_pos, full_pos);
+        assert_eq!(bounded_end, full_end);
+        assert_eq!(bounded_pos.len(), 3);
+
+        // The clamp never grows past the real length and never cuts into the header.
+        let short = SegmentReader::open(Arc::clone(&file))
+            .unwrap()
+            .with_data_end(u64::MAX);
+        assert_eq!(short.file_len, 64 * 1024, "never grown past the file");
+        let floor = SegmentReader::open(Arc::clone(&file))
+            .unwrap()
+            .with_data_end(0);
+        assert_eq!(
+            floor.file_len, SEGMENT_HEADER_LEN as u64,
+            "never cut into the validated header"
+        );
     }
 
     #[test]

--- a/crates/ironbus-storage/tests/conformance_recovery.rs
+++ b/crates/ironbus-storage/tests/conformance_recovery.rs
@@ -175,8 +175,11 @@ fn torn_tail_mid_trailer_matches_the_corpus_loss_tuple() {
 #[test]
 fn mid_log_bit_flip_skips_and_reports_corrupt_body() {
     // A body byte of the SECOND record is flipped: the first survives, recovery stops at the
-    // second frame and reports CorruptRecordBody from there to the file end (the corpus
-    // SkipAndReport verdict).
+    // second frame and reports CorruptRecordBody from there (the corpus SkipAndReport verdict).
+    // The reported end is BOUNDED at one past the tail's last NON-ZERO byte (the zero-tail rule
+    // a preallocated logical extension requires): this frozen fixture's discarded tail happens
+    // to end in zero bytes, so the span excludes exactly those informationless zeros — it may
+    // never extend to a (possibly roll-size) file end.
     let bytes = corpus_bytes("segment_mid_log_bit_flip");
     let rec = recover(&bytes);
     assert_eq!(
@@ -189,11 +192,15 @@ fn mid_log_bit_flip_skips_and_reports_corrupt_body() {
         ReasonCode::CorruptRecordBody,
         "corrupt-body reason"
     );
+    let last_nonzero_end = bytes
+        .iter()
+        .rposition(|&b| b != 0)
+        .map_or(0, |i| i as u64 + 1);
     assert_eq!(
-        loss.byte_offset_end,
-        bytes.len() as u64,
-        "loss ends at the file end"
+        loss.byte_offset_end, last_nonzero_end,
+        "loss ends at one past the tail's last non-zero byte"
     );
+    assert!(loss.byte_offset_end <= bytes.len() as u64);
     assert_eq!(
         rec.seg_len, loss.byte_offset_start,
         "truncated to the corrupt head"
@@ -201,27 +208,26 @@ fn mid_log_bit_flip_skips_and_reports_corrupt_body() {
 }
 
 #[test]
-fn zero_window_tail_recovers_no_records_and_reports_a_corrupt_header() {
-    // A valid header then a zero-filled record region: no record decodes (a zero word is not a
-    // valid magic), recovery reports the zeroed span as a corrupt-header skip (the corpus
-    // SkipAndReport verdict), and recovers zero records.
+fn zero_window_tail_recovers_no_records_and_truncates_silently() {
+    // A valid header then an ALL-ZERO record region: exactly the shape a preallocated,
+    // logically-extended active segment leaves when its records never landed (the corpus
+    // UnwrittenZeroTailTruncate verdict). No record decodes (a zero word is never a valid
+    // magic), and recovery truncates the unwritten span SILENTLY: it is provably never-written
+    // space — no frame was ever written there, nothing was acked — so it is NOT a loss event
+    // and nothing is quarantined. (Production preallocates every active segment to the roll
+    // size, so reporting this span would claim up to a whole roll size of "loss" on every
+    // boot and trip the I3 caps for bytes that never held data.)
     let bytes = corpus_bytes("segment_zero_window_tail");
     let rec = recover(&bytes);
     assert_eq!(rec.record_count, 0, "no record decodes from a zero window");
-    let loss = rec.loss.expect("a zero window reports one loss event");
-    assert_eq!(
-        loss.reason_code,
-        ReasonCode::CorruptRecordHeader,
-        "corrupt-header reason"
-    );
-    assert_eq!(
-        loss.byte_offset_end,
-        bytes.len() as u64,
-        "loss ends at the file end"
+    assert!(
+        rec.loss.is_none(),
+        "an all-zero (unwritten) tail is not reported as loss"
     );
     // The live segment is truncated to the header end (no records landed past it).
     assert_eq!(
-        rec.seg_len, loss.byte_offset_start,
+        rec.seg_len,
+        ironbus_core::format::SEGMENT_HEADER_LEN as u64,
         "truncated to the record-region start"
     );
 }

--- a/crates/ironbus-storage/tests/corruption_corpus.rs
+++ b/crates/ironbus-storage/tests/corruption_corpus.rs
@@ -216,7 +216,21 @@ fn assert_valid_prefix(rec: &Recovered, expected_len: u64) {
 /// Asserts the loss report holds exactly one event, with the given reason, span, and that
 /// recovery never read past the torn / corrupt boundary (the event's start equals the recovered
 /// segment length, so every byte after the durable head was dropped, never replayed).
-fn assert_single_loss(rec: &Recovered, reason: ReasonCode, start: u64, end: u64) {
+/// `start..end` is the crafted DISCARDED tail inside `bytes` (the segment image recovery ran
+/// over). The reported span is pinned under the zero-tail BOUNDING rule (`docs/PREALLOCATION.md`):
+/// it ends at one past the LAST NON-ZERO byte within `[start, end)` — trailing zero bytes of a
+/// discarded tail are informationless and never claimed (on a preallocated, logically-extended
+/// active segment the unbounded end would be a whole roll size) — so the expected end is computed
+/// from the crafted image itself, keeping every fixture's assertion exact.
+fn assert_single_loss(rec: &Recovered, reason: ReasonCode, start: u64, end: u64, bytes: &[u8]) {
+    let expected_end = bytes[usize::try_from(start).unwrap()..usize::try_from(end).unwrap()]
+        .iter()
+        .rposition(|&b| b != 0)
+        .map_or(start, |i| start + i as u64 + 1);
+    assert!(
+        expected_end > start,
+        "a crafted discarded tail must contain a non-zero byte (an all-zero tail is not loss)"
+    );
     assert_eq!(rec.loss.events.len(), 1, "exactly one loss event");
     let e = rec.loss.events[0];
     assert_eq!(e.segment_id, 0);
@@ -225,8 +239,11 @@ fn assert_single_loss(rec: &Recovered, reason: ReasonCode, start: u64, end: u64)
         e.byte_offset_start, start,
         "loss span start (the torn head)"
     );
-    assert_eq!(e.byte_offset_end, end, "loss span end (the file length)");
-    assert_eq!(e.bytes_skipped, end - start, "bytes skipped");
+    assert_eq!(
+        e.byte_offset_end, expected_end,
+        "loss span end (one past the last non-zero discarded byte)"
+    );
+    assert_eq!(e.bytes_skipped, expected_end - start, "bytes skipped");
     // The recovered segment is truncated exactly at the torn head, so recovery never reads past
     // the torn tail: the live length is the loss-span start, not the original (longer) length.
     assert_eq!(
@@ -255,6 +272,7 @@ fn torn_tail_partial_record_header() {
         ReasonCode::TornTail,
         head_start as u64,
         (head_start + 4) as u64,
+        &bytes,
     );
 }
 
@@ -275,6 +293,7 @@ fn torn_tail_partial_record_body() {
         ReasonCode::TornTail,
         last_start as u64,
         (last_start + RECORD_HEADER_LEN + 2) as u64,
+        &bytes,
     );
 }
 
@@ -295,6 +314,7 @@ fn torn_tail_partial_record_trailer() {
         ReasonCode::TornTail,
         last_start as u64,
         (good.len() - 3) as u64,
+        &bytes,
     );
 }
 
@@ -317,6 +337,7 @@ fn flipped_record_header_crc() {
         ReasonCode::CorruptRecordHeader,
         last_start as u64,
         good.len() as u64,
+        &bytes,
     );
 }
 
@@ -336,6 +357,7 @@ fn flipped_record_body_crc() {
         ReasonCode::CorruptRecordBody,
         last_start as u64,
         good.len() as u64,
+        &bytes,
     );
 }
 
@@ -396,6 +418,7 @@ fn flipped_xxh3_field_on_over_threshold_record() {
         ReasonCode::CorruptRecordBody,
         big_frame_start,
         good.len() as u64,
+        &bytes,
     );
 }
 
@@ -417,6 +440,7 @@ fn bad_record_magic() {
         ReasonCode::CorruptRecordHeader,
         last_start as u64,
         good.len() as u64,
+        &bytes,
     );
 }
 
@@ -436,6 +460,7 @@ fn unsupported_record_version() {
         ReasonCode::CorruptRecordHeader,
         last_start as u64,
         good.len() as u64,
+        &bytes,
     );
 }
 
@@ -471,6 +496,7 @@ fn planted_false_magic_mid_log_is_rejected_at_the_checksum() {
         ReasonCode::CorruptRecordBody,
         mid_start as u64,
         good.len() as u64,
+        &bytes,
     );
 }
 
@@ -496,6 +522,7 @@ fn planted_false_magic_in_a_header_is_rejected_at_the_header_crc() {
         ReasonCode::CorruptRecordHeader,
         mid_start as u64,
         good.len() as u64,
+        &bytes,
     );
 }
 
@@ -604,6 +631,7 @@ fn truncated_footer_recovers_records_unsealed() {
         ReasonCode::TornTail,
         (good.len() - SEGMENT_FOOTER_LEN) as u64,
         (good.len() - 4) as u64,
+        &bytes,
     );
 }
 
@@ -792,10 +820,14 @@ fn unsealed_non_final_predecessor() {
 
 #[test]
 fn all_zeros_record_region() {
-    // The whole record region (everything after the 64-byte header) is zeroed, modelling a
-    // freshly preallocated or wiped segment whose records never landed. A zero word is not a valid
-    // record magic, so recovery decodes zero records and reports the zeroed bytes as a torn tail.
-    // No acked record existed there, so this is the empty-active-segment recovery, never a panic.
+    // The whole record region (everything after the 64-byte header) is zeroed: exactly the shape
+    // a preallocated, logically-extended active segment leaves when its records never landed. A
+    // zero word is not a valid record magic, so recovery decodes zero records — and, because the
+    // tail is PROVABLY all zeros (never-written space, never acked data), it truncates the span
+    // SILENTLY: no loss event and nothing quarantined. Production preallocates every active
+    // segment to the roll size with an advanced logical length, so an all-zero tail is the
+    // NORMAL every-boot shape, not a corruption; reporting it would claim a roll size of "loss"
+    // on each boot and trip the I3 caps for bytes that never held data.
     let n = 4u64;
     let good = good_unsealed_segment(n);
     let mut bytes = good.clone();
@@ -804,11 +836,14 @@ fn all_zeros_record_region() {
     }
     let rec = recover_ok(disk_with_segment0(&bytes));
     assert_valid_prefix(&rec, 0);
-    assert_single_loss(
-        &rec,
-        ReasonCode::CorruptRecordHeader,
-        SEGMENT_HEADER_LEN as u64,
-        good.len() as u64,
+    assert!(
+        rec.loss.events.is_empty(),
+        "an all-zero (unwritten) region is not reported as loss"
+    );
+    // The zero span is still truncated: the live segment ends at the durable head (the header).
+    assert_eq!(
+        rec.seg0_len, SEGMENT_HEADER_LEN as u64,
+        "recovery truncated the unwritten zero region"
     );
 }
 

--- a/crates/ironbus-storage/tests/crash_recovery.rs
+++ b/crates/ironbus-storage/tests/crash_recovery.rs
@@ -151,34 +151,49 @@ fn assert_consistent_prefix<F: Filesystem>(log: &Log<F, ManualClock>) {
     }
 }
 
-/// The single-segment loss-bound assertion (#55 acceptance: `loss_bound` == actual discarded suffix).
+/// The single-segment loss-bound assertion (#55 acceptance: `loss_bound` == the discarded suffix,
+/// bounded at its last non-zero byte).
 ///
-/// `durable_active_len` is the active segment's DURABLE byte length captured just before recovery
-/// (the on-disk image a power cut would have left). After `Log::open` recovers and truncates any
-/// torn tail, the active segment file's length IS the kept `valid_end`, so the actual discarded
-/// suffix is `durable_active_len - kept_len`. This asserts the structured `LossReport`'s claimed
-/// byte loss (`total_bytes_skipped`) and the raw `recovered_truncated_bytes` both equal that actual
-/// discarded suffix, so a report that under- or over-claims its loss is mechanically falsified. It
-/// also asserts every claimed loss event names the active segment and the span matches.
+/// `durable_image` is the active segment's DURABLE on-disk image captured just before recovery
+/// (the bytes a power cut would have left). After `Log::open` recovers and truncates any torn
+/// tail, the active segment file's length IS the kept `valid_end`, so the actual discarded suffix
+/// is `durable_image.len() - kept_len`. What the report CLAIMS is that suffix bounded at one past
+/// its last NON-ZERO byte (the zero-tail rule, `docs/PREALLOCATION.md`): the suffix's trailing
+/// zeros were never plausibly-written data (on a preallocated, logically-extended segment they
+/// can be a whole roll size), so the claimed `total_bytes_skipped` and the raw
+/// `recovered_truncated_bytes` must equal EXACTLY the bounded suffix — computed here from the
+/// image itself, so a report that under- or over-claims its loss is still mechanically falsified.
+/// It also asserts every claimed loss event names the active segment and the spans sum to the
+/// same bound.
 fn assert_loss_bound_equals_discarded_suffix(
     fs: &InMemoryFs,
     active_id: u64,
-    durable_active_len: u64,
+    durable_image: &[u8],
     log: &Log<InMemoryFs, ManualClock>,
 ) {
+    let durable_active_len = durable_image.len() as u64;
     let active_name = segment_file_name(active_id);
     let kept_len = fs.open(&active_name).unwrap().len().unwrap();
     let actual_discarded = durable_active_len.saturating_sub(kept_len);
+    let reported_discarded = durable_image[usize::try_from(kept_len).unwrap()..]
+        .iter()
+        .rposition(|&b| b != 0)
+        .map_or(0, |i| i as u64 + 1);
+    assert!(
+        reported_discarded <= actual_discarded,
+        "the claim never exceeds the true discarded suffix"
+    );
     assert_eq!(
         log.loss_report().total_bytes_skipped(),
-        actual_discarded,
-        "the LossReport's claimed byte loss must equal the actual discarded suffix \
-         (durable {durable_active_len} - kept {kept_len})"
+        reported_discarded,
+        "the LossReport's claimed byte loss must equal the discarded suffix bounded at its last \
+         non-zero byte (durable {durable_active_len} - kept {kept_len}, of which \
+         {reported_discarded} plausibly written)"
     );
     assert_eq!(
         log.recovered_truncated_bytes(),
-        actual_discarded,
-        "the raw recovered_truncated_bytes must equal the actual discarded suffix"
+        reported_discarded,
+        "the raw recovered_truncated_bytes must equal the bounded discarded suffix"
     );
     // Every claimed loss event names the active segment and its span equals the discarded bytes.
     let claimed: u64 = log
@@ -195,8 +210,8 @@ fn assert_loss_bound_equals_discarded_suffix(
         })
         .sum();
     assert_eq!(
-        claimed, actual_discarded,
-        "the loss events sum to the discarded suffix"
+        claimed, reported_discarded,
+        "the loss events sum to the bounded discarded suffix"
     );
 }
 
@@ -1154,9 +1169,10 @@ fn loss_bound_equals_the_discarded_suffix_after_a_torn_tail() {
         let torn_len = full_len - chop;
         file.set_len(torn_len).unwrap();
         file.sync_all().unwrap();
-        let durable_active_len = fs.open(&segment_file_name(0)).unwrap().len().unwrap();
+        let durable_image = fs.open(&segment_file_name(0)).unwrap().snapshot();
         assert_eq!(
-            durable_active_len, torn_len,
+            durable_image.len() as u64,
+            torn_len,
             "the torn image is the durable image"
         );
 
@@ -1164,11 +1180,11 @@ fn loss_bound_equals_the_discarded_suffix_after_a_torn_tail() {
         // The whole last record is dropped (its frame is no longer parseable), so the prefix is n-1.
         assert_eq!(log.flushed_offset(), Offset::new(n - 1));
         assert_prefix(&log, n - 1);
-        // The claimed loss bound equals the actual discarded suffix.
-        assert_loss_bound_equals_discarded_suffix(&fs, 0, durable_active_len, &log);
+        // The claimed loss bound equals the discarded suffix (bounded at its last non-zero byte).
+        assert_loss_bound_equals_discarded_suffix(&fs, 0, &durable_image, &log);
         assert!(
-            log.loss_report().total_bytes_skipped() >= chop,
-            "the discarded suffix is at least the bytes we chopped"
+            log.loss_report().total_bytes_skipped() > 0,
+            "a discarded torn frame head reports a non-empty claim"
         );
     }
 }
@@ -1194,12 +1210,11 @@ fn loss_bound_equals_the_discarded_suffix_after_body_corruption() {
     file.set_len(0).unwrap();
     file.write_all_at(&bytes, 0).unwrap();
     file.sync_all().unwrap();
-    let durable_active_len = fs.open(&segment_file_name(0)).unwrap().len().unwrap();
 
     let log = Log::open(fs.clone(), ManualClock::new(), big_config()).unwrap();
     assert_eq!(log.flushed_offset(), Offset::new(n - 1));
     assert_prefix(&log, n - 1);
-    assert_loss_bound_equals_discarded_suffix(&fs, 0, durable_active_len, &log);
+    assert_loss_bound_equals_discarded_suffix(&fs, 0, &bytes, &log);
     // The corruption fell in the record body, so the body-CRC reason is reported (not torn-tail).
     assert!(
         log.loss_report()
@@ -1253,6 +1268,9 @@ fn power_cut_with_reordered_unsynced_tail_recovers_a_consistent_prefix() {
             after_len >= durable_active_len,
             "the durable (acked) bytes always survive the cut"
         );
+        // The post-cut durable image, for the loss-bound gate below (recovery truncates the file,
+        // so the discarded suffix's bytes must be captured before the open).
+        let after_image = fs.open(&segment_file_name(0)).unwrap().snapshot();
 
         // Recovery: the acked prefix survives, the reordered/dropped tail truncates at the first
         // incomplete record, and no acked record is lost.
@@ -1268,8 +1286,9 @@ fn power_cut_with_reordered_unsynced_tail_recovers_a_consistent_prefix() {
         let records = log.read_from(Offset::ZERO, usize::MAX).unwrap();
         let acked: Vec<u64> = (0..durable).collect();
         check_no_acked_loss(&records, &acked).unwrap();
-        // The loss bound equals the actual discarded suffix of the active segment after the cut.
-        assert_loss_bound_equals_discarded_suffix(&fs, 0, after_len, &log);
+        // The loss bound equals the discarded suffix of the active segment after the cut
+        // (bounded at the suffix's last non-zero byte).
+        assert_loss_bound_equals_discarded_suffix(&fs, 0, &after_image, &log);
     }
 }
 

--- a/crates/ironbus-storage/tests/quarantine_recovery.rs
+++ b/crates/ironbus-storage/tests/quarantine_recovery.rs
@@ -74,14 +74,21 @@ fn disk_with_segment0(bytes: &[u8]) -> InMemoryFs {
 
 /// A segment-0 image whose LAST record's body CRC is flipped, so recovery recovers the first `n-1`
 /// records and reports a `CorruptRecordBody` over the last frame (the corpus `flipped_record_body_crc`
-/// case). Returns the bytes and the last frame's [start, end) span.
+/// case). Returns the bytes and the REPORTED [start, end) span of the discarded frame: the end is
+/// bounded at one past the frame's last NON-ZERO byte (the zero-tail rule, `docs/PREALLOCATION.md`)
+/// — recovery reports, and quarantine captures, exactly that span, never trailing zeros (which on a
+/// preallocated, logically-extended segment would be a whole roll size of never-written bytes).
 fn corrupt_body_segment(n: u64) -> (Vec<u8>, usize, usize) {
     let good = good_unsealed_segment(n);
     let last_start = frame_start(n - 1);
     let mut bytes = good.clone();
     // Flip a byte in the last record's payload: passes the header CRC, fails the body CRC.
     bytes[last_start + RECORD_HEADER_LEN] ^= 0x01;
-    let end = bytes.len();
+    let end = bytes
+        .iter()
+        .rposition(|&b| b != 0)
+        .map_or(last_start, |i| i + 1);
+    assert!(end > last_start, "the corrupt frame has a non-zero byte");
     (bytes, last_start, end)
 }
 

--- a/docs/PREALLOCATION.md
+++ b/docs/PREALLOCATION.md
@@ -6,9 +6,23 @@ segments are recycled. The preallocation primitive is now IMPLEMENTED (#330): th
 carries a `RandomAccessFile::preallocate(len)` method, `start_segment` preallocates each
 new active segment to the roll size best-effort, and the production `StdFile` reserves
 real blocks per OS (Linux `fallocate` with `FALLOC_FL_KEEP_SIZE`, macOS
-`fcntl(F_PREALLOCATE)`), falling back to today's grow-on-append on a filesystem that
-supports neither. The recycling question is RESOLVED, not deferred: in v1 a segment is
-never recycled, for the at-rest-encryption nonce reason recorded in
+`fcntl(F_PREALLOCATE)`) AND advances the file's LOGICAL length up to the roll size
+(a `set_len`-up pairing), falling back gracefully on a filesystem that supports less.
+The logical extension is a measured refinement over the original keep-size-only form:
+with every append landing INSIDE the logical size, the per-commit `fdatasync` no longer
+journals an inode-size (`i_size`) update. It is NOT metadata-free — on ext4 an append's
+first touch of a reserved-but-unwritten extent still journals that extent's one-time
+unwritten→written state conversion (both measurement arms paid those) — the EVERY-COMMIT
+`i_size` update is what the extension eliminates (measured on the ext4/virtio bench VM:
+~13us / 7% p50 and ~26us / 10% p99 saved per fdatasync). Two compensating rules keep the
+rest of the engine unchanged: the seal truncates the file back down to the footer end (a
+sealed segment's image stays byte-identical to a never-preallocated one, so footer
+discovery at the file end still works), and recovery and the offline tools apply the
+ZERO-TAIL rule — a provably ALL-ZERO tail is truncated (or, offline, passed over)
+silently as never-written space, and a non-zero tail's REPORTED span (loss event,
+quarantine capture) is bounded at one past its last non-zero byte, never at the extended
+file length. The recycling question is RESOLVED, not deferred: in v1 a segment is never
+recycled, for the at-rest-encryption nonce reason recorded in
 [ADR 0002](adr/0002-segments-never-recycled-in-v1.md).
 
 It complements [WAL.md](WAL.md) (the file lifecycle and the fsync model) and
@@ -64,10 +78,13 @@ engine knowing. v1 satisfies it with `pread`/`ReadFile`-positioned IO on every t
 Preallocation is **default ON**. When a new active segment is created (`Log::open` for the
 first segment, `Log::start_segment` on every roll), the file is preallocated to the
 configured roll size (`LogConfig::max_segment_bytes`, default 64 MiB; 8 MiB at the edge
-size) BEFORE the first record is appended. The file's *logical length* still grows with
-appends as today (the write position is the append cursor, not the preallocated end); what
-preallocation changes is that the *physical blocks* backing those bytes are reserved up
-front, in one call, rather than block by block as each append extends the file.
+size) BEFORE the first record is appended. The production preallocation does two things in
+one call: the *physical blocks* backing the roll size are reserved up front (one call, not
+block by block as appends arrive), and the file's *logical length* is advanced to the roll
+size, so appends land inside the logical size. The write position remains the append
+cursor tracked by the writer — it is never derived from `file.len()` — and the unwritten
+remainder past the cursor reads back as zeros until it is either overwritten by appends,
+truncated down at seal, or truncated silently at recovery.
 
 A knob to disable it for filesystems or operators that prefer not to (`preallocate`,
 default `true`) is a forward config key (there is no TOML config in code yet; see
@@ -131,12 +148,24 @@ calls for, and it reuses the shipped overflow path rather than inventing one.
 Preallocation interacts with the recovery end-of-data rule, tracked as R13 in the design
 risk hunt (RISK_REGISTER.md, RR-06 residual risk). The shipped torn-tail recovery finds
 the active segment's end of data by scanning records forward and stopping at the first
-non-record bytes; preallocated tail blocks read back as zeros. A future implementation
-MUST ensure the recovery scan distinguishes "preallocated-but-unwritten zero tail" from
-"a real record," which the existing framing already does (a zero region is not a valid
-record header: the magic and `header_crc` fail), so recovery truncates the unwritten tail
-exactly as it truncates a torn one. This spec records the requirement; the
-implementing PR carries the recovery-scan test that pins it on a preallocated file.
+non-record bytes; the preallocated (and now logically extended) tail reads back as zeros.
+The recovery scan distinguishes "preallocated-but-unwritten zero tail" from "a real
+record" structurally (a zero region is not a valid record header: the magic and
+`header_crc` fail), so the scan stops at the first unwritten byte, and the streaming scan
+does this with ONE bounded window read, never walking the zero span frame by frame. With
+the logical extension the tail can be a whole roll size, so recovery additionally BOUNDS
+what it REPORTS at one past the tail's LAST NON-ZERO byte (a bounded backward chunk
+scan): a provably all-zero tail is truncated silently (no loss event, no quarantine, no
+`recovered_truncated_bytes` — the bytes were never written, and a roll-size loss event
+on every boot would trip the I3 caps), and a tail with any non-zero byte gets the
+skip-and-report + quarantine treatment over ONLY the span up to that bound (one torn
+byte is a one-byte event and a one-byte forensic blob, never a roll-size one — an
+unbounded span would fail the boot on the I3 per-event 64 MiB cap whenever
+`max_segment_bytes` exceeds it, and would flood the quarantine store with near-all-zero
+blobs). The I3 cap check runs BEFORE recovery's truncate, so a cap-exceeding boot fails
+closed with the evidence still on disk. The file truncation itself still cuts at
+`valid_end`. The recovery-scan tests pin all of this on an extended file (log-level and
+`StdFs` end-to-end).
 
 ---
 
@@ -147,33 +176,59 @@ rather than a raw `fallocate`. Each maps to the same logical contract: reserve `
 backing blocks for the file without changing the bytes a reader sees, then make that
 reservation effective for the steady-state appends that follow.
 
-The implemented form uses the KEEP-SIZE variant on every OS: it reserves blocks WITHOUT
-advancing the file's logical length. This is load-bearing, and is a refinement of the
-earlier draft (which paired the reservation with an `ftruncate`/`posix_fallocate`
-size-grow): the append cursor is the logical end of data, and both recovery's torn-tail
-scan and the offline `dump`/`scrub` tools find the end of data from `file.len()`. If
-preallocation grew the logical length to the full roll size, every reader would see a
-multi-MiB zero tail and (correctly, but needlessly, and breaking the offline-tool output)
-report it as a zero window. Keeping the size means the logical length still grows only
-with appends, which land in the already-reserved blocks. So the macOS `ftruncate` pairing
-is dropped, and Linux uses `FALLOC_FL_KEEP_SIZE`.
+The implemented form pairs a KEEP-SIZE block reservation with an explicit logical
+extension (`set_len` up to the roll size, never down) — together equivalent to Linux's
+mode-0 `fallocate` and to Apple's documented `F_PREALLOCATE` + `ftruncate` recipe. This
+REVERSES the earlier keep-size-only refinement, on measurement: with the keep-size form
+every append advanced `i_size`, so every commit `fdatasync` also journaled an inode-size
+update; extending the logical length up front removes that per-commit `i_size` journal
+entry, worth ~13us (7%) p50 and ~26us (10%) p99 per fdatasync on the ext4/virtio bench
+VM. (Appends into the reserved-but-unwritten extents still journal their one-time
+unwritten→written extent-state conversions — both probe arms paid those — so the
+eliminated cost is precisely the every-commit `i_size` update, not all metadata.) The
+costs the keep-size form was avoiding are handled head-on instead:
+
+- **The append cursor** was never derived from `file.len()`: the writer tracks its own
+  `write_pos` (create starts it at the header end; recovery resumes it at the scanned
+  `valid_end`), so appends land inside the extension by construction.
+- **Footer discovery reads the file END**, so `seal` (and `seal_compacted`) truncates the
+  file down to the exact trailer end before its existing `sync_all` (the documented
+  `set_len`-shrink-needs-`sync_all` pairing). A SEALED segment's on-disk image is therefore
+  byte-identical to a never-preallocated one.
+- **Recovery** stops its torn-tail scan at the first zero word as always (a zero word is
+  never a valid frame magic), then BOUNDS its report at one past the tail's last non-zero
+  byte: a provably ALL-ZERO tail is the unwritten remainder of the extension —
+  never-written, never-acked space — and is truncated SILENTLY (no loss event, no
+  quarantine; reporting up to a roll size of zeros would trip the I3 bounded-loss caps on
+  every boot). Any non-zero byte in the tail means real written bytes are being
+  discarded, and the skip-and-report + quarantine path runs over the span up to that
+  bound only — one torn byte reports (and quarantines) one byte, never the roll-size
+  extension, so a routine crash can never trip the I3 per-event cap or flood the
+  quarantine store with near-all-zero blobs. The I3 check runs BEFORE the truncate, so a
+  genuinely cap-exceeding boot fails closed with the evidence intact.
+- **The offline tools (`verify`/`info`/`dump`/`scrub`)** apply the SAME zero-tail rule
+  through `OfflineReader`: a healthy stopped broker's extended active segment (the
+  normal, every-directory shape) reports ZERO loss, and a torn tail inside the extension
+  is reported bounded at its last non-zero byte — without this, `verify` would claim ~a
+  roll size of data loss (exit 3) for every healthy directory. Sealed segments (the
+  overwhelming majority) are truncated exact at seal and carry no tail at all.
 
 | OS | Primitive | Reserves real blocks? | Durability note |
 |---|---|---|---|
-| **Linux** (production, musl) | `fallocate(fd, FALLOC_FL_KEEP_SIZE, 0, len)` | Yes | `fallocate` reserves real extents and `FALLOC_FL_KEEP_SIZE` leaves the logical size unchanged; the steady-state append then writes into allocated blocks, so the commit `fdatasync` need not also persist a length-grow. On a filesystem that does not support allocation (`EOPNOTSUPP`/`ENOSYS`, rare on ext4/f2fs/xfs, the edge targets) it falls back to no-prealloc (grow-on-append). A genuine `ENOSPC` is surfaced (not swallowed) at the seam. The block reservation itself is not the durability barrier: the I2 commit `fdatasync` still is. |
-| **macOS** (developer, CI) | `fcntl(fd, F_PREALLOCATE)` with `F_ALLOCATECONTIG` then `F_ALLOCATEALL` (NO `ftruncate`) | Yes (contiguous if possible) | `F_PREALLOCATE` reserves blocks and does NOT advance the file's logical size, which is exactly the keep-size reservation wanted, so no `ftruncate` pairing is used. On macOS the durability barrier is `F_FULLFSYNC`, which `std` already issues for both `sync_data` and `sync_all` (see `io.rs`); preallocation does not change that, it only removes the per-commit length-grow. If `F_PREALLOCATE` returns `ENOTSUP`, it falls back to no-prealloc (grow-on-append); any other error is surfaced. |
+| **Linux** (production, musl) | `fallocate(fd, FALLOC_FL_KEEP_SIZE, 0, len)` then `ftruncate` up to `len` | Yes | `fallocate` reserves real extents; the `ftruncate`-up then advances the logical size once, so the steady-state append writes into reserved blocks INSIDE the logical size and the commit `fdatasync` persists no length-grow and allocates no new blocks (each reserved extent's one-time unwritten→written state conversion is still journaled on first touch; the one-time size-grow metadata commit is paid by the first sync after the preallocate). On a filesystem that does not support allocation (`EOPNOTSUPP`/`ENOSYS`, rare on ext4/f2fs/xfs, the edge targets) the reservation half degrades and the logical extension still applies (a sparse extension still removes the per-commit `i_size` update; block allocation then happens — and journals — as appends land). A genuine `ENOSPC` is surfaced (not swallowed) at the seam. Neither half is the durability barrier: the I2 commit `fdatasync` still is. |
+| **macOS** (developer, CI) | `fcntl(fd, F_PREALLOCATE)` with `F_ALLOCATECONTIG` then `F_ALLOCATEALL`, then `ftruncate` up to `len` | Yes (contiguous if possible) | `F_PREALLOCATE` reserves blocks without advancing the size; the `ftruncate`-up pairing (Apple's own documented recipe for a full preallocation) then advances the logical size once. On macOS the durability barrier is `F_FULLFSYNC`, which `std` already issues for both `sync_data` and `sync_all` (see `io.rs`); preallocation does not change that. If `F_PREALLOCATE` returns `ENOTSUP`, the reservation half degrades and the extension still applies; any other error is surfaced. |
 | **Windows** (v1 non-goal; flagged for #17) | `SetFilePointerEx(fd, len)` then `SetEndOfFile(fd)` to set the size; optionally `SetFileValidData` to mark the range valid without zeroing | Size set; blocks valid only with `SetFileValidData` | `SetFilePointerEx` + `SetEndOfFile` set the file size but leave the range as a zeroing-on-first-write valid-data region, so the wear/latency benefit is partial unless `SetFileValidData` is used. **`SetFileValidData` requires the `SE_MANAGE_VOLUME_NAME` privilege** and exposes previously-deleted disk contents in the unwritten range, so it is a deliberate, privileged opt-in, never the default. Without it, Windows preallocation sets the size (avoiding repeated grows) but the OS still zeroes-on-write; the durability barrier on Windows is `FlushFileBuffers`. Windows is a v1 NON-GOAL (the production targets are Linux musl and macOS; `io.rs` ships only the trait and `InMemoryFile` off Unix), so this row is the SPECIFIED Windows mapping for when the build matrix (#17) adds it, not shipped code. |
 
-The common fallback ladder on every OS is: **keep-size block reservation, then no-prealloc
-(grow-on-append)** when the filesystem reports it cannot allocate. The implementation drops
-the intermediate set-size / zero-fill rungs the draft listed precisely because they would
-advance the logical length (the very thing the keep-size form avoids), so they are not
-correct keep-size rungs. Both surviving rungs are correct for durability; the lower rung
-only gives up the wear/latency benefit, never the ack-implies-durable guarantee (which is
-always the commit `fdatasync`, independent of preallocation). Falling back to
-grow-on-append is exactly the shipped v1 behavior, so a platform that supports no
-keep-size reservation primitive (any non-Linux, non-Apple Unix, or an unsupported
-filesystem) degrades to today's code, not to an unsafe one.
+The common fallback ladder on every OS is: **block reservation + logical extension, then
+logical extension alone (a sparse extension, when the filesystem cannot reserve), then
+no-prealloc (grow-on-append, when the whole preallocate call errors and `start_segment`
+swallows it)**. Every rung is correct for durability; a lower rung only gives up part of
+the wear/latency benefit (the sparse rung still removes the per-commit `i_size` update
+but loses the contiguity and journals block allocations as appends land; the bottom rung
+keeps neither), never the ack-implies-durable guarantee (which is always the commit
+`fdatasync`, independent of preallocation). The bottom rung is exactly the pre-#330
+behavior, so a platform or filesystem that supports nothing degrades to the old code, not
+to an unsafe one.
 
 ---
 
@@ -188,12 +243,15 @@ plumbing:
   is a literal no-op (`Ok(())`): a backend with no reservation primitive degrades to
   grow-on-append, which is correct. The in-memory `InMemoryFile` overrides it to TRACK the
   requested reservation (a high-water `preallocated_to`) WITHOUT changing its bytes or its
-  logical length, mirroring the real keep-size reservation. This is deliberate over a
-  `set_len`-extend: a set-len would zero-fill the in-memory image to `len` and diverge the
-  deterministic disk image (the determinism and crash-recovery sweeps assert byte-identical
-  images and exact truncated-tail counts), whereas a tracked reservation keeps a
-  preallocated active segment byte-identical to a grow-on-append one while still letting a
-  test assert the roll-size reservation was requested.
+  logical length. This is deliberate even though the production `StdFile` now ALSO extends
+  the logical length: mirroring the extension in the simulation would materialize (and
+  durably double) `max_segment_bytes` of zeros in RAM for every active segment across every
+  simulation and server test, and would diverge the deterministic disk image the
+  determinism and crash-recovery sweeps assert. The extension-specific recovery and seal
+  behavior is pinned instead by tests that write the zero tail out for real (the log-level
+  extended-tail recovery tests, the seal-truncation tests, the `StdFs` end-to-end test, and
+  the frozen #45 zero-window fixture), while the tracked reservation still lets a test
+  assert the roll-size request was made.
 - The production `StdFile` (Unix) overrides it with the per-OS syscall above. `StdFile`
   already exposes `from_file` for "a preallocated or handed-off descriptor" (`io.rs`), so
   the preallocation can also be done at create time and handed in; the trait method is the
@@ -345,8 +403,9 @@ matrix (#17), which must be flagged so the portability promise is tested, not as
 |---|---|
 | The four-primitive shim (preallocate, file-datasync, directory-sync, sealed-read-map) | (a)(b)(c)(d) all IMPLEMENTED in the seam (a = `RandomAccessFile::preallocate`, #330) |
 | Preallocation always-on best-effort, active segment, full roll size, wear/latency rationale | IMPLEMENTED (`start_segment`, #330); an explicit disable knob is deferred to #14 config |
-| ENOSPC at roll | A keep-size `ENOSPC` is surfaced at the seam; v1 wiring SWALLOWS it in `start_segment` and falls back to grow-on-append (the doc's route-to-`AtCapacity` refinement is a forward improvement, not required for correctness) |
-| Per-OS preallocate (Linux `fallocate` + `FALLOC_FL_KEEP_SIZE`, macOS `fcntl(F_PREALLOCATE)`; Windows `SetEndOfFile`/`SetFileValidData` still SPECIFIED for #17) | IMPLEMENTED for Linux + macOS; other Unix and Windows degrade to the no-op default |
+| Logical extension to the roll size (no per-commit `i_size` journal; seal truncates down; recovery + offline tools silent on all-zero tails, reports bounded at the last non-zero byte) | IMPLEMENTED (perf/r5): `StdFile::preallocate` = reservation + `set_len`-up; `seal`/`seal_compacted` truncate to the trailer end; recovery and `OfflineReader` report loss only for non-zero tails, bounded to the written span |
+| ENOSPC at roll | A reservation `ENOSPC` is surfaced at the seam; v1 wiring SWALLOWS it in `start_segment` and falls back to grow-on-append (the doc's route-to-`AtCapacity` refinement is a forward improvement, not required for correctness) |
+| Per-OS preallocate (Linux `fallocate` + `FALLOC_FL_KEEP_SIZE` + `ftruncate`-up, macOS `fcntl(F_PREALLOCATE)` + `ftruncate`-up; Windows `SetEndOfFile`/`SetFileValidData` still SPECIFIED for #17) | IMPLEMENTED for Linux + macOS; any other Unix gets the sparse extension; Windows degrades to the no-op default |
 | Segment recycling | RESOLVED: v1 NEVER recycles (ADR 0002); no generation stamp; recycling is a v2 nonce-safety decision |
 | Build-matrix implications | FLAGGED to #17 |
 


### PR DESCRIPTION
## What

Active-segment preallocation now **advances the logical file length** (fallocate/F_PREALLOCATE + `set_len` up to the roll boundary) instead of KEEP_SIZE-only, so steady-state appends land inside the logical size and the per-commit fdatasync **carries no i_size update**. Measured on the matched-VM bench rig (ext4/virtio, the #1023-round-2 study): **13µs/7% p50, 26µs/10% p99 saved per fdatasync**. Honest scoping: the one-time unwritten→written extent-state conversions are still journaled (both probe arms paid them); no macOS win is claimed.

## The review caught a real defect family (13th review-caught bug)

Three adversarial lenses all reproduced the same root cause: **recovery/tooling spans ended at the (now-inflated) file length instead of the last written byte**, meaning:
- one torn byte + a 128MiB segment → 134MB "loss" > the I3 per-event cap → **`Log::open` failed after a routine crash** (availability);
- the truncate ran before the cap check, so the failed boot **destroyed its own evidence** (this ordering predates the branch — confirmed against main — but the span inflation weaponized it);
- one torn byte quarantined a ~64MiB near-all-zero forensic blob (4 boots would evict all genuine forensics);
- **`ironbus verify` reported 67MB of data loss on every healthy stopped broker** (OfflineReader never had the zero-tail rule).

## Fixes (all reproduced scenarios now pinned as regression tests)

- New backward bounded-chunk scanner `last_nonzero_end`; both recovery paths + OfflineReader bound every REPORTED span (LossEvent, truncated-bytes accounting, quarantine) at one past the last non-zero byte. File truncation still cuts at `valid_end`.
- `enforce_loss_caps` runs BEFORE the destructive truncate: a cap-failing boot preserves the evidence byte-identically, and boot 2 fails with an identical report.
- Seal/`seal_compacted` truncate the zero tail down to the footer end (footer discovery reads file EOF), fsynced by the seal's existing `sync_all` — sealed images stay byte-identical to never-preallocated ones (frozen conformance corpus untouched).
- `SegmentReader::with_data_end` clamps the rare active-segment full-scan fallback and admin `truncate_to` so they no longer read a roll size of zeros.
- Recovery on an all-zero preallocated tail is silent (no loss event, no quarantine) — the honest re-type of the #45 zero-window fixture verdict (`UnwrittenZeroTailTruncate`), bytes frozen.

## Verification

- Fix re-verified by two fresh lenses (both SHIP), re-running every reproduced scenario from scratch including an off-by-one hunt (torn byte at file end / at exactly `valid_end` / mid-tail) and an end-to-end CLI loop (verify → repair → re-verify) against a real broker directory.
- Mutation-tested: reverting the span bound fails 24 tests across 5 suites; restoring the truncate-before-cap order and removing the seal truncation each fail their dedicated tests.
- Gates: fmt ✓ clippy pedantic ✓ storage 466 + all integration suites ✓ core conformance byte-identity ✓ server 1018 ✓ workspace check ✓ (re-run post-rebase onto the #1046 prep API).

Scope cuts (documented in-code + commit): backup capture of extended segments (TODO, follow-up), recovery-resume doesn't re-extend (perf-only, next roll restores it).

Refs #1040 (R5 of the Redpanda-parity plan), #1023 round 2.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
