### PR TITLE
chore(deps): bump crossbeam-epoch 0.9.18 → 0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,9 +446,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## What

A newly-published advisory — **RUSTSEC-2026-0204** (an invalid pointer dereference in the `fmt::Pointer` impl for crossbeam-epoch's `Atomic`/`Shared` when the underlying pointer is invalid) — fails `cargo deny check advisories` on **every branch, including `main`**. The RUSTSEC DB is fetched live, so it turned CI red across the whole repo with no dependency change on our side (it surfaced while landing an unrelated TLS PR).

## Impact + fix

- **crossbeam-epoch is dev-only** here: `crossbeam-deque → rayon → criterion`, a `[dev-dependencies]` benchmark harness. It is **not** in the shipped `ironbus-cli` normal+build graph (verified), so the vulnerable code never ships in the broker binary.
- The fix is still the correct one — **bump to the patched 0.9.20** rather than ignore the advisory. **Lockfile-only** change (crossbeam-epoch is transitive, not a direct dep); no `Cargo.toml` touched.

## Verification

`cargo-deny 0.19.8 check` → **`advisories ok, bans ok, licenses ok, sources ok`** (was `advisories FAILED` before the bump).

Unblocks cargo-deny on `main` and every open PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)