### PR TITLE
perf(io): configurable durable-write io-mode — the safe T1 O_DIRECT tier (metadata-free barrier, ~3x faster durable ops on EBS)

### DIFF
--- a/crates/ironbus-cli/src/config_file.rs
+++ b/crates/ironbus-cli/src/config_file.rs
@@ -150,6 +150,7 @@ fn key_to_env_name(key: &str) -> Option<&'static str> {
         "storage.segment_size" => "IRONBUS_MAX_SEGMENT_BYTES",
         "storage.data_dir" => "IRONBUS_DATA_DIR",
         "storage.max_total_bytes" => "IRONBUS_MAX_TOTAL_BYTES",
+        "storage.io_mode" => "IRONBUS_IO_MODE",
         "durability.level" => "IRONBUS_DURABILITY_LEVEL",
         "durability.flush_interval_ms" => "IRONBUS_FLUSH_INTERVAL_MS",
         "durability.flush_max_bytes" => "IRONBUS_FLUSH_MAX_BYTES",

--- a/crates/ironbus-cli/src/config_reload.rs
+++ b/crates/ironbus-cli/src/config_reload.rs
@@ -45,9 +45,12 @@ pub enum ReloadClass {
 /// against the candidate; classifying them here, with their [`ReloadClass`], keeps the cold/hot
 /// distinction the design names in one auditable place. `storage.segment_size` and
 /// `storage.data_dir` are COLD because changing them live could strand segments or move the store.
+/// `storage.io_mode` is COLD because the open segment fds carry the io strategy (buffered vs the
+/// `O_DIRECT` direct-write file); switching it live cannot re-open them, so a change requires a restart.
 pub const COLD_KEYS: &[(&str, ReloadClass)] = &[
     ("storage.segment_size", ReloadClass::Cold),
     ("storage.data_dir", ReloadClass::Cold),
+    ("storage.io_mode", ReloadClass::Cold),
 ];
 
 /// The reload class of `key`: [`ReloadClass::Cold`] if it is in the classified [`COLD_KEYS`] set,

--- a/crates/ironbus-cli/src/main.rs
+++ b/crates/ironbus-cli/src/main.rs
@@ -269,6 +269,15 @@ const DEFAULT_DISK_FULL_POLICY: &str = "drop-new";
 /// levels (`interval`/`async`/`none`) are strictly opt-in and weaken I2 by a documented loss window.
 const DEFAULT_DURABILITY_LEVEL: &str = "sync";
 
+/// The default durable-write IO-MODE for `serve` (perf/iomode-direct): `buffered` — today's
+/// `StdFile` (buffered `pwrite` + `fdatasync`), so a zero-config broker is byte-and-behavior
+/// identical to the historical broker. `direct` is the SAFE T1 `O_DIRECT` tier (data straight to the
+/// device over pre-formatted written extents, durability barrier KEPT — ack-implies-durable holds);
+/// `auto` enables it only where the substrate probe confirms network-durable block storage. The
+/// resolved mode is threaded into `StdFs::with_io_mode` at `open_disk_engine`; it never weakens
+/// durability (the barrier is kept in every mode), only the sync MECHANISM differs.
+const DEFAULT_IO_MODE: &str = "buffered";
+
 /// The default storage BACKEND for `serve` (#443): `disk`, the durable on-disk store, so a
 /// zero-config broker is byte-for-byte the historical durable broker. The `memory` backend runs the
 /// SAME engine over the in-memory filesystem (NO files, NO fsync, explicitly NO power-loss or
@@ -870,7 +879,7 @@ ironbus: a durable edge message queue.
 USAGE:
     ironbus serve (--data-dir <dir> | --storage memory) [--config <path>] [--allow-unknown-config]
                   [--profile <edge-tiny|balanced|throughput>]
-                  [--storage <disk|memory>] [--ephemeral-loss-ack]
+                  [--storage <disk|memory>] [--ephemeral-loss-ack] [--io-mode <buffered|direct|auto>]
                   [--addr <host:port>] [--max-connections <n>]
                   [--checkpoint-interval <n>] [--max-deliver <n>] [--allow-unlimited-deliver]
                   [--backoff-ms <ms,ms,...>] [--max-in-flight <n>]
@@ -977,6 +986,16 @@ Notes:
     post-compression bytes, and 0 = unlimited would OOM the device). With --storage memory,
     --data-dir must be ABSENT (the broker keeps no on-disk state). The startup banner states the
     ephemeral contract and the materialized-config line says storage=memory.
+    --io-mode <buffered|direct|auto> (default buffered) selects the durable-write strategy. buffered
+    is today's path (buffered pwrite + fdatasync), byte-and-behavior identical. direct is the SAFE
+    O_DIRECT tier: record bytes go straight to the device over segments whose extents are
+    pre-formatted written at create, and the durability barrier is KEPT (ack still implies durable,
+    same I2 as buffered) — it targets the durable-single-op latency on network-durable block storage
+    (EBS-class) by making the barrier metadata-free and page-cache-free, never by dropping it. auto
+    enables direct only where a substrate probe confirms network-durable storage, and fails closed to
+    buffered otherwise. direct is Linux-only (no O_DIRECT elsewhere -> buffered). It is a COLD knob
+    (a change needs a restart) and never weakens durability in any mode; the resolved strategy is
+    logged at startup and echoed as io_mode= in the materialized-config line.
     --max-in-flight bounds the per-GROUP in-flight (max-ack-pending) window; --consumer-credit
     (default 2048) is the per-CONNECTION un-acked CEILING the auto-tuning credit window grows
     toward (#552): the window starts at a 64-message floor and grows toward this ceiling as the
@@ -2289,6 +2308,11 @@ struct ServeFlags {
     /// `None` resolves to the default `sync` (ack-implies-durable, I2, zero acked loss). An unknown
     /// name is a usage error.
     durability_level: Option<String>,
+    /// The durable-write IO-MODE (perf/iomode-direct) selected by `--io-mode` / `IRONBUS_IO_MODE`.
+    /// `None` resolves to the default `buffered` (today's `StdFile`; byte-and-behavior unchanged).
+    /// `direct` forces the SAFE T1 `O_DIRECT`+kept-barrier file, `auto` enables it only on confirmed
+    /// network-durable storage. An unknown name is a usage error.
+    io_mode: Option<String>,
     /// The compression CODEC (#12, #387) selected by `--compression` / `IRONBUS_COMPRESSION`. `None`
     /// resolves to the default `lz4` (the ADR-0003 pure-Rust default codec). `none` stores every
     /// record raw; `zstd` is rejected on the default build. An unknown name is a usage error.
@@ -2591,6 +2615,9 @@ fn collect_serve_flags(args: &[String]) -> Result<ServeFlags, CliError> {
             }
             "--durability-level" => {
                 f.durability_level = Some(take_value("--durability-level", args, &mut i)?);
+            }
+            "--io-mode" => {
+                f.io_mode = Some(take_value("--io-mode", args, &mut i)?);
             }
             "--compression" => {
                 f.compression = Some(take_value("--compression", args, &mut i)?);
@@ -2989,6 +3016,23 @@ fn parse_serve_flags_with_env_and_reader(
             "`{source}` must be `sync`, `interval`, `async`, or `none`, got `{durability_level_arg}`"
         ))
     })?;
+    // The durable-write IO-MODE (perf/iomode-direct) resolves the same way: flag > env > default
+    // (`buffered`), parsed after resolution so a bad value names its source. The default keeps the
+    // buffered `StdFile`; `direct`/`auto` request the SAFE T1 O_DIRECT tier (barrier kept). The
+    // requested mode is resolved to a concrete strategy at boot, once the data dir exists
+    // (`open_disk_engine`), where the substrate probe runs.
+    let io_mode_from_flag = f.io_mode.is_some();
+    let io_mode_arg = resolve_string("--io-mode", f.io_mode, env, DEFAULT_IO_MODE);
+    let io_mode = ironbus_storage::substrate::IoMode::parse(&io_mode_arg).ok_or_else(|| {
+        let source = if io_mode_from_flag {
+            "--io-mode".to_string()
+        } else {
+            env_var_name("--io-mode")
+        };
+        CliError::Usage(format!(
+            "`{source}` must be `buffered`, `direct`, or `auto`, got `{io_mode_arg}`"
+        ))
+    })?;
     // The compression CODEC (#12, #387) resolves like the disk-full policy: an enum string with
     // flag > env > default (`lz4`) precedence, parsed after resolution so a bad value names its
     // source (the flag if explicit, else the env var). `zstd` is rejected here on the default build
@@ -3182,6 +3226,10 @@ fn parse_serve_flags_with_env_and_reader(
             // set, overridable by env/flag. `async`/`none` are gated behind `--async-loss-ack` in
             // `validate_serve_config`, never reachable by accident.
             durability_level,
+            // The durable-write io-mode (perf/iomode-direct); default `buffered`. Resolved to a
+            // concrete strategy at boot (`open_disk_engine`) once the data dir exists and the
+            // substrate probe can run. Never weakens durability — the barrier is kept in every mode.
+            io_mode,
             // The compression codec (#12, #387); default `lz4` per ADR-0003, `none` stores raw.
             compression,
             flush_interval_ms: resolve_number(
@@ -3491,7 +3539,11 @@ fn build_effective_config(
             let value = match *key {
                 "storage.segment_size" => config.max_segment_bytes.to_string(),
                 "storage.data_dir" => data_dir_cold_value(data_dir),
-                // Unreachable: COLD_KEYS lists only the two above; a new cold key must add its arm.
+                // The io-mode is COLD (open fds carry it): a live reload that changed it is rejected,
+                // the operator must restart. Echo the REQUESTED knob (what the file sets), matching
+                // how the other cold keys carry their configured value.
+                "storage.io_mode" => config.io_mode.as_str().to_string(),
+                // Unreachable: a new cold key must add its arm.
                 other => {
                     debug_assert!(false, "unhandled cold key `{other}`");
                     String::new()
@@ -4941,6 +4993,16 @@ struct ServeConfig {
     /// to boot without `async_loss_ack` (the none/async safety gate). Platform-neutral so it is
     /// validated on every platform; the Unix on-disk path maps it to the engine enum.
     durability_level: DurabilityLevelArg,
+    /// The durable-write IO-MODE knob (perf/iomode-direct). Default
+    /// [`ironbus_storage::substrate::IoMode::Buffered`] — today's buffered `StdFile`, so a
+    /// zero-config broker is byte-and-behavior identical. `Direct` requests the SAFE T1 `O_DIRECT` tier
+    /// (data straight to the device over pre-formatted written extents, durability barrier KEPT —
+    /// ack-implies-durable holds, same I2 as buffered); `Auto` enables it only where the substrate
+    /// probe confirms network-durable storage. Resolved to a concrete `StdFs` strategy at boot in
+    /// `open_disk_engine` (where the data dir exists and the probe can run); never weakens durability
+    /// in any mode (only the sync MECHANISM differs). Platform-neutral so it is parsed on every
+    /// platform; the non-Linux on-disk path degrades `direct`/`auto` to buffered.
+    io_mode: ironbus_storage::substrate::IoMode,
     /// The COMPRESSION CODEC knob (#12, #387, wired by #430). Default [`CompressionArg::Lz4`]
     /// (the ADR-0003 pure-Rust default codec). The resolved knob is threaded into
     /// `EngineConfig::compression` by `open_disk_engine`, so the write path stores each
@@ -5110,6 +5172,7 @@ impl ServeConfig {
             // power-loss-safe guarantee the shipped `serve` default carries.
             durability_level: DurabilityLevelArg::Sync,
             // The bench broker runs the default compression codec (#387): lz4 per ADR-0003.
+            io_mode: ironbus_storage::substrate::IoMode::Buffered,
             compression: CompressionArg::Lz4,
             flush_interval_ms: DEFAULT_FLUSH_INTERVAL_MS,
             flush_max_bytes: DEFAULT_FLUSH_MAX_BYTES,
@@ -6357,6 +6420,12 @@ fn materialized_config_line(config: &ServeConfig, addr: &str, data_dir: Option<&
     // compressible payload at or over the 64-byte threshold is stored compressed behind the
     // `COMPRESSED` record flag (sub-threshold and incompressible payloads store raw by design).
     let compression = config.compression.as_str();
+    // The durable-write io-mode echo (perf/iomode-direct): the REQUESTED knob (`buffered`/`direct`/
+    // `auto`), mirroring how `durability_level` echoes the requested level. The concrete strategy it
+    // resolved to (and why) is logged separately by `open_disk_engine` at boot. Never a durability
+    // signal — every mode keeps the barrier — so it sits next to the mechanism knobs, not the safety
+    // ones.
+    let io_mode = config.io_mode.as_str();
     // The storage backend echo (#443). Memory mode has no data dir, so the `data_dir=` field (kept
     // in place for field-order stability) carries the `none` sentinel there.
     let storage = config.storage.as_str();
@@ -6372,7 +6441,8 @@ fn materialized_config_line(config: &ServeConfig, addr: &str, data_dir: Option<&
          enable_admin={} ram_ceiling_bytes={} dedup_max_ids={} dedup_max_producers={} \
          max_prepared={} max_prepared_bytes={} \
          durability_level={durability_level} \
-         power_loss_safe={power_loss_safe} compression={compression} flush_interval_ms={} \
+         power_loss_safe={power_loss_safe} compression={compression} io_mode={io_mode} \
+         flush_interval_ms={} \
          flush_max_bytes={} async_loss_ack={} wal_fsync_headroom_bytes={} storage={storage} \
          commit_gather_us={} sync_max_dirty_bytes={}",
         config.profile.name(),
@@ -9159,7 +9229,23 @@ fn open_disk_engine(
 ) -> Result<Engine<StdFs, SystemClock>, CliError> {
     std::fs::create_dir_all(data_dir)
         .map_err(|e| CliError::Internal(format!("cannot create {}: {e}", data_dir.display())))?;
-    let fs = StdFs::new(data_dir.to_path_buf());
+    // Resolve the requested io-mode NOW that the data dir exists (the substrate probe needs it), ONCE
+    // — the mode is COLD (open fds carry it; a change needs a restart). The resolver fails closed:
+    // `direct`/`auto` degrade to buffered on any non-Linux / uncertain / local-volatile substrate,
+    // and even a forced `direct` KEEPS the durability barrier, so this can never weaken durability.
+    let resolution = ironbus_storage::substrate::resolve_for_dir(config.io_mode, data_dir);
+    // Log the decision on stderr (the log stream, where the materialized-config line goes). Buffered
+    // (the default) resolves with NO notes, so a zero-config broker and every test stay silent; only
+    // an explicit `direct`/`auto` prints its INFO/WARN. `let _`: a broken stderr never kills serve.
+    for note in &resolution.notes {
+        let prefix = if note.warn {
+            "WARN: io-mode: "
+        } else {
+            "io-mode: "
+        };
+        let _ = writeln!(std::io::stderr(), "{prefix}{}", note.message);
+    }
+    let fs = StdFs::with_io_mode(data_dir.to_path_buf(), resolution.mode);
     open_engine_with(
         fs,
         config,
@@ -12958,6 +13044,7 @@ mod tests {
             // safe (ack-implies-durable), so an unrelated test never accidentally relaxes durability.
             durability_level: DurabilityLevelArg::Sync,
             // The default compression codec (#387): lz4 per ADR-0003.
+            io_mode: ironbus_storage::substrate::IoMode::Buffered,
             compression: CompressionArg::Lz4,
             flush_interval_ms: DEFAULT_FLUSH_INTERVAL_MS,
             flush_max_bytes: DEFAULT_FLUSH_MAX_BYTES,
@@ -16395,6 +16482,7 @@ mod tests {
             // safe (ack-implies-durable), so an unrelated test never accidentally relaxes durability.
             durability_level: DurabilityLevelArg::Sync,
             // The default compression codec (#387): lz4 per ADR-0003.
+            io_mode: ironbus_storage::substrate::IoMode::Buffered,
             compression: CompressionArg::Lz4,
             flush_interval_ms: DEFAULT_FLUSH_INTERVAL_MS,
             flush_max_bytes: DEFAULT_FLUSH_MAX_BYTES,
@@ -16744,6 +16832,89 @@ mod tests {
             }
             other => panic!("a bad durability level must be a usage error, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn serve_io_mode_default_is_buffered_and_parses_each_value_with_env_precedence() {
+        use ironbus_storage::substrate::IoMode;
+        // The default is buffered (byte-and-behavior identical to today).
+        let cfg = parse_serve_flags(&serve_args(&[])).unwrap().config;
+        assert_eq!(cfg.io_mode, IoMode::Buffered, "default io-mode is buffered");
+        // Every accepted spelling round-trips through the flag.
+        for (flag, mode) in [
+            ("buffered", IoMode::Buffered),
+            ("direct", IoMode::Direct),
+            ("auto", IoMode::Auto),
+        ] {
+            let cfg = parse_serve_flags(&serve_args(&["--io-mode", flag]))
+                .unwrap()
+                .config;
+            assert_eq!(cfg.io_mode, mode, "{flag} parses to {mode:?}");
+        }
+        // An unknown value is a usage error naming the accepted values and echoing the bad one.
+        match parse_serve_flags(&serve_args(&["--io-mode", "bogus"])) {
+            Err(CliError::Usage(m)) => {
+                assert!(
+                    m.contains("buffered") && m.contains("direct") && m.contains("auto"),
+                    "names values: {m}"
+                );
+                assert!(m.contains("`bogus`"), "echoes the bad value: {m}");
+            }
+            other => panic!("a bad io-mode must be a usage error, got {other:?}"),
+        }
+        // The env layer resolves it (IRONBUS_IO_MODE), and an explicit flag WINS over the env
+        // (flag > env > default precedence, exactly like every other resolved knob).
+        let env = |name: &str| (name == "IRONBUS_IO_MODE").then(|| "direct".to_string());
+        let cfg = parse_serve_flags_with_env(&serve_args(&[]), &env)
+            .unwrap()
+            .config;
+        assert_eq!(cfg.io_mode, IoMode::Direct, "env IRONBUS_IO_MODE resolves");
+        let cfg = parse_serve_flags_with_env(&serve_args(&["--io-mode", "buffered"]), &env)
+            .unwrap()
+            .config;
+        assert_eq!(cfg.io_mode, IoMode::Buffered, "the flag beats the env");
+        // The materialized-config line echoes the requested io-mode.
+        let line = materialized_config_line(
+            &parse_serve_flags(&serve_args(&["--io-mode", "direct"]))
+                .unwrap()
+                .config,
+            "127.0.0.1:7700",
+            Some(Path::new("/tmp/d")),
+        );
+        assert!(
+            line.contains("io_mode=direct"),
+            "config line carries the io-mode: {line}"
+        );
+    }
+
+    #[test]
+    fn serve_io_mode_reads_from_the_config_file_under_env_precedence() {
+        use ironbus_storage::substrate::IoMode;
+        use std::collections::HashMap;
+        // `[storage] io_mode = "direct"` in the config file flows through the FILE layer (mapped to
+        // IRONBUS_IO_MODE, the new `storage.io_mode` known key) and resolves when no flag/env is set.
+        let doc = "[storage]\nio_mode = \"direct\"\n";
+        let cfg =
+            parse_with_env_and_file(&serve_args(&["--config", "cfg.toml"]), &HashMap::new(), doc)
+                .unwrap()
+                .config;
+        assert_eq!(cfg.io_mode, IoMode::Direct, "the config file sets io-mode");
+        // A flag overrides the file (flag > env > file > default).
+        let cfg = parse_with_env_and_file(
+            &serve_args(&["--config", "cfg.toml", "--io-mode", "buffered"]),
+            &HashMap::new(),
+            doc,
+        )
+        .unwrap()
+        .config;
+        assert_eq!(cfg.io_mode, IoMode::Buffered, "the flag beats the file");
+        // And the env beats the file.
+        let mut env = HashMap::new();
+        env.insert("IRONBUS_IO_MODE".to_string(), "auto".to_string());
+        let cfg = parse_with_env_and_file(&serve_args(&["--config", "cfg.toml"]), &env, doc)
+            .unwrap()
+            .config;
+        assert_eq!(cfg.io_mode, IoMode::Auto, "the env beats the file");
     }
 
     #[test]

--- a/crates/ironbus-core/src/config.rs
+++ b/crates/ironbus-core/src/config.rs
@@ -263,6 +263,13 @@ pub const KEY_TABLE: &[KeySpec] = &[
         key: "storage.max_total_bytes",
         kind: KeyKind::ByteSize,
     },
+    // The durable-write io-mode (perf/iomode-direct): `buffered` (default) | `direct` | `auto`. A
+    // COLD key (open fds carry the mode; a change needs a restart). Never weakens durability — the
+    // barrier is kept in every mode — only the sync MECHANISM differs.
+    KeySpec {
+        key: "storage.io_mode",
+        kind: KeyKind::Str,
+    },
     // [durability]
     KeySpec {
         key: "durability.level",

--- a/crates/ironbus-storage/src/checkpoint.rs
+++ b/crates/ironbus-storage/src/checkpoint.rs
@@ -547,4 +547,37 @@ mod tests {
             Some(vec![1u8; 64])
         );
     }
+
+    // The C1 offset-commit path over the direct-write backend: the checkpoint's per-write
+    // `write_all_at` + `sync_all` land on a `DirectFile` in direct mode. The dual-slot design is a
+    // BACK-PATCH pattern (alternating slot writes RMW a shared block), the exact O_DIRECT read-
+    // modify-write hazard — so this runs the checkpoint end to end on a real `DirectFile` (unix, so
+    // macOS CI too) and asserts the dual-slot crash-safety still recovers the latest durable value.
+    #[cfg(unix)]
+    #[test]
+    fn checkpoint_over_directfile_round_trips_and_stays_torn_safe() {
+        use crate::io::DirectFile;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cursor.ckpt");
+        {
+            let f = DirectFile::create_new(&path).unwrap();
+            let (mut cp, recovered) = Checkpoint::open(f).unwrap();
+            assert_eq!(
+                recovered, None,
+                "a fresh direct-mode checkpoint recovers nothing"
+            );
+            // Several alternating-slot writes: each slot write RMWs the shared boundary block.
+            for v in [&b"one"[..], b"two", b"three", b"four", b"five"] {
+                cp.write(v).unwrap();
+            }
+        }
+        // Reopen (a real fd close + reopen): the LATEST durable value survives, both slots intact.
+        let g = DirectFile::open(&path).unwrap();
+        let (_cp, recovered) = Checkpoint::open(g).unwrap();
+        assert_eq!(
+            recovered,
+            Some(b"five".to_vec()),
+            "direct-mode checkpoint recovers the latest value"
+        );
+    }
 }

--- a/crates/ironbus-storage/src/fs.rs
+++ b/crates/ironbus-storage/src/fs.rs
@@ -14,6 +14,13 @@ use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
 
 #[cfg(unix)]
 use crate::io::{sync_dir, StdFile};
+// The O_DIRECT direct-write backend is unix-only (`DirectFile` uses `RawFd`/`O_DIRECT`). On
+// non-unix (Windows is a v1 non-goal for `StdFs`) the filesystem hands out the buffered `StdFile`
+// directly — exactly today's path — so the whole io-mode surface is a no-op there.
+#[cfg(unix)]
+use crate::io::{DirectFile, MaybeDirectFile};
+#[cfg(unix)]
+use crate::substrate::ResolvedIoMode;
 
 /// A flat directory of named files: the seam through which the storage engine
 /// creates, opens, lists, and removes the segment files of one data directory.
@@ -499,14 +506,39 @@ impl Filesystem for EphemeralFs {
 #[derive(Clone, Debug)]
 pub struct StdFs {
     root: std::path::PathBuf,
+    /// The durable-write io-mode every file this fs hands out uses (COLD: fixed for the fs's life,
+    /// and inherited by [`StdFs::subdir`] so a DLQ / stream subtree writes the same way). Defaults
+    /// to [`ResolvedIoMode::Buffered`] via [`StdFs::new`], so every existing caller is unchanged.
+    io_mode: ResolvedIoMode,
 }
 
 #[cfg(unix)]
 impl StdFs {
-    /// Roots a filesystem at `root`. The directory itself must already exist.
+    /// Roots a BUFFERED filesystem at `root` (the default io-mode). The directory itself must
+    /// already exist. Byte-and-behavior identical to today — every file it hands out is a plain
+    /// buffered [`StdFile`].
     #[must_use]
     pub fn new(root: std::path::PathBuf) -> StdFs {
-        StdFs { root }
+        StdFs {
+            root,
+            io_mode: ResolvedIoMode::Buffered,
+        }
+    }
+
+    /// Roots a filesystem at `root` with an explicit resolved durable-write io-mode. In
+    /// [`ResolvedIoMode::Direct`] every file it hands out is a [`DirectFile`] (`O_DIRECT` writes over
+    /// pre-formatted written extents, barrier KEPT); in [`ResolvedIoMode::Buffered`] it is exactly
+    /// [`StdFs::new`]. The mode is COLD (open fds carry it; a change needs a restart). Production
+    /// only reaches `Direct` where `substrate::resolve_for_dir` confirmed it is supported.
+    #[must_use]
+    pub fn with_io_mode(root: std::path::PathBuf, io_mode: ResolvedIoMode) -> StdFs {
+        StdFs { root, io_mode }
+    }
+
+    /// The io-mode this filesystem writes with.
+    #[must_use]
+    pub fn io_mode(&self) -> ResolvedIoMode {
+        self.io_mode
     }
 
     /// Resolves `name` to a path inside the data directory, rejecting anything that is
@@ -528,12 +560,34 @@ impl StdFs {
 
 #[cfg(unix)]
 impl Filesystem for StdFs {
+    #[cfg(unix)]
+    type File = MaybeDirectFile;
+    // Non-unix: the buffered `StdFile` IS the file — no io-mode dispatch (direct mode is unix-only).
+    #[cfg(not(unix))]
     type File = StdFile;
 
+    #[cfg(unix)]
+    fn open(&self, name: &str) -> io::Result<MaybeDirectFile> {
+        let path = self.resolve(name)?;
+        match self.io_mode {
+            ResolvedIoMode::Buffered => Ok(MaybeDirectFile::Buffered(StdFile::open(&path)?)),
+            ResolvedIoMode::Direct => Ok(MaybeDirectFile::Direct(DirectFile::open(&path)?)),
+        }
+    }
+    #[cfg(not(unix))]
     fn open(&self, name: &str) -> io::Result<StdFile> {
         StdFile::open(&self.resolve(name)?)
     }
 
+    #[cfg(unix)]
+    fn create_new(&self, name: &str) -> io::Result<MaybeDirectFile> {
+        let path = self.resolve(name)?;
+        match self.io_mode {
+            ResolvedIoMode::Buffered => Ok(MaybeDirectFile::Buffered(StdFile::create_new(&path)?)),
+            ResolvedIoMode::Direct => Ok(MaybeDirectFile::Direct(DirectFile::create_new(&path)?)),
+        }
+    }
+    #[cfg(not(unix))]
     fn create_new(&self, name: &str) -> io::Result<StdFile> {
         StdFile::create_new(&self.resolve(name)?)
     }
@@ -586,7 +640,12 @@ impl Filesystem for StdFs {
             Err(e) if e.kind() == io::ErrorKind::AlreadyExists => {}
             Err(e) => return Err(e),
         }
-        Ok(StdFs { root: path })
+        // The subtree inherits the parent's io-mode, so a DLQ / stream subdir writes durably the
+        // same way the root does.
+        Ok(StdFs {
+            root: path,
+            io_mode: self.io_mode,
+        })
     }
 
     fn subdir_exists(&self, name: &str) -> io::Result<bool> {

--- a/crates/ironbus-storage/src/io.rs
+++ b/crates/ironbus-storage/src/io.rs
@@ -1554,6 +1554,553 @@ mod std_file_tests {
     }
 }
 
+// ============================================================================
+// Direct-write (O_DIRECT) backend — the SAFE T1 durable io-mode (perf/iomode-direct).
+//
+// `DirectFile` is the `direct` io-mode's [`RandomAccessFile`]: it writes record bytes
+// straight to the device with `O_DIRECT` (no page cache) over segments whose extents are
+// pre-formatted `written` at create time, and KEEPS the durability barrier (`fdatasync` /
+// `fsync`) exactly as buffered mode does. The speed comes from making that barrier
+// metadata-free (written extents => no `unwritten->written` conversion, no `i_size` update)
+// and page-cache-free (O_DIRECT), NOT from dropping it, so ack-implies-durable (I2) holds
+// identically to buffered: an ack releases only after the covering write's `pwrite` returned
+// AND the barrier returned. See `docs`/the io-mode spec for the full durability argument.
+//
+// The whole O_DIRECT complexity lives HERE, behind the `RandomAccessFile` seam, so the
+// buffered [`StdFile`] path is byte-and-behavior identical to today. The on-disk byte IMAGE
+// a `DirectFile` produces is identical to [`StdFile`]'s (same header/frames, and the tail
+// past the write frontier is zeros in both — pre-format zeros here, preallocated-hole zeros
+// there), so recovery, the offline reader, and the conformance byte-identity gate are
+// mode-agnostic (the mode is an IO strategy, not a format).
+//
+// `DirectFile` is `#[cfg(unix)]` (not linux-only) SO ITS RMW/ALIGNMENT/PRE-FORMAT LOGIC IS
+// EXERCISED BY THE UNIX TEST SUITE (macOS CI included): those bytes are platform-independent.
+// The `O_DIRECT` OPEN FLAG — the only genuinely-linux-specific piece — is applied only on
+// Linux (`open_direct_write_fd`); on other unix the fds are ordinary (still block-aligned IO,
+// still a real barrier via `F_FULLFSYNC`), which is a faithful model of the byte path. In
+// PRODUCTION `direct` is selected only where the substrate probe confirms it (Linux); the
+// resolver fails closed to `buffered` on non-Linux (see `substrate.rs`), so a `DirectFile` is
+// constructed on macOS ONLY by a test that asks for one directly.
+// ============================================================================
+
+/// The `O_DIRECT` alignment IronBus uses for every direct-mode write: buffer address, file
+/// offset, and length are all multiples of this. 4096 is a superset of every common device's
+/// logical block size (512 and 4096 both divide it), so a single fixed alignment satisfies
+/// 512-sector and 4K-native devices alike without probing `BLKSSZGET`. A device with a larger
+/// logical block (rare) would reject the `O_DIRECT` write with `EINVAL`, which surfaces as a
+/// fatal writer error (fail-closed) rather than a silent downgrade.
+///
+/// `cfg(unix)`: only the `O_DIRECT` `DirectFile` path consumes it; on non-unix (buffered-only) it
+/// would be dead code.
+#[cfg(unix)]
+pub(crate) const DIO_ALIGN: usize = 4096;
+
+/// The pre-format zero-write chunk (a multiple of [`DIO_ALIGN`]): the whole segment is made
+/// `written` at create by streaming zeros through one reusable aligned buffer of this size, so
+/// pre-format costs O(1) heap regardless of the segment size (~213ms/64MiB at ~300MB/s).
+#[cfg(unix)]
+const PREFORMAT_CHUNK_BYTES: usize = 1024 * 1024;
+
+/// Rounds `x` down to the nearest multiple of `align` (a power of two).
+#[cfg(unix)]
+#[inline]
+fn align_down(x: u64, align: usize) -> u64 {
+    let mask = align as u64 - 1;
+    x & !mask
+}
+
+/// Rounds `x` up to the nearest multiple of `align` (a power of two), saturating at [`u64::MAX`]
+/// (an offset that near the top of the address space is never reached by a bounded segment).
+#[cfg(unix)]
+#[inline]
+fn align_up(x: u64, align: usize) -> u64 {
+    let mask = align as u64 - 1;
+    x.saturating_add(mask) & !mask
+}
+
+/// A heap buffer whose start address is [`DIO_ALIGN`]-aligned and whose length is a multiple of
+/// [`DIO_ALIGN`], the buffer `O_DIRECT` requires. Allocated zeroed (so the tail padding of a
+/// sub-block write, and the whole pre-format image, is zeros with no extra fill). It is only ever a
+/// method-local temporary (never stored in a shared struct, never moved across a thread), so it
+/// needs no `Send`/`Sync` impl.
+#[cfg(unix)]
+struct AlignedBuf {
+    ptr: std::ptr::NonNull<u8>,
+    layout: std::alloc::Layout,
+}
+
+#[cfg(unix)]
+impl AlignedBuf {
+    /// Allocates a zeroed, [`DIO_ALIGN`]-aligned buffer of exactly `len` bytes, where `len` must
+    /// be a nonzero multiple of [`DIO_ALIGN`].
+    fn zeroed(len: usize) -> io::Result<AlignedBuf> {
+        debug_assert!(
+            len > 0 && len % DIO_ALIGN == 0,
+            "aligned buffer length must be a nonzero multiple of the block size"
+        );
+        let layout = std::alloc::Layout::from_size_align(len, DIO_ALIGN)
+            .map_err(|_| invalid_input("aligned buffer layout out of range"))?;
+        // SAFETY: `layout` has a nonzero size (guaranteed by the debug assert / caller contract),
+        // which is the sole precondition of `alloc_zeroed`. The returned pointer is checked for
+        // null below and is deallocated with the identical `layout` in `Drop`.
+        #[allow(unsafe_code)]
+        let raw = unsafe { std::alloc::alloc_zeroed(layout) };
+        let ptr = std::ptr::NonNull::new(raw).ok_or_else(|| {
+            io::Error::new(io::ErrorKind::OutOfMemory, "aligned allocation failed")
+        })?;
+        Ok(AlignedBuf { ptr, layout })
+    }
+
+    fn as_slice(&self) -> &[u8] {
+        // SAFETY: `ptr` points to `layout.size()` initialized bytes owned by `self` (allocated
+        // zeroed, only ever written through `as_mut_slice`), and the returned slice borrows `self`,
+        // so no aliasing `&mut` can exist for its lifetime.
+        #[allow(unsafe_code)]
+        unsafe {
+            std::slice::from_raw_parts(self.ptr.as_ptr(), self.layout.size())
+        }
+    }
+
+    fn as_mut_slice(&mut self) -> &mut [u8] {
+        // SAFETY: `self` is borrowed mutably, so this is the unique reference to the `layout.size()`
+        // owned, initialized bytes at `ptr` for the returned slice's lifetime.
+        #[allow(unsafe_code)]
+        unsafe {
+            std::slice::from_raw_parts_mut(self.ptr.as_ptr(), self.layout.size())
+        }
+    }
+}
+
+#[cfg(unix)]
+impl Drop for AlignedBuf {
+    fn drop(&mut self) {
+        // SAFETY: `ptr` came from `alloc_zeroed` with exactly `self.layout` and has not been freed
+        // elsewhere (unique ownership), so freeing it with the same layout is sound.
+        #[allow(unsafe_code)]
+        unsafe {
+            std::alloc::dealloc(self.ptr.as_ptr(), self.layout);
+        }
+    }
+}
+
+/// The cached image of the current partial *frontier block* (the block that holds the last
+/// written byte), so a frontier append can preserve that block's committed prefix WITHOUT a
+/// device read. It is a strict cache: whenever it is present it equals what a device read of
+/// `[base, base+DIO_ALIGN)` would return, and `None` simply forces the read — so the cache can
+/// never cause an incorrect write, only save a read on the hot append path.
+#[cfg(unix)]
+struct FrontierBlock {
+    base: u64,
+    bytes: Box<[u8]>,
+}
+
+/// The mutable write-side state of a [`DirectFile`], guarded by a `Mutex` because
+/// [`RandomAccessFile`] writes take `&self`. There is a single logical writer (the append
+/// actor), so the lock is uncontended; the off-actor durability barrier (`sync_data`, #1040)
+/// touches NEITHER field, so it never contends here.
+#[cfg(unix)]
+struct DirectWriteState {
+    /// One past the highest byte the CALLER has written (the log's header/records/footer), i.e.
+    /// the RMW high-water. A block entirely at or above `data_end` is known-fresh (pre-format
+    /// zeros) and needs no read-back on a re-write; a block below it holds committed bytes and is
+    /// read (unless it is the cached frontier block). Pre-format zeros do NOT advance it — they
+    /// are the background, not caller data — which is what keeps a fresh segment's appends
+    /// read-free. Initialized to the file length on `open` (conservative: every existing byte is
+    /// treated as committed) and to 0 on `create_new`.
+    data_end: u64,
+    /// The cached frontier block (see [`FrontierBlock`]).
+    tail: Option<FrontierBlock>,
+}
+
+/// A production [`RandomAccessFile`] that writes with ``O_DIRECT`` (Linux) and keeps the durability
+/// barrier — the `direct` io-mode's file (the T1 tier). See the module section header above.
+#[cfg(unix)]
+pub struct DirectFile {
+    /// The write fd: opened ``O_DIRECT`` on Linux (all writes block-aligned, cache-bypassing), plain
+    /// on other unix. Every append and the pre-format go through it; it is also the fd the kept
+    /// barrier (`sync_data`/`sync_all`) flushes.
+    write: std::fs::File,
+    /// The read fd: always buffered, for arbitrary unaligned `pread`s (reads are not the
+    /// bottleneck, and an `O_DIRECT` read would force the caller's buffers to be aligned). On Linux
+    /// an `O_DIRECT` write invalidates the overlapping page-cache pages, so a subsequent buffered
+    /// read re-reads fresh from the device — coherent as long as readers use `pread` (never mmap),
+    /// which IronBus does.
+    read: std::fs::File,
+    state: Mutex<DirectWriteState>,
+}
+
+#[cfg(unix)]
+impl std::fmt::Debug for DirectFile {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DirectFile").finish_non_exhaustive()
+    }
+}
+
+/// Opens the write fd for a [`DirectFile`], adding ``O_DIRECT`` on Linux (the only platform where it
+/// is a cache-bypass; on other unix the flag is omitted and the fds are ordinary, which the tests
+/// exercise). `create_new` selects `O_EXCL` create vs open-existing.
+#[cfg(unix)]
+fn open_direct_write_fd(path: &std::path::Path, create_new: bool) -> io::Result<std::fs::File> {
+    let mut opts = std::fs::OpenOptions::new();
+    opts.read(true).write(true);
+    if create_new {
+        opts.create_new(true);
+    }
+    #[cfg(target_os = "linux")]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        // O_DIRECT: bytes go straight to the device, bypassing the page cache. Its per-arch value
+        // is provided by `libc` (0o40000 on x86_64, 0o200000 on aarch64, ...).
+        opts.custom_flags(libc::O_DIRECT);
+    }
+    opts.open(path)
+}
+
+#[cfg(unix)]
+impl DirectFile {
+    /// Opens an existing file in direct mode (both the `O_DIRECT` write fd and the buffered read fd).
+    ///
+    /// # Errors
+    /// Propagates the underlying IO error.
+    pub fn open(path: &std::path::Path) -> io::Result<DirectFile> {
+        let write = open_direct_write_fd(path, false)?;
+        let read = std::fs::OpenOptions::new().read(true).open(path)?;
+        let data_end = write.metadata()?.len();
+        Ok(DirectFile {
+            write,
+            read,
+            state: Mutex::new(DirectWriteState {
+                data_end,
+                tail: None,
+            }),
+        })
+    }
+
+    /// Creates a new file (`O_EXCL`) in direct mode, failing with
+    /// [`io::ErrorKind::AlreadyExists`] if it exists.
+    ///
+    /// # Errors
+    /// Returns `AlreadyExists` if the path exists, or propagates the underlying IO error.
+    pub fn create_new(path: &std::path::Path) -> io::Result<DirectFile> {
+        let write = open_direct_write_fd(path, true)?;
+        let read = std::fs::OpenOptions::new().read(true).open(path)?;
+        Ok(DirectFile {
+            write,
+            read,
+            state: Mutex::new(DirectWriteState {
+                data_end: 0,
+                tail: None,
+            }),
+        })
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, DirectWriteState> {
+        self.state.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+}
+
+/// Writes `buf` to `file` at `offset` with positioned writes, looping until every byte lands.
+/// For an `O_DIRECT` fd the caller guarantees `buf`'s address, `offset`, and `buf.len()` are all
+/// block-aligned; a partial write returned by the kernel is itself block-aligned, so the
+/// continuation stays aligned.
+#[cfg(unix)]
+fn pwrite_all(file: &std::fs::File, mut buf: &[u8], mut offset: u64) -> io::Result<()> {
+    use std::os::unix::fs::FileExt;
+    while !buf.is_empty() {
+        match file.write_at(buf, offset) {
+            Ok(0) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::WriteZero,
+                    "direct write returned zero bytes",
+                ))
+            }
+            Ok(n) => {
+                buf = &buf[n..];
+                offset += n as u64;
+            }
+            Err(e) if e.kind() == io::ErrorKind::Interrupted => {}
+            Err(e) => return Err(e),
+        }
+    }
+    Ok(())
+}
+
+/// Reads up to a full block of `file` into `block` at `offset` via the buffered read fd,
+/// zero-filling any bytes past the current end of file (a block that straddles EOF reads back
+/// as its bytes plus zeros, exactly the RMW background a partial trailing block needs).
+#[cfg(unix)]
+fn read_block_background(file: &std::fs::File, block: &mut [u8], offset: u64) -> io::Result<()> {
+    use std::os::unix::fs::FileExt;
+    let mut filled = 0usize;
+    while filled < block.len() {
+        match file.read_at(&mut block[filled..], offset + filled as u64) {
+            Ok(0) => break,
+            Ok(n) => filled += n,
+            Err(e) if e.kind() == io::ErrorKind::Interrupted => {}
+            Err(e) => return Err(e),
+        }
+    }
+    for b in &mut block[filled..] {
+        *b = 0;
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+impl RandomAccessFile for DirectFile {
+    fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<usize> {
+        use std::os::unix::fs::FileExt;
+        // Always the BUFFERED read fd: reads may be unaligned, and O_DIRECT invalidates the
+        // overlapping page-cache pages on write, so this re-reads fresh from the device.
+        self.read.read_at(buf, offset)
+    }
+
+    fn write_all_at(&self, buf: &[u8], offset: u64) -> io::Result<()> {
+        if buf.is_empty() {
+            return Ok(());
+        }
+        let bs = DIO_ALIGN;
+        let end = offset
+            .checked_add(buf.len() as u64)
+            .ok_or_else(|| invalid_input("write extends past the addressable range"))?;
+        let blo = align_down(offset, bs);
+        let bhi = align_up(end, bs);
+        let span =
+            usize::try_from(bhi - blo).map_err(|_| invalid_input("aligned span out of range"))?;
+        let mut chunk = AlignedBuf::zeroed(span)?;
+        let cbuf = chunk.as_mut_slice();
+
+        let mut guard = self.lock();
+        let st = &mut *guard;
+
+        // Materialize the correct on-device background for every block that this write does not
+        // FULLY cover (a fully-covered block is overwritten wholesale, so its prior content is
+        // irrelevant). A partially-covered block gets its content from, in order: the cached
+        // frontier block (no read); known-fresh zeros if it sits at or above `data_end`; else a
+        // device read (a header re-write, a checkpoint's other slot, or a resumed segment's tail).
+        let bs_u64 = bs as u64;
+        let mut b = blo;
+        while b < bhi {
+            let bo = usize::try_from(b - blo).expect("block offset fits (span already fits usize)");
+            let covers_lo = offset <= b;
+            let covers_hi = end >= b + bs_u64;
+            if !(covers_lo && covers_hi) {
+                let block = &mut cbuf[bo..bo + bs];
+                let cache_hit = st.tail.as_ref().is_some_and(|t| t.base == b);
+                if cache_hit {
+                    block.copy_from_slice(&st.tail.as_ref().expect("cache_hit implies Some").bytes);
+                } else if b >= st.data_end {
+                    // Known-fresh (pre-format zeros): `AlignedBuf` already zeroed this block.
+                } else {
+                    read_block_background(&self.read, block, b)?;
+                }
+            }
+            b += bs_u64;
+        }
+
+        // Overlay the caller's bytes.
+        let ov = usize::try_from(offset - blo).expect("overlay offset fits");
+        cbuf[ov..ov + buf.len()].copy_from_slice(buf);
+
+        // One O_DIRECT write of the whole aligned span (so a group-commit batch is one write, and
+        // the barrier stays a real group commit).
+        debug_assert_eq!(blo % bs_u64, 0, "aligned write offset");
+        debug_assert_eq!(cbuf.len() % bs, 0, "aligned write length");
+        debug_assert_eq!(
+            cbuf.as_ptr() as usize % bs,
+            0,
+            "aligned write buffer address"
+        );
+        pwrite_all(&self.write, cbuf, blo)?;
+
+        // Advance the high-water and refresh the frontier-block cache. Capturing the frontier
+        // block from the just-written image keeps the cache device-consistent with no extra read.
+        st.data_end = st.data_end.max(end);
+        if st.data_end % bs_u64 == 0 {
+            // A block-aligned frontier: the next append starts a fresh block, nothing partial to
+            // cache.
+            st.tail = None;
+        } else {
+            let fbase = align_down(st.data_end, bs);
+            if fbase >= blo && fbase < bhi {
+                let fo = usize::try_from(fbase - blo).expect("frontier offset within span");
+                let mut bytes = vec![0u8; bs].into_boxed_slice();
+                bytes.copy_from_slice(&cbuf[fo..fo + bs]);
+                st.tail = Some(FrontierBlock { base: fbase, bytes });
+            }
+            // else: this write did not touch the frontier block (a pure back-patch below it), so
+            // the existing cache is still valid — leave it.
+        }
+        Ok(())
+    }
+
+    fn sync_data(&self) -> io::Result<()> {
+        // The KEPT durability barrier (T1). On a pre-formatted written extent with O_DIRECT data
+        // already on the device this is metadata-free — its cost is exactly the substrate's true
+        // flush cost — but it is a real barrier and is what makes an ack durable (I2), identical to
+        // buffered mode. Off-actor via the #1040 flusher; touches no write-side state.
+        self.write.sync_data()
+    }
+
+    fn sync_all(&self) -> io::Result<()> {
+        self.write.sync_all()
+    }
+
+    fn len(&self) -> io::Result<u64> {
+        Ok(self.write.metadata()?.len())
+    }
+
+    fn set_len(&self, len: u64) -> io::Result<()> {
+        self.write.set_len(len)?;
+        let mut guard = self.lock();
+        let st = &mut *guard;
+        // A shrink (the seal's truncate-to-footer-end) drops any high-water and cached block past
+        // the new end; a grow zero-fills sparsely (never used on the segment path, which
+        // pre-formats instead) and leaves the caller high-water alone.
+        if len < st.data_end {
+            st.data_end = len;
+        }
+        if st
+            .tail
+            .as_ref()
+            .is_some_and(|t| t.base + DIO_ALIGN as u64 > len)
+        {
+            st.tail = None;
+        }
+        Ok(())
+    }
+
+    fn preallocate(&self, len: u64) -> io::Result<()> {
+        // The WRITTEN-EXTENT PRE-FORMAT (direct mode's replacement for the buffered keep-size
+        // fallocate, spec §4): make every extent of the segment `written` and journal-durable ONCE
+        // at create, so every steady-state append is an overwrite of a written extent — no
+        // `unwritten->written` conversion, no `i_size` update, no per-op metadata journaling. After
+        // this the kept barrier is metadata-free. `len == 0` is a no-op.
+        //
+        // PRECONDITION: this zero-writes `[0, len)`, so it MUST run on a freshly-created, still-empty
+        // segment — exactly where the log calls it (`create_new` then `preallocate`, before the
+        // header write). A resumed segment is `SegmentWriter::resume`d and NEVER re-preallocated, so
+        // this never zeroes committed data. The debug assert pins that invariant against future
+        // misuse (a release build still zeroes from 0, correct for the only real call path).
+        if len == 0 {
+            return Ok(());
+        }
+        debug_assert_eq!(
+            self.lock().data_end,
+            0,
+            "pre-format (preallocate) must run on a freshly-created empty segment, before any write"
+        );
+        let bs = DIO_ALIGN;
+        let hi = align_up(len, bs);
+        // 1) Reserve the blocks (Linux). Best-effort: an fs without allocation support degrades to
+        //    the zero-write below allocating on demand.
+        #[cfg(target_os = "linux")]
+        {
+            use std::os::unix::io::AsRawFd;
+            let off = libc::off_t::try_from(hi)
+                .map_err(|_| invalid_input("preallocate length out of range"))?;
+            // SAFETY: `fallocate` is a libc syscall wrapper; `self.write` owns a valid, open,
+            // writable fd that outlives the call; the mode flag and two `off_t` args are passed by
+            // value and it touches only the kernel block map for that fd.
+            #[allow(unsafe_code)]
+            let rc = unsafe {
+                libc::fallocate(self.write.as_raw_fd(), libc::FALLOC_FL_KEEP_SIZE, 0, off)
+            };
+            if rc != 0 {
+                let err = io::Error::last_os_error();
+                match err.raw_os_error() {
+                    Some(libc::EOPNOTSUPP | libc::ENOSYS) => {}
+                    _ => return Err(err),
+                }
+            }
+        }
+        // 2) Sequentially O_DIRECT-write zeros over the whole logical length, one reusable aligned
+        //    chunk at a time, so every extent becomes `written`. `hi` and `PREFORMAT_CHUNK_BYTES`
+        //    are both block multiples, so their min is a block-aligned buffer length (>= one block).
+        let cap = (PREFORMAT_CHUNK_BYTES as u64).min(hi);
+        let chunk_len = usize::try_from(cap).unwrap_or(PREFORMAT_CHUNK_BYTES);
+        let zeros = AlignedBuf::zeroed(chunk_len)?;
+        let mut off = 0u64;
+        while off < hi {
+            let n =
+                usize::try_from((hi - off).min(chunk_len as u64)).expect("chunk length fits usize");
+            pwrite_all(&self.write, &zeros.as_slice()[..n], off)?;
+            off += n as u64;
+        }
+        // 3) Trim the block-rounded tail back to the exact logical length so the file length is
+        //    byte-identical to the buffered preallocation (`set_len` up to `len`); the trimmed tail
+        //    was zeros anyway.
+        if self.write.metadata()?.len() > len {
+            self.write.set_len(len)?;
+        }
+        // 4) One barrier makes the extent map + length durable (the metadata domain, closed once).
+        self.write.sync_all()?;
+        // The pre-format zeros are BACKGROUND, not caller data: the RMW high-water stays where it
+        // was (0 for a fresh create), which is what keeps the following appends read-free.
+        Ok(())
+    }
+}
+
+/// The [`Filesystem`](crate::fs::Filesystem)-selected production file: either the buffered
+/// [`StdFile`] (the default, byte-and-behavior identical to today) or the [`DirectFile`] `O_DIRECT`
+/// backend, chosen once by the resolved io-mode when the filesystem is built. Dispatch is a plain
+/// enum (no `Box<dyn>`) so the file stays `Clone`-free-`Send + Sync` and every method is a direct
+/// delegation — the buffered arm adds nothing but a match to today's path.
+#[cfg(unix)]
+#[derive(Debug)]
+pub enum MaybeDirectFile {
+    /// The default buffered file. Delegates VERBATIM to [`StdFile`], so buffered mode is unchanged.
+    Buffered(StdFile),
+    /// The `O_DIRECT` direct-write file (the T1 tier).
+    Direct(DirectFile),
+}
+
+#[cfg(unix)]
+impl RandomAccessFile for MaybeDirectFile {
+    fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<usize> {
+        match self {
+            MaybeDirectFile::Buffered(f) => f.read_at(buf, offset),
+            MaybeDirectFile::Direct(f) => f.read_at(buf, offset),
+        }
+    }
+    fn write_all_at(&self, buf: &[u8], offset: u64) -> io::Result<()> {
+        match self {
+            MaybeDirectFile::Buffered(f) => f.write_all_at(buf, offset),
+            MaybeDirectFile::Direct(f) => f.write_all_at(buf, offset),
+        }
+    }
+    fn sync_data(&self) -> io::Result<()> {
+        match self {
+            MaybeDirectFile::Buffered(f) => f.sync_data(),
+            MaybeDirectFile::Direct(f) => f.sync_data(),
+        }
+    }
+    fn sync_all(&self) -> io::Result<()> {
+        match self {
+            MaybeDirectFile::Buffered(f) => f.sync_all(),
+            MaybeDirectFile::Direct(f) => f.sync_all(),
+        }
+    }
+    fn len(&self) -> io::Result<u64> {
+        match self {
+            MaybeDirectFile::Buffered(f) => f.len(),
+            MaybeDirectFile::Direct(f) => f.len(),
+        }
+    }
+    fn set_len(&self, len: u64) -> io::Result<()> {
+        match self {
+            MaybeDirectFile::Buffered(f) => f.set_len(len),
+            MaybeDirectFile::Direct(f) => f.set_len(len),
+        }
+    }
+    fn preallocate(&self, len: u64) -> io::Result<()> {
+        match self {
+            MaybeDirectFile::Buffered(f) => f.preallocate(len),
+            MaybeDirectFile::Direct(f) => f.preallocate(len),
+        }
+    }
+}
+
 /// Sharing a file behind a reference forwards to the inner implementation, so the
 /// single writer and the lock-free readers can hold the same file.
 impl<F: RandomAccessFile + ?Sized> RandomAccessFile for &F {
@@ -1602,5 +2149,264 @@ impl<F: RandomAccessFile + ?Sized> RandomAccessFile for std::sync::Arc<F> {
     }
     fn preallocate(&self, len: u64) -> io::Result<()> {
         (**self).preallocate(len)
+    }
+}
+
+// The direct-write backend's byte-level correctness (alignment, the partial-tail read-modify-write,
+// pre-format, and byte-identity with the buffered `StdFile`) is platform-independent, so these run
+// on EVERY unix target (macOS CI included), not just Linux. On non-Linux the `DirectFile` fds are
+// ordinary (no O_DIRECT), which is a faithful model of the exact byte path; the Linux-only property
+// (O_DIRECT truly bypasses the page cache) plus the physical-device durability are validated by the
+// separate real-fs / t4g step.
+#[cfg(all(test, unix))]
+mod direct_file_tests {
+    use super::*;
+
+    const BS: usize = DIO_ALIGN;
+
+    fn dir() -> tempfile::TempDir {
+        tempfile::tempdir().unwrap()
+    }
+
+    /// Reads the whole file (through the buffered read fd) into a `Vec` for oracle comparison.
+    fn read_all(f: &DirectFile, len: usize) -> Vec<u8> {
+        let mut v = vec![0u8; len];
+        let mut filled = 0;
+        while filled < len {
+            match f.read_at(&mut v[filled..], filled as u64).unwrap() {
+                0 => break,
+                k => filled += k,
+            }
+        }
+        v.truncate(filled);
+        v
+    }
+
+    #[test]
+    fn direct_write_read_roundtrip_and_persists_across_reopen() {
+        let d = dir();
+        let path = d.path().join("seg");
+        {
+            let f = DirectFile::create_new(&path).unwrap();
+            f.write_all_at(b"hello world", 0).unwrap();
+            f.sync_all().unwrap();
+            let mut buf = [0u8; 11];
+            f.read_exact_at(&mut buf, 0).unwrap();
+            assert_eq!(&buf, b"hello world");
+        }
+        // Reopen (models a process restart): the synced bytes survive.
+        let g = DirectFile::open(&path).unwrap();
+        let mut buf = [0u8; 5];
+        assert_eq!(g.read_at(&mut buf, 6).unwrap(), 5);
+        assert_eq!(&buf, b"world");
+    }
+
+    #[test]
+    fn direct_matches_a_byte_oracle_across_alignment_edge_cases() {
+        // The load-bearing RMW test: an arbitrary write sequence covering header@0, sub-block
+        // frontier appends, an append that SPANS a block boundary, a multi-block append with a
+        // sub-block tail, and a back-patch (rewriting offset 0 after records exist) must leave the
+        // file byte-identical to a plain in-memory oracle for EVERY case.
+        let d = dir();
+        let f = DirectFile::create_new(&d.path().join("seg")).unwrap();
+        let mut oracle: Vec<u8> = Vec::new();
+        let writes: Vec<(u64, Vec<u8>)> = vec![
+            (0, vec![0xA1; 64]),                               // header@0 (sub-block)
+            (64, vec![0xB2; 100]),                             // frontier append within block 0
+            (164, vec![0xC3; (BS - 164) + 10]),                // append SPANS the block boundary
+            (u64::try_from(BS + 10).unwrap(), vec![0xD4; BS]), // a full-block-sized append mid-block
+            (u64::try_from(2 * BS + 10).unwrap(), vec![0xE5; 3 * BS + 7]), // multi-block, sub-block tail
+            (0, vec![0xFF; 64]), // back-patch: rewrite the header
+        ];
+        for (off, bytes) in &writes {
+            let start = usize::try_from(*off).unwrap();
+            let end = start + bytes.len();
+            if oracle.len() < end {
+                oracle.resize(end, 0);
+            }
+            oracle[start..end].copy_from_slice(bytes);
+            f.write_all_at(bytes, *off).unwrap();
+            f.sync_data().unwrap();
+            assert_eq!(
+                read_all(&f, oracle.len()),
+                oracle,
+                "mismatch after write at {off}"
+            );
+        }
+        f.sync_all().unwrap();
+        drop(f);
+        let g = DirectFile::open(&d.path().join("seg")).unwrap();
+        assert_eq!(read_all(&g, oracle.len()), oracle, "mismatch after reopen");
+    }
+
+    #[test]
+    fn direct_is_byte_identical_to_buffered_over_the_same_record_stream() {
+        // The byte-identity guarantee (spec §7): the SAME write sequence through the buffered
+        // `StdFile` and the `DirectFile` yields the same durable byte prefix. (The direct file may be
+        // block-padded LONGER; the data prefix `[0, logical_end)` is identical.)
+        let d = dir();
+        let sf = StdFile::create(&d.path().join("buffered")).unwrap();
+        let df = DirectFile::create_new(&d.path().join("direct")).unwrap();
+        let header = vec![0x5A; 64];
+        sf.write_all_at(&header, 0).unwrap();
+        df.write_all_at(&header, 0).unwrap();
+        let mut off = 64u64;
+        for i in 0..200u32 {
+            let len = 1 + (i as usize * 37) % 900; // spans sub-block, block, multi-block writes
+            let rec = vec![u8::try_from(i % 251).unwrap(); len];
+            sf.write_all_at(&rec, off).unwrap();
+            df.write_all_at(&rec, off).unwrap();
+            off += len as u64;
+        }
+        sf.sync_all().unwrap();
+        df.sync_all().unwrap();
+        let end = usize::try_from(off).unwrap();
+        let mut a = vec![0u8; end];
+        let mut b = vec![0u8; end];
+        sf.read_exact_at(&mut a, 0).unwrap();
+        df.read_exact_at(&mut b, 0).unwrap();
+        assert_eq!(
+            a, b,
+            "direct-mode durable image differs from buffered over [0, {end})"
+        );
+    }
+
+    #[test]
+    fn direct_partial_tail_rmw_preserves_the_committed_prefix_byte_for_byte() {
+        // The crux of the §3 crash-consistency proof: re-writing a partial frontier block to append
+        // more re-writes the already-committed prefix bytes BYTE-IDENTICALLY (and the padding stays
+        // zero), so a torn re-write can only ever damage the newly-appended, not-yet-acked bytes —
+        // never a committed byte. Assert the re-write leaves the committed prefix untouched.
+        let d = dir();
+        let f = DirectFile::create_new(&d.path().join("seg")).unwrap();
+        f.write_all_at(b"HDR", 0).unwrap();
+        f.write_all_at(b"AAAAAAAA", 3).unwrap();
+        f.sync_data().unwrap();
+        let committed_end = 11usize;
+        let mut before = vec![0u8; committed_end];
+        f.read_exact_at(&mut before, 0).unwrap();
+        f.write_all_at(b"BBBB", committed_end as u64).unwrap(); // a tail-block RMW
+        let mut after = vec![0u8; committed_end];
+        f.read_exact_at(&mut after, 0).unwrap();
+        assert_eq!(
+            before, after,
+            "the tail-block RMW must not disturb the committed prefix"
+        );
+        let mut all = vec![0u8; 15];
+        f.read_exact_at(&mut all, 0).unwrap();
+        assert_eq!(&all, b"HDRAAAAAAAABBBB");
+    }
+
+    #[test]
+    fn direct_preformat_makes_written_zeros_and_composes_with_the_zero_tail_rule() {
+        // Pre-format (`preallocate`) writes zeros over the whole segment (making the extents
+        // `written`) and trims the length back to exactly the requested size — byte-identical to the
+        // buffered preallocation's zero tail. After a header + records, the tail past the frontier is
+        // all zeros and `last_nonzero_end` bounds recovery exactly at the last written byte.
+        let d = dir();
+        let f = DirectFile::create_new(&d.path().join("seg")).unwrap();
+        let seg_bytes = 64 * 1024u64; // block-aligned
+        f.preallocate(seg_bytes).unwrap();
+        assert_eq!(
+            f.len().unwrap(),
+            seg_bytes,
+            "pre-format trims to the exact logical length"
+        );
+        assert_eq!(
+            last_nonzero_end(&f, 0, seg_bytes).unwrap(),
+            0,
+            "a pre-formatted segment is all zeros"
+        );
+        f.write_all_at(b"HEADERHEADER", 0).unwrap();
+        f.write_all_at(&[0x11; 300], 12).unwrap();
+        f.sync_data().unwrap();
+        let frontier = 12 + 300u64;
+        assert_eq!(
+            last_nonzero_end(&f, 0, seg_bytes).unwrap(),
+            frontier,
+            "the zero tail past the frontier bounds recovery at the last written byte"
+        );
+        assert_eq!(
+            f.len().unwrap(),
+            seg_bytes,
+            "appends land inside the pre-format, no i_size churn"
+        );
+    }
+
+    #[test]
+    fn direct_seal_shape_truncates_to_the_exact_footer_end() {
+        // The seal path (footer `write_all_at` at the frontier, then `set_len` down + `sync_all`)
+        // must leave the file at EXACTLY the footer end — byte-identical to a buffered seal, so
+        // footer-at-file-end discovery still works — even though the O_DIRECT footer write padded to
+        // a block first.
+        let d = dir();
+        let f = DirectFile::create_new(&d.path().join("seg")).unwrap();
+        f.preallocate(64 * 1024).unwrap();
+        f.write_all_at(b"HEADER", 0).unwrap();
+        f.write_all_at(&[0x22; 500], 6).unwrap();
+        let write_pos = 506u64;
+        f.write_all_at(&[0x33; 32], write_pos).unwrap(); // the footer at the frontier
+        let end = write_pos + 32;
+        if f.len().unwrap() > end {
+            f.set_len(end).unwrap();
+        }
+        f.sync_all().unwrap();
+        assert_eq!(
+            f.len().unwrap(),
+            end,
+            "sealed length is the exact footer end"
+        );
+        let mut footer = [0u8; 32];
+        f.read_exact_at(&mut footer, write_pos).unwrap();
+        assert_eq!(footer, [0x33; 32]);
+    }
+
+    #[test]
+    fn direct_resumed_segment_appends_correctly_after_reopen() {
+        // A resumed (reopened) segment sets its RMW high-water to the file length (conservative), so
+        // the first append after reopen preserves the boundary block via a device read; the bytes
+        // must still be correct.
+        let d = dir();
+        let path = d.path().join("seg");
+        {
+            let f = DirectFile::create_new(&path).unwrap();
+            f.preallocate(64 * 1024).unwrap();
+            f.write_all_at(b"HEADER", 0).unwrap();
+            f.write_all_at(b"first", 6).unwrap();
+            f.sync_all().unwrap();
+        }
+        let g = DirectFile::open(&path).unwrap();
+        g.write_all_at(b"second", 11).unwrap(); // append at the recovered frontier
+        g.sync_data().unwrap();
+        let mut all = vec![0u8; 17];
+        g.read_exact_at(&mut all, 0).unwrap();
+        assert_eq!(&all, b"HEADERfirstsecond");
+    }
+
+    #[test]
+    fn direct_empty_write_is_a_noop() {
+        let d = dir();
+        let f = DirectFile::create_new(&d.path().join("seg")).unwrap();
+        f.write_all_at(b"", 0).unwrap();
+        assert_eq!(f.len().unwrap(), 0);
+    }
+
+    #[test]
+    fn aligned_buf_address_and_length_are_block_aligned() {
+        // O_DIRECT's precondition: the buffer ADDRESS and length must both be block multiples.
+        let b = AlignedBuf::zeroed(BS).unwrap();
+        assert_eq!(
+            b.as_slice().as_ptr() as usize % BS,
+            0,
+            "buffer address is block-aligned"
+        );
+        assert_eq!(
+            b.as_slice().len() % BS,
+            0,
+            "buffer length is a block multiple"
+        );
+        assert!(b.as_slice().iter().all(|&x| x == 0), "allocated zeroed");
+        let big = AlignedBuf::zeroed(4 * BS).unwrap();
+        assert_eq!(big.as_slice().as_ptr() as usize % BS, 0);
     }
 }

--- a/crates/ironbus-storage/src/lib.rs
+++ b/crates/ironbus-storage/src/lib.rs
@@ -48,6 +48,10 @@ pub mod sim;
 /// recovers to its own valid prefix + loss report without touching a sibling — and per-record cost
 /// stays flat as streams grow (no per-record structure is added).
 pub mod streamset;
+/// Durable-write io-mode selection and storage-substrate detection (`buffered` | `direct` | `auto`):
+/// the SAFE T1 O_DIRECT tier's config surface + the network-durable-storage probe. See the module
+/// docs; the io-strategy itself lives in [`io::DirectFile`] behind [`io::MaybeDirectFile`].
+pub mod substrate;
 /// The durable transactional half-message store (`txn/` sub-log, V2-M8, #640 part 1/2): a second
 /// segmented [`log::Log`] (modeled on the `dlq/` sink) holding the durable, consumer-INVISIBLE half
 /// (prepared) messages and their resolution (commit/rollback) op-markers, plus the in-memory

--- a/crates/ironbus-storage/src/log.rs
+++ b/crates/ironbus-storage/src/log.rs
@@ -8780,6 +8780,186 @@ mod tests {
         assert_eq!(read_back(log.filesystem(), 0).len(), 3);
     }
 
+    // ---- direct io-mode (the SAFE T1 O_DIRECT tier), end to end over a real StdFs ----
+    // These run on every unix target (macOS included): `DirectFile`'s bytes are platform-independent
+    // (only the O_DIRECT cache-bypass is Linux-specific, and it does not change the recovered image),
+    // so the whole segment/roll/seal/recovery machinery is exercised over the direct backend here;
+    // the physical-device durability + the actual O_DIRECT flag are validated by the t4g step.
+
+    #[cfg(unix)]
+    #[test]
+    fn direct_io_mode_recovers_every_acked_record_across_rolls() {
+        // The crash-consistency tooth: append+sync a record stream that ROLLS across several
+        // segments in direct mode (so the written pre-format + O_DIRECT appends + seal all run), then
+        // kill + reopen (still direct) and assert every acked record recovered, in order, with NO
+        // loss event and no torn block.
+        use crate::fs::StdFs;
+        use crate::substrate::ResolvedIoMode;
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        let open = |root: std::path::PathBuf| {
+            Log::open(
+                StdFs::with_io_mode(root, ResolvedIoMode::Direct),
+                ManualClock::new(),
+                small_config(),
+            )
+            .unwrap()
+        };
+        let mut log = open(root.clone());
+        let n = 24u8;
+        for i in 0..n {
+            log.append(&rec(&[i; 20])).unwrap();
+            log.sync().unwrap();
+        }
+        assert!(
+            log.active_segment_id() >= 2,
+            "the stream rolled across several segments"
+        );
+        drop(log); // an unclean kill (the segment files stay as the O_DIRECT writes left them)
+
+        let log = open(root.clone());
+        assert_eq!(
+            log.next_offset(),
+            Offset::new(u64::from(n)),
+            "every acked record recovered"
+        );
+        assert!(
+            log.loss_report().events.is_empty(),
+            "no loss on a clean direct-mode restart"
+        );
+        assert_eq!(log.recovered_truncated_bytes(), 0);
+        let records = log.read_from(Offset::ZERO, 1000).unwrap();
+        assert_eq!(records.len(), usize::from(n));
+        for (i, r) in records.iter().enumerate() {
+            assert_eq!(r.offset, Offset::new(i as u64));
+            assert_eq!(&r.payload[..], &[u8::try_from(i).unwrap(); 20][..]);
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn direct_and_buffered_produce_identical_sealed_bytes_and_recovered_state() {
+        // The metamorphic byte-identity proof (spec §7): the SAME record stream through a BUFFERED
+        // log and a DIRECT log yields byte-identical SEALED segment images and identical recovered
+        // records. If the bytes are identical, recovery (and the conformance gate) are mode-agnostic
+        // by construction.
+        use crate::fs::StdFs;
+        use crate::substrate::ResolvedIoMode;
+        let base = tempfile::tempdir().unwrap();
+        let buf_root = base.path().join("buffered");
+        let dir_root = base.path().join("direct");
+        std::fs::create_dir(&buf_root).unwrap();
+        std::fs::create_dir(&dir_root).unwrap();
+
+        let run = |fs: StdFs| {
+            let mut log = Log::open(fs, ManualClock::new(), small_config()).unwrap();
+            for i in 0..24u8 {
+                log.append(&rec(&[i; 20])).unwrap();
+                log.sync().unwrap();
+            }
+            log.active_segment_id()
+        };
+        let buf_active = run(StdFs::new(buf_root.clone()));
+        let dir_active = run(StdFs::with_io_mode(
+            dir_root.clone(),
+            ResolvedIoMode::Direct,
+        ));
+        assert_eq!(buf_active, dir_active, "both modes roll at the same points");
+
+        // Every SEALED segment (all but the active one) is byte-identical between the two modes.
+        let buf_fs = StdFs::new(buf_root.clone());
+        let dir_fs = StdFs::new(dir_root.clone()); // read back in BUFFERED mode: a sealed segment is exact
+        for id in 0..buf_active {
+            let name = segment_file_name(id);
+            let bf = buf_fs.open(&name).unwrap();
+            let df = dir_fs.open(&name).unwrap();
+            let bl = bf.len().unwrap();
+            let dl = df.len().unwrap();
+            assert_eq!(
+                bl, dl,
+                "sealed segment {id} lengths differ (buffered {bl}, direct {dl})"
+            );
+            let mut b = vec![0u8; usize::try_from(bl).unwrap()];
+            let mut d = vec![0u8; usize::try_from(dl).unwrap()];
+            bf.read_exact_at(&mut b, 0).unwrap();
+            df.read_exact_at(&mut d, 0).unwrap();
+            assert_eq!(
+                b, d,
+                "sealed segment {id} bytes differ between buffered and direct"
+            );
+        }
+
+        // And the recovered record streams are identical.
+        let recovered = |root: std::path::PathBuf| {
+            let log = Log::open(StdFs::new(root), ManualClock::new(), small_config()).unwrap();
+            log.read_from(Offset::ZERO, 1000)
+                .unwrap()
+                .iter()
+                .map(|r| (r.offset, r.payload.to_vec()))
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(
+            recovered(buf_root),
+            recovered(dir_root),
+            "recovered state differs across modes"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn direct_io_mode_torn_tail_is_dropped_and_acked_records_survive() {
+        // A torn/garbage tail block past the acked frontier (a crash mid-append that left partial,
+        // non-frame bytes) must be caught by the frame CRC on recovery and dropped — never accepted
+        // as data — while every acked record survives. We simulate the torn write by stamping
+        // non-frame garbage just past the durable frontier of the active segment.
+        use crate::fs::StdFs;
+        use crate::io::StdFile;
+        use crate::substrate::ResolvedIoMode;
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        let mut log = Log::open(
+            StdFs::with_io_mode(root.clone(), ResolvedIoMode::Direct),
+            ManualClock::new(),
+            small_config(),
+        )
+        .unwrap();
+        for i in 0..3u8 {
+            log.append(&rec(&[i; 20])).unwrap();
+            log.sync().unwrap(); // acked
+        }
+        let acked = log.next_offset();
+        let active = log.active_segment_id();
+        drop(log);
+
+        // Stamp garbage at the TRUE frame boundary (the scan's `valid_end`, one past record 2's
+        // complete frame — NOT `last_nonzero_end`, which can point INSIDE a frame that ends in zero
+        // bytes), exactly as a crash mid-4th-append would leave a torn, non-frame tail.
+        let name = segment_file_name(active);
+        let frontier = SegmentReader::open(StdFile::open(&root.join(&name)).unwrap())
+            .unwrap()
+            .scan()
+            .unwrap()
+            .valid_end;
+        let raw = StdFile::open(&root.join(&name)).unwrap();
+        raw.write_all_at(&[0xAB; 48], frontier).unwrap();
+        raw.sync_all().unwrap();
+        drop(raw);
+
+        // Recover: the acked records survive, the torn tail is dropped (not accepted as a record).
+        let log = Log::open(
+            StdFs::with_io_mode(root.clone(), ResolvedIoMode::Direct),
+            ManualClock::new(),
+            small_config(),
+        )
+        .unwrap();
+        assert_eq!(
+            log.next_offset(),
+            acked,
+            "no acked record lost, no torn block accepted"
+        );
+        assert_eq!(log.read_from(Offset::ZERO, 100).unwrap().len(), 3);
+    }
+
     // Fills a small-segment log with `n` single-byte records (each `payload` byte `i`), synced,
     // and returns it rolled across several segments so the reaper has sealed predecessors.
     fn rolled_log(n: u8) -> Log<InMemoryFs, ManualClock> {

--- a/crates/ironbus-storage/src/substrate.rs
+++ b/crates/ironbus-storage/src/substrate.rs
@@ -1,0 +1,531 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! Durable-write io-mode selection and storage-substrate detection.
+//!
+//! The `direct` io-mode (the SAFE T1 tier) writes record bytes straight to the device with
+//! `O_DIRECT` over pre-formatted `written` extents and KEEPS the durability barrier, so it is
+//! correct on ANY substrate — the barrier is never dropped. Its performance WIN, though, only
+//! materializes on network-durable block storage (EBS-class): the barrier there becomes
+//! metadata-free and its residual cost is the substrate's true (near-zero on durable-on-ack)
+//! flush. On a local SSD or laptop the O_DIRECT round-trip buys nothing.
+//!
+//! Hence three knobs (`--io-mode <buffered|direct|auto>`), resolved ONCE at boot after the data
+//! dir exists:
+//! * `buffered` (default): today's `StdFile` — buffered `pwrite` + `fdatasync`. Everywhere.
+//! * `direct`: force the T1 O_DIRECT+kept-barrier file. Safe on any substrate; a loud WARN if the
+//!   substrate is not confirmed network-durable (it is still safe, just maybe not faster). Linux
+//!   only — a non-Linux host has no `O_DIRECT`, so `direct` degrades to `buffered` with a WARN.
+//! * `auto`: enable `direct` ONLY where a probe positively confirms network-durable storage
+//!   (the EBS-class signal); fail closed to `buffered` on anything uncertain, local-volatile, or
+//!   non-Linux. `auto` never turns direct on speculatively.
+//!
+//! The detection walks the data dir's backing block device in `/sys` (Linux). The RISK-FREE
+//! posture: any probe failure resolves to `Unknown`, and `auto`'s only reaction to `Unknown` is
+//! to stay buffered — so a probe bug can never do worse than pick the safe default. The
+//! classification + mode-mapping are pure functions ([`classify`], [`resolve`]) tested against
+//! fixtures on every platform; only the thin `/sys` reader is Linux-only and best-effort.
+
+use std::path::Path;
+
+/// The io-mode a user asks for (`--io-mode`, `IRONBUS_IO_MODE`, `storage.io_mode`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum IoMode {
+    /// The DEFAULT: buffered `pwrite` + `fdatasync` (today's `StdFile`), on every platform.
+    Buffered,
+    /// Force the T1 `O_DIRECT` direct-write file with the barrier kept.
+    Direct,
+    /// Enable `direct` only where the substrate probe confirms network-durable storage; else
+    /// fall back to `buffered`.
+    Auto,
+}
+
+impl IoMode {
+    /// Parses the flag / env / config spelling, accepting `buffered`, `direct`, or `auto`.
+    #[must_use]
+    pub fn parse(value: &str) -> Option<IoMode> {
+        match value {
+            "buffered" => Some(IoMode::Buffered),
+            "direct" => Some(IoMode::Direct),
+            "auto" => Some(IoMode::Auto),
+            _ => None,
+        }
+    }
+
+    /// The canonical spelling, the inverse of [`IoMode::parse`] (for the materialized-config log
+    /// and a resolvable default).
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            IoMode::Buffered => "buffered",
+            IoMode::Direct => "direct",
+            IoMode::Auto => "auto",
+        }
+    }
+}
+
+/// The io-mode actually in force after resolution — the two file strategies the storage layer
+/// can build. (`auto` and the substrate probe collapse into one of these before any fd opens.)
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ResolvedIoMode {
+    /// Buffered `StdFile` (default). Byte-and-behavior identical to today.
+    Buffered,
+    /// The T1 `O_DIRECT` direct-write file with the durability barrier kept.
+    Direct,
+}
+
+/// How the backing storage substrate classifies for the io-mode decision. The ONLY positive
+/// class is [`SubstrateClass::NetworkDurable`] (an EBS-class device `auto` will enable direct on);
+/// everything else is a conservative non-positive that keeps `auto` buffered.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SubstrateClass {
+    /// Confirmed network-durable block storage (the EBS allowlist): `auto` enables direct here.
+    NetworkDurable,
+    /// Confirmed local + volatile (an instance-store `NVMe` / ephemeral disk): `auto` stays
+    /// buffered (direct would add an `O_DIRECT` round-trip for no durability win).
+    LocalVolatile,
+    /// Could not be positively classified (a generic disk, an unresolvable stacked device, a
+    /// non-Linux host, or any probe failure). `auto` fails closed to buffered.
+    Unknown,
+}
+
+/// The raw signals a `/sys` probe (or a test fixture) gathers about the data dir's backing block
+/// device. Every field is optional/best-effort: an absent or unreadable signal is `None`/`false`.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct SubstrateProbe {
+    /// `/sys/block/<phys>/device/model`, trimmed (e.g. `Amazon Elastic Block Store`).
+    pub model: Option<String>,
+    /// `/sys/block/<phys>/queue/rotational` (`0` = non-rotational). A corroborator only.
+    pub rotational: Option<bool>,
+    /// `/sys/block/<phys>/queue/write_cache` (`write through` / `write back`). INCONCLUSIVE for the
+    /// durability question on EBS (`write back` is a conservative flag on a durable-on-ack device),
+    /// so it is recorded for the log but never disqualifies T1.
+    pub write_cache: Option<String>,
+    /// A device-mapper / MD / LVM / loop layer that the probe could NOT resolve to a backing
+    /// physical device (e.g. a writeback dm-cache, or an unreadable `slaves/` tree). Forces
+    /// [`SubstrateClass::Unknown`] — the stacked-device fail-closed.
+    pub stacked_unresolved: bool,
+}
+
+/// The confirmed network-durable device models (substring match, case-insensitive). Kept
+/// deliberately tiny and explicit: only devices whose durability-on-ack is documented.
+const NETWORK_DURABLE_MODELS: &[&str] = &[
+    "amazon elastic block store",
+    "nvme amazon elastic block store",
+];
+
+/// Confirmed local + volatile device models (substring match): lost on stop/terminate, so never a
+/// direct-mode win and explicitly rejected from `auto`.
+const LOCAL_VOLATILE_MODELS: &[&str] = &["amazon ec2 nvme instance storage", "instance storage"];
+
+/// Classifies a substrate probe. Pure and total — tested against `/sys` fixtures on every
+/// platform. Fail-closed: an unresolved stacked device or an unrecognized model is
+/// [`SubstrateClass::Unknown`], never an optimistic positive.
+#[must_use]
+pub fn classify(probe: &SubstrateProbe) -> SubstrateClass {
+    // A stacked device we could not walk down to a physical backing store (a writeback dm-cache
+    // hides the true durability behind the virtual node) is Unknown — the fail-closed hardening.
+    if probe.stacked_unresolved {
+        return SubstrateClass::Unknown;
+    }
+    if let Some(model) = &probe.model {
+        let m = model.to_ascii_lowercase();
+        // Local-volatile is checked FIRST so an instance-store device is never mistaken for durable.
+        if LOCAL_VOLATILE_MODELS.iter().any(|k| m.contains(k)) {
+            return SubstrateClass::LocalVolatile;
+        }
+        if NETWORK_DURABLE_MODELS.iter().any(|k| m.contains(k)) {
+            return SubstrateClass::NetworkDurable;
+        }
+    }
+    // No decisive model: do not guess network-durable from rotational/write_cache alone (neither is
+    // decisive for the durability-on-ack question). Unknown — `auto` stays buffered.
+    SubstrateClass::Unknown
+}
+
+/// A resolved io-mode plus the human-readable notes to log at boot (mirroring how the durability
+/// level logs its choice). A `warn` note is a loud banner (a fall-back the operator should see);
+/// an info note is the routine "here is what I picked and why".
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct IoModeResolution {
+    /// The io-mode actually in force.
+    pub mode: ResolvedIoMode,
+    /// Notes to log, in order.
+    pub notes: Vec<IoModeNote>,
+}
+
+/// One boot-time note about the io-mode decision.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct IoModeNote {
+    /// `true` = a loud WARN banner; `false` = an INFO line.
+    pub warn: bool,
+    /// The message.
+    pub message: String,
+}
+
+impl IoModeResolution {
+    fn info(mode: ResolvedIoMode, message: impl Into<String>) -> IoModeResolution {
+        IoModeResolution {
+            mode,
+            notes: vec![IoModeNote {
+                warn: false,
+                message: message.into(),
+            }],
+        }
+    }
+    fn warn(mode: ResolvedIoMode, message: impl Into<String>) -> IoModeResolution {
+        IoModeResolution {
+            mode,
+            notes: vec![IoModeNote {
+                warn: true,
+                message: message.into(),
+            }],
+        }
+    }
+}
+
+/// Whether the host has ``O_DIRECT`` (Linux). The `direct`/`auto` modes are Linux-first; on any
+/// other unix ``O_DIRECT`` does not exist, so the resolver degrades to buffered.
+#[must_use]
+pub const fn host_supports_direct() -> bool {
+    cfg!(target_os = "linux")
+}
+
+/// Maps a requested [`IoMode`] + the substrate [`SubstrateClass`] + host ``O_DIRECT`` support to the
+/// [`ResolvedIoMode`] in force, plus the notes to log. Pure — the whole decision matrix, tested
+/// exhaustively without touching a real disk.
+///
+/// * `buffered` -> buffered, always, no note.
+/// * `direct` -> direct on a host with ``O_DIRECT`` (INFO if network-durable is confirmed, WARN
+///   otherwise — still safe, the barrier is kept); on a host without ``O_DIRECT`` -> buffered + WARN.
+/// * `auto` -> direct ONLY on a confirmed [`SubstrateClass::NetworkDurable`] host with ``O_DIRECT``;
+///   otherwise buffered (fail-closed) with an INFO explaining why.
+#[must_use]
+pub fn resolve(requested: IoMode, class: SubstrateClass, host_direct: bool) -> IoModeResolution {
+    match requested {
+        IoMode::Buffered => IoModeResolution {
+            mode: ResolvedIoMode::Buffered,
+            notes: Vec::new(),
+        },
+        IoMode::Direct => {
+            if !host_direct {
+                return IoModeResolution::warn(
+                    ResolvedIoMode::Buffered,
+                    "io-mode=direct requested but this host has no O_DIRECT (direct is Linux-only); \
+                     falling back to buffered (fully durable, unchanged behavior)",
+                );
+            }
+            match class {
+                SubstrateClass::NetworkDurable => IoModeResolution::info(
+                    ResolvedIoMode::Direct,
+                    "io-mode=direct on confirmed network-durable storage: O_DIRECT writes over \
+                     pre-formatted written extents, durability barrier KEPT (ack-implies-durable holds)",
+                ),
+                SubstrateClass::LocalVolatile => IoModeResolution::warn(
+                    ResolvedIoMode::Direct,
+                    "io-mode=direct on LOCAL-VOLATILE storage (instance-store/ephemeral): still \
+                     durable (the barrier is kept), but likely NO throughput win here — direct mode \
+                     targets network-durable block storage",
+                ),
+                SubstrateClass::Unknown => IoModeResolution::warn(
+                    ResolvedIoMode::Direct,
+                    "io-mode=direct on a substrate that could not be confirmed network-durable: \
+                     enabling direct anyway — it is SAFE (the durability barrier is kept), it just \
+                     may not be faster; pass --io-mode=buffered to opt out",
+                ),
+            }
+        }
+        IoMode::Auto => {
+            if !host_direct {
+                return IoModeResolution::info(
+                    ResolvedIoMode::Buffered,
+                    "io-mode=auto: no O_DIRECT on this host (Linux-only); using buffered",
+                );
+            }
+            match class {
+                SubstrateClass::NetworkDurable => IoModeResolution::info(
+                    ResolvedIoMode::Direct,
+                    "io-mode=auto detected network-durable storage: enabling direct (O_DIRECT + \
+                     kept barrier)",
+                ),
+                SubstrateClass::LocalVolatile => IoModeResolution::info(
+                    ResolvedIoMode::Buffered,
+                    "io-mode=auto: local-volatile storage detected — using buffered (direct has no \
+                     win here)",
+                ),
+                SubstrateClass::Unknown => IoModeResolution::info(
+                    ResolvedIoMode::Buffered,
+                    "io-mode=auto: could not confirm network-durable storage — failing closed to \
+                     buffered (pass --io-mode=direct to force it; it is safe anywhere)",
+                ),
+            }
+        }
+    }
+}
+
+/// Resolves the io-mode for a real data directory: probes the backing substrate (Linux; a
+/// best-effort, fail-closed `/sys` walk) and runs the pure [`resolve`]. Non-Linux hosts skip the
+/// probe (there is no ``O_DIRECT`` to enable).
+#[must_use]
+pub fn resolve_for_dir(requested: IoMode, data_dir: &Path) -> IoModeResolution {
+    // Buffered needs no probe (and the probe's only consumer is the direct/auto path).
+    if requested == IoMode::Buffered {
+        return resolve(requested, SubstrateClass::Unknown, host_supports_direct());
+    }
+    let class = classify(&probe_backing_substrate(data_dir));
+    resolve(requested, class, host_supports_direct())
+}
+
+/// Gathers the backing-device signals for `data_dir`. Linux reads `/sys`; every other platform
+/// (and every failure) yields a probe that classifies as [`SubstrateClass::Unknown`].
+#[cfg(target_os = "linux")]
+fn probe_backing_substrate(data_dir: &Path) -> SubstrateProbe {
+    linux_probe::probe(data_dir).unwrap_or(SubstrateProbe {
+        stacked_unresolved: true,
+        ..SubstrateProbe::default()
+    })
+}
+
+/// Non-Linux: no `/sys`, no ``O_DIRECT``. Return an Unknown-classifying probe; the resolver already
+/// short-circuits a non-``O_DIRECT`` host to buffered regardless.
+#[cfg(not(target_os = "linux"))]
+fn probe_backing_substrate(_data_dir: &Path) -> SubstrateProbe {
+    SubstrateProbe::default()
+}
+
+/// The Linux-only, best-effort `/sys` reader. Isolated so its untested-on-macOS surface is small
+/// and every failure path returns `None` (→ Unknown → `auto` stays buffered), so a bug here can
+/// never do worse than pick the safe default.
+#[cfg(target_os = "linux")]
+mod linux_probe {
+    use super::SubstrateProbe;
+    use std::os::unix::fs::MetadataExt;
+    use std::path::Path;
+
+    /// Probes the block device backing `data_dir`, walking a stacked (`dm`/`md`/`loop`) node down to
+    /// its physical backing device before reading the model / rotational / `write_cache` signals.
+    pub(super) fn probe(data_dir: &Path) -> Option<SubstrateProbe> {
+        let dev = std::fs::metadata(data_dir).ok()?.dev();
+        // `major`/`minor` are safe pure-arithmetic libc fns on Linux (no memory access).
+        let (major, minor) = (libc::major(dev), libc::minor(dev));
+        let sys_block = Path::new("/sys/dev/block").join(format!("{major}:{minor}"));
+        // Canonicalize the symlink into /sys/devices/... so we can inspect the real node.
+        let node = std::fs::canonicalize(&sys_block).ok()?;
+
+        let mut probe = SubstrateProbe::default();
+        // Resolve down to the physical device (strip a partition, descend a stacked node).
+        let Some(phys) = resolve_physical(&node) else {
+            probe.stacked_unresolved = true;
+            return Some(probe);
+        };
+
+        probe.model = read_trimmed(&phys.join("device/model"));
+        // The `rotational` file is "1" (rotational) or "0" (non-rotational); anything else -> None.
+        probe.rotational = match read_trimmed(&phys.join("queue/rotational")).as_deref() {
+            Some("0") => Some(false),
+            Some("1") => Some(true),
+            _ => None,
+        };
+        probe.write_cache = read_trimmed(&phys.join("queue/write_cache"));
+        Some(probe)
+    }
+
+    /// Given a `/sys/devices/.../<node>` path, resolve to the physical device directory: strip a
+    /// partition to its parent disk, and descend one `slaves/` level for a `dm`/`md`/`loop` node.
+    /// Returns `None` (→ `stacked_unresolved`) if a stacked node cannot be walked down.
+    fn resolve_physical(node: &Path) -> Option<std::path::PathBuf> {
+        let name = node.file_name()?.to_str()?.to_string();
+        // A partition has a `partition` file; its disk is the parent directory.
+        if node.join("partition").exists() {
+            if let Some(parent) = node.parent() {
+                return resolve_physical(parent);
+            }
+        }
+        // A stacked node (device-mapper/MD/loop) exposes its backing devices under `slaves/`.
+        let is_stacked = name.starts_with("dm-")
+            || name.starts_with("md")
+            || name.starts_with("loop")
+            || node.join("slaves").is_dir() && has_entries(&node.join("slaves"));
+        if is_stacked {
+            let slaves = node.join("slaves");
+            let first = std::fs::read_dir(&slaves).ok()?.flatten().next()?;
+            let backing = std::fs::canonicalize(first.path()).ok()?;
+            return resolve_physical(&backing);
+        }
+        Some(node.to_path_buf())
+    }
+
+    fn has_entries(dir: &Path) -> bool {
+        std::fs::read_dir(dir)
+            .ok()
+            .and_then(|mut d| d.next())
+            .is_some()
+    }
+
+    fn read_trimmed(path: &Path) -> Option<String> {
+        std::fs::read_to_string(path)
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn io_mode_parse_roundtrips() {
+        for m in [IoMode::Buffered, IoMode::Direct, IoMode::Auto] {
+            assert_eq!(IoMode::parse(m.as_str()), Some(m));
+        }
+        assert_eq!(IoMode::parse("nonsense"), None);
+        assert_eq!(IoMode::parse(""), None);
+    }
+
+    fn probe_model(model: &str) -> SubstrateProbe {
+        SubstrateProbe {
+            model: Some(model.to_string()),
+            rotational: Some(false),
+            write_cache: Some("write back".to_string()),
+            stacked_unresolved: false,
+        }
+    }
+
+    #[test]
+    fn classify_confirms_ebs_as_network_durable() {
+        // The primary positive signal: the EBS device model, even with a `write back` cache (which
+        // is INCONCLUSIVE, not disqualifying, on a durable-on-ack device).
+        assert_eq!(
+            classify(&probe_model("Amazon Elastic Block Store")),
+            SubstrateClass::NetworkDurable
+        );
+        assert_eq!(
+            classify(&probe_model("nvme Amazon Elastic Block Store")),
+            SubstrateClass::NetworkDurable
+        );
+    }
+
+    #[test]
+    fn classify_rejects_instance_store_as_local_volatile() {
+        assert_eq!(
+            classify(&probe_model("Amazon EC2 NVMe Instance Storage")),
+            SubstrateClass::LocalVolatile
+        );
+    }
+
+    #[test]
+    fn classify_is_unknown_for_a_generic_or_absent_model() {
+        assert_eq!(
+            classify(&probe_model("Samsung SSD 990 PRO")),
+            SubstrateClass::Unknown
+        );
+        assert_eq!(
+            classify(&SubstrateProbe::default()),
+            SubstrateClass::Unknown
+        );
+        // write_cache alone (write through / write back) is never decisive on its own.
+        let mut p = SubstrateProbe {
+            write_cache: Some("write through".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(classify(&p), SubstrateClass::Unknown);
+        p.write_cache = Some("write back".to_string());
+        assert_eq!(classify(&p), SubstrateClass::Unknown);
+    }
+
+    #[test]
+    fn classify_fails_closed_on_an_unresolved_stacked_device() {
+        // Even an EBS-looking model is Unknown if it sits behind a stacked node we could not walk
+        // down (a writeback dm-cache could be hiding the true durability).
+        let p = SubstrateProbe {
+            model: Some("Amazon Elastic Block Store".to_string()),
+            stacked_unresolved: true,
+            ..Default::default()
+        };
+        assert_eq!(classify(&p), SubstrateClass::Unknown);
+    }
+
+    #[test]
+    fn resolve_buffered_is_always_buffered_with_no_note() {
+        for class in [
+            SubstrateClass::NetworkDurable,
+            SubstrateClass::LocalVolatile,
+            SubstrateClass::Unknown,
+        ] {
+            for host in [true, false] {
+                let r = resolve(IoMode::Buffered, class, host);
+                assert_eq!(r.mode, ResolvedIoMode::Buffered);
+                assert!(r.notes.is_empty());
+            }
+        }
+    }
+
+    #[test]
+    fn resolve_direct_enables_direct_on_any_substrate_when_host_supports_it() {
+        // T1 is safe everywhere, so explicit `direct` always enables direct on an O_DIRECT host —
+        // INFO on confirmed network-durable, WARN otherwise (still safe).
+        let net = resolve(IoMode::Direct, SubstrateClass::NetworkDurable, true);
+        assert_eq!(net.mode, ResolvedIoMode::Direct);
+        assert!(!net.notes[0].warn);
+
+        for class in [SubstrateClass::LocalVolatile, SubstrateClass::Unknown] {
+            let r = resolve(IoMode::Direct, class, true);
+            assert_eq!(
+                r.mode,
+                ResolvedIoMode::Direct,
+                "direct is safe on {class:?}"
+            );
+            assert!(r.notes[0].warn, "unconfirmed direct warns loudly");
+        }
+    }
+
+    #[test]
+    fn resolve_direct_without_o_direct_falls_back_to_buffered_loudly() {
+        let r = resolve(IoMode::Direct, SubstrateClass::NetworkDurable, false);
+        assert_eq!(r.mode, ResolvedIoMode::Buffered);
+        assert!(r.notes[0].warn);
+    }
+
+    #[test]
+    fn resolve_auto_enables_direct_only_on_confirmed_network_durable() {
+        assert_eq!(
+            resolve(IoMode::Auto, SubstrateClass::NetworkDurable, true).mode,
+            ResolvedIoMode::Direct
+        );
+        // Fail-closed to buffered on everything else, including unknown and local-volatile.
+        for class in [SubstrateClass::LocalVolatile, SubstrateClass::Unknown] {
+            assert_eq!(
+                resolve(IoMode::Auto, class, true).mode,
+                ResolvedIoMode::Buffered,
+                "auto fails closed on {class:?}"
+            );
+        }
+        // And never on a non-O_DIRECT host.
+        assert_eq!(
+            resolve(IoMode::Auto, SubstrateClass::NetworkDurable, false).mode,
+            ResolvedIoMode::Buffered
+        );
+    }
+
+    #[test]
+    fn resolve_for_dir_buffered_needs_no_probe() {
+        // A missing directory must not matter for buffered (no probe path taken).
+        let r = resolve_for_dir(IoMode::Buffered, Path::new("/nonexistent/does/not/matter"));
+        assert_eq!(r.mode, ResolvedIoMode::Buffered);
+    }
+
+    #[test]
+    fn resolve_for_dir_on_non_linux_is_buffered() {
+        // On this build's host: direct/auto degrade to buffered unless it is Linux (where the probe
+        // may still say buffered). The point: never a panic, always a resolution.
+        let r = resolve_for_dir(IoMode::Auto, Path::new("."));
+        if !host_supports_direct() {
+            assert_eq!(r.mode, ResolvedIoMode::Buffered);
+        }
+        // direct on a non-linux host falls back to buffered with a warn.
+        let d = resolve_for_dir(IoMode::Direct, Path::new("."));
+        if !host_supports_direct() {
+            assert_eq!(d.mode, ResolvedIoMode::Buffered);
+            assert!(d.notes.iter().any(|n| n.warn));
+        }
+    }
+}


### PR DESCRIPTION
Refs #1044 (the O_DIRECT/network-durable strand), the tunability directive.

## What

A configurable durable-write **io-mode** (`--io-mode buffered|direct|auto`, env `IRONBUS_IO_MODE`, config `storage.io_mode`; default `buffered`). The `direct` tier makes the durability barrier **metadata-free and page-cache-free** — a large safe speedup on network-replicated block storage (EBS) — **with the `fdatasync` barrier kept, so zero durability compromise.**

## Why it's safe *and* fast (measured on t4g / real EBS gp3)

The "expensive ~3ms EBS `fdatasync`" is **not** a device-cache flush — it's **metadata journaling** (every append converts a fresh extent `unwritten→written`). Proof: on a **pre-formatted** file (extents already written), `fdatasync` after an O_DIRECT overwrite is **1µs** (vs ~2850µs on a fallocate-only file). So:

- **O_DIRECT write** (~948µs, data straight to the device) **+ the kept `fdatasync`** (now ~1µs, nothing left to flush) = **~949µs durable op vs ~3000µs buffered.**
- We **keep** the barrier — if EBS ever needed a real flush, `fdatasync` still enforces it. The speed comes purely from making the barrier metadata-free (a written pre-format) and page-cache-free (O_DIRECT). No "trust the write-ack" gamble.
- Projected: IronBus P1 ~1054 rec/s vs Redpanda's ~533 — a **2× win**, and it also relieves the P2/128 single-conn residual and the C1 fsync-per-commit path. (Full t4g A/B is the follow-on validation.)

The design panel deliberately did **not** build the aggressive "drop the barrier" tier — T1 already gets the full win safely.

## Design (contained, buffered untouched)

- **`MaybeDirectFile { Buffered(StdFile) | Direct(DirectFile) }`** behind the existing `RandomAccessFile` triad — the buffered arm delegates verbatim, so the default path is **byte-and-behavior identical**.
- **`DirectFile`**: O_DIRECT write fd + buffered read fd; 4096-aligned staging with partial-tail read-modify-write (from a device-consistent frontier cache); the kept `sync_data`/`sync_all` barrier. `cfg(unix)` for coverage; the O_DIRECT flag applies on Linux only (arm64 `O_DIRECT`); macOS falls back to buffered.
- **Written pre-format** at segment create (fallocate + chunked 1 MiB O_DIRECT zero-write + one `sync_all`) so every extent is `written` before any append. Chunked = 213ms/64 MiB, amortized over ~512k records.
- **On-disk format byte-identical** between modes (only the sync mechanism differs) → recovery + the conformance byte-identity gate are mode-agnostic; the pre-format zeros compose with the existing zero-tail recovery rule.
- **Auto-detect + fail-closed**: `auto` picks `direct` only on confirmed network-durable storage (a `/sys` block-device probe), else buffered; `direct` on an unconfirmed substrate warns loudly but stays safe (barrier kept); non-Linux → buffered.
- Applies to durable **produce** (the #1040 barrier) *and* **consumer offset commits** (checkpoint.rs — the C1 path).

## Invariants + verification

I2 ack-implies-durable (barrier kept, same control flow), buffered byte-identity, O_DIRECT alignment (every write 4096-aligned in addr/offset/length), crash-consistency (torn tail caught by the frame CRC + zero-tail recovery), sim/conformance/determinism unaffected (in-memory fs can't construct DirectFile). Three adversarial lenses: **crash-consistency/I2 SHIP, byte-identity/conformance SHIP, alignment/perf verified GOOD** (the only block was Linux-only clippy lints in the `/sys` probe, fixed here).

Gates: fmt ✓, storage 491 + server 1053 + cli 462 tests ✓, conformance byte-identity + determinism ✓, `cargo check --workspace` ✓. New tests: alignment oracle, byte-identity vs buffered, partial-tail RMW, pre-format + zero-tail composition, direct-mode crash recovery, checkpoint over DirectFile, substrate classify/resolve matrix, config precedence.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
