### PR TITLE
feat(tls): async client TLS 1.3 (ADR-0004 / #957, increment 4b)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,6 +992,7 @@ dependencies = [
  "ironbus-server",
  "ironbus-storage",
  "tokio",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -2010,6 +2011,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/ironbus-client-async/Cargo.toml
+++ b/crates/ironbus-client-async/Cargo.toml
@@ -8,6 +8,18 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 
+[features]
+# TLS 1.3 async client transport (ADR-0004 / #766, client-side #957). The NON-DEFAULT feature that adds
+# `tokio-rustls` — the async adapter over the SAME rustls 0.23 + aws-lc-rs stack the sync client uses — so
+# the async client can VERIFY a broker's certificate and drive the TLS 1.3 handshake on the tokio runtime.
+# Off by default: the default async client links ZERO TLS code and stays byte-for-byte plain-TCP, pure-Rust.
+# `ironbus-client/tls` is forwarded so the SHARED `ClientConfig::tls` field and `TlsClientConfig` (the SAME
+# config type the sync client uses — there is no async-specific TLS config) are in scope here. As with the
+# sync client, `ironbus-server/tls` is forwarded ONLY to give this crate's own integration test a real
+# TLS-terminating broker to connect to (ironbus-server is a dev-dependency); it is a no-op for the shipped
+# `cargo build` of this library, so a downstream `--features tls` async client links only tokio-rustls.
+tls = ["dep:tokio-rustls", "ironbus-client/tls", "ironbus-server/tls"]
+
 [dependencies]
 # REUSE the sync client's public data types (ClientError, ClientConfig, Message, Fetch,
 # ProduceAck, DeadLetter, Truncation, Gap, TxnId, ...) verbatim — this crate is the async
@@ -29,6 +41,13 @@ tokio = { version = "1", default-features = false, features = [
     "sync",
     "time",
 ] }
+# TLS 1.3 async adapter (the `tls` feature only; the default build links none of this). `default-features
+# = false` drops tokio-rustls's ring-backed default provider, and `aws-lc-rs` selects the same provider as
+# the sync client — the async client is TLS 1.3-only with aws-lc-rs, never ring (ring is pulled into the
+# lock as an unbuilt optional only, verified unreachable via `cargo tree -i ring`, so the deny.toml ring
+# ban stays intact). tokio-rustls re-exports rustls 0.23, unified with the sync client's copy, so the
+# shared `TlsClientConfig::build()` `ClientConfig` plugs straight into `tokio_rustls::TlsConnector`.
+tokio-rustls = { version = "0.26", optional = true, default-features = false, features = ["aws-lc-rs"] }
 
 [dev-dependencies]
 # The real broker, spawned in-process for the wire-compatibility round-trip test.

--- a/crates/ironbus-client-async/src/lib.rs
+++ b/crates/ironbus-client-async/src/lib.rs
@@ -75,8 +75,11 @@ use ironbus_proto::message::{
 // an already-encoded `Connect` body. A verbatim port of the sync client's `connect_with` auth wiring;
 // the credential itself lives on the re-exported `ClientConfig::credential`.
 use ironbus_proto::message::append_connect_auth;
+use std::io;
 use std::net::SocketAddr;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, ReadBuf};
 use tokio::net::{TcpStream, ToSocketAddrs};
 
 /// The smallest per-read scratch size. Reading at least this many bytes even when the decoder asks
@@ -110,6 +113,14 @@ pub use ironbus_client::{
     StreamConsumerConfig, Truncation, TxnId, DEFAULT_STREAM_COMMIT_EVERY_BATCHES,
     DEFAULT_STREAM_FETCH_RECORDS,
 };
+
+// Re-export the SHARED client TLS config (ADR-0004 / #957) under the `tls` feature, so an async caller
+// can build [`ClientConfig::tls`] without depending on `ironbus-client` directly. This is the SAME type
+// the sync client uses — there is no async-specific TLS config; the async client just drives its handshake
+// on the tokio runtime. Brings `TlsClientConfig` into module scope for the async `Wire::connect_tls`.
+#[cfg(feature = "tls")]
+#[doc(no_inline)]
+pub use ironbus_client::{TlsClientConfig, TlsClientError};
 
 /// The proto body/codec types a caller constructs to drive [`AsyncClient`] (e.g. [`PubBody`]),
 /// re-exported so a caller can build requests without depending on `ironbus-proto` directly.
@@ -262,7 +273,7 @@ fn ingest_delivery(
 /// `Incomplete` read more bytes from the socket and append. The ONLY change is the read: tokio's
 /// `AsyncReadExt::read(...).await` in place of the blocking `std::io::Read::read`.
 async fn read_frame_from(
-    stream: &mut TcpStream,
+    stream: &mut (impl AsyncRead + Unpin),
     buf: &mut Vec<u8>,
 ) -> Result<(FrameType, Vec<u8>), ClientError> {
     // Reused scratch for each socket read. `buf` grows ONLY via `extend_from_slice`, run
@@ -299,6 +310,131 @@ async fn read_frame_from(
     }
 }
 
+/// The transport under an [`AsyncClient`]: a plain tokio TCP stream, or — behind the `tls` feature and
+/// when [`ClientConfig::tls`] is set — a TLS 1.3 session over that stream. `AsyncClient` performs ALL of
+/// its IO through this enum, so the produce/consume/handshake paths are transport-agnostic. The async twin
+/// of the sync client's `Wire` (same Plain/Tls shape); it implements tokio's [`AsyncRead`]/[`AsyncWrite`]
+/// so the existing `read_frame_from` / `write_all` sites work UNCHANGED over either transport. There is no
+/// `try_clone` analog: the async client never splits its stream (its pipelined `produce_window` writes the
+/// whole window on the one owned stream), so a TLS session is never asked to span two owners.
+enum Wire {
+    /// A plaintext TCP connection (the default; the only variant on a non-`tls` build).
+    Plain(TcpStream),
+    /// A TLS 1.3 session over the TCP connection (broker verified; optional mTLS client cert). Boxed so
+    /// the large rustls connection state does not bloat the `Plain` variant.
+    #[cfg(feature = "tls")]
+    Tls(Box<tokio_rustls::client::TlsStream<TcpStream>>),
+}
+
+impl std::fmt::Debug for Wire {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Wire::Plain(_) => f.write_str("Wire::Plain"),
+            #[cfg(feature = "tls")]
+            Wire::Tls(_) => f.write_str("Wire::Tls"),
+        }
+    }
+}
+
+impl Wire {
+    /// The local socket address of the underlying TCP connection (a stable per-connection seed for
+    /// transaction ids), whether plaintext or wrapped in TLS.
+    ///
+    /// # Errors
+    /// Returns the underlying [`std::io::Error`] when the OS cannot report the local address.
+    fn local_addr(&self) -> io::Result<SocketAddr> {
+        match self {
+            Wire::Plain(s) => s.local_addr(),
+            #[cfg(feature = "tls")]
+            Wire::Tls(s) => s.get_ref().0.local_addr(),
+        }
+    }
+
+    /// Read back the `TCP_NODELAY` state of the underlying socket (used by a test), whether plaintext or
+    /// wrapped in TLS.
+    #[cfg(test)]
+    fn nodelay(&self) -> io::Result<bool> {
+        match self {
+            Wire::Plain(s) => s.nodelay(),
+            #[cfg(feature = "tls")]
+            Wire::Tls(s) => s.get_ref().0.nodelay(),
+        }
+    }
+
+    /// Establish a TLS 1.3 client session over an already-connected socket (#957): VERIFY the broker's
+    /// certificate against the configured trust anchor (mandatory — a verification failure returns an
+    /// error, never a silent fallback to plaintext), drive the async handshake to completion, and wrap.
+    /// The async twin of the sync client's `Wire::connect_tls`, using `tokio_rustls::TlsConnector` in
+    /// place of the blocking `complete_io`. The shared [`TlsClientConfig::build`] yields the rustls
+    /// `ClientConfig`; both crates resolve the SAME rustls 0.23, so the config type unifies.
+    #[cfg(feature = "tls")]
+    async fn connect_tls(socket: TcpStream, config: &TlsClientConfig) -> Result<Wire, ClientError> {
+        let client_config = config
+            .build()
+            .map_err(|e| ClientError::Tls(e.to_string()))?;
+        let server_name =
+            tokio_rustls::rustls::pki_types::ServerName::try_from(config.server_name().to_string())
+                .map_err(|_| {
+                    ClientError::Tls(format!("invalid server name `{}`", config.server_name()))
+                })?;
+        let connector = tokio_rustls::TlsConnector::from(std::sync::Arc::new(client_config));
+        // Drive the TLS 1.3 handshake to completion. A certificate that does not verify, or a server
+        // name mismatch, fails HERE and returns the error — before any Connect frame is sent.
+        let tls = connector
+            .connect(server_name, socket)
+            .await
+            .map_err(ClientError::Io)?;
+        Ok(Wire::Tls(Box::new(tls)))
+    }
+}
+
+// `Wire` delegates every poll to the active variant. Both variants are `Unpin` (a tokio `TcpStream` is
+// `Unpin`, and a `Box<T>` is always `Unpin`), so `self.get_mut()` + `Pin::new(inner)` is sound without a
+// pin-projection crate.
+impl AsyncRead for Wire {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        match self.get_mut() {
+            Wire::Plain(s) => Pin::new(s).poll_read(cx, buf),
+            #[cfg(feature = "tls")]
+            Wire::Tls(s) => Pin::new(s.as_mut()).poll_read(cx, buf),
+        }
+    }
+}
+
+impl AsyncWrite for Wire {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        match self.get_mut() {
+            Wire::Plain(s) => Pin::new(s).poll_write(cx, buf),
+            #[cfg(feature = "tls")]
+            Wire::Tls(s) => Pin::new(s.as_mut()).poll_write(cx, buf),
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        match self.get_mut() {
+            Wire::Plain(s) => Pin::new(s).poll_flush(cx),
+            #[cfg(feature = "tls")]
+            Wire::Tls(s) => Pin::new(s.as_mut()).poll_flush(cx),
+        }
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        match self.get_mut() {
+            Wire::Plain(s) => Pin::new(s).poll_shutdown(cx),
+            #[cfg(feature = "tls")]
+            Wire::Tls(s) => Pin::new(s.as_mut()).poll_shutdown(cx),
+        }
+    }
+}
+
 /// A connected async IronBus client over one [`tokio::net::TcpStream`].
 ///
 /// The async twin of [`ironbus_client::Client`]: it carries the same negotiated-capability state and
@@ -310,7 +446,7 @@ async fn read_frame_from(
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug)]
 pub struct AsyncClient {
-    stream: TcpStream,
+    stream: Wire,
     buf: Vec<u8>,
     /// The per-consumer MESSAGE credit NEGOTIATED for this connection, learned from the server's
     /// `Info` at handshake. `None` if the server did not advertise (an old/empty `Info`).
@@ -371,6 +507,17 @@ impl AsyncClient {
         // a failed setsockopt degrades latency only, never correctness, so it must not fail an
         // otherwise-successful connect.
         let _ = stream.set_nodelay(true);
+        // Wrap the socket: TLS 1.3 when `config.tls` is set (verify the broker + drive the handshake
+        // HERE, so a bad certificate fails the connect, never a silent plaintext fallback), else a
+        // zero-cost plaintext `Wire`. On a non-tls build every connection is plaintext. A verbatim port
+        // of the sync client's `connect_with` wrap, swapping the blocking handshake for the async one.
+        #[cfg(feature = "tls")]
+        let stream = match &config.tls {
+            Some(tls_config) => Wire::connect_tls(stream, tls_config).await?,
+            None => Wire::Plain(stream),
+        };
+        #[cfg(not(feature = "tls"))]
+        let stream = Wire::Plain(stream);
         let mut client = AsyncClient {
             stream,
             buf: Vec::new(),
@@ -405,6 +552,24 @@ impl AsyncClient {
         // wire the server parses with `parse_connect_auth`. With no credential (the default) nothing is
         // appended and the body stays the pre-#631 `Connect`, so an unauthenticated connect is unchanged.
         if let Some(cred) = &config.credential {
+            // The `Mtls` mechanism authenticates on the client CERTIFICATE presented at the TLS handshake
+            // — its `Connect` body carries no credential bytes (#957). Guard it client-side: sending
+            // `Mtls` without a configured client certificate would be rejected by the server as an
+            // authorization violation, so fail fast here with an actionable error instead. A verbatim port
+            // of the sync client's guard.
+            #[cfg(feature = "tls")]
+            if matches!(cred.mechanism, AuthMechanism::Mtls)
+                && !config
+                    .tls
+                    .as_ref()
+                    .is_some_and(TlsClientConfig::has_client_cert)
+            {
+                return Err(ClientError::Tls(
+                    "the Mtls credential authenticates on a client certificate, but none is \
+                     configured: set ClientConfig.tls to a TlsClientConfig::with_client_cert(...)"
+                        .to_string(),
+                ));
+            }
             append_connect_auth(&mut connect_body, cred).map_err(ClientError::Body)?;
         }
         client.send(FrameType::Connect, &connect_body).await?;

--- a/crates/ironbus-client-async/tests/roundtrip.rs
+++ b/crates/ironbus-client-async/tests/roundtrip.rs
@@ -25,12 +25,10 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread::JoinHandle;
 
-/// Starts an in-process broker on a loopback port and returns its bound address, a shutdown flag, and
-/// the accept-loop thread handle. A faithful copy of the sync client's `start_server` /
-/// `start_server_with` / `spawn_serving` helpers: an in-memory engine driven by a `spawn_actor` append
-/// actor, served by the real `serve` accept loop on a blocking std thread.
-fn start_server() -> (SocketAddr, Arc<AtomicBool>, JoinHandle<()>) {
-    let engine = Engine::open(
+/// Opens the in-memory test engine shared by the plaintext and (feature-gated) TLS broker helpers: an
+/// `InMemoryFs` + `SystemClock` with the historical test `EngineConfig` (64 credit, no caps).
+fn open_engine() -> Engine<InMemoryFs, SystemClock> {
+    Engine::open(
         InMemoryFs::new(),
         SystemClock::new(),
         EngineConfig {
@@ -70,7 +68,15 @@ fn start_server() -> (SocketAddr, Arc<AtomicBool>, JoinHandle<()>) {
             dead_letter_expired: false,
         },
     )
-    .unwrap();
+    .unwrap()
+}
+
+/// Starts an in-process broker on a loopback port and returns its bound address, a shutdown flag, and
+/// the accept-loop thread handle. A faithful copy of the sync client's `start_server` /
+/// `start_server_with` / `spawn_serving` helpers: an in-memory engine driven by a `spawn_actor` append
+/// actor, served by the real `serve` accept loop on a blocking std thread.
+fn start_server() -> (SocketAddr, Arc<AtomicBool>, JoinHandle<()>) {
+    let engine = open_engine();
 
     // The engine is owned by the append actor; the wire server reaches it through the handle. The
     // actor join handle is detached: when the server thread stops, the actor's channel disconnects and
@@ -645,4 +651,128 @@ async fn async_streaming_consumer_durably_consumes_and_commits_against_a_real_se
     drop(c2);
     shutdown.store(true, Ordering::Release);
     handle.join().unwrap();
+}
+
+/// End-to-end async client TLS (ADR-0004 / #957), compiled only under `--features tls`. The async twin of
+/// the sync client's `a_client_produces_over_a_verified_tls_connection_and_a_wrong_anchor_is_rejected`:
+/// an `AsyncClient` VERIFIES a real TLS-terminating broker and produces over the encrypted session, while
+/// a client pointed at the WRONG trust anchor is rejected at the handshake (mandatory verification, no
+/// plaintext fallback).
+#[cfg(feature = "tls")]
+mod tls {
+    use super::*;
+    use ironbus_client_async::TlsClientConfig;
+
+    // A long-lived self-signed server cert + key for "localhost", and a DIFFERENT (wrong) trust anchor.
+    // The SAME embedded fixtures the sync client's TLS test uses (rcgen pulls banned ring, so no runtime
+    // cert generation).
+    const TLS_SERVER_CERT: &[u8] = b"\
+-----BEGIN CERTIFICATE-----
+MIIBVzCB/aADAgECAhMjGIxpQAwb+081fMl2nX2WEMQ8MAoGCCqGSM49BAMCMB4x
+HDAaBgNVBAMME2lyb25idXMtdGVzdC1zZXJ2ZXIwIBcNMjAwMTAxMDAwMDAwWhgP
+MjEwMDAxMDEwMDAwMDBaMB4xHDAaBgNVBAMME2lyb25idXMtdGVzdC1zZXJ2ZXIw
+WTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAS4ZuCioex4thlFvAdYg6ER4GlPiFK/
+yqG6VNwt0cp7LoCwHmOkcr6JLYLNSa2mar9F2nTFk2cSj49+OzMYbF+AoxgwFjAU
+BgNVHREEDTALgglsb2NhbGhvc3QwCgYIKoZIzj0EAwIDSQAwRgIhAJ+smDY9Jybx
+FoJDOjOor9Cb56IyQQ64ts0roLO5NVx9AiEAnB1pAliacK3UDfG6xKEig12h4tzf
+UrjVOalNQ4uwFJg=
+-----END CERTIFICATE-----
+";
+    const TLS_SERVER_KEY: &[u8] = b"\
+-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgWd4kisc5NnK6Nv0I
+RL0rrbnn9ozoIOti7I4eisF3CHWhRANCAAS4ZuCioex4thlFvAdYg6ER4GlPiFK/
+yqG6VNwt0cp7LoCwHmOkcr6JLYLNSa2mar9F2nTFk2cSj49+OzMYbF+A
+-----END PRIVATE KEY-----
+";
+    const TLS_OTHER_CERT: &[u8] = b"\
+-----BEGIN CERTIFICATE-----
+MIIBWjCCAQCgAwIBAgIUfIjY91xg+z0LSwh5bngCs73UQLswCgYIKoZIzj0EAwIw
+HTEbMBkGA1UEAwwSaXJvbmJ1cy10ZXN0LW90aGVyMCAXDTIwMDEwMTAwMDAwMFoY
+DzIxMDAwMTAxMDAwMDAwWjAdMRswGQYDVQQDDBJpcm9uYnVzLXRlc3Qtb3RoZXIw
+WTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAS/sQWpzoGIBq0tyDdZLN7918LWW/j0
++CsRiYQa+vfAdERrw1POkGOIed4wUocAT9+tMkOY/VB/OSbHJxeZwPSBoxwwGjAY
+BgNVHREEETAPgg1vdGhlci5pbnZhbGlkMAoGCCqGSM49BAMCA0gAMEUCIC4trwko
+Aq57VS5iw0sm+NFBdTHX5XSCUQvACWp0elXzAiEArjyI3F1SeVHMY/DKGtuy7J/3
+toYtkjmdU2eQ2pK/3gM=
+-----END CERTIFICATE-----
+";
+
+    /// Spins a TLS-terminating in-process broker: the same engine + append actor as [`start_server`], but
+    /// served by `serve_with_auth_connz_preauth_audit` with a `TlsTermination`, so every accepted
+    /// connection completes a TLS 1.3 handshake before the app-level `Connect`.
+    fn start_tls_server() -> (SocketAddr, Arc<AtomicBool>, JoinHandle<()>) {
+        let (handle_engine, _actor) = spawn_actor(open_engine(), DEFAULT_CHANNEL_BOUND);
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let server_config =
+            ironbus_server::tls::server_config_from_pem(TLS_SERVER_CERT, TLS_SERVER_KEY).unwrap();
+        let tls = ironbus_server::server::TlsTermination::with_config(Arc::new(server_config));
+        let handle = std::thread::spawn({
+            let shutdown = Arc::clone(&shutdown);
+            move || {
+                let clock = SystemClock::new();
+                let beacon =
+                    ironbus_server::liveness::LivenessBeacon::new(clock.now_monotonic_nanos());
+                let connz = Arc::new(ironbus_server::connz::ConnectionMetrics::new());
+                ironbus_server::server::serve_with_auth_connz_preauth_audit(
+                    &listener,
+                    &handle_engine,
+                    &shutdown,
+                    16,
+                    &clock,
+                    &beacon,
+                    None,
+                    &connz,
+                    None,
+                    None,
+                    tls,
+                )
+                .unwrap();
+            }
+        });
+        (addr, shutdown, handle)
+    }
+
+    #[tokio::test]
+    async fn async_client_produces_over_a_verified_tls_connection_and_a_wrong_anchor_is_rejected() {
+        let (addr, shutdown, handle) = start_tls_server();
+
+        // Correct trust anchor: verify the broker, connect over TLS 1.3, and produce.
+        let config = ClientConfig {
+            tls: Some(TlsClientConfig::new(TLS_SERVER_CERT.to_vec(), "localhost")),
+            ..Default::default()
+        };
+        let mut client = AsyncClient::connect_with(addr, &config)
+            .await
+            .expect("the async client verifies the broker and connects");
+        let offset = client
+            .produce(&PubBody {
+                flags: 0,
+                timestamp_ms: 0,
+                key: b"",
+                headers: b"",
+                dedup: None,
+                fire_and_forget: false,
+                payload: b"produced-over-async-client-tls",
+            })
+            .await
+            .expect("a produce travels over the TLS connection");
+        assert_eq!(offset, 0, "the produce is durable at offset 0");
+
+        // Wrong trust anchor: the server certificate does not verify, so the handshake FAILS at connect.
+        let bad = ClientConfig {
+            tls: Some(TlsClientConfig::new(TLS_OTHER_CERT.to_vec(), "localhost")),
+            ..Default::default()
+        };
+        assert!(
+            AsyncClient::connect_with(addr, &bad).await.is_err(),
+            "a client with the wrong trust anchor must be rejected at the TLS handshake"
+        );
+
+        shutdown.store(true, Ordering::Release);
+        drop(client);
+        let _ = handle.join();
+    }
 }


### PR DESCRIPTION
## Increment 4b — async client TLS 1.3 (ADR-0004 / #957)

The async (tokio) `AsyncClient` gains the same non-default `tls` feature the sync client shipped in **4a (#1091)**: it **verifies** a broker's certificate and drives the TLS 1.3 handshake on the tokio runtime, so an async producer/consumer's `Connect` + credential travel **encrypted**. **Off by default** — the shipped async client links zero TLS code and stays byte-for-byte plain-TCP, pure-Rust.

### What
- **`tls` feature** = `tokio-rustls` (`default-features = false`, `aws-lc-rs` — the *same* provider as the sync client; `ring` is only an unbuilt lock optional, verified unreachable via `cargo tree -i ring`) + forwards `ironbus-client/tls` so the **shared** `ClientConfig::tls` field and `TlsClientConfig` are in scope (there is no async-specific TLS config). Re-exports `TlsClientConfig`/`TlsClientError`. `ironbus-server/tls` is forwarded **only** to give the crate's own integration test a real TLS broker (dev-dep; no-op for the shipped lib build).
- **Async `Wire { Plain | Tls(Box<tokio_rustls::client::TlsStream>) }`** mirroring the sync client's, implementing tokio `AsyncRead`/`AsyncWrite` so every produce/consume/handshake site works **unchanged** over either transport; `read_frame_from` is generic over `AsyncRead`. `connect_with` verifies + handshakes via `TlsConnector` **before** the `Connect` frame (a bad certificate fails the connect — *no silent plaintext fallback*). The `Mtls` credential is guarded client-side exactly like the sync client. **No `try_clone` analog** — the async client never splits its stream.
- **e2e integration test** (feature-gated): an `AsyncClient` verifies a real TLS-terminating broker and produces over the encrypted session; a client with the **wrong trust anchor** is rejected at the handshake. `start_server`'s engine build is extracted to a shared `open_engine()` helper.

### Verification (in-container, `rust:1-bookworm` + cmake)
| Gate | Result |
|---|---|
| `cargo build --features tls` / default | ✅ both compile |
| tls tests (9 roundtrip incl. TLS e2e + 11 unit + doc) | ✅ |
| default tests (8 roundtrip + 11 unit + doc) | ✅ unchanged |
| clippy `--all-features` + default | ✅ |
| rustfmt | ✅ |
| C-FFI ban | ✅ default C-FFI-free; `ring` unreachable even with tls |
| cargo-deny (bans/advisories/licenses) | ✅ |
| `cargo +1.78 build --workspace --all-features --locked` (MSRV) | ✅ der/spki/zeroize_derive pins held |

**Lock delta is exactly `tokio-rustls 0.26.4`** — no other package moved; every #1089 MSRV pin is intact.

Increment **4c** (CLI client TLS flags) closes out the #957 client story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01McmNfYNWPmohVS8umY9Lkp
