### PR TITLE
fix(go-sdk): validate Config.DefaultAckLevel client-side (#1039) + auth example

### DIFF
--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -87,6 +87,9 @@ Each example runs against a live broker
 - `examples/cluster_notleader`: following the typed NotLeader redirect (a
   single-node broker never emits it; run against a cluster node to see the
   redirect).
+- `examples/auth`: connecting with a bearer or username+password credential
+  (secret redacted when logged; safe to run against a no-auth broker, which
+  ignores it).
 
 The only dependency is `github.com/pierrec/lz4/v4` (the broker compresses
 stored payloads transparently, so the SDK must decode lz4 blocks).

--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -85,6 +85,14 @@ type Client struct {
 // Connect dials the broker, completes the Connect/Info handshake, and adopts
 // the negotiated capabilities.
 func Connect(ctx context.Context, cfg Config) (*Client, error) {
+	// Symmetric client-side validation (#1039): the connection-wide default ack
+	// level must be one of the three frozen wire levels (0, 1, 2), exactly as
+	// ProduceWithAckLevel rejects an out-of-range per-publish level. Reject it here
+	// rather than dialing and sending an invalid byte the broker would refuse at the
+	// handshake — a config mistake surfaces as a clear typed error, not a wire error.
+	if cfg.DefaultAckLevel != nil && *cfg.DefaultAckLevel > AckLevelServerAndClient {
+		return nil, &InvalidAckLevelError{Level: *cfg.DefaultAckLevel}
+	}
 	addr := cfg.Addr
 	if addr == "" {
 		addr = DefaultAddr

--- a/sdk/go/client_test.go
+++ b/sdk/go/client_test.go
@@ -97,3 +97,33 @@ func TestProduceWithAckLevelRejectsUnknownLevel(t *testing.T) {
 		t.Fatalf("level-3 produce = %v, want *InvalidAckLevelError with level 3", err)
 	}
 }
+
+// TestConnectRejectsInvalidDefaultAckLevel pins the symmetric client-side check
+// (#1039): a Config.DefaultAckLevel outside the frozen 0/1/2 spectrum is rejected
+// with the same typed *InvalidAckLevelError as the per-publish guard, BEFORE any
+// socket is dialed — so a config mistake never becomes a handshake-time wire error.
+func TestConnectRejectsInvalidDefaultAckLevel(t *testing.T) {
+	// Level 3 is rejected before any dial: the address is unroutable, so if the
+	// check regressed and Connect tried to reach it, the error would be a dial
+	// failure, not the typed *InvalidAckLevelError this asserts.
+	bad := uint8(3)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if _, err := Connect(ctx, Config{Addr: "203.0.113.1:1", DefaultAckLevel: &bad}); err != nil {
+		var want *InvalidAckLevelError
+		if !errors.As(err, &want) || want.Level != 3 {
+			t.Fatalf("connect with default ack level 3 = %v, want *InvalidAckLevelError with level 3", err)
+		}
+	} else {
+		t.Fatal("connect with default ack level 3 returned nil, want *InvalidAckLevelError")
+	}
+
+	// The boundary level 2 is VALID: validation lets it through and the handshake
+	// completes against a broker.
+	ok := AckLevelServerAndClient
+	c, err := Connect(context.Background(), Config{Addr: startStalledBroker(t), DefaultAckLevel: &ok})
+	if err != nil {
+		t.Fatalf("connect with default ack level 2 = %v, want success", err)
+	}
+	c.Close()
+}

--- a/sdk/go/examples/auth/main.go
+++ b/sdk/go/examples/auth/main.go
@@ -1,0 +1,84 @@
+// Command auth connects to a broker with an authentication credential — a
+// bearer token or a username+password. An auth-enabled broker requires every
+// connection to present one in the Connect handshake; the credential material is
+// redacted in the Credential/Config String, so logging them never leaks the secret.
+//
+// The credential is sourced from the environment so the secret is never a literal
+// in code or process args. Against a broker with auth DISABLED the credential is
+// simply ignored and the connect still succeeds, so this example is safe to run
+// either way; a WRONG credential against an auth-REQUIRED broker fails at connect
+// with a *ServerError, which the example reports. See docs/AUTHENTICATION.md for
+// broker-side setup.
+//
+// Start a broker (add your auth configuration for a real test):
+//
+//	ironbus serve --data-dir /tmp/ironbus-demo --addr 127.0.0.1:7777
+//
+// Then: IRONBUS_TOKEN=the-token go run ./examples/auth [-addr 127.0.0.1:7777]
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	ironbus "github.com/ELares/IronBus/sdk/go"
+)
+
+func main() {
+	addr := flag.String("addr", ironbus.DefaultAddr, "broker address")
+	flag.Parse()
+
+	// A BEARER credential: an opaque token the broker checks. Bearer returns an
+	// error only if the token exceeds the wire field cap.
+	token := os.Getenv("IRONBUS_TOKEN")
+	if token == "" {
+		token = "example-bearer-token"
+	}
+	bearer, err := ironbus.Bearer(token)
+	if err != nil {
+		log.Fatalf("build bearer credential: %v", err)
+	}
+
+	// A PASSWORD credential: username + password, packed into the mechanism's
+	// material. The broker verifies the password against an Argon2id hash; the
+	// plaintext only travels inside the (ideally TLS-wrapped) handshake. Built here
+	// to show the constructor — swap it into the Config below to use it instead.
+	if _, err := ironbus.Password("alice", "correct horse battery staple"); err != nil {
+		log.Fatalf("build password credential: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Present the credential in the handshake. The credential redacts its secret
+	// when formatted, so this is safe to log.
+	cfg := ironbus.Config{Addr: *addr, Credential: bearer}
+	fmt.Printf("connecting to %s with a bearer credential (secret redacted: %v)\n", *addr, bearer)
+
+	client, err := ironbus.Connect(ctx, cfg)
+	if err != nil {
+		// An auth-REQUIRED broker rejects a bad/absent credential at connect with a
+		// server error. Report it rather than failing hard — the fix is a valid
+		// credential, not a code change.
+		var srv *ironbus.ServerError
+		if errors.As(err, &srv) {
+			fmt.Printf("broker rejected the credential: %v (is the token correct for this broker?)\n", srv)
+			return
+		}
+		log.Fatalf("connect: %v", err)
+	}
+	defer client.Close()
+
+	// Authenticated: produce as usual. On an auth broker, whether this specific
+	// action is allowed depends on the credential's granted scopes.
+	offset, err := client.Produce(ctx, &ironbus.Message{Payload: []byte("authenticated-hello")})
+	if err != nil {
+		log.Fatalf("produce: %v", err)
+	}
+	fmt.Printf("authenticated connect OK; produced at offset %d\n", offset)
+}


### PR DESCRIPTION
## Fixes #1039

`Config.DefaultAckLevel` (a `*uint8`) was passed straight into the `Connect` handshake body with **no client-side validation**, while `ProduceWithAckLevel` already rejects an out-of-range per-publish level (`produce.go`). That asymmetry let an invalid default ack byte (`> 2`) travel on the wire for the broker to reject at handshake time.

`Connect` now validates it **before dialing** and returns the same typed `*InvalidAckLevelError` — a config mistake becomes a clear local error, not a wire error.

```go
if cfg.DefaultAckLevel != nil && *cfg.DefaultAckLevel > AckLevelServerAndClient {
    return nil, &InvalidAckLevelError{Level: *cfg.DefaultAckLevel}
}
```

A test pins both directions: **level 3 is rejected before any dial** (an unroutable address proves no socket is opened — a regression would surface as a dial error instead), and the **boundary level 2 connects fine** against a broker.

## Also: `examples/auth`

Connecting with a **bearer** or **username+password** credential (`Bearer` / `Password` → `Config.Credential`), with the secret **redacted when logged**. Safe to run against a no-auth broker (the credential is ignored) and reports a `*ServerError` against an auth-required one. Smoke-tested against a live broker:

```
connecting to 127.0.0.1:7802 with a bearer credential (secret redacted: ironbus.Credential{mechanism: bearer, material: <redacted>})
authenticated connect OK; produced at offset 0
```

*(A `cumulative_ack` example was considered but deferred: `CumulativeAck` requires a broadcast group, and the Go SDK's `Subscribe` doesn't yet expose broadcast-group creation — a separate follow-up.)*

## Verification
- `gofmt -l` clean, `go vet ./...` clean, `go build ./...` clean.
- `go test ./...` — all pass, including the new `TestConnectRejectsInvalidDefaultAckLevel`.
- Live smoke test of `examples/auth`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)