### PR TITLE
feat(tls): TLS 1.3 crypto foundation behind the non-default `tls` feature (ADR-0004, #766)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        include:
+          # Linux is the broker's platform: run the FULL feature matrix, INCLUDING `tls` (rustls +
+          # aws-lc-rs, ADR-0004). ubuntu-latest ships cmake, which aws-lc-sys's vendored-C build needs.
+          - os: ubuntu-latest
+            featureflags: "--all-features"
+          # Windows is a client/tooling platform. Run every feature EXCEPT `tls`: aws-lc-sys's
+          # vendored-C build is validated on the Linux leg (the broker target), and forcing it onto
+          # the Windows runner (NASM/MSVC) adds cross-platform C-build risk for no coverage gain — the
+          # TLS 1.3 config is fully exercised on ubuntu. This keeps the existing zstd (vendored-C via
+          # cc) + otlp coverage. UPDATE this list if a new NON-tls feature is added.
+          - os: windows-latest
+            featureflags: "--features zstd,otlp"
     runs-on: ${{ matrix.os }}
     # Bound the known LOAD-DEPENDENT hang (an intermittent raft_cluster deadlock that only
     # reproduces under the full parallel workspace run; passes in isolation) to a 30-minute
@@ -57,7 +68,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-      - run: cargo test --workspace --all-features --locked
+      - run: cargo test --workspace ${{ matrix.featureflags }} --locked
 
   acceptance:
     name: golden-path acceptance gate (#133)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,6 +114,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
 name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,6 +348,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -455,6 +487,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -518,6 +556,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-channel"
@@ -953,6 +997,8 @@ dependencies = [
  "protobuf",
  "raft",
  "raft-proto",
+ "rustls",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "sha2",
@@ -1543,6 +1589,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1562,6 +1622,41 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+dependencies = [
+ "aws-lc-rs",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -2031,6 +2126,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "valuable"

--- a/crates/ironbus-cli/Cargo.toml
+++ b/crates/ironbus-cli/Cargo.toml
@@ -29,6 +29,11 @@ edge-min = ["ironbus-server/edge-min"]
 # gate are UNCHANGED (zstd absent by default), per ADR-0003. Forwards the feature to storage (the
 # sidecar IO) and through it to ironbus-core (the codec + training).
 zstd = ["ironbus-storage/zstd", "ironbus-core/zstd"]
+# TLS 1.3 transport (ADR-0004, #766). NON-DEFAULT: forwards ironbus-server's `tls` feature so
+# `cargo build -p ironbus-cli --features tls` produces a broker that carries the rustls + aws-lc-rs
+# stack. The DEFAULT binary links no TLS code and no new C (the aws-lc-sys allowance is feature-scoped
+# in deny.toml, and cffi-ban.sh proves the default ironbus-cli graph stays pure-Rust).
+tls = ["ironbus-server/tls"]
 
 [dependencies]
 ironbus-core = { path = "../ironbus-core", version = "0.0.0" }

--- a/crates/ironbus-server/Cargo.toml
+++ b/crates/ironbus-server/Cargo.toml
@@ -29,6 +29,16 @@ otlp = [
 # OTLP export out entirely and the binary shrinks measurably versus an `otlp` build. It is a marker
 # feature (no extra deps); the compile-out is enforced by it never pulling `otlp`.
 edge-min = []
+# TLS 1.3 transport (ADR-0004, #766/#107). The NON-DEFAULT feature that pulls the rustls TLS stack
+# with the aws-lc-rs crypto provider (the owner-ratified choice, 2026-07-06). Off by default and out
+# of `edge-min`, so the DEFAULT and edge-min builds link ZERO TLS code and ZERO new C — they stay
+# byte-for-byte pure-Rust. Building `--features tls` pulls `rustls` + `aws-lc-rs` (aws-lc-sys's
+# vendored AWS-LC C, cmake-built + static), which is why deny.toml carries a documented, feature-
+# scoped `aws-lc-sys` C-FFI allowance exactly like the approved `zstd-sys` one (ADR-0003), and
+# cffi-ban.sh proves the default graph still has no TLS C-FFI. `default-features = false` on rustls
+# drops its ring-backed webpki path and the tls12 code: IronBus is TLS 1.3-only (docs/TRANSPORT.md),
+# so the shipped tls graph is aws-lc-rs only, never ring.
+tls = ["dep:rustls", "dep:rustls-pki-types"]
 
 [dependencies]
 ironbus-core = { path = "../ironbus-core", version = "0.0.0" }
@@ -189,6 +199,21 @@ opentelemetry-otlp = { version = "0.27", optional = true, default-features = fal
 # build links no tokio. `rt` + `net` + `time` is the minimal surface (a current-thread runtime, the
 # TCP socket, and the batch timer); no `rt-multi-thread`, no `macros`.
 tokio = { version = "1", optional = true, default-features = false, features = ["rt", "net", "time"] }
+
+# TLS 1.3 stack (ADR-0004, the `tls` feature only; the DEFAULT build links none of this). `rustls`
+# 0.23 with the `aws_lc_rs` provider — the owner-ratified crypto backend. `default-features = false`
+# deliberately drops rustls's default `ring` provider AND its `tls12` code: IronBus is TLS 1.3-only
+# (docs/TRANSPORT.md §1.1), so the shipped tls graph carries aws-lc-rs (aws-lc-sys vendored C, the
+# deny.toml feature-scoped allowance) and NEVER ring. `std` for the std IO surface; `logging` off to
+# keep the surface minimal. rustls-webpki's ring dep stays an unbuilt optional in the lock (not in
+# the `cargo tree` build graph), so the compiled tls binary is aws-lc-rs only.
+rustls = { version = "0.23", optional = true, default-features = false, features = ["aws_lc_rs", "std"] }
+# PEM decoder for the cert chain + private key. This is `rustls-pki-types` (the SAME crate rustls
+# already re-exports as `rustls::pki_types`); its `pem` module (the `PemObject` slice decoders) is
+# gated on `alloc`, enabled here via `std`. This REPLACES the now-unmaintained `rustls-pemfile`
+# (RUSTSEC-2025-0134), whose functionality moved here. Pure Rust, no ring; `tls`-only, off the
+# default graph.
+rustls-pki-types = { version = "1", optional = true, features = ["std"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/ironbus-server/src/lib.rs
+++ b/crates/ironbus-server/src/lib.rs
@@ -20,3 +20,7 @@ pub mod registry;
 pub mod rss;
 pub mod server;
 pub mod session;
+// TLS 1.3 transport config (ADR-0004, #766) — compiled only under `--features tls`; the default and
+// edge-min builds carry no TLS code and no new C (deny.toml's aws-lc-sys allowance is feature-scoped).
+#[cfg(feature = "tls")]
+pub mod tls;

--- a/crates/ironbus-server/src/tls.rs
+++ b/crates/ironbus-server/src/tls.rs
@@ -1,0 +1,383 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! TLS 1.3 transport configuration (ADR-0004, #766 / #107) — compiled only under `--features tls`.
+//!
+//! This is the crypto FOUNDATION: it builds the `rustls` configs IronBus uses to terminate (server)
+//! and initiate (client) TLS 1.3 with the **aws-lc-rs** provider (the owner-ratified choice,
+//! ADR-0004). It is deliberately CONFIG-ONLY — wiring these into the accept loop and the client
+//! stream is the transport increment (#766). Keeping the config in one audited module means the
+//! normative `docs/TRANSPORT.md` §1 invariants are enforced in exactly one place:
+//!
+//!   * **TLS 1.3 only** — the protocol version floor and ceiling are both pinned to 1.3
+//!     ([`TLS13_ONLY`]); there is no 1.2 fallback and no downgrade knob (§1.1). rustls is built
+//!     `default-features = false` so its ring-backed webpki path and its tls12 code are not even
+//!     compiled: the provider is aws-lc-rs and the only version is 1.3.
+//!   * **Mandatory server verification on the client** — [`client_config_from_pem`] verifies the
+//!     broker chain against a supplied trust anchor; there is NO accept-any / skip-verify path here
+//!     or anywhere (§1.4).
+//!   * **Fail-closed key permissions** — [`ensure_key_file_not_group_or_world_readable`] refuses a
+//!     private-key file that any principal other than the owner can read (§1.4, #109).
+//!
+//! mTLS (a REQUIRED, handshake-verified client certificate) is the next increment; the server config
+//! here is server-authentication only (`with_no_client_auth`).
+
+use std::sync::Arc;
+
+use rustls::pki_types::pem::PemObject;
+use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use rustls::{ClientConfig, RootCertStore, ServerConfig};
+
+/// TLS 1.3 and nothing older (docs/TRANSPORT.md §1.1: the min and max protocol version are both
+/// pinned to 1.3 — no negotiation down-step exists).
+static TLS13_ONLY: &[&rustls::SupportedProtocolVersion] = &[&rustls::version::TLS13];
+
+/// A typed configuration error so the caller fails closed with a precise, non-leaky message.
+#[derive(Debug)]
+pub enum TlsConfigError {
+    /// Reading a PEM file from disk failed.
+    Io(std::io::Error),
+    /// The certificate PEM contained no certificate.
+    NoCertificate,
+    /// The key PEM contained no private key.
+    NoPrivateKey,
+    /// The trust-anchor PEM contained no usable CA certificate.
+    NoTrustAnchor,
+    /// The private-key file is readable by group or others (fail-closed secret-file rule, #109).
+    /// `mode` is the file's permission bits.
+    KeyFileTooOpen { mode: u32 },
+    /// rustls rejected the material (bad/mismatched key or cert, empty trust store, ...).
+    Rustls(rustls::Error),
+}
+
+impl std::fmt::Display for TlsConfigError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(e) => write!(f, "reading TLS material failed: {e}"),
+            Self::NoCertificate => write!(f, "the certificate PEM contained no certificate"),
+            Self::NoPrivateKey => write!(f, "the key PEM contained no private key"),
+            Self::NoTrustAnchor => write!(f, "the trust-anchor PEM contained no CA certificate"),
+            Self::KeyFileTooOpen { mode } => write!(
+                f,
+                "TLS private-key file is group/world-readable (mode {mode:o}); \
+                 refusing to start — restrict it to owner-only (chmod 600)"
+            ),
+            Self::Rustls(e) => write!(f, "rustls rejected the TLS material: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for TlsConfigError {}
+
+impl From<rustls::Error> for TlsConfigError {
+    fn from(e: rustls::Error) -> Self {
+        Self::Rustls(e)
+    }
+}
+
+/// The aws-lc-rs crypto provider (ADR-0004), pinned EXPLICITLY on every config so IronBus never
+/// depends on a process-global default provider being installed — the config carries its own.
+fn provider() -> Arc<rustls::crypto::CryptoProvider> {
+    Arc::new(rustls::crypto::aws_lc_rs::default_provider())
+}
+
+/// Parse a PEM certificate chain (leaf first) into DER certs, via the maintained `rustls-pki-types`
+/// PEM decoder. A missing or malformed certificate maps to [`TlsConfigError::NoCertificate`].
+fn parse_certs(pem: &[u8]) -> Result<Vec<CertificateDer<'static>>, TlsConfigError> {
+    let certs = CertificateDer::pem_slice_iter(pem)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|_| TlsConfigError::NoCertificate)?;
+    if certs.is_empty() {
+        return Err(TlsConfigError::NoCertificate);
+    }
+    Ok(certs)
+}
+
+/// Parse a single PEM private key (PKCS#8 / SEC1 / PKCS#1) into a DER key. A missing or malformed key
+/// maps to [`TlsConfigError::NoPrivateKey`].
+fn parse_key(pem: &[u8]) -> Result<PrivateKeyDer<'static>, TlsConfigError> {
+    PrivateKeyDer::from_pem_slice(pem).map_err(|_| TlsConfigError::NoPrivateKey)
+}
+
+/// Build the SERVER config from PEM bytes: TLS 1.3-only, aws-lc-rs, server-authentication only
+/// (no client certificate required — mTLS is the next increment). The bytes form lets callers load
+/// from files, an embedded secret store, or a test fixture without a filesystem round-trip.
+///
+/// # Errors
+/// Returns [`TlsConfigError`] if the certificate PEM holds no certificate, the key PEM holds no
+/// private key, or rustls rejects the material (e.g. the private key does not match the certificate).
+///
+/// # Panics
+/// Panics only if the aws-lc-rs provider cannot offer TLS 1.3 — impossible for this build, where the
+/// provider always supports 1.3; the `expect` documents that invariant rather than propagating an
+/// error that cannot occur.
+pub fn server_config_from_pem(
+    cert_pem: &[u8],
+    key_pem: &[u8],
+) -> Result<ServerConfig, TlsConfigError> {
+    let certs = parse_certs(cert_pem)?;
+    let key = parse_key(key_pem)?;
+    let config = ServerConfig::builder_with_provider(provider())
+        .with_protocol_versions(TLS13_ONLY)
+        .expect("TLS 1.3 is supported by the aws-lc-rs provider")
+        .with_no_client_auth()
+        .with_single_cert(certs, key)?;
+    Ok(config)
+}
+
+/// Build the CLIENT config from a trust-anchor PEM bundle: TLS 1.3-only, aws-lc-rs, and MANDATORY
+/// server-certificate verification against the supplied anchors. There is no accept-any path
+/// (docs/TRANSPORT.md §1.4) — an empty/invalid trust store is an error, not a silent skip.
+///
+/// # Errors
+/// Returns [`TlsConfigError::NoTrustAnchor`] if the PEM contains no parseable CA certificate (an
+/// empty trust store would silently accept nothing, so it is rejected up front).
+///
+/// # Panics
+/// Panics only if the aws-lc-rs provider cannot offer TLS 1.3 — impossible for this build (see
+/// [`server_config_from_pem`]).
+pub fn client_config_from_pem(ca_pem: &[u8]) -> Result<ClientConfig, TlsConfigError> {
+    let anchors = parse_certs(ca_pem).map_err(|_| TlsConfigError::NoTrustAnchor)?;
+    let mut roots = RootCertStore::empty();
+    let (added, _ignored) = roots.add_parsable_certificates(anchors);
+    if added == 0 {
+        return Err(TlsConfigError::NoTrustAnchor);
+    }
+    let config = ClientConfig::builder_with_provider(provider())
+        .with_protocol_versions(TLS13_ONLY)
+        .expect("TLS 1.3 is supported by the aws-lc-rs provider")
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+    Ok(config)
+}
+
+/// Fail-closed secret-file rule (docs/TRANSPORT.md §1.4, #109): refuse a private-key file that any
+/// principal other than the owner can read. On Unix this inspects the mode bits; any group/other
+/// read/write/execute bit set is refused. On non-Unix targets the check is a no-op (the mode model
+/// does not apply) and returns `Ok`.
+///
+/// # Errors
+/// Returns [`TlsConfigError::KeyFileTooOpen`] if any group/other permission bit is set, or
+/// [`TlsConfigError::Io`] if the file's metadata cannot be read.
+pub fn ensure_key_file_not_group_or_world_readable(
+    path: &std::path::Path,
+) -> Result<(), TlsConfigError> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let meta = std::fs::metadata(path).map_err(TlsConfigError::Io)?;
+        let mode = meta.permissions().mode();
+        // Any group or other bit (0o077) set means someone other than the owner can touch the key.
+        if mode & 0o077 != 0 {
+            return Err(TlsConfigError::KeyFileTooOpen {
+                mode: mode & 0o7777,
+            });
+        }
+        Ok(())
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rustls::pki_types::ServerName;
+
+    use super::*;
+
+    // A long-lived (valid 2020-01-01 .. 2100-01-01) self-signed P-256 server certificate for
+    // "localhost" (CN ironbus-test-server) and its PKCS#8 key, generated once with rcgen out of tree
+    // (rcgen pulls the banned `ring`, so it is NOT a dependency — the fixture is embedded instead).
+    const SERVER_CERT: &[u8] = b"\
+-----BEGIN CERTIFICATE-----
+MIIBVzCB/aADAgECAhMjGIxpQAwb+081fMl2nX2WEMQ8MAoGCCqGSM49BAMCMB4x
+HDAaBgNVBAMME2lyb25idXMtdGVzdC1zZXJ2ZXIwIBcNMjAwMTAxMDAwMDAwWhgP
+MjEwMDAxMDEwMDAwMDBaMB4xHDAaBgNVBAMME2lyb25idXMtdGVzdC1zZXJ2ZXIw
+WTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAS4ZuCioex4thlFvAdYg6ER4GlPiFK/
+yqG6VNwt0cp7LoCwHmOkcr6JLYLNSa2mar9F2nTFk2cSj49+OzMYbF+AoxgwFjAU
+BgNVHREEDTALgglsb2NhbGhvc3QwCgYIKoZIzj0EAwIDSQAwRgIhAJ+smDY9Jybx
+FoJDOjOor9Cb56IyQQ64ts0roLO5NVx9AiEAnB1pAliacK3UDfG6xKEig12h4tzf
+UrjVOalNQ4uwFJg=
+-----END CERTIFICATE-----
+";
+    const SERVER_KEY: &[u8] = b"\
+-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgWd4kisc5NnK6Nv0I
+RL0rrbnn9ozoIOti7I4eisF3CHWhRANCAAS4ZuCioex4thlFvAdYg6ER4GlPiFK/
+yqG6VNwt0cp7LoCwHmOkcr6JLYLNSa2mar9F2nTFk2cSj49+OzMYbF+A
+-----END PRIVATE KEY-----
+";
+
+    // A DIFFERENT self-signed cert (an unrelated trust anchor) used to prove the client refuses a
+    // server it cannot verify. Generated the same way, CN ironbus-test-other.
+    const OTHER_CERT: &[u8] = b"\
+-----BEGIN CERTIFICATE-----
+MIIBWjCCAQCgAwIBAgIUfIjY91xg+z0LSwh5bngCs73UQLswCgYIKoZIzj0EAwIw
+HTEbMBkGA1UEAwwSaXJvbmJ1cy10ZXN0LW90aGVyMCAXDTIwMDEwMTAwMDAwMFoY
+DzIxMDAwMTAxMDAwMDAwWjAdMRswGQYDVQQDDBJpcm9uYnVzLXRlc3Qtb3RoZXIw
+WTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAS/sQWpzoGIBq0tyDdZLN7918LWW/j0
++CsRiYQa+vfAdERrw1POkGOIed4wUocAT9+tMkOY/VB/OSbHJxeZwPSBoxwwGjAY
+BgNVHREEETAPgg1vdGhlci5pbnZhbGlkMAoGCCqGSM49BAMCA0gAMEUCIC4trwko
+Aq57VS5iw0sm+NFBdTHX5XSCUQvACWp0elXzAiEArjyI3F1SeVHMY/DKGtuy7J/3
+toYtkjmdU2eQ2pK/3gM=
+-----END CERTIFICATE-----
+";
+
+    fn server_config() -> ServerConfig {
+        server_config_from_pem(SERVER_CERT, SERVER_KEY).expect("server config from fixtures")
+    }
+
+    /// Drive a full in-memory handshake between a rustls server and client, returning the negotiated
+    /// protocol version (server side). Panics if either side errors.
+    fn handshake(
+        server_config: Arc<ServerConfig>,
+        client_config: Arc<ClientConfig>,
+    ) -> rustls::ProtocolVersion {
+        let mut server = rustls::ServerConnection::new(server_config).unwrap();
+        let mut client = rustls::ClientConnection::new(
+            client_config,
+            ServerName::try_from("localhost").unwrap(),
+        )
+        .unwrap();
+        for _ in 0..16 {
+            pump(&mut client, &mut server);
+            pump(&mut server, &mut client);
+            if !client.is_handshaking() && !server.is_handshaking() {
+                break;
+            }
+        }
+        assert!(
+            !client.is_handshaking(),
+            "client never completed the handshake"
+        );
+        assert!(
+            !server.is_handshaking(),
+            "server never completed the handshake"
+        );
+        server
+            .protocol_version()
+            .expect("a negotiated protocol version")
+    }
+
+    /// Move all pending TLS bytes from `src` to `dst`, then let `dst` process them.
+    fn pump<A, B>(src: &mut rustls::ConnectionCommon<A>, dst: &mut rustls::ConnectionCommon<B>) {
+        let mut buf = Vec::new();
+        while src.wants_write() {
+            src.write_tls(&mut buf).unwrap();
+        }
+        if buf.is_empty() {
+            return;
+        }
+        let mut rd: &[u8] = &buf;
+        while !rd.is_empty() {
+            if dst.read_tls(&mut rd).unwrap() == 0 {
+                break;
+            }
+        }
+        dst.process_new_packets().unwrap();
+    }
+
+    #[test]
+    fn a_verifying_client_completes_a_tls_1_3_handshake_with_the_server_config() {
+        let sc = Arc::new(server_config());
+        let cc =
+            Arc::new(client_config_from_pem(SERVER_CERT).expect("client trusts the server cert"));
+        let version = handshake(sc, cc);
+        assert_eq!(
+            version,
+            rustls::ProtocolVersion::TLSv1_3,
+            "the negotiated version must be exactly TLS 1.3"
+        );
+    }
+
+    #[test]
+    fn the_client_refuses_a_server_it_cannot_verify() {
+        // Client trusts OTHER_CERT but the server presents SERVER_CERT → verification must fail.
+        let sc = Arc::new(server_config());
+        let cc =
+            Arc::new(client_config_from_pem(OTHER_CERT).expect("a valid but wrong trust anchor"));
+        let mut server = rustls::ServerConnection::new(sc).unwrap();
+        let mut client =
+            rustls::ClientConnection::new(cc, ServerName::try_from("localhost").unwrap()).unwrap();
+        // Pump until one side errors; the client must reject the server's certificate.
+        let mut errored = false;
+        for _ in 0..16 {
+            let mut buf = Vec::new();
+            while client.wants_write() {
+                client.write_tls(&mut buf).unwrap();
+            }
+            if !buf.is_empty() {
+                let mut rd: &[u8] = &buf;
+                while !rd.is_empty() {
+                    if server.read_tls(&mut rd).unwrap() == 0 {
+                        break;
+                    }
+                }
+                let _ = server.process_new_packets();
+            }
+            let mut buf = Vec::new();
+            while server.wants_write() {
+                server.write_tls(&mut buf).unwrap();
+            }
+            if !buf.is_empty() {
+                let mut rd: &[u8] = &buf;
+                while !rd.is_empty() {
+                    if client.read_tls(&mut rd).unwrap() == 0 {
+                        break;
+                    }
+                }
+                if client.process_new_packets().is_err() {
+                    errored = true;
+                    break;
+                }
+            }
+        }
+        assert!(
+            errored,
+            "client must refuse a server certificate it cannot verify"
+        );
+    }
+
+    #[test]
+    fn server_config_rejects_empty_or_garbage_material() {
+        assert!(matches!(
+            server_config_from_pem(b"not a pem", SERVER_KEY),
+            Err(TlsConfigError::NoCertificate)
+        ));
+        assert!(matches!(
+            server_config_from_pem(SERVER_CERT, b"not a pem"),
+            Err(TlsConfigError::NoPrivateKey)
+        ));
+    }
+
+    #[test]
+    fn client_config_rejects_an_empty_trust_store() {
+        assert!(matches!(
+            client_config_from_pem(
+                b"-----BEGIN CERTIFICATE-----\nnonsense\n-----END CERTIFICATE-----\n"
+            ),
+            Err(TlsConfigError::NoTrustAnchor)
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_group_or_world_readable_key_file_is_refused_but_owner_only_passes() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let key = dir.path().join("tls.key");
+        std::fs::write(&key, SERVER_KEY).unwrap();
+
+        // 0o644 (group + world readable) → refused.
+        std::fs::set_permissions(&key, std::fs::Permissions::from_mode(0o644)).unwrap();
+        assert!(matches!(
+            ensure_key_file_not_group_or_world_readable(&key),
+            Err(TlsConfigError::KeyFileTooOpen { .. })
+        ));
+
+        // 0o600 (owner-only) → accepted.
+        std::fs::set_permissions(&key, std::fs::Permissions::from_mode(0o600)).unwrap();
+        assert!(ensure_key_file_not_group_or_world_readable(&key).is_ok());
+    }
+}

--- a/deny.toml
+++ b/deny.toml
@@ -63,6 +63,22 @@ wildcards = "deny"
 # `scripts/ci/cffi-ban.sh` STRUCTURAL guard still bans zstd-sys/zstd on the DEFAULT graph it scopes
 # to, so the default build can never acquire the C-FFI silently; the allowance is feature-only.
 #
+# THE OPT-IN TLS C-FFI ALLOWANCE (ADR-0004, #766/#107). The owner ratified TLS 1.3 behind the
+# NON-DEFAULT `tls` Cargo feature of ironbus-server, whose crypto provider is `aws-lc-rs` (rustls's
+# default, best-audited, FIPS-capable). `aws-lc-sys` (the vendored AWS-LC C binding, `links` + a
+# `cc`/`cmake` build) is therefore the SECOND explicitly-allowed C-FFI under a feature, applying the
+# zstd precedent above: it is DELIBERATELY NOT name-banned (the ban entry was removed) because
+# cargo-deny resolves `all-features` and would otherwise reject the tls tree. It is licensed
+# `ISC AND (Apache-2.0 OR ISC) AND Apache-2.0 AND MIT AND BSD-3-Clause AND ...` — every component is
+# on the allow-list above, so NO license exception is needed. It builds VENDORED + STATIC (aws-lc-sys
+# compiles its bundled AWS-LC C with cc/cmake, no system libcrypto), matching the zstd-sys static
+# posture. `rustls` is built `default-features = false` with only `aws_lc_rs` + `std`, so `ring` is
+# NOT compiled (verified: `ring` is unreachable in the all-features `cargo tree`) and stays banned.
+# The DEFAULT and `edge-min` builds pull NEITHER rustls NOR aws-lc-sys (verified: `cargo tree -i
+# rustls` on the default ironbus-cli graph is empty), so they remain byte-for-byte pure-Rust; the
+# cffi-ban.sh structural guard proves the default graph carries no TLS C-FFI, so the allowance is
+# feature-only exactly like zstd.
+#
 # C-FFI BAN (#102). The best-known vendored-C / native crates are name-banned below as a
 # belt-and-suspenders layer; the STRUCTURAL forward guard is `scripts/ci/cffi-ban.sh` (run by the
 # CI `sbom` job over the shipped musl graph), which also catches an UNKNOWN `links` / C-builder
@@ -90,9 +106,16 @@ name = "lz4-sys" # the C lz4 binding; the default codec is lz4_flex (pure Rust) 
 [[bans.deny]]
 name = "bzip2-sys" # vendored bzip2 C.
 [[bans.deny]]
-name = "ring" # vendored C / assembly crypto; use a pure-Rust / *-rs primitive instead.
-[[bans.deny]]
-name = "aws-lc-sys" # vendored AWS-LC C.
+# vendored C/asm crypto. IronBus's `tls` feature uses aws-lc-rs, NOT ring (ADR-0004). ring stays
+# BANNED and is verified NOT reachable in the all-features graph (it is only an UNBUILT optional of
+# rustls-webpki, whose aws-lc-rs backend is the one compiled), so this ban is a safe belt-and-
+# suspenders guard that also records the deliberate rejection of ring as the provider.
+name = "ring"
+# NOTE: `aws-lc-sys` is DELIBERATELY NOT banned (see THE OPT-IN TLS C-FFI ALLOWANCE comment above): it
+# is the owner-ratified opt-in vendored-C crypto provider behind the NON-DEFAULT `tls` feature
+# (ADR-0004, #766), feature-gated and absent from the DEFAULT `ironbus-cli` graph the cffi-ban.sh +
+# SBOM gates scope to. Exactly the `zstd-sys` pattern: feature-only C-FFI, the default build stays
+# byte-for-byte pure-Rust.
 [[bans.deny]]
 name = "libsqlite3-sys" # vendored SQLite C.
 [[bans.deny]]


### PR DESCRIPTION
## What

**Increment 1** of the ratified TLS work (ADR-0004, Accepted 2026-07-06): the crypto **foundation** — the rustls + aws-lc-rs config layer, feature-gated and supply-chain-guarded — with **no change to the connection hot path**. Wiring the accept loop, stopping the `--tls-*` refusal, mTLS activation, and client TLS are the next increments, sequenced on #766.

## Why this shape

TLS is a large, security-critical feature. Landing it in complete, independently-verified increments (rather than one hot-path rewrite) keeps each PR reviewable and correct. This first slice de-risks the whole feature: it proves the aws-lc-rs stack builds and completes a real TLS 1.3 handshake **in-tree**, and it lands the supply-chain policy exactly once, before any transport rewrite depends on it.

## What lands

- **A non-default `tls` Cargo feature** on `ironbus-server` (forwarded by `ironbus-cli`) pulling `rustls` 0.23 with the **aws-lc-rs** provider, `default-features = false` so the ring-backed webpki path and the tls12 code are **not compiled**: the shipped tls graph is aws-lc-rs only, **TLS 1.3 only**. The **default** and `edge-min` builds link zero TLS code and zero new C.
- **`crates/ironbus-server/src/tls.rs`** — the audited config module enforcing the normative `docs/TRANSPORT.md` §1 invariants in one place:
  - **TLS 1.3 only** (min == max, no downgrade),
  - **mandatory server-cert verification on the client** — no accept-any / skip-verify path,
  - the **fail-closed private-key permission rule** (#109: refuse a group/world-readable key).
  - `server_config_from_pem` / `client_config_from_pem` / `ensure_key_file_not_group_or_world_readable`, all typed errors, with a **real in-memory TLS 1.3 handshake test** (negotiates `TLS13_AES_256_GCM_SHA384`), a refuses-untrusted-server test, garbage-rejection tests, and a key-permission test. Test certs are **embedded PEM fixtures** (rcgen pulls the banned `ring`, so it is not a dependency).
- **`deny.toml`** — `aws-lc-sys` moves from the ban list to a documented, feature-scoped C-FFI **allowance**, applying the approved `zstd-sys` precedent (ADR-0003): vendored + static, licenses all already on the allow-list (no exception needed), off the default graph. **`ring` stays banned** and is verified unreachable in the all-features graph (an unbuilt optional of `rustls-webpki`).
- **CI** — the `test` matrix runs the full `--all-features` set (incl. tls) on the **Linux** broker platform (ubuntu ships cmake for aws-lc-sys's vendored C) and the **all-but-tls** set on **Windows** (a client/tooling platform; the aws-lc-sys C build is validated on Linux, avoiding cross-platform NASM/MSVC risk for no coverage gain). MSRV is safe: every TLS crate is `rust-version` **1.71** (≤ the 1.78 gate).

## Verification (in a Linux aarch64 container with cmake)

Because `aws-lc-sys` needs cmake (absent on the dev Mac), the whole increment was built and tested in a colima Linux container — I do not merge security-critical crypto on CI-green alone:

- `cargo test -p ironbus-server --features tls` → **5/5 pass** (handshake negotiates TLS 1.3, untrusted server refused, garbage rejected, key-perms enforced).
- default `ironbus-cli` build → **green and TLS-free** (`cargo tree` shows no rustls/aws-lc-sys/ring in the default graph).
- `cffi-ban.sh` → **clean** (71 shipped crates, none denylisted).
- `clippy --features tls -D warnings` → **clean**; `rustfmt --check` → **clean**.
- `cargo-deny 0.19.8 check bans licenses` → **`bans ok, licenses ok`**.

## Not in this PR (tracked on #766)

Server-side TLS termination (the accept-loop stream rewire + stop refusing `--tls-*`), mTLS identity activation, and client TLS (#957).

🤖 Generated with [Claude Code](https://claude.com/claude-code)