### PR TITLE
feat(tls): client-side TLS 1.3 for the sync client (ADR-0004 / #957, increment 4a)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,6 +978,8 @@ dependencies = [
  "ironbus-proto",
  "ironbus-server",
  "ironbus-storage",
+ "rustls",
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/crates/ironbus-client/Cargo.toml
+++ b/crates/ironbus-client/Cargo.toml
@@ -8,11 +8,29 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 
+[features]
+# TLS 1.3 client transport (ADR-0004 / #766, client-side #957). The NON-DEFAULT feature that pulls the
+# rustls stack with the aws-lc-rs provider, so the client can VERIFY a broker's certificate and connect
+# INSIDE a TLS session (presenting the bearer credential encrypted), and optionally present a client
+# certificate for mTLS. Off by default: the default client links ZERO TLS code and stays byte-for-byte
+# plain-TCP, pure-Rust. Mirrors the server's `tls` feature (deny.toml carries the feature-scoped
+# aws-lc-sys allowance already). No X.509 SAN parsing is needed client-side, so this pulls no x509 crate.
+# `ironbus-server/tls` is forwarded ONLY to give the crate's own integration tests a real
+# TLS-terminating broker to connect to (ironbus-server is a dev-dependency); it is a no-op for the
+# shipped `cargo build` of this library (dev-deps are absent there), so a downstream `--features tls`
+# client still links only rustls + rustls-pki-types, never aws-lc-sys.
+tls = ["dep:rustls", "dep:rustls-pki-types", "ironbus-server/tls"]
+
 [dependencies]
 # The IO-free core: the client's transparent deliver-path decompression (#430) uses the codec
 # runtime (`compress`) and the record-flag bits (`types`). Pure Rust on the default build.
 ironbus-core = { path = "../ironbus-core", version = "0.0.0" }
 ironbus-proto = { path = "../ironbus-proto", version = "0.0.0" }
+# TLS 1.3 client stack (the `tls` feature only; the default build links none of this). `default-features
+# = false` drops rustls's ring-backed webpki path and its tls12 code — the client is TLS 1.3-only with
+# the aws-lc-rs provider, never ring. `rustls-pki-types` decodes the PEM trust anchors / client cert+key.
+rustls = { version = "0.23", optional = true, default-features = false, features = ["aws_lc_rs", "std"] }
+rustls-pki-types = { version = "1", optional = true, features = ["std"] }
 
 [dev-dependencies]
 ironbus-server = { path = "../ironbus-server", version = "0.0.0" }

--- a/crates/ironbus-client/src/lib.rs
+++ b/crates/ironbus-client/src/lib.rs
@@ -90,6 +90,13 @@ pub mod proto {
     pub use ironbus_proto::message::{AckLevel, ConsumeTier, PubBody, PubDedup};
 }
 
+// Client-side TLS 1.3 (ADR-0004 / #766, client side #957) — compiled only under `--features tls`. The
+// default client links no TLS code and stays byte-for-byte plain-TCP.
+#[cfg(feature = "tls")]
+pub mod tls;
+#[cfg(feature = "tls")]
+pub use tls::{TlsClientConfig, TlsClientError};
+
 use std::io::{self, Read, Write};
 use std::net::{TcpStream, ToSocketAddrs};
 use std::time::Duration;
@@ -144,6 +151,11 @@ pub enum ClientError {
     LocalTransaction(String),
     /// The connection closed before a complete response arrived.
     Closed,
+    /// A client-side TLS configuration or handshake failure (#957, `--features tls`): a bad trust
+    /// anchor / client certificate, an invalid server name, or the broker's certificate failing
+    /// verification. (A verification failure at the handshake itself surfaces as [`ClientError::Io`].)
+    #[cfg(feature = "tls")]
+    Tls(String),
     /// The server REDIRECTED a produce: the node this client is connected to holds a clustered replica
     /// role for the target partition but is NOT its current leader (#735), so the produce was NOT
     /// appended/acked here — it must go to the leader. `leader_hint` is the current leader's CLIENT
@@ -208,6 +220,8 @@ impl core::fmt::Display for ClientError {
                 )
             }
             ClientError::Closed => write!(f, "connection closed mid-response"),
+            #[cfg(feature = "tls")]
+            ClientError::Tls(why) => write!(f, "client TLS error: {why}"),
             ClientError::Decompress { source, offset, .. } => {
                 write!(
                     f,
@@ -436,6 +450,15 @@ pub struct ClientConfig {
     /// still plain TCP, so a bearer/password credential is safe to use over loopback or an already-
     /// secured transport, and a TLS-wrapped stream (and the `Mtls` mechanism) is deferred.
     pub credential: Option<AuthCredential>,
+
+    /// The client TLS configuration (ADR-0004 / #957), or `None` for a plaintext connection. When
+    /// `Some`, [`Client::connect_with`] VERIFIES the broker's certificate and connects INSIDE a TLS 1.3
+    /// session, so the `credential` above travels ENCRYPTED (and a configured client certificate
+    /// authenticates the connection as mTLS). Mandatory server verification — a broker whose
+    /// certificate does not verify fails the connect, never a silent fallback to plaintext. Present
+    /// only behind `--features tls`; the default (plain-TCP) build has no TLS and this field is absent.
+    #[cfg(feature = "tls")]
+    pub tls: Option<TlsClientConfig>,
 }
 
 impl Default for ClientConfig {
@@ -478,6 +501,10 @@ impl Default for ClientConfig {
             // unauthenticated connect to a no-auth broker is unchanged (#884). A caller opts into auth
             // by setting this to the credential the broker verifies.
             credential: None,
+            // None by default: an unconfigured client is plain TCP (byte-for-byte the pre-#957 path). A
+            // caller opts into TLS by setting this to a `TlsClientConfig` (#957, `--features tls`).
+            #[cfg(feature = "tls")]
+            tls: None,
         }
     }
 }
@@ -705,7 +732,7 @@ struct StreamFlow {
 /// (notifying `room` as slots free) until the terminal `Pong` or a fatal error. Runs on the
 /// scoped reader thread over the cloned read half.
 fn drain_stream_replies(
-    stream: &mut TcpStream,
+    stream: &mut impl Read,
     buf: &mut Vec<u8>,
     flow: &std::sync::Mutex<StreamFlow>,
     room: &std::sync::Condvar,
@@ -938,7 +965,7 @@ fn classify_pub_reply(ty: FrameType, body: &[u8]) -> Result<PubReply, ClientErro
 /// form of [`Client::read_frame`] so [`Client::produce_stream`]'s reader thread can drain a
 /// cloned read half with its own buffer (#458).
 fn read_frame_from(
-    stream: &mut TcpStream,
+    stream: &mut impl Read,
     buf: &mut Vec<u8>,
 ) -> Result<(FrameType, Vec<u8>), ClientError> {
     // Reused scratch for each socket read. `buf` is mutated ONLY by `extend_from_slice` AFTER a read
@@ -1055,10 +1082,123 @@ impl TxnDecision {
 // Each bool records a DISTINCT server-CONFIRMED wire capability for this connection (gap-marker /
 // streaming / deliver-batch / streams), each set from its `Info` echo bit — protocol negotiation
 // state, not internal flags a bitfield could replace.
+/// The client's per-connection byte stream: plaintext TCP, or — behind `--features tls` (#957) — a
+/// rustls-terminated TCP carrying a completed TLS 1.3 session. `Read`/`Write` flow through the
+/// (possibly TLS) layer; the lifecycle shims (`try_clone`, `shutdown`) reach the underlying socket.
+enum Wire {
+    Plain(TcpStream),
+    #[cfg(feature = "tls")]
+    Tls(Box<rustls::StreamOwned<rustls::ClientConnection, TcpStream>>),
+}
+
+impl std::fmt::Debug for Wire {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Wire::Plain(_) => f.write_str("Wire::Plain"),
+            #[cfg(feature = "tls")]
+            Wire::Tls(_) => f.write_str("Wire::Tls"),
+        }
+    }
+}
+
+impl Wire {
+    /// The underlying accepted TCP socket, for the socket-level lifecycle operations.
+    fn socket(&self) -> &TcpStream {
+        match self {
+            Wire::Plain(s) => s,
+            #[cfg(feature = "tls")]
+            Wire::Tls(s) => s.get_ref(),
+        }
+    }
+
+    /// Clone the stream so a reader thread can drain replies while the main thread writes (the
+    /// pipelined `produce_stream`/`produce_window` fan-out). A plaintext socket clones fine; a TLS
+    /// session is single-owner and CANNOT be split across threads, so this returns `Unsupported` for a
+    /// TLS wire — pipelined produce over TLS is a documented follow-up (use `produce()` over TLS, or a
+    /// plaintext connection for pipelined produce).
+    fn try_clone(&self) -> io::Result<Wire> {
+        match self {
+            Wire::Plain(s) => Ok(Wire::Plain(s.try_clone()?)),
+            #[cfg(feature = "tls")]
+            Wire::Tls(_) => Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "pipelined produce (produce_stream / produce_window) is not supported over TLS: a TLS \
+                 session cannot be split across threads. Use produce() over TLS, or a plaintext \
+                 connection for pipelined produce.",
+            )),
+        }
+    }
+
+    /// Shut down the connection in `how` direction(s) on the underlying socket.
+    fn shutdown(&self, how: std::net::Shutdown) -> io::Result<()> {
+        self.socket().shutdown(how)
+    }
+
+    /// The local socket address (a stable per-connection seed for transaction ids).
+    fn local_addr(&self) -> io::Result<std::net::SocketAddr> {
+        self.socket().local_addr()
+    }
+
+    /// Read back the `TCP_NODELAY` state of the underlying socket (used by a test).
+    #[cfg(test)]
+    fn nodelay(&self) -> io::Result<bool> {
+        self.socket().nodelay()
+    }
+
+    /// Establish a TLS 1.3 client session over an already-connected socket (#957): VERIFY the broker's
+    /// certificate against the configured trust anchor (mandatory — a verification failure returns an
+    /// error, never a silent fallback to plaintext), complete the handshake, and wrap.
+    #[cfg(feature = "tls")]
+    fn connect_tls(mut socket: TcpStream, config: &TlsClientConfig) -> Result<Wire, ClientError> {
+        let client_config = config
+            .build()
+            .map_err(|e| ClientError::Tls(e.to_string()))?;
+        let server_name = rustls::pki_types::ServerName::try_from(config.server_name().to_string())
+            .map_err(|_| {
+                ClientError::Tls(format!("invalid server name `{}`", config.server_name()))
+            })?;
+        let mut conn =
+            rustls::ClientConnection::new(std::sync::Arc::new(client_config), server_name)
+                .map_err(|e| ClientError::Tls(e.to_string()))?;
+        // Drive the TLS 1.3 handshake to completion (blocking). A certificate that does not verify, or a
+        // server name mismatch, fails HERE and returns the error — before any Connect frame is sent.
+        conn.complete_io(&mut socket).map_err(ClientError::Io)?;
+        Ok(Wire::Tls(Box::new(rustls::StreamOwned::new(conn, socket))))
+    }
+}
+
+impl Read for Wire {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match self {
+            Wire::Plain(s) => s.read(buf),
+            #[cfg(feature = "tls")]
+            Wire::Tls(s) => s.read(buf),
+        }
+    }
+}
+
+impl Write for Wire {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        match self {
+            Wire::Plain(s) => s.write(buf),
+            #[cfg(feature = "tls")]
+            Wire::Tls(s) => s.write(buf),
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        match self {
+            Wire::Plain(s) => s.flush(),
+            #[cfg(feature = "tls")]
+            Wire::Tls(s) => s.flush(),
+        }
+    }
+}
+
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug)]
 pub struct Client {
-    stream: TcpStream,
+    stream: Wire,
     buf: Vec<u8>,
     /// The per-consumer MESSAGE credit NEGOTIATED for this connection (#292), learned from the
     /// server's `Info` body at handshake: the server has already clamped this client's `Connect`
@@ -1132,8 +1272,20 @@ impl Client {
         config: &ClientConfig,
     ) -> Result<Client, ClientError> {
         let stream = Client::dial(addr, config.connect_timeout)?;
+        // Set the slowloris timeouts on the RAW socket before wrapping — they persist on the same fd
+        // inside the `Wire` (the handshake below also runs under the read timeout).
         stream.set_read_timeout(config.read_timeout)?;
         stream.set_write_timeout(config.write_timeout)?;
+        // Wrap the socket: TLS 1.3 when `config.tls` is set (verify the broker + complete the handshake
+        // HERE, so a bad certificate fails the connect, never a silent plaintext fallback), else a
+        // zero-cost plaintext `Wire`. On a non-tls build every connection is plaintext.
+        #[cfg(feature = "tls")]
+        let stream = match &config.tls {
+            Some(tls_config) => Wire::connect_tls(stream, tls_config)?,
+            None => Wire::Plain(stream),
+        };
+        #[cfg(not(feature = "tls"))]
+        let stream = Wire::Plain(stream);
         let mut client = Client {
             stream,
             buf: Vec::new(),
@@ -1185,6 +1337,23 @@ impl Client {
         // unauthenticated connect is unchanged. An oversized credential fails closed here (a typed
         // `ClientError::Body`) rather than sending a truncated auth section.
         if let Some(cred) = &config.credential {
+            // The `Mtls` mechanism authenticates on the client CERTIFICATE presented at the TLS
+            // handshake — its `Connect` body carries no credential bytes (#957). Guard it client-side:
+            // sending `Mtls` without a configured client certificate would be rejected by the server as
+            // an authorization violation, so fail fast here with an actionable error instead.
+            #[cfg(feature = "tls")]
+            if matches!(cred.mechanism, AuthMechanism::Mtls)
+                && !config
+                    .tls
+                    .as_ref()
+                    .is_some_and(TlsClientConfig::has_client_cert)
+            {
+                return Err(ClientError::Tls(
+                    "the Mtls credential authenticates on a client certificate, but none is \
+                     configured: set ClientConfig.tls to a TlsClientConfig::with_client_cert(...)"
+                        .to_string(),
+                ));
+            }
             append_connect_auth(&mut connect_body, cred).map_err(ClientError::Body)?;
         }
         client.send(FrameType::Connect, &connect_body)?;
@@ -4169,6 +4338,188 @@ mod tests {
             }
         });
         (addr, shutdown, handle)
+    }
+
+    /// Opens an in-memory test engine with the shared default config, extracted so the client-TLS
+    /// integration test can reuse it.
+    #[cfg(feature = "tls")]
+    fn open_test_engine(
+        consumer_credit: u32,
+        consumer_credit_bytes: u64,
+        compression: ironbus_core::compress::Codec,
+    ) -> Engine<InMemoryFs, SystemClock> {
+        Engine::open(
+            InMemoryFs::new(),
+            SystemClock::new(),
+            EngineConfig {
+                log: LogConfig::default(),
+                lease: LeaseConfig::default(),
+                delivery: DeliveryConfig::new(5, false, vec![]).unwrap(),
+                max_in_flight: 16,
+                consumer_credit,
+                consumer_credit_bytes,
+                checkpoint_interval: 1024,
+                max_retained_bytes: 0,
+                max_age_ms: 0,
+                max_messages: 0,
+                max_groups: DEFAULT_MAX_GROUPS,
+                max_streams: 0,
+                group_idle_evict_ms: DEFAULT_GROUP_IDLE_EVICT_MS,
+                ram_ceiling_bytes: 0,
+                disk_full_policy: DiskFullPolicy::DropNew,
+                dedup: ironbus_core::dedup::DedupConfig::default(),
+                durability_level: ironbus_server::engine::DurabilityLevel::Sync,
+                flush_interval_ms: 0,
+                flush_max_bytes: 0,
+                codel_target_ms: 0,
+                codel_interval_ms: 0,
+                retry_budget_ratio_per_million: 0,
+                retry_budget_window_ms: 0,
+                fire_and_forget_msg_rate: 0,
+                fire_and_forget_byte_rate: 0,
+                fire_and_forget_refill_ms: 0,
+                egress_limit: 0,
+                wal_fsync_headroom_bytes: 0,
+                sync_max_dirty_bytes: 0,
+                compression,
+                default_message_ttl_ms: 0,
+                dead_letter_exchange: None,
+                dead_letter_expired: false,
+            },
+        )
+        .unwrap()
+    }
+
+    // A long-lived self-signed server cert + key for "localhost", and a DIFFERENT (wrong) trust
+    // anchor, for the client-TLS integration test. Embedded (rcgen pulls banned ring).
+    #[cfg(feature = "tls")]
+    const TLS_SERVER_CERT: &[u8] = b"\
+-----BEGIN CERTIFICATE-----
+MIIBVzCB/aADAgECAhMjGIxpQAwb+081fMl2nX2WEMQ8MAoGCCqGSM49BAMCMB4x
+HDAaBgNVBAMME2lyb25idXMtdGVzdC1zZXJ2ZXIwIBcNMjAwMTAxMDAwMDAwWhgP
+MjEwMDAxMDEwMDAwMDBaMB4xHDAaBgNVBAMME2lyb25idXMtdGVzdC1zZXJ2ZXIw
+WTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAS4ZuCioex4thlFvAdYg6ER4GlPiFK/
+yqG6VNwt0cp7LoCwHmOkcr6JLYLNSa2mar9F2nTFk2cSj49+OzMYbF+AoxgwFjAU
+BgNVHREEDTALgglsb2NhbGhvc3QwCgYIKoZIzj0EAwIDSQAwRgIhAJ+smDY9Jybx
+FoJDOjOor9Cb56IyQQ64ts0roLO5NVx9AiEAnB1pAliacK3UDfG6xKEig12h4tzf
+UrjVOalNQ4uwFJg=
+-----END CERTIFICATE-----
+";
+    #[cfg(feature = "tls")]
+    const TLS_SERVER_KEY: &[u8] = b"\
+-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgWd4kisc5NnK6Nv0I
+RL0rrbnn9ozoIOti7I4eisF3CHWhRANCAAS4ZuCioex4thlFvAdYg6ER4GlPiFK/
+yqG6VNwt0cp7LoCwHmOkcr6JLYLNSa2mar9F2nTFk2cSj49+OzMYbF+A
+-----END PRIVATE KEY-----
+";
+    #[cfg(feature = "tls")]
+    const TLS_OTHER_CERT: &[u8] = b"\
+-----BEGIN CERTIFICATE-----
+MIIBWjCCAQCgAwIBAgIUfIjY91xg+z0LSwh5bngCs73UQLswCgYIKoZIzj0EAwIw
+HTEbMBkGA1UEAwwSaXJvbmJ1cy10ZXN0LW90aGVyMCAXDTIwMDEwMTAwMDAwMFoY
+DzIxMDAwMTAxMDAwMDAwWjAdMRswGQYDVQQDDBJpcm9uYnVzLXRlc3Qtb3RoZXIw
+WTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAS/sQWpzoGIBq0tyDdZLN7918LWW/j0
++CsRiYQa+vfAdERrw1POkGOIed4wUocAT9+tMkOY/VB/OSbHJxeZwPSBoxwwGjAY
+BgNVHREEETAPgg1vdGhlci5pbnZhbGlkMAoGCCqGSM49BAMCA0gAMEUCIC4trwko
+Aq57VS5iw0sm+NFBdTHX5XSCUQvACWp0elXzAiEArjyI3F1SeVHMY/DKGtuy7J/3
+toYtkjmdU2eQ2pK/3gM=
+-----END CERTIFICATE-----
+";
+
+    /// Spins a TLS-terminating in-memory broker (ADR-0004 / #957): the same engine + serve loop as
+    /// [`spawn_serving`], but every accepted connection completes a TLS 1.3 handshake first.
+    #[cfg(feature = "tls")]
+    fn spawn_serving_tls(
+        engine: Engine<InMemoryFs, SystemClock>,
+    ) -> (
+        std::net::SocketAddr,
+        Arc<AtomicBool>,
+        std::thread::JoinHandle<()>,
+    ) {
+        let (handle_engine, _actor) = spawn_actor(engine, DEFAULT_CHANNEL_BOUND);
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let server_config =
+            ironbus_server::tls::server_config_from_pem(TLS_SERVER_CERT, TLS_SERVER_KEY).unwrap();
+        let tls =
+            ironbus_server::server::TlsTermination::with_config(std::sync::Arc::new(server_config));
+        let handle = std::thread::spawn({
+            let shutdown = Arc::clone(&shutdown);
+            move || {
+                let clock = SystemClock::new();
+                let beacon =
+                    ironbus_server::liveness::LivenessBeacon::new(clock.now_monotonic_nanos());
+                let connz = Arc::new(ironbus_server::connz::ConnectionMetrics::new());
+                ironbus_server::server::serve_with_auth_connz_preauth_audit(
+                    &listener,
+                    &handle_engine,
+                    &shutdown,
+                    16,
+                    &clock,
+                    &beacon,
+                    None,
+                    &connz,
+                    None,
+                    None,
+                    tls,
+                )
+                .unwrap();
+            }
+        });
+        (addr, shutdown, handle)
+    }
+
+    /// End-to-end client TLS (ADR-0004 / #957): a `Client` VERIFIES the broker and connects over a real
+    /// TLS 1.3 session (so its `Connect`/credential travels encrypted), then produces over it. A client
+    /// pointed at the WRONG trust anchor fails the handshake — mandatory verification, no plaintext
+    /// fallback.
+    #[cfg(feature = "tls")]
+    #[test]
+    fn a_client_produces_over_a_verified_tls_connection_and_a_wrong_anchor_is_rejected() {
+        let engine = open_test_engine(64, 0, ironbus_core::compress::Codec::None);
+        let (addr, shutdown, handle) = spawn_serving_tls(engine);
+
+        // Correct trust anchor: verify the broker, connect over TLS 1.3, and produce.
+        let config = ClientConfig {
+            tls: Some(crate::tls::TlsClientConfig::new(
+                TLS_SERVER_CERT.to_vec(),
+                "localhost",
+            )),
+            ..Default::default()
+        };
+        let mut client = Client::connect_with(addr, &config)
+            .expect("the client verifies the broker and connects");
+        let offset = client
+            .produce(&proto::PubBody {
+                flags: 0,
+                timestamp_ms: 0,
+                key: b"",
+                headers: b"",
+                dedup: None,
+                fire_and_forget: false,
+                payload: b"produced-over-client-tls",
+            })
+            .expect("a produce travels over the TLS connection");
+        assert_eq!(offset, 0, "the produce is durable at offset 0");
+
+        // Wrong trust anchor: the server certificate does not verify, so the handshake FAILS at connect.
+        let bad = ClientConfig {
+            tls: Some(crate::tls::TlsClientConfig::new(
+                TLS_OTHER_CERT.to_vec(),
+                "localhost",
+            )),
+            ..Default::default()
+        };
+        assert!(
+            Client::connect_with(addr, &bad).is_err(),
+            "a client with the wrong trust anchor must be rejected at the TLS handshake"
+        );
+
+        shutdown.store(true, Ordering::Release);
+        drop(client);
+        let _ = handle.join();
     }
 
     /// Encodes one framed reply (length prefix, type, body).

--- a/crates/ironbus-client/src/tls.rs
+++ b/crates/ironbus-client/src/tls.rs
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! Client-side TLS 1.3 configuration (ADR-0004 / #766, client side #957) — compiled only under
+//! `--features tls`.
+//!
+//! This builds the rustls `ClientConfig` the client uses to VERIFY a broker's certificate and connect
+//! inside a TLS 1.3 session (so a bearer/password credential travels encrypted), and optionally to
+//! present a client certificate for mTLS. It enforces the normative `docs/TRANSPORT.md` §1.4 client
+//! rules in one place:
+//!
+//!   * **TLS 1.3 only** — floor == ceiling == 1.3, aws-lc-rs provider (the same as the server).
+//!   * **Server-certificate verification is MANDATORY** — the chain is verified against the configured
+//!     trust anchor and the server name is checked. There is NO accept-any / insecure-skip-verify path;
+//!     an empty/invalid trust store is an error, not a silent skip.
+//!   * **mTLS is optional** — a configured client cert+key is presented at the handshake.
+
+use std::sync::Arc;
+
+use rustls::pki_types::pem::PemObject;
+use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use rustls::{ClientConfig, RootCertStore};
+
+/// TLS 1.3 and nothing older (docs/TRANSPORT.md §1.1).
+static TLS13_ONLY: &[&rustls::SupportedProtocolVersion] = &[&rustls::version::TLS13];
+
+/// A typed client-TLS configuration error.
+#[derive(Debug)]
+pub enum TlsClientError {
+    /// The trust-anchor (CA) PEM contained no usable certificate.
+    NoTrustAnchor,
+    /// The client-certificate PEM contained no certificate.
+    NoClientCert,
+    /// The client private-key PEM contained no key.
+    NoClientKey,
+    /// The configured server name is not a valid DNS name / IP for SNI + verification.
+    BadServerName,
+    /// rustls rejected the material (e.g. a client cert/key that do not match).
+    Rustls(rustls::Error),
+}
+
+impl std::fmt::Display for TlsClientError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoTrustAnchor => {
+                write!(f, "the TLS CA bundle contained no usable trust anchor")
+            }
+            Self::NoClientCert => write!(f, "the client-certificate PEM contained no certificate"),
+            Self::NoClientKey => write!(f, "the client-key PEM contained no private key"),
+            Self::BadServerName => write!(f, "the TLS server name is not a valid DNS name or IP"),
+            Self::Rustls(e) => write!(f, "rustls rejected the client TLS material: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for TlsClientError {}
+
+/// The client's TLS settings for a connection (ADR-0004, #957): the trust anchor to verify the broker
+/// against, the expected server name, and an OPTIONAL client certificate for mTLS. Cloneable so it can
+/// live on the shared [`ClientConfig`](crate::ClientConfig). Its `Debug` REDACTS the secret client key.
+#[derive(Clone)]
+pub struct TlsClientConfig {
+    /// The PEM trust-anchor bundle (one or more CA certs) the broker's chain must verify against.
+    ca_pem: Vec<u8>,
+    /// The expected server name (SNI + certificate name verification).
+    server_name: String,
+    /// An optional `(client_cert_pem, client_key_pem)` for mTLS — the cert the client presents.
+    client_auth: Option<(Vec<u8>, Vec<u8>)>,
+}
+
+impl std::fmt::Debug for TlsClientConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Never print the CA bytes or (especially) the client key. Shape only.
+        f.debug_struct("TlsClientConfig")
+            .field("server_name", &self.server_name)
+            .field("has_client_cert", &self.client_auth.is_some())
+            .finish_non_exhaustive()
+    }
+}
+
+impl TlsClientConfig {
+    /// Server-verification-only client TLS: verify the broker's chain against `ca_pem`, checking the
+    /// certificate against `server_name` (also used as SNI). No client certificate is presented.
+    #[must_use]
+    pub fn new(ca_pem: impl Into<Vec<u8>>, server_name: impl Into<String>) -> Self {
+        Self {
+            ca_pem: ca_pem.into(),
+            server_name: server_name.into(),
+            client_auth: None,
+        }
+    }
+
+    /// Add a client certificate for mTLS: the client presents `client_cert_pem` + `client_key_pem` at
+    /// the handshake, so a broker configured with `--tls-client-ca` can authenticate it by certificate.
+    #[must_use]
+    pub fn with_client_cert(
+        mut self,
+        client_cert_pem: impl Into<Vec<u8>>,
+        client_key_pem: impl Into<Vec<u8>>,
+    ) -> Self {
+        self.client_auth = Some((client_cert_pem.into(), client_key_pem.into()));
+        self
+    }
+
+    /// The configured server name (SNI + verification).
+    #[must_use]
+    pub fn server_name(&self) -> &str {
+        &self.server_name
+    }
+
+    /// Whether a client certificate is configured (mTLS).
+    #[must_use]
+    pub fn has_client_cert(&self) -> bool {
+        self.client_auth.is_some()
+    }
+
+    /// Build the rustls [`ClientConfig`]: TLS 1.3-only, aws-lc-rs, MANDATORY server verification against
+    /// the configured trust anchor, and — when a client cert is set — mTLS client authentication.
+    ///
+    /// # Errors
+    /// [`TlsClientError`] if the CA bundle has no usable anchor, the client cert/key is missing or
+    /// malformed, or rustls rejects the material.
+    ///
+    /// # Panics
+    /// Panics only if the aws-lc-rs provider cannot offer TLS 1.3 — impossible for this build, where the
+    /// provider always supports 1.3; the `expect` documents that invariant rather than propagating an
+    /// error that cannot occur.
+    pub fn build(&self) -> Result<ClientConfig, TlsClientError> {
+        let anchors = CertificateDer::pem_slice_iter(&self.ca_pem)
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|_| TlsClientError::NoTrustAnchor)?;
+        let mut roots = RootCertStore::empty();
+        let (added, _ignored) = roots.add_parsable_certificates(anchors);
+        if added == 0 {
+            return Err(TlsClientError::NoTrustAnchor);
+        }
+        let provider = Arc::new(rustls::crypto::aws_lc_rs::default_provider());
+        let builder = ClientConfig::builder_with_provider(provider)
+            .with_protocol_versions(TLS13_ONLY)
+            .expect("TLS 1.3 is supported by the aws-lc-rs provider")
+            .with_root_certificates(roots);
+        let config = match &self.client_auth {
+            Some((cert_pem, key_pem)) => {
+                let certs = CertificateDer::pem_slice_iter(cert_pem)
+                    .collect::<Result<Vec<_>, _>>()
+                    .map_err(|_| TlsClientError::NoClientCert)?;
+                if certs.is_empty() {
+                    return Err(TlsClientError::NoClientCert);
+                }
+                let key = PrivateKeyDer::from_pem_slice(key_pem)
+                    .map_err(|_| TlsClientError::NoClientKey)?;
+                builder
+                    .with_client_auth_cert(certs, key)
+                    .map_err(TlsClientError::Rustls)?
+            }
+            None => builder.with_no_client_auth(),
+        };
+        Ok(config)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A long-lived self-signed cert + key (the server test fixture) used here only as a trust anchor /
+    // client-cert pair to exercise the builder — the handshake itself is tested in the client crate's
+    // integration test against a real broker.
+    const CERT: &[u8] = b"\
+-----BEGIN CERTIFICATE-----
+MIIBVzCB/aADAgECAhMjGIxpQAwb+081fMl2nX2WEMQ8MAoGCCqGSM49BAMCMB4x
+HDAaBgNVBAMME2lyb25idXMtdGVzdC1zZXJ2ZXIwIBcNMjAwMTAxMDAwMDAwWhgP
+MjEwMDAxMDEwMDAwMDBaMB4xHDAaBgNVBAMME2lyb25idXMtdGVzdC1zZXJ2ZXIw
+WTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAS4ZuCioex4thlFvAdYg6ER4GlPiFK/
+yqG6VNwt0cp7LoCwHmOkcr6JLYLNSa2mar9F2nTFk2cSj49+OzMYbF+AoxgwFjAU
+BgNVHREEDTALgglsb2NhbGhvc3QwCgYIKoZIzj0EAwIDSQAwRgIhAJ+smDY9Jybx
+FoJDOjOor9Cb56IyQQ64ts0roLO5NVx9AiEAnB1pAliacK3UDfG6xKEig12h4tzf
+UrjVOalNQ4uwFJg=
+-----END CERTIFICATE-----
+";
+    const KEY: &[u8] = b"\
+-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgWd4kisc5NnK6Nv0I
+RL0rrbnn9ozoIOti7I4eisF3CHWhRANCAAS4ZuCioex4thlFvAdYg6ER4GlPiFK/
+yqG6VNwt0cp7LoCwHmOkcr6JLYLNSa2mar9F2nTFk2cSj49+OzMYbF+A
+-----END PRIVATE KEY-----
+";
+
+    #[test]
+    fn server_verify_only_config_builds() {
+        let cfg = TlsClientConfig::new(CERT.to_vec(), "localhost");
+        assert!(!cfg.has_client_cert());
+        cfg.build()
+            .expect("a valid trust anchor builds a client config");
+    }
+
+    #[test]
+    fn mtls_config_with_a_client_cert_builds() {
+        let cfg = TlsClientConfig::new(CERT.to_vec(), "localhost")
+            .with_client_cert(CERT.to_vec(), KEY.to_vec());
+        assert!(cfg.has_client_cert());
+        cfg.build()
+            .expect("a client cert+key builds an mTLS client config");
+    }
+
+    #[test]
+    fn an_empty_or_garbage_trust_anchor_is_rejected() {
+        assert!(matches!(
+            TlsClientConfig::new(b"not a pem".to_vec(), "localhost").build(),
+            Err(TlsClientError::NoTrustAnchor)
+        ));
+    }
+
+    #[test]
+    fn debug_redacts_the_secret_key() {
+        let cfg = TlsClientConfig::new(CERT.to_vec(), "localhost")
+            .with_client_cert(CERT.to_vec(), KEY.to_vec());
+        let s = format!("{cfg:?}");
+        assert!(s.contains("localhost") && s.contains("has_client_cert"));
+        // The key/cert bytes never appear.
+        assert!(!s.contains("MIGHAgEA") && !s.contains("BEGIN"));
+    }
+}


### PR DESCRIPTION
## What

The official clients were plain TCP: a bearer/password credential travelled in **cleartext** over an untrusted network (#957). This adds client-side TLS to the **sync** client so the credential travels **inside a verified TLS 1.3 session** (and a client cert authenticates mTLS). Behind a **non-default `tls` feature**; the default client is byte-for-byte plain-TCP, pure-Rust (verified: no rustls/aws-lc in the default graph).

This is **increment 4a**; the async client (4b, tokio-rustls) and CLI flags (4c) follow.

## What lands

- **`tls` feature** pulling rustls (aws-lc-rs, TLS 1.3-only) + rustls-pki-types. No X.509 SAN parsing is needed client-side, so **no x509/time/der MSRV trap** — just the server's already-vetted rustls stack.
- **`TlsClientConfig`** (trust anchor + server name + optional client cert) → a rustls `ClientConfig` with **mandatory server verification** (no accept-any / insecure-skip-verify) and `with_client_auth_cert` for mTLS. Its `Debug` **redacts the secret client key**.
- **`ClientConfig.tls: Option<TlsClientConfig>`** (Default `None` — plaintext).
- A client-side **`Wire` enum** (`Plain` / `Tls`); `Client.stream` is now `Wire`. The plaintext path is byte-for-byte delegation (92 existing tests pass unchanged). **`connect_with` verifies the broker + completes the handshake before any `Connect` frame** — a bad certificate fails the connect, **never a plaintext fallback**.
- **`try_clone` returns `Unsupported` for a TLS wire**: pipelined produce (`produce_stream`/`produce_window`) splits the socket across threads, which a TLS session cannot do, so it errors clearly over TLS (a documented follow-up); single `produce()`/`consume()` work over TLS.
- **`Mtls` credential guard** (#957): sending `Mtls` without a configured client cert fails fast client-side.

## Verification (Linux container, aarch64, cmake)

- **An e2e test**: a `Client` **verifies the broker, connects over TLS 1.3, and produces** over it; a client with the **wrong trust anchor is rejected** at the handshake.
- tls unit tests (config builds, `Debug` redacts the key, garbage anchor rejected).
- **92 existing client tests pass** (the `Wire` refactor is behavior-preserving).
- default client graph **TLS-free**, `clippy --all-features -D warnings` clean, `rustfmt` clean, cffi-ban clean, **cargo-deny** advisories/bans/licenses/sources ok, and the **msrv (1.78) `--all-features --locked`** build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)