### PR TITLE
chore(release): prepare v0.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,26 +122,29 @@ jobs:
       # regression needs a human --ratify to block. The gate's fire/no-op/advisory/ratify logic is
       # unit + binary tested (the lib `regression` tests and `tests/regression_gate_cli.rs`), run by
       # the workspace `test` job above; this job additionally EXECUTES the shipped gate binary against
-      # the checked-in history fixture to prove the END-TO-END wiring. IMPORTANT: there is NO released
-      # tag / baseline history yet (v0.1.0 is the maintainer's action), so with no `--baseline` the
-      # gate GRACEFULLY NO-OPS (exit 0, logged "no baseline history yet") rather than failing. Once a
-      # release archives a baseline JSON, pass it via `--baseline` and the gate begins enforcing. The
+      # the checked-in history fixture to prove the END-TO-END wiring. ARMED at v0.1.0 (#1068): the
+      # release archived a baseline JSON (docs/benchmarks/baselines/v0.1.0/perf-baseline.json), so the
+      # gate now runs its ENFORCING path (`--baseline`) instead of the pre-release no-baseline no-op —
+      # an un-ratified rolling-median regression exits non-zero and (via pipefail) FAILS this step. The
       # LIVE per-device numbers come from the #111 macro-bench run on the reference edge device, which
-      # is a documented device residual, not a CI run; this job validates the GATE, not the runs.
-      - name: run the regression gate against the checked-in history (no baseline yet => no-op)
+      # is a documented device residual, not a CI run; this job validates the GATE against the checked-in
+      # history + the archived baseline (see the baseline README for the re-anchor note), not live runs.
+      - name: run the regression gate against the checked-in history (v0.1.0 baseline => enforcing)
         run: |
           set -euo pipefail
           cargo run --locked -p ironbus-bench --bin ironbus-regression-gate -- \
             --history crates/ironbus-bench/tests/fixtures/regression-history.json \
+            --baseline docs/benchmarks/baselines/v0.1.0/perf-baseline.json \
             | tee gate-output.txt
-          # Until the first release archives a baseline, assert the gate took the documented no-op
-          # path rather than silently doing something else. This line changes to a real --baseline
-          # invocation (dropping this grep) the moment a baseline JSON exists.
-          if ! grep -q 'no baseline history yet' gate-output.txt; then
-            echo "::error::the regression gate did not take the expected no-baseline no-op path"
+          # The gate now ENFORCES: a fired (un-ratified) regression exits 1 and fails this step via
+          # pipefail. Additionally assert the enforcing within-thresholds PASS path was taken, so a
+          # silent fallback to the no-baseline no-op (a moved/deleted/renamed baseline file) also fails
+          # rather than passing vacuously.
+          if ! grep -q 'all device medians within thresholds' gate-output.txt; then
+            echo "::error::the regression gate did not take the expected enforcing within-thresholds path (baseline missing, or a regression fired)"
             exit 1
           fi
-          echo "ok: regression gate no-ops gracefully with no baseline history (exit 0)"
+          echo "ok: regression gate enforced against the v0.1.0 baseline (within thresholds, exit 0)"
 
   consume-corpus-gate:
     name: consume corpus fairness gate (#554)

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -198,17 +198,18 @@ jobs:
     # gate and adds no external coverage service or token. It succeeds as long as coverage is
     # collected, so a drop in coverage is visible in the artifact without ever blocking a merge.
     #
-    # COVERAGE-REGRESSION GATE (#385, intended mechanism, documented here, NOT yet enforcing):
-    # the planned "coverage-below-last-release" gate compares this run's line coverage against the
-    # coverage archived for the last released tag and fails on an un-ratified drop. It is NOT wired
-    # as a hard gate yet for the SAME reason the #114 perf regression gate no-ops today: there is no
-    # released tag / baseline yet (v0.1.0 is the maintainer's action), so there is nothing to compare
-    # against. What IS wired cheaply now: this job emits the summary percentage to the job log and
-    # the step summary every night, and retains the lcov.info artifact for 90 days, so a release can
-    # archive a baseline lcov.info and a future revision of this job can flip the comparison on
-    # (read the baseline percentage, FAIL if `current < baseline - tolerance`), mirroring the perf
-    # gate's baseline/no-op/ratify shape. Documented in fuzz/README.md and CHANGELOG.
-    name: coverage (informational)
+    # COVERAGE-REGRESSION GATE (#385, WIRED at v0.1.0 per #1068): the "coverage-below-last-release"
+    # gate compares this run's line coverage against the coverage baseline archived for the last
+    # released tag (docs/benchmarks/baselines/v0.1.0/coverage-baseline.json) and FAILS on an
+    # un-tolerated drop (`current < line_coverage_pct - tolerance_pct`), mirroring the #114 perf
+    # gate's baseline/enforce shape. The comparison step below is now wired. ONE value remains for
+    # the maintainer to arm the block: the baseline's `line_coverage_pct` is null at cut time because
+    # the authoritative number is what THIS lane computes with `cargo llvm-cov --workspace
+    # --all-features` on the CI runner (the runner with the cmake/cc toolchain the all-features
+    # instrumented build needs), which is not faithfully reproducible off it. While null, the step
+    # logs a documented PENDING no-op; recording the first post-tag nightly percentage in that file
+    # flips it to blocking. This job also still emits the percentage and retains lcov.info for 90 days.
+    name: coverage (informational + regression gate #385)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -244,6 +245,43 @@ jobs:
           fi
           echo "line coverage: ${pct}% (${total_lh}/${total_lf} lines)"
           echo "line coverage: ${pct}% (${total_lh}/${total_lf} lines)" >> "$GITHUB_STEP_SUMMARY"
+      - name: coverage-regression gate against the archived v0.1.0 baseline (#385, #1068)
+        # ARMED at v0.1.0 (#1068): compare this run's line coverage against the coverage baseline
+        # archived at the release and FAIL on an un-tolerated drop, mirroring the perf gate's
+        # baseline/enforce shape. The baseline's `line_coverage_pct` is null until the maintainer
+        # records the first post-tag nightly's number (see the baseline README + the file's note);
+        # while null this step logs a documented PENDING no-op rather than failing, so the mechanism
+        # is fully wired and one recorded value away from blocking. Dependency-free: reads the flat,
+        # machine-written baseline JSON with grep and does the compare in awk.
+        run: |
+          set -euo pipefail
+          baseline_file="docs/benchmarks/baselines/v0.1.0/coverage-baseline.json"
+          total_lf=$(awk -F: '/^LF:/ {s+=$2} END {print s+0}' lcov.info)
+          total_lh=$(awk -F: '/^LH:/ {s+=$2} END {print s+0}' lcov.info)
+          if [ "$total_lf" -eq 0 ]; then
+            echo "::error::no instrumented lines found in lcov.info; cannot evaluate the coverage gate"
+            exit 1
+          fi
+          current=$(awk -v lh="$total_lh" -v lf="$total_lf" 'BEGIN { printf "%.2f", (lh*100.0)/lf }')
+          if [ ! -f "$baseline_file" ]; then
+            echo "::error::coverage baseline ${baseline_file} not found"
+            exit 1
+          fi
+          baseline=$(grep -oE '"line_coverage_pct"[[:space:]]*:[[:space:]]*[0-9]+(\.[0-9]+)?' "$baseline_file" | grep -oE '[0-9]+(\.[0-9]+)?$' || true)
+          tolerance=$(grep -oE '"tolerance_pct"[[:space:]]*:[[:space:]]*[0-9]+(\.[0-9]+)?' "$baseline_file" | grep -oE '[0-9]+(\.[0-9]+)?$' || true)
+          tolerance="${tolerance:-0}"
+          if [ -z "$baseline" ]; then
+            echo "coverage gate: PENDING (no baseline line_coverage_pct recorded yet; current ${current}%). Record the first post-v0.1.0 nightly percentage in ${baseline_file} to arm the block." | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          floor=$(awk -v b="$baseline" -v t="$tolerance" 'BEGIN { printf "%.2f", b - t }')
+          echo "coverage gate: current ${current}% vs baseline ${baseline}% (tolerance ${tolerance}%, floor ${floor}%)" | tee -a "$GITHUB_STEP_SUMMARY"
+          if awk -v c="$current" -v f="$floor" 'BEGIN { exit (c + 0 >= f + 0) ? 0 : 1 }'; then
+            echo "ok: line coverage ${current}% >= floor ${floor}%"
+          else
+            echo "::error::line coverage ${current}% dropped below the v0.1.0 floor ${floor}% (baseline ${baseline}% - tolerance ${tolerance}%)"
+            exit 1
+          fi
       - name: upload the coverage report
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,89 @@
 # Changelog
 
 All notable changes to IronBus are documented here. The format follows
-[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project aims
-to follow Semantic Versioning once it reaches a tagged release.
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project
+follows [Semantic Versioning](https://semver.org/) from the first tagged
+release (`v0.1.0`) onward. Pre-1.0, the public API and wire/on-disk formats may
+still change between minor versions; the frozen v1 record/segment format and the
+negotiated wire envelope are the stability anchors called out per entry.
 
 ## [Unreleased]
+
+## [v0.1.0]
+
+_Release date set at tag time by the maintainer (prepared 2026-07-07)._
+
+First formal, semver-tagged release of IronBus — the durable, single-binary edge
+message bus. This entry consolidates the full pre-release engineering campaign
+(all changes prior to the first `v*` tag) that previously accumulated under
+`[Unreleased]`; the exhaustive, per-change record follows below under the
+standard Keep-a-Changelog subsections. The campaign, grouped by theme:
+
+- **Durable storage engine.** Segmented write-ahead log with CRC-framed records,
+  a frozen v1 on-disk format, longest-valid-prefix recovery with bounded +
+  reported loss, and group-committed `fdatasync` as the durability boundary. The
+  pipelined sync tier (#1040/#1049) decouples the covering `fdatasync` into a
+  self-clocking group commit, and the configurable durable-write **io-mode**
+  (#1054, `buffered`/`direct`/`auto`) adds the metadata-free `O_DIRECT` barrier
+  that turns the real-EBS single-connection durable rows from a loss into a win
+  while keeping the full fsync guarantee. Segment preallocation (#330/#1047) and
+  the cross-stream commit coordinator (#564) round out the engine.
+- **Clustering & Raft.** Embedded metadata Raft group (tikv/raft-rs, vendored
+  build-script-free codec, #578/#580), quorum-fsync ISR gate, quarantine-never-
+  delete divergence detection (#611/#697), epoch-fenced promotion (#668),
+  leader-completeness election eligibility (#614/#615), cooperative learner
+  join/rebalance (#617), and the ratified cluster recovery invariants CI1–CI4.
+  The cluster **peer wire** is fail-closed bound and origin-authenticated with
+  interim shared-secret HMAC-SHA256 on both the raft-metadata and data-plane
+  wires (#1067 increments 1–3: #1094/#1095/#1097).
+- **Security: TLS 1.3 + mTLS.** Native TLS 1.3 termination and client transport
+  behind the non-default `tls` feature (ADR-0004, #766/#957): server-side
+  termination (#1086/#1087), verified-client-cert → SAN → auth identity mTLS
+  (#1089/#1090), and sync/async/CLI clients (#1091/#1092/#1093). Connection-scoped
+  authentication — bearer tokens (SHA-256 digest, constant-time compare) and
+  Argon2id passwords — plus zeroizing secret types (#631/#635).
+- **Client SDKs.** First-party Rust blocking and async clients, an official
+  dependency-light Go SDK speaking the frozen wire natively with 47 golden frame
+  vectors (#1021/#1037), subject-addressed verbs (#585), pipelined durable
+  producers (#508, Go `ProduceWindow` #1059), and runnable examples + a
+  getting-started guide across all three clients (#1022/#1056/#1058).
+- **Wire & format compatibility.** Frozen `[len][tag][body]` envelope with
+  capability-bit AND negotiation, hash-pinned wire tag map (#1081), the
+  cross-language golden-vector conformance that stops the Go decoder drifting
+  from the Rust encoders, and a `Connect` capability gate for compressed
+  delivery (#1066) that closes the one silent-wrong-data path to pre-#430
+  consumers.
+- **Compression.** lz4 block compression on by default (per-record cap), opt-in
+  zstd codec with the trained per-message-type dictionary lifecycle behind the
+  non-default `zstd` feature (#357/#78).
+- **Performance.** `TCP_NODELAY` on every data/cluster socket (#1028), the
+  self-clocking group-commit tier, concurrent-producer benchmarking (#1048),
+  opt-in event-driven commit-notify long-poll delivery (#1098, default off), and
+  matched-substrate benchmark studies vs Redpanda / NATS / Kafka with per-row
+  durability labels and full disclosures (#1023/#1050/#1051).
+- **Flow control & backpressure.** Consumer-credit auto-tuner (64→2048, RAM-
+  bounded, #552/#672), durable spill + deterministic reported shed.
+- **Observability.** JSON structured logging always-on, OTLP span export behind
+  the non-default `otlp` feature (#99), metrics surface, `/healthz`+`/readyz`
+  flipping on append-actor death (#922), and a structured JSON panic line before
+  abort (#1080).
+- **Supply chain & reproducibility.** `cargo-deny` license/advisory/ban gates,
+  C-FFI ban keeping the default graph pure-Rust, cargo-auditable + CycloneDX
+  SBOMs, byte-identical reproducible musl builds (#101), MSRV 1.78 floor, and a
+  weekly advisory rescan.
+- **Distribution.** Single static musl binary for three edge triples, `.deb`
+  per triple, distroless container, and a fail-closed `curl | sh` installer with
+  Sigstore provenance — over both the automatic rolling calendar-versioned
+  channel and this curated, tagged channel.
+
+### Security
+- Cluster peer-wire authentication (#1067) — the intra-cluster consensus + replication wire, previously silently plaintext and trusted only by a spoofable claimed node id, hardened in three increments. **Increment 1, fail-closed bind guard (#1094):** the raft and data-plane peer listeners bound ANY address with no guard, so a reachable non-loopback peer port let an outsider forge raft/ISR frames and drive committed cluster state. A pure, unit-tested `peer_bind_decision` (the peer-wire twin of the client-wire guard) now runs PRE-LISTEN in both `serve` and `config validate` / `--check-only`: a non-loopback peer bind fails closed unless the operator passes the new `--insecure-plaintext-peers` (honored, loud startup warning); loopback and single-node stay byte-for-byte unchanged. Added `--cluster-secret-file` (reserved fail-closed until Increment 2). No wire/consensus change. **Increment 2, interim HMAC on the raft metadata wire (#1095):** an HMAC-SHA256 origin-authentication + per-frame-integrity envelope keyed by a cluster-wide shared secret (`PeerKey`, a SHA-256 KDF over `--cluster-secret-file`, zeroized with a redacting `Debug`), hand-rolled over the pure-Rust `sha2` already in the tree (ZERO new dependency, RFC 4231-tested, constant-time `subtle` compare). A new append-only `FrameType::RaftAuth = 50` carries `[len][50][ver:1][mac:32][raft_pb]` whose inner body is byte-identical to a tag-27 body, so a downgrade is a tag check an un-upgraded/no-key receiver rejects. New `--cluster-peer-auth off|permissive|signed|required` (default `required` when a secret is present); the off→permissive→signed→required rollout ladder is quorum-safe (each accept-set a superset of any peer's send) and a fresh cluster boots straight to `required`. **Increment 3, data-plane HMAC (#1097):** the same envelope extended to every data-plane verb (FetchRecords/FetchResponse/AckReplicated/OffsetForLeaderEpoch/CommittedHwQuery) under a domain label DISTINCT from `RaftAuth` (so a key cannot cross-authenticate the two wires) via `FrameType::DataPlaneAuth = 51`, preserving the zero-copy 8 MiB `FetchResponse` fast path (the MAC streams over the borrowed outbound buffer, byte-identical to a materialize-then-seal reference). Honest guarantees: cluster-MEMBERSHIP origin auth defeating OUTSIDER `from`-spoofing (one symmetric key, not per-node identity — a compromised secret-holder is closed by mTLS #766), NOT confidentiality and NOT anti-replay (raft term/index idempotence blunts replay). Single-node and loopback clusters are inert; no consensus or on-disk format change beyond the two new self-describing auth tags (the format-registry gate + `docs/compat/versions.md` frame-tags hash re-pinned). Increments 2–3 adversarially reviewed (19- and multi-agent workflows); the metadata-only scope of Increment 2 (data-plane still needed `--insecure-plaintext-peers`) is closed by Increment 3.
+
+### Added
+- Event-driven commit-notify long-poll delivery (#1098), an OPT-IN, server-only latency lever, TUNABLE and OFF by default. An idle consumer polling an empty group returns an empty batch and is re-polled by the client on a timer, flooring its wakeup latency at one client poll interval; a `Flow`/`Fetch` that draws nothing now blocks briefly on a broker-wide commit-notify seam and re-polls the instant a record commits (or a budget elapses). New `commit_notify` module — a lock+condvar generation counter, lost-wakeup-safe (`wait_for_change(snapshot, timeout)` snapshots the seq before the poll batch) — owned by the append actor, which bumps it STRICTLY AFTER the durability work that advances the poll-visible frontier (pure observation, never reordering existing statements; over-bumping is harmless, under-bumping only costs latency) and shares it into every `EngineHandle` clone. `--consume-longpoll-ms` (flag > env > default) defaults to **0 = OFF**, byte-for-byte today's empty-and-return path, so it is a pure tunable with NO wire, client, or format-registry change; a `no_wait` fetch is exempt (single immediate pass) and v1 wake granularity is global (a spurious cross-stream wake just re-polls empty). Proven over a real spawned actor: `longpoll=0` returns `FlowEnd(0)` immediately, a concurrent produce wakes an idle consumer to `delivered=1` far below the budget, and a no-producer wait times out to `FlowEnd(0)` after ~the budget.
+
+### Fixed
+- Compressed delivery is now gated on a `Connect` capability bit (#1066), closing the ONE silent-wrong-data path in an otherwise fail-loud system. A default-on `--compression lz4` broker previously delivered stored-compressed `descriptor + codec-stream` bytes (with the COMPRESSED record flag set) VERBATIM to any consumer, including pre-#430 clients (rolling builds `2026.0609.2`–`2026.0610.7`) that mis-decode them during a normal broker-first upgrade — guarded until now only by prose in COMPATIBILITY.md. A new `CONNECT_FLAG2_COMPRESSED_DELIVERY` bit — the first bit of a NEWLY appended `flags2` byte (the historical `flags` byte's 8 bits are all allocated), emitted only when non-zero so a client that does not advertise it sends a body byte-for-byte the historical layout and an old reader ignores it — lets a consumer advertise it understands compressed delivery. A capable consumer gets the stored-compressed record verbatim (zero-CPU passthrough) on EVERY per-record Deliver path (Tier-W poll + fetch, Tier-S, follower-read, and the DeliverBatch active tail); a non-capable consumer (an old client, or the empty Connect) gets it DECOMPRESSED with the COMPRESSED bit cleared. The first-party Rust and async clients advertise the capability by default (so real clients keep getting compression); the safe default for an unknown consumer is uncompressed delivery, and a non-capable delivery that cannot be decompressed (a zstd-with-dictionary record on an opt-in build) fails loud, never corrupt. Mirrors the GapMarker (#292/#346) / DeliverBatch (#541) capability mechanism and replaces the prose-only COMPATIBILITY.md guard with an enforced gate.
 
 ### Removed
 - The **macOS cross-broker benchmark** — the README `## Benchmarks` macOS tables (IronBus vs Kafka/NATS), `docs/benchmarks/CROSS_BROKER_2026_07.md`, and its `cross-broker-harness/`. macOS `F_FULLFSYNC`/thermal/SSD variance makes it an unreliable benchmark substrate (every power-loss-safe broker floors at ~250 msg/s against the ~4 ms barrier), and its Redpanda-in-VM column — parenthesized and ~10× inflated by page-cache "durability" with no real barrier — misled readers into thinking Redpanda was an order of magnitude faster than IronBus. The authoritative IronBus-vs-Redpanda comparison is now solely on **matched substrates**: the Linux matched-VM study and the AWS **t4g / EBS** real-hardware run (`docs/benchmarks/REDPANDA_MATCHED_2026_07.md`), where IronBus wins or ties every durable row. The README Benchmarks section and the `REDPANDA_MATCHED` study were reworded to stand alone (no dangling references to the retired study). Docs only.
@@ -501,3 +580,6 @@ to follow Semantic Versioning once it reaches a tagged release.
 - `docs/DICTIONARY_LIFECYCLE.md`: the normative DESIGN spec (specified, not yet implemented) for trained per-message-type compression dictionaries (#78, parent #12). Specifies the offline `ironbus dict train` flow (per-type real-telemetry corpus, min/target sample floors, the `dicts/<dict_id>.zstd` output), a content-addressed `dict_id` (a u32 truncation of BLAKE3-256 of the dictionary bytes) that is collision-checked and refused fail-closed at train time so reuse is structurally impossible with no central registry, self-contained distribution (a per-segment on-disk `dicts/` sidecar PLUS the active set embedded in the static binary via `include_bytes!`, #17), the sidecar-first then embedded resolution order (so a binary downgrade never strands readable data), an unresolved dict_id routed through #8 as a NEW append-only loss reason `UnresolvedDictId` (code 7, label `unresolved_dict_id`, data-loss; codes 1-6 byte-identical, `schema_version` stays 1), append-only immutability/rotation (a re-train is a new dict_id, old data readable forever), the before/after per-batch ratio METHOD (one variable, real telemetry, the `ironbus bench`/#114 surface, on-device per #19) with the measured number left as a residual, and a proof the v1 frame's u32 dict_id reservation (`COMPRESSED` flag clear, `dict_id=0` unset in v1) makes this additive with no wire/on-disk break. The `ZDICT` training call, the sidecar IO, the embed, the reason emission, and the measured ratio are the impl follow-up. Linked from `docs/README.md`. Docs only, no source changed (refs #78).
 - `docs/EDGE_CONSTRAINTS.md`: the design synthesis for #20 (edge resource constraints). Writes the three missing pieces: the hardware-constraint-to-knob mapping table (one row per limit with its failure mode, governing knob, `tiny` default, and owning issue; conceptual knobs labelled SPECIFIED-NOT-YET-A-FIELD); the `tiny` profile fully specified with concrete defaults shown summing ~9 MiB under the 64 MiB ceiling and reachable in the single static binary (the auto-selection flag and RSS boot guard are the #115/#17/#87 residual, not claimed enforced); and the RTC-less clock model (monotonic `seq` is the sole, clock-independent, disk-durable ordering authority, wall-clock `timestamp` is producer-supplied advisory metadata with a Redis-Streams never-emit-a-smaller broker-timestamp rule, age retention is best-effort and fail-safe under a backward jump), tied to the `Clock` seam. Reconciles the four already-satisfied #20 criteria to RAM_BUDGET.md, DURABILITY.md, EDGE_RUN_DISCIPLINE.md, and ADR-0003; no contradictions found. Linked from `docs/README.md`. Docs only, no source changed (refs #20, #115, #117).
 - Documented the cross-platform durability barrier and resolved #153: an acknowledged produce always clears a true device write-barrier. On Linux (the production musl target) that is `fdatasync`/`fsync`; on Apple targets `std` maps both `sync_data` and `sync_all` to `fcntl(fd, F_FULLFSYNC)` (a real drive-cache flush, not a plain `fsync`), which is exactly what `StdFile` relies on, so no redundant `fcntl` wrapper is added. Verified against the `std::sys::fs::unix` source. IronBus deliberately keeps `std`'s no-`ENOTSUP`-fallback behaviour: a filesystem that cannot honour the barrier freezes the writer and stops acking rather than silently downgrading durability. Added a platform durability table to the usage guide, a load-bearing comment on the sync path, and an Apple-gated test that exercises the `F_FULLFSYNC` path.
+
+[Unreleased]: https://github.com/ELares/IronBus/compare/v0.1.0...HEAD
+[v0.1.0]: https://github.com/ELares/IronBus/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "io-free-check"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "ironbus-bench"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "hdrhistogram",
  "ironbus-client",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "ironbus-cli"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "argon2",
  "bytes",
@@ -973,7 +973,7 @@ dependencies = [
 
 [[package]]
 name = "ironbus-client"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "ironbus-core",
  "ironbus-proto",
@@ -985,7 +985,7 @@ dependencies = [
 
 [[package]]
 name = "ironbus-client-async"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "ironbus-client",
  "ironbus-core",
@@ -998,7 +998,7 @@ dependencies = [
 
 [[package]]
 name = "ironbus-core"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "arc-swap",
  "blake3",
@@ -1012,7 +1012,7 @@ dependencies = [
 
 [[package]]
 name = "ironbus-proto"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "criterion",
  "lz4_flex",
@@ -1021,7 +1021,7 @@ dependencies = [
 
 [[package]]
 name = "ironbus-server"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "argon2",
  "base64ct",
@@ -1056,7 +1056,7 @@ dependencies = [
 
 [[package]]
 name = "ironbus-storage"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "arc-swap",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = ["crates/*", "tools/*"]
 exclude = ["tools/loom-tests"]
 
 [workspace.package]
-version = "0.0.0"
+version = "0.1.0"
 edition = "2021"
 rust-version = "1.78"
 license = "MIT OR Apache-2.0"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -29,8 +29,12 @@ FAILS the whole release if `## [Unreleased]` in `CHANGELOG.md` has no content, s
 never ship without an audit-trail entry. Tag a release only after the entries are present.
 
 1. Land all changes for the release via the normal PR flow (CI green, self-reviewed, merged).
-2. Move the `## [Unreleased]` section of `CHANGELOG.md` under a new `## [vX.Y.Z]` heading and
-   bump the workspace `version` in the top-level `Cargo.toml`, in a final PR.
+2. In a final PR: move the `## [Unreleased]` section of `CHANGELOG.md` under a new `## [vX.Y.Z]`
+   heading (the changelog gate matches that heading EXACTLY, so keep it `## [vX.Y.Z]` with no
+   trailing date — put the release date on a line under the heading), bump the workspace `version`
+   in the top-level `Cargo.toml` (`cargo build` reconciles `Cargo.lock`), and archive the release's
+   perf + coverage baselines under `docs/benchmarks/baselines/vX.Y.Z/` (see
+   [Regression-gate baselines](#regression-gate-baselines-perf--coverage) below).
 3. After it merges, tag the merge commit and push the tag:
 
    ```sh
@@ -44,6 +48,30 @@ never ship without an audit-trail entry. Tag a release only after the entries ar
    Re-running the workflow for a tag that already has a published release fails at the
    `gh release create` step (it does not clobber); delete the existing release first
    (`gh release delete vX.Y.Z`) to rebuild it.
+
+## Regression-gate baselines (perf + coverage)
+
+Two CI regression gates compare each build against the LAST RELEASED TAG's archived baseline, so a
+release must archive its baselines for the gates to enforce. They were dormant (no-op) until the
+first tag because there was nothing to compare against; `v0.1.0` armed them (#1068). Each release
+archives its own `docs/benchmarks/baselines/vX.Y.Z/` directory and the gates point at the newest.
+
+- **Perf regression gate** (`regression-gate` job in `.github/workflows/ci.yml`, #114). Archive
+  `docs/benchmarks/baselines/vX.Y.Z/perf-baseline.json` in the
+  `ironbus_bench::regression::Baseline` schema (`{ "tag", "runs": [RunPoint...] }`) — the per-device
+  reference macro-bench medians (#111). The job passes it via `--baseline`; the gate then FAILS on an
+  un-ratified rolling-median regression (throughput -10%, p99 +15%, p99.9 +25%). The live per-device
+  numbers are a documented device residual (see [BASELINE_RIG.md](docs/BASELINE_RIG.md)); the checked-in
+  history fixture stands in for the current run so the job validates the GATE wiring, not live runs.
+  Update `--baseline` in `ci.yml` to point at the newest tag's file each release.
+- **Coverage regression gate** (`coverage` job in `.github/workflows/nightly.yml`, #385). Archive
+  `docs/benchmarks/baselines/vX.Y.Z/coverage-baseline.json`
+  (`{ "tag", "line_coverage_pct", "tolerance_pct" }`). The nightly `coverage-regression-gate` step
+  reads it and FAILS on `current < line_coverage_pct - tolerance_pct`. **Record the number** from the
+  first post-tag nightly run: the `coverage` lane prints the workspace line-coverage percentage
+  (`cargo llvm-cov --workspace --all-features`) to the job log + step summary and retains `lcov.info`
+  for 90 days — copy that percentage into `line_coverage_pct` (it is `null` until you do, which the
+  step reports as a documented PENDING no-op rather than a failure).
 
 ## What the release produces
 

--- a/crates/ironbus-bench/Cargo.toml
+++ b/crates/ironbus-bench/Cargo.toml
@@ -68,8 +68,8 @@ path = "src/bin/cluster_durability_bench.rs"
 [dependencies]
 # The harness drives the broker through the REAL #11 client over a real socket, never a privileged
 # test path; it launches the shipping `ironbus` binary built by `ironbus-cli`.
-ironbus-client = { path = "../ironbus-client", version = "0.0.0" }
-ironbus-proto = { path = "../ironbus-proto", version = "0.0.0" }
+ironbus-client = { path = "../ironbus-client", version = "0.1.0" }
+ironbus-proto = { path = "../ironbus-proto", version = "0.1.0" }
 # HdrHistogram for the latency tail (1 us to 60 s, 3 significant figures). The `serialization`
 # feature gives the standard V2+DEFLATE encoder so a run's RAW histogram is archived base64 and is
 # recomputable/mergeable across windows. MIT OR Apache-2.0.
@@ -91,9 +91,9 @@ serde_json = "1"
 # (a condvar gate, no OS scheduling), so the freeze ALWAYS lands in the recorded tail.
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
-ironbus-server = { path = "../ironbus-server", version = "0.0.0" }
-ironbus-storage = { path = "../ironbus-storage", version = "0.0.0" }
-ironbus-core = { path = "../ironbus-core", version = "0.0.0" }
+ironbus-server = { path = "../ironbus-server", version = "0.1.0" }
+ironbus-storage = { path = "../ironbus-storage", version = "0.1.0" }
+ironbus-core = { path = "../ironbus-core", version = "0.1.0" }
 
 [lints]
 workspace = true

--- a/crates/ironbus-cli/Cargo.toml
+++ b/crates/ironbus-cli/Cargo.toml
@@ -38,11 +38,11 @@ zstd = ["ironbus-storage/zstd", "ironbus-core/zstd"]
 tls = ["ironbus-server/tls", "ironbus-client/tls"]
 
 [dependencies]
-ironbus-core = { path = "../ironbus-core", version = "0.0.0" }
-ironbus-proto = { path = "../ironbus-proto", version = "0.0.0" }
-ironbus-client = { path = "../ironbus-client", version = "0.0.0" }
-ironbus-server = { path = "../ironbus-server", version = "0.0.0" }
-ironbus-storage = { path = "../ironbus-storage", version = "0.0.0" }
+ironbus-core = { path = "../ironbus-core", version = "0.1.0" }
+ironbus-proto = { path = "../ironbus-proto", version = "0.1.0" }
+ironbus-client = { path = "../ironbus-client", version = "0.1.0" }
+ironbus-server = { path = "../ironbus-server", version = "0.1.0" }
+ironbus-storage = { path = "../ironbus-storage", version = "0.1.0" }
 
 # A content fingerprint for the upgrade rollback's known-bad guard (#348): the failed-start counter
 # records the fingerprint of the binary that failed N starts, so a rollback re-entered after a power

--- a/crates/ironbus-client-async/Cargo.toml
+++ b/crates/ironbus-client-async/Cargo.toml
@@ -25,9 +25,9 @@ tls = ["dep:tokio-rustls", "ironbus-client/tls", "ironbus-server/tls"]
 # ProduceAck, DeadLetter, Truncation, Gap, TxnId, ...) verbatim — this crate is the async
 # TWIN of `ironbus-client`, not a redefinition of its surface. The proto codecs and the
 # IO-free core (transparent deliver-path decompression) are shared identically.
-ironbus-client = { path = "../ironbus-client", version = "0.0.0" }
-ironbus-proto = { path = "../ironbus-proto", version = "0.0.0" }
-ironbus-core = { path = "../ironbus-core", version = "0.0.0" }
+ironbus-client = { path = "../ironbus-client", version = "0.1.0" }
+ironbus-proto = { path = "../ironbus-proto", version = "0.1.0" }
+ironbus-core = { path = "../ironbus-core", version = "0.1.0" }
 # tokio is already vetted in this workspace (ironbus-server's OTLP exporter depends on it),
 # so it passes cargo-deny + the MSRV floor. Use the SAME no-default-features form and add
 # only the features the async client needs: a runtime, the TCP socket, the async read/write
@@ -51,8 +51,8 @@ tokio-rustls = { version = "0.26", optional = true, default-features = false, fe
 
 [dev-dependencies]
 # The real broker, spawned in-process for the wire-compatibility round-trip test.
-ironbus-server = { path = "../ironbus-server", version = "0.0.0" }
-ironbus-storage = { path = "../ironbus-storage", version = "0.0.0" }
+ironbus-server = { path = "../ironbus-server", version = "0.1.0" }
+ironbus-storage = { path = "../ironbus-storage", version = "0.1.0" }
 # A multi-thread runtime + macros + timers for `#[tokio::test]`: the broker's accept loop runs
 # on a blocking std thread (it is sync/thread-per-connection), so the test's runtime must be
 # able to make progress on the async client while that thread blocks.

--- a/crates/ironbus-client/Cargo.toml
+++ b/crates/ironbus-client/Cargo.toml
@@ -24,8 +24,8 @@ tls = ["dep:rustls", "dep:rustls-pki-types", "ironbus-server/tls"]
 [dependencies]
 # The IO-free core: the client's transparent deliver-path decompression (#430) uses the codec
 # runtime (`compress`) and the record-flag bits (`types`). Pure Rust on the default build.
-ironbus-core = { path = "../ironbus-core", version = "0.0.0" }
-ironbus-proto = { path = "../ironbus-proto", version = "0.0.0" }
+ironbus-core = { path = "../ironbus-core", version = "0.1.0" }
+ironbus-proto = { path = "../ironbus-proto", version = "0.1.0" }
 # TLS 1.3 client stack (the `tls` feature only; the default build links none of this). `default-features
 # = false` drops rustls's ring-backed webpki path and its tls12 code — the client is TLS 1.3-only with
 # the aws-lc-rs provider, never ring. `rustls-pki-types` decodes the PEM trust anchors / client cert+key.
@@ -33,8 +33,8 @@ rustls = { version = "0.23", optional = true, default-features = false, features
 rustls-pki-types = { version = "1", optional = true, features = ["std"] }
 
 [dev-dependencies]
-ironbus-server = { path = "../ironbus-server", version = "0.0.0" }
-ironbus-storage = { path = "../ironbus-storage", version = "0.0.0" }
+ironbus-server = { path = "../ironbus-server", version = "0.1.0" }
+ironbus-storage = { path = "../ironbus-storage", version = "0.1.0" }
 
 [lints]
 workspace = true

--- a/crates/ironbus-server/Cargo.toml
+++ b/crates/ironbus-server/Cargo.toml
@@ -41,9 +41,9 @@ edge-min = []
 tls = ["dep:rustls", "dep:rustls-pki-types", "dep:x509-cert", "dep:const-oid"]
 
 [dependencies]
-ironbus-core = { path = "../ironbus-core", version = "0.0.0" }
-ironbus-proto = { path = "../ironbus-proto", version = "0.0.0" }
-ironbus-storage = { path = "../ironbus-storage", version = "0.0.0" }
+ironbus-core = { path = "../ironbus-core", version = "0.1.0" }
+ironbus-proto = { path = "../ironbus-proto", version = "0.1.0" }
+ironbus-storage = { path = "../ironbus-storage", version = "0.1.0" }
 
 # Embedded metadata Raft group (V2-C1, #578). `raft` is tikv/raft-rs, the production TiKV
 # Raft CORE (Apache-2.0): storage- and transport-agnostic, SYNCHRONOUS and caller-driven

--- a/crates/ironbus-storage/Cargo.toml
+++ b/crates/ironbus-storage/Cargo.toml
@@ -33,7 +33,7 @@ crc32c = "0.6"
 # the consume hot path. `bytes` is pure Rust (no `links`, no C build script), already in the workspace
 # tree (a direct dependency of `ironbus-server`), and is on the pure-Rust data-path allow-list.
 bytes = { version = "1", default-features = false }
-ironbus-core = { path = "../ironbus-core", version = "0.0.0" }
+ironbus-core = { path = "../ironbus-core", version = "0.1.0" }
 # `serde` (derive only) makes the structured loss report (`loss::LossReport`) a versioned,
 # stable, fixture-assertable artifact (#120). Kept derive-only so the static edge binary stays
 # small: the JSON format crate (`serde_json`) is a dev-dependency, not shipped in the binary.

--- a/docs/benchmarks/baselines/v0.1.0/README.md
+++ b/docs/benchmarks/baselines/v0.1.0/README.md
@@ -1,0 +1,42 @@
+# v0.1.0 archived baselines
+
+The performance and coverage baselines snapshotted at the `v0.1.0` release, so the
+two dormant CI regression gates have something to compare against and begin
+enforcing (issue #1068). Each subsequent release archives its own
+`docs/benchmarks/baselines/<tag>/` directory; the CI gates point at the newest.
+
+## `perf-baseline.json` — the #114 rolling-median perf gate baseline
+
+Format: the `ironbus_bench::regression::Baseline` struct
+(`crates/ironbus-bench/src/regression.rs`) — `{ "tag", "runs": [RunPoint...] }`,
+one `RunPoint` per archived reference-device run
+(`device`, `unix_secs`, `throughput_msgs_per_sec`, `p99_us`, `p999_us`,
+`warmup_cov_ok`). The `regression-gate` job in `.github/workflows/ci.yml` passes
+this file via `--baseline`, so the gate runs its ENFORCING path (per-device
+7-day rolling median vs this baseline, thresholds: throughput -10%, p99 +15%,
+p99.9 +25%) instead of the pre-release no-op.
+
+**Provenance / honesty note.** These numbers are seeded from the committed
+reference run history (`crates/ironbus-bench/tests/fixtures/regression-history.json`,
+which encodes the documented ~60k msg/s reference-Pi4 target). Per
+[`docs/BASELINE_RIG.md`](../../../BASELINE_RIG.md), the LIVE per-device macro-bench
+runs (the #111 reference-device numbers) are a documented host/device residual
+that CI cannot produce, so this is the best faithful baseline available at the
+first tag. **Owner action to re-anchor:** replace these runs with the medians
+from a real `ironbus bench` macro-bench run on the reference edge device (#111)
+when one is next taken, keeping the same schema and `"tag": "v0.1.0"`.
+
+## `coverage-baseline.json` — the #385 coverage-regression gate baseline
+
+Format: `{ "tag", "line_coverage_pct", "tolerance_pct", "note" }`. The nightly
+`coverage-regression-gate` step (`.github/workflows/nightly.yml`) reads it and
+enforces `current >= line_coverage_pct - tolerance_pct`.
+
+`line_coverage_pct` is `null` at cut time on purpose: the authoritative number is
+what the nightly `coverage` lane computes with `cargo llvm-cov --workspace
+--all-features` on the CI runner (which carries the cmake/cc toolchain the
+all-features instrumented build needs — aws-lc-sys/zstd-sys). It is not faithfully
+reproducible off that runner, so it is deliberately left for the maintainer to
+fill from the first post-tag nightly run (which prints the percentage and retains
+`lcov.info`). While `null`, the gate step logs a documented PENDING no-op and does
+not fail. Setting the number arms it. See the file's own `note`.

--- a/docs/benchmarks/baselines/v0.1.0/coverage-baseline.json
+++ b/docs/benchmarks/baselines/v0.1.0/coverage-baseline.json
@@ -1,0 +1,6 @@
+{
+  "tag": "v0.1.0",
+  "line_coverage_pct": null,
+  "tolerance_pct": 1.0,
+  "note": "line_coverage_pct is intentionally null: the authoritative number is the workspace line-coverage percentage the nightly `coverage` lane (.github/workflows/nightly.yml) computes with `cargo llvm-cov --workspace --all-features` on the CI runner (which has the cmake/cc toolchain the all-features instrumented build needs). It cannot be faithfully reproduced off that runner. To ARM the coverage-regression gate: take the percentage the first post-v0.1.0-tag nightly prints (job log / step summary, and the retained lcov.info artifact), set line_coverage_pct to it here, and the nightly `coverage-regression-gate` step begins enforcing `current >= line_coverage_pct - tolerance_pct`. While null, the step logs a documented PENDING no-op (it does not fail), mirroring the perf gate's pre-baseline no-op."
+}

--- a/docs/benchmarks/baselines/v0.1.0/perf-baseline.json
+++ b/docs/benchmarks/baselines/v0.1.0/perf-baseline.json
@@ -1,0 +1,29 @@
+{
+  "tag": "v0.1.0",
+  "runs": [
+    {
+      "device": "edge-min-pi4",
+      "unix_secs": 1700000000,
+      "throughput_msgs_per_sec": 61000.0,
+      "p99_us": 5200.0,
+      "p999_us": 9100.0,
+      "warmup_cov_ok": true
+    },
+    {
+      "device": "edge-min-pi4",
+      "unix_secs": 1699913600,
+      "throughput_msgs_per_sec": 60500.0,
+      "p99_us": 5100.0,
+      "p999_us": 9000.0,
+      "warmup_cov_ok": true
+    },
+    {
+      "device": "edge-mid-rk3399",
+      "unix_secs": 1700000000,
+      "throughput_msgs_per_sec": 121000.0,
+      "p99_us": 4050.0,
+      "p999_us": 8100.0,
+      "warmup_cov_ok": true
+    }
+  ]
+}

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -100,10 +100,13 @@ Commit the new seed. From then on the per-PR replay (below) guards it on every P
   night; a target file missing its `Cargo.toml` `[[bin]]` entry fails both lanes loudly. A
   target with no committed regression corpus yet fuzzes from scratch until seeds are promoted.
 - **Coverage regression:** the nightly `coverage` job emits the workspace line-coverage
-  percentage and retains `lcov.info`. The intended "coverage-below-last-release" gate
-  (compare to the last released tag's archived coverage, fail on an un-ratified drop) is
-  documented in `nightly.yml`; it stays informational until a release archives a baseline,
-  mirroring the #114 perf gate's baseline/no-op shape.
+  percentage and retains `lcov.info`. The "coverage-below-last-release" gate (compare to the
+  last released tag's archived coverage, fail on an un-tolerated drop) was ARMED at `v0.1.0`
+  (#1068): the `coverage-regression-gate` step reads
+  `docs/benchmarks/baselines/v0.1.0/coverage-baseline.json` and enforces
+  `current >= line_coverage_pct - tolerance_pct`, mirroring the #114 perf gate's baseline shape.
+  The baseline's `line_coverage_pct` is recorded by the maintainer from the first post-tag
+  nightly percentage (it is `null`/PENDING-no-op until then; see the baseline README).
 
 The build outputs, the discovered working corpora, and the crash artifacts are git-ignored;
 the regression corpus and `Cargo.lock` are committed so a soak is reproducible.


### PR DESCRIPTION
Prepares the first formal, semver-tagged release. Closes #1068 once tagged. **Draft** — no tag is created here; tagging/releasing is the maintainer's action.

## What this does

**1. Version bump 0.0.0 → 0.1.0**
- `[workspace.package] version` in the root `Cargo.toml`, plus the sibling path-dependency version requirements (`version = "0.0.0"` → `"0.1.0"`) across the 6 member crates that carry them.
- `Cargo.lock` reconciled (all 8 `ironbus-*` crates + the `io-free-check` tool now `0.1.0`); zero dependency drift, diff is only the version lines.
- `fuzz/` and `tools/loom-tests` are **separate workspaces** with their own lockfiles — deliberately left at `0.0.0`.
- Verified: `cargo build --workspace --locked` green in the colima container.

**2. CHANGELOG**
- The entire `[Unreleased]` block (the whole pre-tag campaign) became `## [v0.1.0]`; a fresh empty `## [Unreleased]` sits above it; a themed **campaign summary** is prepended (Storage engine · Clustering/Raft · TLS+mTLS · Client SDKs · Wire/format · Compression · Perf · Flow control · Observability · Supply chain · Distribution); Keep-a-Changelog link refs added.
- The `#128` changelog gate matches the version heading **exactly**, so the heading is `## [v0.1.0]` with **no in-heading date** (date on a sub-line). Verified: `changelog-unreleased.sh CHANGELOG.md v0.1.0` → PASS.

**3. Archived baselines** — `docs/benchmarks/baselines/v0.1.0/`
- `perf-baseline.json` — `ironbus_bench::regression::Baseline` schema, seeded from the committed reference run history (the ~60k msg/s reference-Pi4 target). Live per-device macro-bench numbers are a documented device residual (`BASELINE_RIG.md`); **owner action:** re-anchor from a real #111 macro-bench when next taken.
- `coverage-baseline.json` — `line_coverage_pct` is `null` (see below).
- `README.md` — provenance + how to re-anchor.

**4. Armed the two dormant gates**
- **Perf regression gate** (`ci.yml`, #114): now runs its **enforcing** path via `--baseline docs/benchmarks/baselines/v0.1.0/perf-baseline.json` and asserts the within-thresholds PASS (so a moved/deleted baseline that silently falls back to the no-op also fails). Verified in-container: `regression gate: PASS (all device medians within thresholds)`, exit 0.
- **Coverage regression gate** (`nightly.yml`, #385): added a `coverage-regression-gate` step that reads the baseline and fails on `current < line_coverage_pct - tolerance_pct`. Logic unit-tested for PENDING/PASS/FAIL. It is **wired but one value from blocking**: `line_coverage_pct` is `null` because the authoritative number is what the nightly lane computes with `cargo llvm-cov --workspace --all-features` on the CI runner (cmake/cc toolchain), which can't be faithfully reproduced off it. While null it logs a documented PENDING no-op.

**5. RELEASING.md** — added the baseline-archival + coverage-recording steps (previously had zero coverage steps) and the exact-heading changelog caveat.

## Owner decisions
- **Exact version string:** `0.1.0` assumed. Release date is a sub-line placeholder (`prepared 2026-07-07`) — set at tag time.
- **Perf baseline numbers:** currently seeded from the committed reference fixture. Re-anchor with a live #111 device macro-bench if desired before tagging (mechanism works either way).
- **Coverage gate arming:** paste the first post-v0.1.0 nightly's line-coverage % into `coverage-baseline.json` to flip it from PENDING to blocking. This is the one deliberately-deferred arming step.
- **Do not merge/tag from here** — this is the prep branch per #1068.

## Validation
- `cargo build --workspace --locked` — green.
- `cargo test -p ironbus-bench` — green (incl. 5 `regression_gate_cli` tests).
- Perf gate run against fixture + baseline — PASS, exit 0.
- Coverage-gate shell logic — PENDING/PASS/FAIL all correct.
- Both workflow YAMLs parse; `changelog-unreleased.sh` PASS for the `[v0.1.0]` section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01McmNfYNWPmohVS8umY9Lkp
