### PR TITLE
feat(delivery): gate compressed delivery on a Connect capability bit (#1066)

### DIFF
--- a/crates/ironbus-client-async/src/lib.rs
+++ b/crates/ironbus-client-async/src/lib.rs
@@ -544,6 +544,10 @@ impl AsyncClient {
                 default_tier: config.default_consume_tier.map(ConsumeTier::as_u8),
                 understands_deliver_batch: config.understands_deliver_batch,
                 understands_streams: config.understands_streams,
+                // The compressed-delivery capability bit (#1066), ON by default — byte-for-byte the sync
+                // client's body, so a `--compression` broker ships this decode-capable client
+                // stored-compressed records verbatim.
+                understands_compressed_delivery: config.understands_compressed_delivery,
             },
             &mut connect_body,
         );

--- a/crates/ironbus-client/src/lib.rs
+++ b/crates/ironbus-client/src/lib.rs
@@ -431,6 +431,18 @@ pub struct ClientConfig {
     /// today's behavior. A caller checks [`Client::streams_enabled`] after connecting to learn whether
     /// the server confirmed it.
     pub understands_streams: bool,
+    /// Whether this client ADVERTISES that it can DECODE a compression-codec-encoded delivery — the
+    /// per-record `COMPRESSED` flag and `descriptor + codec-stream` payload a `--compression` broker
+    /// stores (#1066): when `true` (the DEFAULT), the `Connect` sets the
+    /// [`CONNECT_FLAG2_COMPRESSED_DELIVERY`] capability bit, so a `--compression lz4` broker ships
+    /// stored-compressed records to this client verbatim (which it decodes on read, as every client has
+    /// since #430). When `false`, the client does NOT advertise it, so the broker DECOMPRESSES a
+    /// stored-compressed record before delivering it — the plain payload, byte-for-byte the produced
+    /// bytes. The default is `true` because this client decodes compression; a caller that wraps a
+    /// legacy consumer which cannot decode the descriptor bytes sets it `false` to force uncompressed
+    /// delivery. The decoded `Message` payload is IDENTICAL either way; this only governs whether the
+    /// bytes travel compressed on the wire.
+    pub understands_compressed_delivery: bool,
     /// The connection-scoped authentication credential this client presents in its `Connect`
     /// handshake (#631, #884), or `None` (the default) for an unauthenticated connection. When
     /// `Some(cred)`, `connect_with` appends the auth section the broker verifies (via
@@ -496,6 +508,12 @@ impl Default for ClientConfig {
             // only the default-stream verbs exactly as before (#588). A caller that wants to address
             // named streams opts in by setting this.
             understands_streams: false,
+            // ON by default (#1066): this client decodes compression (every client has since #430), so
+            // it advertises the capability and a `--compression` broker may ship it stored-compressed
+            // records verbatim. This is safe by construction and preserves the broker's zero-CPU
+            // passthrough. A caller wrapping a legacy consumer that cannot decode the descriptor sets it
+            // `false` to force the broker to decompress before delivery (the silent-corruption guard).
+            understands_compressed_delivery: true,
             // None by default: an unconfigured client presents NO credential, so `connect_with`
             // appends no auth section and the `Connect` body is byte-for-byte the pre-#631 layout — an
             // unauthenticated connect to a no-auth broker is unchanged (#884). A caller opts into auth
@@ -1327,6 +1345,11 @@ impl Client {
                 // byte-for-byte the pre-#588 `Connect` and the client uses only the default-stream
                 // verbs; a caller opts in via the config to address named streams by id.
                 understands_streams: config.understands_streams,
+                // The compressed-delivery capability bit (#1066, the `flags2` byte). ON by default, so
+                // a `--compression` broker ships stored-compressed records to this (decode-capable)
+                // client verbatim; a caller wrapping a legacy consumer sets it `false` to force the
+                // broker to decompress before delivery.
+                understands_compressed_delivery: config.understands_compressed_delivery,
             },
             &mut connect_body,
         );

--- a/crates/ironbus-proto/src/message.rs
+++ b/crates/ironbus-proto/src/message.rs
@@ -1238,8 +1238,27 @@ pub const CONNECT_FLAG_UNDERSTANDS_DELIVER_BATCH: u8 = 0b0100_0000;
 /// a pure capability flag (no associated value), so it occupies no slot in the v1 field block beyond
 /// this `flags` bit, exactly like [`CONNECT_FLAG_WANTS_GAP_MARKER`]. It is the LAST free bit (bit 7)
 /// of the handshake `flags` byte; a future capability needs an appended flags byte (the version+len
-/// framing already tolerates it).
+/// framing already tolerates it) — see [`CONNECT_FLAG2_COMPRESSED_DELIVERY`], the first such bit.
 pub const CONNECT_FLAG_UNDERSTANDS_STREAMS: u8 = 0b1000_0000;
+
+/// The FIRST bit of the `Connect` handshake's SECOND capability-flags byte (`flags2`, #1066), by which
+/// a consumer advertises that it UNDERSTANDS a compression-CODEC-encoded `Deliver` payload: the
+/// per-record `COMPRESSED` record flag and the `descriptor + codec-stream` payload shape a
+/// `--compression`-enabled broker stores and, by default, ships verbatim. When set, the server MAY
+/// deliver a stored-compressed record to this consumer with the `COMPRESSED` bit and codec bytes intact
+/// (the zero-CPU passthrough). When CLEAR (an old client, one that opts out, or the empty `Connect`
+/// body) the server DECOMPRESSES a stored-compressed record before delivery and clears the `COMPRESSED`
+/// bit, so a pre-#430 consumer that would mis-decode the descriptor bytes receives the plain payload —
+/// the #1066 silent-corruption fix. It is a pure capability flag (no associated value).
+///
+/// It lives in a SECOND flags byte because the historical `Connect` `flags` byte is FULL — bit 7
+/// ([`CONNECT_FLAG_UNDERSTANDS_STREAMS`]) was its last free bit. `flags2` is an APPENDED in-block byte
+/// that follows the v1 fixed fields and any appended `default_ack_level`/`default_tier`; it is emitted
+/// ONLY when non-zero, so a client that advertises no `flags2` capability sends a body byte-for-byte the
+/// historical layout, and an old reader (which stops after the v1 fields) ignores it. A future flags2
+/// capability takes the next bit of this same byte; a future appended VALUE field must follow the
+/// whole `flags2` byte so this single-byte read stays forward-compatible.
+pub const CONNECT_FLAG2_COMPRESSED_DELIVERY: u8 = 0b0000_0001;
 
 /// The `Info` presence-flag bit signalling that the server's advertised per-consumer message-credit
 /// fields (`negotiated` + `cap`) are present (#292). A server that does not advertise leaves it clear,
@@ -1312,10 +1331,12 @@ pub const INFO_FLAG_STREAMS: u8 = 0b1000_0000;
 /// follows), then the v1 block: `flags: u8`, `requested_credit: u32 LE`, `requested_credit_bytes:
 /// u64 LE`, then — each ONLY when its presence bit is set, in this fixed order — an APPENDED
 /// `default_ack_level: u8` (#494, when [`CONNECT_FLAG_HAS_DEFAULT_ACK_LEVEL`]) and an APPENDED
-/// `default_tier: u8` (#543, when [`CONNECT_FLAG_HAS_DEFAULT_TIER`]). Each appended byte is OMITTED
+/// `default_tier: u8` (#543, when [`CONNECT_FLAG_HAS_DEFAULT_TIER`]), then — LAST — an APPENDED
+/// `flags2: u8` SECOND capability-flags byte (#1066, [`CONNECT_FLAG2_COMPRESSED_DELIVERY`]), present
+/// ONLY when non-zero (the historical `flags` byte is full). Each appended byte is OMITTED
 /// (and `field_len` shrinks by it) when its field is absent; the encoder and decoder walk them in the
 /// SAME conditional order, so an absent earlier byte never shifts a present later one. A request with
-/// neither appended byte is byte-for-byte the historical body. Any bytes past `field_len` (a FUTURE
+/// none of these appended bytes is byte-for-byte the historical body. Any bytes past `field_len` (a FUTURE
 /// version's appended fields, e.g. the #71 `wire_protocol_version`) are TOLERATED and ignored by a v1
 /// reader. An empty body is the all-absent default.
 // Each bool is a DISTINCT negotiated wire CAPABILITY flag (gap-marker / streaming / deliver-batch /
@@ -1373,6 +1394,16 @@ pub struct ConnectBody {
     /// never sent a streams reply it did not request. A pure capability flag, so it adds no block slot
     /// beyond its `flags` bit.
     pub understands_streams: bool,
+    /// Whether this consumer UNDERSTANDS a compression-codec-encoded `Deliver` payload — the per-record
+    /// `COMPRESSED` flag and `descriptor + codec-stream` shape a `--compression` broker stores (#1066):
+    /// the [`CONNECT_FLAG2_COMPRESSED_DELIVERY`] capability bit (the first bit of the appended `flags2`
+    /// byte). When `true`, the server may ship a stored-compressed record verbatim (COMPRESSED bit +
+    /// codec bytes) for this consumer to decode. When `false` (the default, an old client, or the empty
+    /// `Connect` body) the server DECOMPRESSES a stored-compressed record before delivery and clears the
+    /// COMPRESSED bit, so a pre-#430 consumer that cannot decode the descriptor never receives it — the
+    /// silent-corruption fix. Advertising it sets a bit in the appended `flags2` byte (emitted only when
+    /// non-zero), so a client that leaves it `false` sends a body byte-for-byte the historical layout.
+    pub understands_compressed_delivery: bool,
 }
 
 /// The number of bytes in the `Connect` v1 known-field block with NO appended bytes (#494, #543):
@@ -1495,14 +1526,24 @@ pub const CONNECT_AUTH_SECTION_MARKER: u8 = 0xA7;
 /// [`decode_connect`] accepts both.
 pub fn encode_connect(req: &ConnectBody, out: &mut Vec<u8>) {
     out.push(HANDSHAKE_BODY_VERSION);
+    // The SECOND capability-flags byte (#1066): the historical `flags` byte is full, so a new PURE
+    // capability rides here. It is an APPENDED in-block byte, emitted ONLY when non-zero (below), so a
+    // request that advertises no `flags2` capability keeps the body byte-for-byte the historical layout.
+    let mut flags2 = 0u8;
+    if req.understands_compressed_delivery {
+        flags2 |= CONNECT_FLAG2_COMPRESSED_DELIVERY;
+    }
     // The block length is the historical fixed block plus ONE byte for each present appended field, in
-    // declared order (ack-level, then tier). An all-absent request encodes the historical length and
-    // bytes verbatim (byte-identity, #494/#543).
+    // declared order (ack-level, tier, then flags2). An all-absent request encodes the historical length
+    // and bytes verbatim (byte-identity, #494/#543/#1066).
     let mut field_len = CONNECT_V1_FIELD_LEN;
     if req.default_ack_level.is_some() {
         field_len += 1;
     }
     if req.default_tier.is_some() {
+        field_len += 1;
+    }
+    if flags2 != 0 {
         field_len += 1;
     }
     out.extend_from_slice(&field_len.to_le_bytes());
@@ -1542,6 +1583,12 @@ pub fn encode_connect(req: &ConnectBody, out: &mut Vec<u8>) {
     }
     if let Some(tier) = req.default_tier {
         out.push(tier);
+    }
+    // The appended `flags2` byte (#1066) follows the tier byte, present ONLY when a flags2 capability is
+    // set. The decoder reads it after tier from whatever remains in the block, so a clear flags2 keeps
+    // the body byte-for-byte the historical layout and an old reader ignores the (absent) byte.
+    if flags2 != 0 {
+        out.push(flags2);
     }
 }
 
@@ -1601,6 +1648,12 @@ pub fn decode_connect(body: &[u8]) -> Result<ConnectBody, BodyError> {
     // encoder wrote them, so a present tier byte is read from the right offset whether or not the
     // ack-level byte preceded it. Read AFTER ack-level; a clear bit (or short block) reads no byte.
     let default_tier = (flags & CONNECT_FLAG_HAS_DEFAULT_TIER != 0).then(|| fr.u8().unwrap_or(0));
+    // The appended `flags2` byte (#1066) is the FIRST byte of the block PAST the v1 fixed fields and the
+    // conditional ack-level/tier bytes. An old body (which stops there) leaves nothing, so `unwrap_or(0)`
+    // reads no capability and every `flags2` bit is clear — byte-for-byte the historical decode. A future
+    // in-block additive VALUE field MUST follow the whole `flags2` byte, so reading exactly this one byte
+    // stays forward-compatible (an unknown later byte is tolerated and ignored, as it is today).
+    let flags2 = fr.u8().unwrap_or(0);
     let requested_credit = (flags & CONNECT_FLAG_HAS_CREDIT != 0).then_some(credit);
     let requested_credit_bytes =
         (flags & CONNECT_FLAG_HAS_CREDIT_BYTES != 0).then_some(credit_bytes);
@@ -1608,6 +1661,7 @@ pub fn decode_connect(body: &[u8]) -> Result<ConnectBody, BodyError> {
     let understands_streaming = flags & CONNECT_FLAG_UNDERSTANDS_STREAMING != 0;
     let understands_deliver_batch = flags & CONNECT_FLAG_UNDERSTANDS_DELIVER_BATCH != 0;
     let understands_streams = flags & CONNECT_FLAG_UNDERSTANDS_STREAMS != 0;
+    let understands_compressed_delivery = flags2 & CONNECT_FLAG2_COMPRESSED_DELIVERY != 0;
     Ok(ConnectBody {
         requested_credit,
         requested_credit_bytes,
@@ -1617,6 +1671,7 @@ pub fn decode_connect(body: &[u8]) -> Result<ConnectBody, BodyError> {
         default_tier,
         understands_deliver_batch,
         understands_streams,
+        understands_compressed_delivery,
     })
 }
 
@@ -3119,6 +3174,7 @@ mod tests {
             default_tier: None,
             understands_deliver_batch: false,
             understands_streams: false,
+            understands_compressed_delivery: false,
         };
         let mut buf = Vec::new();
         encode_connect(&req, &mut buf);
@@ -4299,8 +4355,9 @@ mod tests {
             default_tier in proptest::option::of(any::<u8>()),
             understands_deliver_batch in any::<bool>(),
             understands_streams in any::<bool>(),
+            understands_compressed_delivery in any::<bool>(),
         ) {
-            let req = ConnectBody { requested_credit: credit, requested_credit_bytes: credit_bytes, wants_gap_marker, default_ack_level, understands_streaming, default_tier, understands_deliver_batch, understands_streams };
+            let req = ConnectBody { requested_credit: credit, requested_credit_bytes: credit_bytes, wants_gap_marker, default_ack_level, understands_streaming, default_tier, understands_deliver_batch, understands_streams, understands_compressed_delivery };
             let mut buf = Vec::new();
             encode_connect(&req, &mut buf);
             prop_assert_eq!(buf[0], HANDSHAKE_BODY_VERSION, "the body leads with its version");
@@ -4359,7 +4416,7 @@ mod tests {
             credit in proptest::option::of(any::<u32>()),
             trailing in prop::collection::vec(any::<u8>(), 0..64),
         ) {
-            let req = ConnectBody { requested_credit: credit, requested_credit_bytes: None, wants_gap_marker: false, default_ack_level: None, understands_streaming: false, default_tier: None, understands_deliver_batch: false, understands_streams: false };
+            let req = ConnectBody { requested_credit: credit, requested_credit_bytes: None, wants_gap_marker: false, default_ack_level: None, understands_streaming: false, default_tier: None, understands_deliver_batch: false, understands_streams: false, understands_compressed_delivery: false };
             let mut buf = Vec::new();
             encode_connect(&req, &mut buf);
             let mut extended = buf.clone();
@@ -4450,6 +4507,7 @@ mod tests {
                 default_tier: None,
                 understands_deliver_batch: false,
                 understands_streams: false,
+                understands_compressed_delivery: false,
             }
         );
     }
@@ -4475,6 +4533,7 @@ mod tests {
                 default_tier: Some(1),
                 understands_deliver_batch: true,
                 understands_streams: true,
+                understands_compressed_delivery: false,
             },
             &mut full,
         );
@@ -4523,6 +4582,7 @@ mod tests {
                     default_tier: Some(1),
                     understands_deliver_batch: false,
                     understands_streams: false,
+                    understands_compressed_delivery: false,
                 },
                 &mut body,
             );
@@ -4672,6 +4732,7 @@ mod tests {
             default_tier: None,
             understands_deliver_batch: false,
             understands_streams: false,
+            understands_compressed_delivery: false,
         };
         let mut buf = Vec::new();
         encode_connect(&req, &mut buf);
@@ -4939,6 +5000,7 @@ mod tests {
             default_tier: None,
             understands_deliver_batch: false,
             understands_streams: false,
+            understands_compressed_delivery: false,
         };
         let mut pre = Vec::new();
         encode_connect(&no_level, &mut pre);
@@ -5032,6 +5094,7 @@ mod tests {
             default_tier: None,
             understands_deliver_batch: false,
             understands_streams: false,
+            understands_compressed_delivery: false,
         };
         let mut pre = Vec::new();
         encode_connect(&none, &mut pre);
@@ -5144,6 +5207,7 @@ mod tests {
             default_tier: Some(ConsumeTier::Streaming.as_u8()),
             understands_deliver_batch: false,
             understands_streams: false,
+            understands_compressed_delivery: false,
         };
         let mut buf = Vec::new();
         encode_connect(&both, &mut buf);
@@ -5205,6 +5269,7 @@ mod tests {
                 default_tier: None,
                 understands_deliver_batch: false,
                 understands_streams: false,
+                understands_compressed_delivery: false,
             }
         );
 
@@ -5272,6 +5337,76 @@ mod tests {
         );
         assert_eq!(decode_info(&ibuf).unwrap(), info);
         assert!(!decode_info(&[]).unwrap().streams);
+    }
+
+    // ===== Compressed-delivery capability (#1066) =====
+
+    #[test]
+    fn connect_carries_the_compressed_delivery_capability_in_a_second_flags_byte() {
+        // #1066: a compression-decode-capable consumer sets CONNECT_FLAG2_COMPRESSED_DELIVERY, the
+        // FIRST bit of the APPENDED `flags2` byte (the historical `flags` byte is full). The bit
+        // round-trips, appends EXACTLY ONE block byte (the flags2 byte), and an EMPTY (old-client)
+        // Connect never advertises it — so an old consumer decodes to "not capable" and the server
+        // decompresses before delivery.
+        let req = ConnectBody {
+            understands_compressed_delivery: true,
+            ..ConnectBody::default()
+        };
+        let mut buf = Vec::new();
+        encode_connect(&req, &mut buf);
+        // The capability rides `flags2`, NOT the historical `flags` byte at index 3.
+        assert_eq!(
+            buf[3] & CONNECT_FLAG2_COMPRESSED_DELIVERY,
+            0,
+            "the capability does NOT ride the historical (full) flags byte"
+        );
+        let mut plain = Vec::new();
+        encode_connect(&ConnectBody::default(), &mut plain);
+        assert_eq!(
+            buf.len(),
+            plain.len() + 1,
+            "advertising the capability appends exactly one flags2 block byte"
+        );
+        // The appended flags2 byte is the LAST block byte and carries the capability bit.
+        assert_eq!(
+            buf[buf.len() - 1] & CONNECT_FLAG2_COMPRESSED_DELIVERY,
+            CONNECT_FLAG2_COMPRESSED_DELIVERY,
+            "the flags2 byte carries the compressed-delivery capability bit"
+        );
+        assert_eq!(decode_connect(&buf).unwrap(), req);
+        // An EMPTY (old-client) Connect never advertises the capability, and a body that leaves it
+        // clear is byte-for-byte the historical layout (no flags2 byte, no length change).
+        assert!(!decode_connect(&[]).unwrap().understands_compressed_delivery);
+        assert!(
+            !decode_connect(&plain)
+                .unwrap()
+                .understands_compressed_delivery
+        );
+    }
+
+    #[test]
+    fn a_clear_compressed_delivery_capability_is_byte_for_byte_the_historical_connect() {
+        // #1066: leaving the capability clear must NOT change the wire — the flags2 byte is emitted
+        // ONLY when non-zero, so an all-else-equal body with the capability off is byte-identical to
+        // one built without the field (the field defaults false).
+        let with_field = ConnectBody {
+            requested_credit: Some(4096),
+            wants_gap_marker: true,
+            understands_compressed_delivery: false,
+            ..ConnectBody::default()
+        };
+        let without = ConnectBody {
+            requested_credit: Some(4096),
+            wants_gap_marker: true,
+            ..ConnectBody::default()
+        };
+        let (mut a, mut b) = (Vec::new(), Vec::new());
+        encode_connect(&with_field, &mut a);
+        encode_connect(&without, &mut b);
+        assert_eq!(
+            a, b,
+            "a clear compressed-delivery capability appends no byte"
+        );
     }
 
     #[test]

--- a/crates/ironbus-proto/tests/export_go_vectors.rs
+++ b/crates/ironbus-proto/tests/export_go_vectors.rs
@@ -83,6 +83,7 @@ fn connect_fields(req: &ConnectBody, auth: Option<&AuthCredential>) -> String {
             "{{\"requested_credit\":{},\"requested_credit_bytes\":{},\"wants_gap_marker\":{},",
             "\"default_ack_level\":{},\"understands_streaming\":{},\"default_tier\":{},",
             "\"understands_deliver_batch\":{},\"understands_streams\":{},",
+            "\"understands_compressed_delivery\":{},",
             "\"auth_mechanism\":{},\"auth_material_hex\":{}}}"
         ),
         opt_u32(req.requested_credit),
@@ -93,6 +94,7 @@ fn connect_fields(req: &ConnectBody, auth: Option<&AuthCredential>) -> String {
         opt_u8(req.default_tier),
         req.understands_deliver_batch,
         req.understands_streams,
+        req.understands_compressed_delivery,
         mechanism,
         material,
     )
@@ -275,6 +277,7 @@ fn build_vectors() -> Vec<Vector> {
         default_tier: Some(1),
         understands_deliver_batch: true,
         understands_streams: true,
+        understands_compressed_delivery: true,
     };
     let mut body = Vec::new();
     encode_connect(&full, &mut body);

--- a/crates/ironbus-server/src/session.rs
+++ b/crates/ironbus-server/src/session.rs
@@ -28,7 +28,9 @@ use bytes::Bytes;
 use ironbus_core::binding::{single_home, Resolution};
 use ironbus_core::clock::Clock;
 use ironbus_core::codec::BodyChecksums;
-use ironbus_core::compress::{validate_descriptor_shape, DEFAULT_MAX_DECOMPRESSED_BYTES};
+use ironbus_core::compress::{
+    decompress_payload, validate_descriptor_shape, NoDictionaries, DEFAULT_MAX_DECOMPRESSED_BYTES,
+};
 use ironbus_core::confirm::{ConfirmStatus, ReadyConfirm};
 use ironbus_core::dedup::{MAX_MSG_ID_LEN, MAX_PRODUCER_ID_LEN};
 use ironbus_core::keyshared::{KeyOrdering, MemberId};
@@ -53,6 +55,7 @@ use ironbus_proto::message::{
 use ironbus_storage::fs::Filesystem;
 use ironbus_storage::log::Append;
 use ironbus_storage::streamset::StreamId;
+use std::borrow::Cow;
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 
@@ -374,6 +377,18 @@ pub struct Session {
     /// connection uses ONLY the default-stream verbs (`Pub`/`Sub`/`Flow`/`Fetch`), which target the
     /// default stream `""` — byte-for-byte today's behavior. Default `false` (backward-compatible).
     streams_enabled: bool,
+    /// Whether this consumer negotiated COMPRESSED delivery (#1066): set at `Connect` time when the
+    /// client advertised [`ironbus_proto::message::CONNECT_FLAG2_COMPRESSED_DELIVERY`]. When `true`, a
+    /// stored-COMPRESSED record (a `--compression` broker's `descriptor + codec-stream` payload with the
+    /// `COMPRESSED` record flag) is delivered VERBATIM — the codec bytes and the flag pass through, the
+    /// broker's zero-CPU passthrough, which a #430+ client decodes. When `false` (an old client, one that
+    /// opts out, or the empty `Connect` body) a stored-COMPRESSED record is DECOMPRESSED before delivery
+    /// and the `COMPRESSED` bit is cleared, so a pre-#430 consumer that would mis-decode the descriptor
+    /// bytes receives the plain produced payload instead — the ONE silent-wrong-data path is closed.
+    /// UNCOMPRESSED records are unaffected either way (identity passthrough). Default `false`
+    /// (backward-compatible): the safe choice for an unmarked consumer even on a `--compression lz4`
+    /// broker.
+    compressed_delivery_enabled: bool,
     /// The NAMED stream this connection's consume path is bound to (#588, M2-I10), `""` (the default
     /// stream) until a `SubTo` binds a named one. A `SubTo` sets BOTH this and `subscription` (the
     /// work-group within the stream); a plain `Sub`/`Unsub` resets it to the default stream. The Flow
@@ -1244,6 +1259,14 @@ impl Session {
         // that did not advertise is REFUSED those verbs (a typed `Err`) and is never sent a streams
         // reply it did not ask for, so an old client uses only the default-stream verbs unchanged.
         self.streams_enabled = req.understands_streams;
+        // Negotiate COMPRESSED delivery (#1066): the capability is active exactly when this consumer
+        // advertised it can DECODE a compression-codec-encoded delivery. A capable consumer receives a
+        // stored-COMPRESSED record VERBATIM (the codec bytes + `COMPRESSED` flag, the broker's zero-CPU
+        // passthrough); one that did NOT advertise (an old client, or the empty `Connect`) has a
+        // stored-COMPRESSED record DECOMPRESSED before delivery with the `COMPRESSED` bit cleared, so a
+        // pre-#430 consumer that would mis-decode the descriptor bytes never receives them — even on a
+        // `--compression lz4` broker. This is the silent-corruption fix: the safe default is uncompressed.
+        self.compressed_delivery_enabled = req.understands_compressed_delivery;
         // A repeated Connect re-negotiates idempotently: reset the active named stream to the default
         // so a re-handshake never leaves a stale named-stream binding from a prior negotiation.
         self.stream = GroupName::default();
@@ -2182,14 +2205,24 @@ impl Session {
                 })?;
                 match poll {
                     Ok(Poll::Message(d)) => {
+                        // Gate the delivery encoding on the negotiated compressed-delivery capability
+                        // (#1066): a non-capable consumer gets a stored-COMPRESSED record DECOMPRESSED
+                        // with the COMPRESSED bit cleared; a capable consumer (and every uncompressed
+                        // record) passes through verbatim. `None` = the record cannot be safely
+                        // delivered, so stop the batch rather than ship a byte it cannot decode.
+                        let Some((wire_flags, wire_payload)) =
+                            self.deliver_encoding(d.record.flags.bits(), &d.record.payload)
+                        else {
+                            break;
+                        };
                         let msg = DeliverBody {
                             offset: d.offset.get(),
                             generation: d.token.generation,
-                            flags: d.record.flags.bits(),
+                            flags: wire_flags,
                             timestamp_ms: d.record.timestamp_ms,
                             key: &d.record.key,
                             headers: &d.record.headers,
-                            payload: &d.record.payload,
+                            payload: wire_payload.as_ref(),
                         };
                         frame_body.clear();
                         // The record's key/headers came through PUB (u16-bounded), so this cannot
@@ -2448,14 +2481,23 @@ impl Session {
                 let member = self.member_id;
                 match engine.with(move |e| e.poll_now_in_member(&group, member))? {
                     Ok(Poll::Message(d)) => {
+                        // Compressed-delivery gate (#1066), IDENTICAL to `handle_flow`: a non-capable
+                        // consumer gets a stored-COMPRESSED record decompressed (COMPRESSED bit cleared);
+                        // a capable consumer and every uncompressed record pass through verbatim. `None`
+                        // stops the batch rather than ship a byte the consumer cannot decode.
+                        let Some((wire_flags, wire_payload)) =
+                            self.deliver_encoding(d.record.flags.bits(), &d.record.payload)
+                        else {
+                            break;
+                        };
                         let msg = DeliverBody {
                             offset: d.offset.get(),
                             generation: d.token.generation,
-                            flags: d.record.flags.bits(),
+                            flags: wire_flags,
                             timestamp_ms: d.record.timestamp_ms,
                             key: &d.record.key,
                             headers: &d.record.headers,
-                            payload: &d.record.payload,
+                            payload: wire_payload.as_ref(),
                         };
                         frame_body.clear();
                         if encode_deliver(&msg, &mut frame_body).is_err() {
@@ -2640,7 +2682,8 @@ impl Session {
             want,
             max_bytes,
         ) {
-            let delivered = Self::serve_follower_read_outcome(outcome, out);
+            let delivered =
+                Self::serve_follower_read_outcome(outcome, self.compressed_delivery_enabled, out);
             // Terminate with the SAME FlowEnd a leader Tier-S batch uses, so the client frames a
             // follower-read response exactly like any other streaming batch. No keep-up auto-tune on the
             // follower path (the credit window is the leader engine's concern); a follower-read just serves
@@ -2655,11 +2698,19 @@ impl Session {
         // Serve the batch (raw-framed if the consumer advertised DeliverBatch, else per-record), getting
         // back how many records were delivered (`None` = a recoverable reject already replied as an Err,
         // which is the response terminator, so there is no keep-up and no FlowEnd to add).
+        let capable = self.compressed_delivery_enabled;
         let delivered = if self.deliver_batch_enabled {
-            Self::serve_stream_fetch_batch(engine, &group, member, start, want, max_bytes, out)?
+            // The RAW DeliverBatch path ships the on-disk frame bytes VERBATIM (including any stored
+            // COMPRESSED records), which is sound WITHOUT a compressed-delivery gate: decoding a raw
+            // batch means decoding the on-disk record layout, so a DeliverBatch-capable consumer is
+            // compression-capable by construction. The ACTIVE-tail per-record remainder is still gated
+            // via `capable` inside the fn. (#1066)
+            Self::serve_stream_fetch_batch(
+                engine, &group, member, start, want, max_bytes, capable, out,
+            )?
         } else {
             Self::serve_stream_fetch_per_record(
-                engine, &group, member, start, want, max_bytes, out,
+                engine, &group, member, start, want, max_bytes, capable, out,
             )?
         };
         let Some(delivered) = delivered else {
@@ -2681,6 +2732,43 @@ impl Session {
         Ok(())
     }
 
+    /// Chooses the WIRE encoding of a stored record's `(flags, payload)` for delivery to THIS consumer,
+    /// honoring the negotiated compressed-delivery capability (#1066). The instance method reads this
+    /// connection's `compressed_delivery_enabled`; see [`Session::deliver_encoding_for`] for the shared
+    /// logic (the lease-free Tier-S / follower-read serves are associated fns, so they pass the flag in).
+    fn deliver_encoding<'p>(&self, flags: u8, payload: &'p [u8]) -> Option<(u8, Cow<'p, [u8]>)> {
+        Self::deliver_encoding_for(self.compressed_delivery_enabled, flags, payload)
+    }
+
+    /// The shared compressed-delivery gate (#1066): given whether the consumer advertised it can decode
+    /// a compression-codec-encoded delivery, returns the `(wire_flags, wire_payload)` to put on the
+    /// `Deliver` frame, or `None` when the record cannot be safely delivered (never ship a bad byte).
+    ///
+    /// - A CAPABLE consumer, or an UNCOMPRESSED record, is the PASSTHROUGH: the stored flags and a
+    ///   borrowed payload go on the wire verbatim — zero copy, zero codec CPU, byte-for-byte today's
+    ///   behavior (the common case, and every record on a `--compression none` broker).
+    /// - A NON-capable consumer receiving a stored-COMPRESSED record is the #1066 FIX: the payload is
+    ///   DECOMPRESSED here and the `COMPRESSED` bit is cleared, so the consumer receives the plain
+    ///   produced payload it can actually read, never the descriptor bytes it would mis-decode. The
+    ///   default build is dict-free lz4, so [`NoDictionaries`] resolves every default-codec record; a
+    ///   decode failure (e.g. a zstd-with-dictionary record on an opt-in build, whose dictionary this
+    ///   dict-free resolver cannot supply) is FAIL-LOUD — `None`, so the caller stops the batch rather
+    ///   than deliver a byte the consumer cannot decode. It is NEVER silent corruption.
+    fn deliver_encoding_for(
+        capable: bool,
+        flags: u8,
+        payload: &[u8],
+    ) -> Option<(u8, Cow<'_, [u8]>)> {
+        let rf = RecordFlags::from_bits(flags);
+        if capable || !rf.contains(RecordFlags::COMPRESSED) {
+            return Some((flags, Cow::Borrowed(payload)));
+        }
+        let plain =
+            decompress_payload(rf, payload, &NoDictionaries, DEFAULT_MAX_DECOMPRESSED_BYTES)
+                .ok()?;
+        Some((flags & !RecordFlags::COMPRESSED.bits(), Cow::Owned(plain)))
+    }
+
     /// Emit a CLUSTER FOLLOWER-READ outcome (#735, half B) as per-record `Deliver` frames, returning the
     /// number of records written. The follower serves the committed prefix from its OWN read plane as a
     /// zero-copy [`RawSealedRead`] run; this decodes each CRC-framed record (re-validating the header AND
@@ -2690,7 +2778,11 @@ impl Session {
     /// never by a fencing token. A [`FollowerReadOutcome::ConfirmWithLeader`] (a latest/dirty read above
     /// the safe watermark) serves NOTHING here — never a speculative unconfirmed serve; the over-the-wire
     /// dirty-tier leader confirm is the flagged follow-up.
-    fn serve_follower_read_outcome(outcome: FollowerReadOutcome, out: &mut Vec<u8>) -> u32 {
+    fn serve_follower_read_outcome(
+        outcome: FollowerReadOutcome,
+        capable: bool,
+        out: &mut Vec<u8>,
+    ) -> u32 {
         let run = match outcome {
             FollowerReadOutcome::Served(read) => read.run,
             // A latest/dirty read above the safe watermark: do NOT speculatively serve unconfirmed bytes.
@@ -2710,15 +2802,23 @@ impl Session {
             let Ok((view, consumed)) = ironbus_core::codec::decode(&run.bytes[cursor..]) else {
                 break;
             };
+            // Compressed-delivery gate (#1066): a non-capable consumer gets a stored-COMPRESSED record
+            // decompressed (COMPRESSED bit cleared); a capable consumer and every uncompressed record
+            // pass through verbatim. `None` stops the run rather than ship an undecodable byte.
+            let Some((wire_flags, wire_payload)) =
+                Self::deliver_encoding_for(capable, view.flags.bits(), view.payload)
+            else {
+                break;
+            };
             let msg = DeliverBody {
                 offset,
                 // Lease-free Tier-S follower-read: generation 0, commit-by-offset (no fencing token).
                 generation: 0,
-                flags: view.flags.bits(),
+                flags: wire_flags,
                 timestamp_ms: view.timestamp_ms,
                 key: view.key,
                 headers: view.headers,
-                payload: view.payload,
+                payload: wire_payload.as_ref(),
             };
             frame_body.clear();
             if encode_deliver(&msg, &mut frame_body).is_err() {
@@ -2737,6 +2837,7 @@ impl Session {
     /// of records delivered (`Some(n)`), or `None` when a recoverable engine reject was surfaced as an
     /// `Err` terminator (so the caller adds no `FlowEnd`). Does NOT write the `FlowEnd`; the caller
     /// does, after the shared #552 keep-up check, so both batch halves terminate identically.
+    #[allow(clippy::too_many_arguments)]
     fn serve_stream_fetch_per_record<
         F: Filesystem + 'static,
         C: Clock + Clone + 'static,
@@ -2748,6 +2849,7 @@ impl Session {
         start: Offset,
         want: usize,
         max_bytes: Option<usize>,
+        capable: bool,
         out: &mut Vec<u8>,
     ) -> Result<Option<u32>, SessionError> {
         let group = group.clone();
@@ -2761,16 +2863,24 @@ impl Session {
                 // cleared and reused each iteration instead of a fresh `Vec` per delivered record.
                 let mut frame_body = Vec::with_capacity(DELIVER_FRAME_SCRATCH_CAP);
                 for record in &records {
+                    // Compressed-delivery gate (#1066): a non-capable consumer gets a stored-COMPRESSED
+                    // record decompressed (COMPRESSED bit cleared); a capable consumer and every
+                    // uncompressed record pass through verbatim. `None` stops the batch here.
+                    let Some((wire_flags, wire_payload)) =
+                        Self::deliver_encoding_for(capable, record.flags.bits(), &record.payload)
+                    else {
+                        break;
+                    };
                     let msg = DeliverBody {
                         offset: record.offset.get(),
                         // No lease, no fence: a streaming delivery carries generation 0. The consumer
                         // commits by offset (StreamCommit), never by a per-record fencing token.
                         generation: 0,
-                        flags: record.flags.bits(),
+                        flags: wire_flags,
                         timestamp_ms: record.timestamp_ms,
                         key: &record.key,
                         headers: &record.headers,
-                        payload: &record.payload,
+                        payload: wire_payload.as_ref(),
                     };
                     frame_body.clear();
                     if encode_deliver(&msg, &mut frame_body).is_err() {
@@ -2826,6 +2936,7 @@ impl Session {
         start: Offset,
         want: usize,
         max_bytes: Option<usize>,
+        capable: bool,
         out: &mut Vec<u8>,
     ) -> Result<Option<u32>, SessionError> {
         let group = group.clone();
@@ -2860,14 +2971,23 @@ impl Session {
                 // and reused each iteration instead of a fresh `Vec` per delivered record.
                 let mut frame_body = Vec::with_capacity(DELIVER_FRAME_SCRATCH_CAP);
                 for record in &tail {
+                    // Compressed-delivery gate (#1066) on the ACTIVE-tail per-record remainder: a
+                    // non-capable consumer gets a stored-COMPRESSED record decompressed (COMPRESSED bit
+                    // cleared); a capable consumer and every uncompressed record pass through verbatim.
+                    // (The raw SEALED prefix above ships verbatim — sound, see the call site.)
+                    let Some((wire_flags, wire_payload)) =
+                        Self::deliver_encoding_for(capable, record.flags.bits(), &record.payload)
+                    else {
+                        break;
+                    };
                     let msg = DeliverBody {
                         offset: record.offset.get(),
                         generation: 0,
-                        flags: record.flags.bits(),
+                        flags: wire_flags,
                         timestamp_ms: record.timestamp_ms,
                         key: &record.key,
                         headers: &record.headers,
-                        payload: &record.payload,
+                        payload: wire_payload.as_ref(),
                     };
                     frame_body.clear();
                     if encode_deliver(&msg, &mut frame_body).is_err() {
@@ -5242,6 +5362,7 @@ mod tests {
                 default_tier: None,
                 understands_deliver_batch: false,
                 understands_streams: false,
+                understands_compressed_delivery: false,
             },
             &mut body,
         );
@@ -6462,6 +6583,7 @@ mod tests {
                 default_tier: default_tier.map(ConsumeTier::as_u8),
                 understands_deliver_batch: false,
                 understands_streams: false,
+                understands_compressed_delivery: false,
             },
             &mut body,
         );
@@ -6619,6 +6741,7 @@ mod tests {
                 default_tier: None,
                 understands_deliver_batch,
                 understands_streams: false,
+                understands_compressed_delivery: false,
             },
             &mut body,
         );
@@ -9355,6 +9478,154 @@ mod tests {
         assert_eq!(back, original, "one decode recovers the original");
     }
 
+    // ---- Compressed-delivery capability gate (#1066) ----
+
+    /// A `Connect` body advertising the compressed-delivery capability (#1066).
+    fn compressed_delivery_connect_body() -> Vec<u8> {
+        let mut body = Vec::new();
+        ironbus_proto::message::encode_connect(
+            &ironbus_proto::message::ConnectBody {
+                understands_compressed_delivery: true,
+                ..Default::default()
+            },
+            &mut body,
+        );
+        body
+    }
+
+    /// A large, highly compressible payload — well over the raw-store threshold, so a `--compression
+    /// lz4` engine stores it COMPRESSED (the #1066 fixture).
+    fn lz4_compressible_payload() -> Vec<u8> {
+        b"ironbus.telemetry.sensor.v1 compressed-delivery-gate #1066 "
+            .iter()
+            .copied()
+            .cycle()
+            .take(8192)
+            .collect()
+    }
+
+    /// The `(flags, payload)` of every `Deliver` frame in `out` (the wire form the consumer receives).
+    fn delivered_flags_and_payloads(out: &[u8]) -> Vec<(u8, Vec<u8>)> {
+        decode_all(out)
+            .iter()
+            .filter(|(t, _)| *t == FrameType::Deliver)
+            .map(|(_, b)| {
+                let d = decode_deliver(b).unwrap();
+                (d.flags, d.payload.to_vec())
+            })
+            .collect()
+    }
+
+    #[test]
+    fn a_non_capable_consumer_gets_uncompressed_delivery_from_an_lz4_broker() {
+        // THE #1066 FIX: on a `--compression lz4` broker a stored-COMPRESSED record is delivered
+        // DECOMPRESSED (the COMPRESSED bit CLEAR, the plain produced payload) to a consumer that did
+        // NOT advertise it can decode compression (an old/empty Connect) — never the descriptor bytes
+        // it would silently mis-decode. This is the ONE silent-wrong-data path, now closed.
+        use ironbus_core::compress::{compress_payload, CompressConfig};
+        let original = lz4_compressible_payload();
+        // The fixture genuinely compresses, so the lz4 engine stores it COMPRESSED — otherwise this
+        // test would be vacuous (a raw store would deliver `original` with no decompression exercised).
+        assert!(
+            compress_payload(&original, &CompressConfig::default())
+                .unwrap()
+                .compressed,
+            "the fixture must genuinely compress"
+        );
+
+        let e = DirectEngine::new(engine_lz4());
+        produce(&e, &original);
+        // A NON-capable consumer: the empty (old-client) Connect never advertises the capability.
+        let mut s = connected_session(&e);
+        let mut out = Vec::new();
+        s.process(&e, &frame(FrameType::Flow, &1u32.to_le_bytes()), &mut out)
+            .unwrap();
+        let delivered = delivered_flags_and_payloads(&out);
+        assert_eq!(delivered.len(), 1, "exactly one record delivered");
+        assert_eq!(
+            delivered[0].0 & RecordFlags::COMPRESSED.bits(),
+            0,
+            "the COMPRESSED bit is CLEARED for a non-capable consumer"
+        );
+        assert_eq!(
+            delivered[0].1, original,
+            "the non-capable consumer receives the PLAIN produced payload, not the descriptor bytes"
+        );
+    }
+
+    #[test]
+    fn a_capable_consumer_gets_compressed_delivery_from_an_lz4_broker() {
+        // The complement of the fix: a consumer that ADVERTISES the capability receives the stored
+        // record VERBATIM (COMPRESSED bit SET, the codec bytes) — the broker's zero-CPU passthrough —
+        // and those bytes decode back to the produced payload end-to-end.
+        let e = DirectEngine::new(engine_lz4());
+        let original = lz4_compressible_payload();
+        produce(&e, &original);
+        let mut s = Session::new();
+        let mut out = Vec::new();
+        s.process(
+            &e,
+            &frame(FrameType::Connect, &compressed_delivery_connect_body()),
+            &mut out,
+        )
+        .unwrap();
+        out.clear();
+        s.process(&e, &frame(FrameType::Flow, &1u32.to_le_bytes()), &mut out)
+            .unwrap();
+        let delivered = delivered_flags_and_payloads(&out);
+        assert_eq!(delivered.len(), 1, "exactly one record delivered");
+        assert_ne!(
+            delivered[0].0 & RecordFlags::COMPRESSED.bits(),
+            0,
+            "the COMPRESSED bit is PRESERVED for a capable consumer"
+        );
+        assert_ne!(
+            delivered[0].1, original,
+            "a capable consumer receives the compressed codec bytes, not the plain payload"
+        );
+        let back = decompress_payload(
+            RecordFlags::from_bits(delivered[0].0),
+            &delivered[0].1,
+            &NoDictionaries,
+            DEFAULT_MAX_DECOMPRESSED_BYTES,
+        )
+        .unwrap();
+        assert_eq!(
+            back, original,
+            "the compressed delivery decodes to the produced payload"
+        );
+    }
+
+    #[test]
+    fn a_connect_that_omits_the_compressed_delivery_bit_still_gets_uncompressed_delivery() {
+        // The gate keys on the SPECIFIC capability bit, not merely "empty vs non-empty Connect": a
+        // consumer that advertises OTHER capabilities (here gap-marker) but NOT compressed-delivery is
+        // still served DECOMPRESSED on an lz4 broker — the safe default holds for any client that does
+        // not opt into compressed delivery.
+        let e = DirectEngine::new(engine_lz4());
+        let original = lz4_compressible_payload();
+        produce(&e, &original);
+        let mut s = Session::new();
+        let mut out = Vec::new();
+        s.process(
+            &e,
+            &frame(FrameType::Connect, &gap_marker_connect_body()),
+            &mut out,
+        )
+        .unwrap();
+        out.clear();
+        s.process(&e, &frame(FrameType::Flow, &1u32.to_le_bytes()), &mut out)
+            .unwrap();
+        let delivered = delivered_flags_and_payloads(&out);
+        assert_eq!(delivered.len(), 1, "exactly one record delivered");
+        assert_eq!(
+            delivered[0].0 & RecordFlags::COMPRESSED.bits(),
+            0,
+            "a client that did not advertise compressed delivery gets the COMPRESSED bit cleared"
+        );
+        assert_eq!(delivered[0].1, original, "and the plain produced payload");
+    }
+
     #[test]
     fn a_compressed_pub_over_garbage_is_rejected_and_appends_nothing() {
         // THE #438 TEETH: bit 0 over bytes that are not a descriptor used to be acked durably
@@ -9506,6 +9777,7 @@ mod tests {
                 default_tier: None,
                 understands_deliver_batch: false,
                 understands_streams: false,
+                understands_compressed_delivery: false,
             },
             &mut connect_body,
         );
@@ -11210,6 +11482,7 @@ mod tests {
                 default_tier: None,
                 understands_deliver_batch: false,
                 understands_streams: false,
+                understands_compressed_delivery: false,
             },
             &mut connect_body,
         );
@@ -11514,6 +11787,7 @@ mod tests {
                 default_tier: None,
                 understands_deliver_batch: false,
                 understands_streams: true,
+                understands_compressed_delivery: false,
             },
             &mut body,
         );

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -136,14 +136,34 @@ storage flag:
   unchanged. It is an ADDITIVE flag only: the `FrameType` tag vocabulary is unchanged (the
   `type_tags_have_their_exact_frozen_wire_values` pin still holds).
 
-### Mixed-version rollout with write-path compression (#430)
+### Mixed-version rollout with write-path compression (#430, gated by #1066)
 
 Upgrading only the broker flips real compression on by default (`serve --compression` defaults
-to `lz4`), and a pre-#430 client receives the descriptor + codec stream bytes verbatim with the
-`COMPRESSED` bit set, which is spec-legal but silently different from the produced payload. The
-operational rule is therefore: upgrade consumers to a #430+ client FIRST, or run the broker with
-`--compression none` during the transition. A client downgrade after compressed data exists
-regresses those consumers to the raw stored bytes for every compressed record still retained.
+to `lz4`). Compressed DELIVERY is now GATED on a `Connect` capability bit
+(`CONNECT_FLAG2_COMPRESSED_DELIVERY`, #1066), so this is no longer a silent-corruption path — it
+is enforced at the wire, not just documented here:
+
+- A consumer that ADVERTISES the capability (every #430+ client does by default —
+  `ClientConfig::understands_compressed_delivery`, on by default) receives a stored-compressed
+  record VERBATIM (the `descriptor + codec-stream` bytes with the `COMPRESSED` bit set) and decodes
+  it, exactly as before. The broker's zero-CPU passthrough is preserved.
+- A consumer that does NOT advertise it (a pre-#430 client, one that opts out, or the EMPTY
+  old-client `Connect` body) is served the record DECOMPRESSED — the plain produced payload with the
+  `COMPRESSED` bit CLEARED. The broker decompresses per-delivery for that consumer; the STORED record
+  is unaffected (this is a per-consumer delivery-encoding decision, not a re-store).
+
+The result: a normal broker-first upgrade is safe even with released pre-#430 clients
+(2026.0609.2 – 2026.0610.7) still connected — they transparently receive uncompressed deliveries.
+Running the broker with `--compression none` is therefore no longer REQUIRED for the transition
+(it remains available as a blanket opt-out). The gate mirrors the `GapMarker` (#292/#346) and
+`DeliverBatch` (#541) capability mechanism. A consumer that advertises `DeliverBatch` is
+compression-capable by construction (decoding a raw batch means decoding the on-disk record layout,
+including `COMPRESSED` records), so the raw-batch path ships verbatim without a separate gate.
+
+Note (opt-in `zstd` builds): the broker's per-delivery decompression for a non-capable consumer uses
+the dictionary-free resolver, which covers every default `lz4` (and dict-less `zstd`) record. A
+`zstd`-with-trained-dictionary record delivered to a non-capable consumer FAILS LOUD (the record is
+dropped from that batch) rather than shipping undecodable bytes — never silent corruption.
 
 ### The Connect/Info handshake bodies are an ADDITIVE, version-prefixed change (#292)
 


### PR DESCRIPTION
## Summary

Closes the ONE silent-wrong-data path in an otherwise fail-loud system (#1066, P0). Default-on `--compression lz4` delivered stored-compressed `descriptor + codec-stream` bytes verbatim (COMPRESSED record flag set) to any consumer, including pre-#430 clients (released `2026.0609.2` – `2026.0610.7`) that mis-decode them during a normal broker-first upgrade. It was guarded only by prose in `COMPATIBILITY.md`.

This gates compressed **delivery** on a `Connect` capability bit, mirroring the proven `GapMarker` (#292/#346) and `DeliverBatch` (#541) mechanism.

## How it negotiates

**Connect bit → Session field → delivery gate**

- **proto:** new `CONNECT_FLAG2_COMPRESSED_DELIVERY`, the first bit of a NEW appended `flags2` byte. The historical `Connect` `flags` byte has all 8 bits allocated (`UNDERSTANDS_STREAMS` was the last), so a new capability needs a second flags byte. `flags2` is an in-block appended byte emitted **only when non-zero** — a client that doesn't advertise it sends a body byte-for-byte the historical layout, and an old reader ignores it. `ConnectBody` gains `understands_compressed_delivery`.
- **server:** `Session::compressed_delivery_enabled` is set at `Connect` time. A new gate `Session::deliver_encoding(flags, payload)` returns the wire `(flags, payload)`: a **capable** consumer (or any uncompressed record) gets a verbatim borrowed passthrough (zero copy, zero codec CPU); a **non-capable** consumer receiving a stored-COMPRESSED record gets it **decompressed** with the COMPRESSED bit cleared. The stored record is untouched — this is a per-consumer delivery-encoding decision.
- **client / client-async:** advertise the capability by **default** (`ClientConfig::understands_compressed_delivery = true`), so real clients keep receiving compression; a wrapper around a legacy consumer sets it `false`.

## Client-side advertisement

`ClientConfig::understands_compressed_delivery` defaults `true` (every client decodes compression since #430). Both the sync and async clients set the `flags2` bit in their `Connect`.

## Delivery paths gated

Every per-record `Deliver` construction: Tier-W poll (`handle_flow`) + batch fetch, Tier-S per-record, cluster follower-read, and the DeliverBatch active-tail. The **raw** DeliverBatch sealed prefix ships verbatim without a separate gate — a batch-capable consumer decodes the on-disk record layout (including COMPRESSED records), so it is compression-capable by construction (documented at the call site).

## Safety

- Safe default: a consumer that advertises nothing (old client, empty `Connect`) gets **uncompressed** delivery even on a `--compression lz4` broker.
- A non-capable delivery that cannot be decompressed (a `zstd`-with-trained-dictionary record on an opt-in build, which the dict-free resolver can't supply) **fails loud** (record dropped from the batch), never corrupt.

## Tests

- `a_non_capable_consumer_gets_uncompressed_delivery_from_an_lz4_broker` — the core fix.
- `a_capable_consumer_gets_compressed_delivery_from_an_lz4_broker` — verbatim + decodes end-to-end.
- `a_connect_that_omits_the_compressed_delivery_bit_still_gets_uncompressed_delivery` — the gate keys on the specific bit, not empty-vs-non-empty.
- proto: `flags2` round-trip, byte-identity when clear, and the `any_connect_round_trips` proptest extended.

## Verification (colima container, debug)

- `cargo test -p ironbus-proto -p ironbus-server` → **158** + **1102** passed, 0 failed.
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` → clean (tls/zstd/otlp all compiled).
- `cargo fmt --all --check` → clean.
- `scripts/check-format-registry.sh` → on-disk format + frame-tag digests unchanged (the Connect handshake body is not a pinned on-disk format).

## Follow-up (out of scope)

The env-gated Go golden-vector exporter (`export_go_vectors.rs`) now includes the field and sets it on the `full` vector; regenerating `sdk/go/.../golden_vectors.json` and adding the field to the Go wire decoder is a cross-language follow-up. This repo's CI is unaffected (exporter is a no-op without `IRONBUS_EXPORT_GO_VECTORS`; the committed corpus is untouched).

## Design forks for review

1. **`flags2` second byte** vs. reusing a bit — no free bit remained in `flags`; `flags2` is appended in-block and emitted only when non-zero (forward/backward compatible).
2. **No `Info` echo bit.** Unlike gap-marker/streaming, the capability needs no server confirmation to function — the client decodes per-record COMPRESSED flags it already understands by advertising. The `Info` `flags` byte is also full (bit 7 = `INFO_FLAG_STREAMS`), so skipping the echo avoids a second Info flags byte. Observability-only; can add later if wanted.
3. **Session field named `compressed_delivery_enabled`** (matches the existing `*_enabled` convention) rather than the issue's `*_capable`.
4. **Raw DeliverBatch not separately gated** (soundness argument above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01McmNfYNWPmohVS8umY9Lkp