### PR TITLE
fuzz: cover the two pre-auth credential parsers (unauthenticated attack surface)

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -163,6 +163,20 @@ test = false
 doc = false
 bench = false
 
+[[bin]]
+name = "connect_auth_section"
+path = "fuzz_targets/connect_auth_section.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "password_material"
+path = "fuzz_targets/password_material.rs"
+test = false
+doc = false
+bench = false
+
 # Detach from the parent workspace (which is `crates/*`): a cargo-fuzz crate must build with the
 # nightly sanitizer toolchain, separately from the merge-blocking stable workspace.
 [workspace]

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -19,6 +19,12 @@ of bounds.
 | `frame_decode` | `ironbus_proto::frame::decode_frame` | The length-framed wire decoder reads bytes straight off a client socket. |
 | `cursor_snapshot` | `ironbus_core::cursor::AckCursor::decode_snapshot` | A torn or hostile durable checkpoint payload must not crash recovery. |
 | `segment_scan` | `ironbus_storage::segment::SegmentReader` scan and recovery | The most security-critical parser: it runs on every startup over on-disk bytes a power cut may have corrupted. |
+| `connect_auth_section` | `ironbus_proto::message::parse_connect_auth` | The auth section of the `Connect` body, parsed on a NOT-YET-AUTHENTICATED connection — the most hostile input position (a panic here under `panic = "abort"` is an unauthenticated remote kill). |
+| `password_material` | `ironbus_proto::message::unpack_password_material` | Splits attacker-supplied credential bytes before the Argon2id verify, on the same pre-auth path. |
+
+The table above is representative, not exhaustive — CI derives the full target set from
+`fuzz_targets/*.rs` at run time (see [CI](#ci)), so adding a target here never requires
+touching a hardcoded list and can never silently orphan a parser.
 
 ## Running locally
 

--- a/fuzz/fuzz_targets/connect_auth_section.rs
+++ b/fuzz/fuzz_targets/connect_auth_section.rs
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! Fuzz the CONNECT auth-section parser (#631, #884; refs #21, #123): `parse_connect_auth` runs on
+//! the UNTRUSTED `Connect` body of a not-yet-authenticated connection — the single most hostile
+//! input position in the broker (under the release profile's `panic = "abort"`, a panic here is an
+//! unauthenticated remote kill). Parsing any byte string must never panic, read out of bounds, or
+//! over-allocate: only `Ok(None)` (no auth section), `Ok(Some(credential))`, or a typed `BodyError`.
+//! A crasher found here becomes a permanent regression seed.
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = ironbus_proto::message::parse_connect_auth(data);
+});

--- a/fuzz/fuzz_targets/password_material.rs
+++ b/fuzz/fuzz_targets/password_material.rs
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! Fuzz the password credential-material unpacker (#631, #884; refs #21, #123):
+//! `unpack_password_material` splits ATTACKER-SUPPLIED credential bytes (two u16-length-prefixed
+//! fields, username then password) on a not-yet-authenticated connection, BEFORE the Argon2id
+//! verify runs. Under the release profile's `panic = "abort"`, a panic here is an unauthenticated
+//! remote kill, so unpacking any byte string must never panic or read out of bounds: only a valid
+//! `(username, password)` view pair or a typed `BodyError`. A crasher found here becomes a
+//! permanent regression seed.
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = ironbus_proto::message::unpack_password_material(data);
+});


### PR DESCRIPTION
## Verified audit finding (quick win #6)

`parse_connect_auth` and `unpack_password_material` were the **only unfuzzed parsers on the pre-authentication path** — the most hostile input position in the broker. `parse_connect_auth` decodes the auth section of the `Connect` body from a **not-yet-authenticated** connection; `unpack_password_material` splits attacker-supplied credential bytes **before** the Argon2id verify. Under the release profile's `panic = "abort"`, a panic in either is an **unauthenticated remote kill**.

## What
Two libFuzzer targets (`connect_auth_section`, `password_material`), each asserting the standard contract: any input ⇒ typed `BodyError` or valid view, never a panic or OOB read.

Because of #1079, both CI lanes now **derive** their target list from `fuzz_targets/*.rs`, so these are **ASan-fuzzed on this PR** (`fuzz-smoke`) and soaked the same night — the only wiring is the two `[[bin]]` entries (placed before the detaching `[workspace]` table). README lists both and clarifies its table is representative, not exhaustive.

Both targets typecheck; harness builds; `relative-link-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)