### PR TITLE
ci(fuzz): derive fuzz-target lists from the filesystem; bound the test job at 30 min

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,13 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    # Bound the known LOAD-DEPENDENT hang (an intermittent raft_cluster deadlock that only
+    # reproduces under the full parallel workspace run; passes in isolation) to a 30-minute
+    # failure instead of the runner's 6-hour default. The job normally finishes in ~6 min
+    # (ubuntu) / ~4 min (windows), so 30 min is ~5x headroom: a timeout here is a REAL hang
+    # signal, never ordinary-slowness noise. Root-causing the deadlock is tracked separately;
+    # this line is the containment.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -610,8 +617,9 @@ jobs:
     # A bounded per-PR libFuzzer smoke: replay the committed regression corpus and fuzz each target
     # for a few seconds under ASan, so a crash-class regression is caught on the PR, not only in the
     # nightly soak. This is the LIGHT lane; the DEEP exploratory soak (180 s/target, raising toward
-    # 30 min) stays in nightly.yml and is NOT weakened. Kept short so it never dominates PR latency.
-    timeout-minutes: 20
+    # 30 min) stays in nightly.yml and is NOT weakened. Kept short so it never dominates PR latency
+    # (30 min bounds 21 targets: one shared ASan build + ~15 s exploration each).
+    timeout-minutes: 30
     env:
       # cargo-fuzz computes its own sanitizer RUSTFLAGS; clear the inherited "-D warnings" so it
       # builds from a clean slate rather than risking a clobber, exactly as the nightly fuzz job does.
@@ -631,13 +639,22 @@ jobs:
       - name: replay the regression corpus and short-fuzz each target
         env:
           # Per-target wall-clock budget for the short exploratory leg AFTER the corpus replay.
-          # Small on purpose (8 targets => ~2 min of fuzzing): the deep soak is nightly's job.
+          # Small on purpose (21 targets => ~5 min of fuzzing): the deep soak is nightly's job.
           MAX_TOTAL_TIME: "15"
         run: |
           set -euo pipefail
-          for target in record_codec frame_decode cursor_snapshot seq_snapshot segment_scan segment_scan_compacted pub_body ack_body deliver_body dead_letter_body; do
+          # The target list is DERIVED from fuzz_targets/ (never hardcoded), exactly like the
+          # nightly soak: a hardcoded list silently orphaned targets from every lane. A new fuzz
+          # target is smoke-tested on the very PR that adds it; one missing its fuzz/Cargo.toml
+          # [[bin]] entry fails the lane loudly.
+          for target_file in fuzz/fuzz_targets/*.rs; do
+            target="$(basename "${target_file}" .rs)"
             echo "::group::fuzz-smoke ${target}"
             corpus="corpus-regression/${target}"
+            # A target with no committed regression corpus yet gets an (ephemeral) empty dir —
+            # libFuzzer requires the positional corpus dir to exist; the replay leg is then a no-op
+            # and the exploratory leg starts from scratch until seeds are promoted (#385).
+            mkdir -p "fuzz/${corpus}"
             # FIRST replay the committed regression seeds deterministically (-runs=0: execute each
             # input once, mutate nothing), so a seed that now crashes fails fast and reproducibly.
             # `--target x86_64-unknown-linux-gnu` is REQUIRED: cargo-fuzz is binstalled as a

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -40,6 +40,9 @@ jobs:
     # input is uploaded so it can be minimized into a permanent regression seed.
     name: fuzz soak (parsers)
     runs-on: ubuntu-latest
+    # ~63 min of fuzzing (21 targets x 180 s) + the ASan build; 120 bounds a wedged target to a
+    # loud failure instead of the runner's 6-hour default.
+    timeout-minutes: 120
     env:
       # cargo-fuzz computes its own sanitizer RUSTFLAGS; clear the inherited "-D warnings" so it
       # builds from a clean slate rather than risking a clobber or append ambiguity across versions.
@@ -57,16 +60,24 @@ jobs:
           tool: cargo-fuzz@0.13.1
       - name: soak each parser fuzz target
         env:
-          # Per-target wall-clock budget; 13 targets => ~39 min of fuzzing per nightly run. The #385
+          # Per-target wall-clock budget; 21 targets => ~63 min of fuzzing per nightly run. The #385
           # plan is to raise this toward 30 min/target; it is a single knob so deepening the soak is
           # a one-line change once the nightly runner-time budget allows.
           MAX_TOTAL_TIME: "180"
         run: |
+          set -euo pipefail
           # Select nightly explicitly via the rustup proxy: cargo-fuzz needs the nightly
           # sanitizer (-Zsanitizer=address). dtolnay/rust-toolchain does run `rustup default
           # nightly`, but that step is continue-on-error, so the `+nightly` makes the
           # toolchain unambiguous and matches the documented local command in fuzz/README.md.
-          for target in record_codec frame_decode cursor_snapshot seq_snapshot segment_scan segment_scan_compacted pub_body ack_body deliver_body dead_letter_body connect_body info_body gap_marker_body; do
+          #
+          # The target list is DERIVED from fuzz_targets/ (never hardcoded): a hardcoded list
+          # silently orphaned 8 of 21 targets from every CI lane while the docs claimed "every
+          # target" was soaked. Deriving from the filesystem makes orphaning impossible by
+          # construction — a new fuzz target is picked up the night it lands, and a target file
+          # missing its fuzz/Cargo.toml [[bin]] entry fails the run loudly.
+          for target_file in fuzz_targets/*.rs; do
+            target="$(basename "${target_file}" .rs)"
             echo "::group::fuzz ${target}"
             # Pin the fuzz build to the rustc HOST target (gnu), not cargo-fuzz's self-detected
             # default. cargo-fuzz infers its default --target from its OWN binary triple, and
@@ -78,7 +89,10 @@ jobs:
             #
             # The committed regression corpus (fuzz/corpus-regression/<target>, #385) is passed as
             # the seed corpus, so the soak always REPLAYS every #45 vector and every promoted crasher
-            # first, then explores from them rather than from an empty corpus each night.
+            # first, then explores from them rather than from an empty corpus each night. A target
+            # with no committed corpus yet gets an (ephemeral) empty dir — libFuzzer requires the
+            # positional corpus dir to exist — and explores from scratch until seeds are promoted.
+            mkdir -p "corpus-regression/${target}"
             cargo +nightly fuzz run "${target}" --target x86_64-unknown-linux-gnu \
               "corpus-regression/${target}" -- -max_total_time="${MAX_TOTAL_TIME}"
             echo "::endgroup::"

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -87,6 +87,12 @@ Commit the new seed. From then on the per-PR replay (below) guards it on every P
 - **Nightly (deep):** the `fuzz` job soaks every target under ASan (180 s/target today,
   rising toward 30 min/target), seeded by the regression corpus. A crash fails the job and
   uploads the input (90-day retention) for triage and promotion.
+- **"Every target" is structural, not aspirational:** both the nightly soak and the per-PR
+  `fuzz-smoke` DERIVE their target list from `fuzz_targets/*.rs` at run time — there is no
+  hardcoded list to forget to update (a hardcoded list once silently orphaned 8 of 21 targets
+  from every lane). A new target is smoke-tested on the PR that adds it and soaked the same
+  night; a target file missing its `Cargo.toml` `[[bin]]` entry fails both lanes loudly. A
+  target with no committed regression corpus yet fuzzes from scratch until seeds are promoted.
 - **Coverage regression:** the nightly `coverage` job emits the workspace line-coverage
   percentage and retains `lcov.info`. The intended "coverage-below-last-release" gate
   (compare to the last released tag's archived coverage, fail on an un-ratified drop) is


### PR DESCRIPTION
## Two verified audit findings (2026-07-06 production-readiness audit)

### 1. Hardcoded fuzz lists silently orphaned **8 of 21 targets** from every CI lane
`bind_subject_body`, `compressed_unit`, `deliver_batch_body`, `pub_subject_body`, `pub_to_body`, `sub_subject_body`, `sub_to_body`, `txn_prepare_body` — the **entire subject/stream-addressed verb surface and the txn prepare parser were never fuzzed anywhere**, while `fuzz/README.md` claimed the nightly soaks "every target".

**Fix (CS-sound):** eliminate the duplicated source of truth instead of testing its consistency — both lanes now **derive the target list from `fuzz_targets/*.rs` at run time**:
- a new fuzz target is smoke-tested on the PR that adds it and soaked the same night;
- a target file missing its `[[bin]]` entry fails both lanes loudly;
- a target with no committed corpus yet gets an ephemeral empty dir (libFuzzer requires the positional dir) and explores from scratch until seeds are promoted (#385 unchanged).

Budgets: nightly ~63 min of fuzzing (was ~39) with a new 120-min job bound; `fuzz-smoke` 20→30 min. All 21 targets verified to typecheck (`cargo check` in `fuzz/`).

### 2. The merge-blocking `test` job had **no timeout**
The known intermittent load-dependent raft_cluster deadlock (passes in isolation; hangs only under the full parallel workspace run) could pin a runner for the **6-hour default**. `timeout-minutes: 30` bounds it to a loud failure — measured normal durations are ~6 min (ubuntu) / ~4 min (windows), so a timeout is a real hang signal, never slowness noise. Root-cause remains tracked; this is containment. 17 sibling jobs already carry timeouts.

Shell blocks are shellcheck-clean glob iteration (no SC2046); YAML parse validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)