### PR TITLE
chore(release): automate the release process (workflow + prepare-release script)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,9 +58,28 @@ jobs:
           TAG: ${{ github.event.inputs.tag || github.ref_name }}
         run: sh scripts/ci/changelog-unreleased.sh CHANGELOG.md "$TAG"
 
+  version-gate:
+    name: tag version matches the manifest
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+      # A `v*` tag whose version does not equal `[workspace.package] version` in Cargo.toml means the
+      # prep PR forgot to bump the manifest (or the wrong tag was pushed): the shipped binary would
+      # report one version while the release claims another. FAIL here, before any binary is built —
+      # the build jobs `needs:` this gate — so a mislabeled artifact is never published. In the normal
+      # flow scripts/prepare-release.sh keeps the two in lockstep; this is the belt-and-suspenders
+      # check at tag time.
+      - name: assert the tag version equals the workspace version
+        env:
+          TAG: ${{ github.event.inputs.tag || github.ref_name }}
+        run: sh scripts/ci/assert-tag-version.sh "$TAG" Cargo.toml
+
   build:
     name: build (${{ matrix.target }})
-    needs: changelog-gate
+    needs: [changelog-gate, version-gate]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -422,6 +441,29 @@ jobs:
             v0.*|v0) echo "value=true" >> "$GITHUB_OUTPUT" ;;
             *) echo "value=false" >> "$GITHUB_OUTPUT" ;;
           esac
+      - name: render the release notes from the CHANGELOG
+        env:
+          TAG: ${{ github.event.inputs.tag || github.ref_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # The GitHub Release body is the curated `## [vX.Y.Z]` CHANGELOG section (the #128 gate
+          # already proved it non-empty) plus a fixed artifact/verify footer, NOT a hand-kept string
+          # that drifts from the log. release-notes.sh handles GitHub's 125000-char body cap: an
+          # oversized changelog is truncated at a line boundary with a link to the full CHANGELOG at
+          # the tag, so a large release still posts a short summary + link instead of failing.
+          mkdir -p dist
+          sh scripts/ci/release-notes.sh "$TAG" CHANGELOG.md "$REPO" dist/release-notes.md
+          echo "----- release notes preview (first 40 lines) -----"
+          head -n 40 dist/release-notes.md
+      # crates.io publish: DELIBERATELY SKIPPED. IronBus ships as a single binary over four channels
+      # (installer, .deb, container, checksummed GitHub Releases; see docs/DISTRIBUTION.md) and does
+      # NOT publish its library crates to crates.io — docs/CLIENT_SDKS.md pins the Rust crates "by git
+      # until a crates.io release", there is no CRATES_IO_TOKEN secret, and `[patch.crates-io]
+      # raft-proto` in Cargo.toml redirects a dependency to a vendored build-script-free codec that a
+      # real `cargo publish` would not carry. To ENABLE it later: add a `CRATES_IO_TOKEN` secret and a
+      # job that runs `cargo publish -p <crate>` in dependency order (proto/core/storage -> server ->
+      # client -> client-async -> cli), gated on `startsWith(github.ref, 'refs/tags/v')`.
       - name: create the GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -440,7 +482,7 @@ jobs:
             --title "$TAG" \
             --verify-tag \
             $prerelease_flag \
-            --notes "Static musl binaries for the three edge triples (x86_64, aarch64, armv7) and a .deb package per triple, each with a SHA256 checksum, a consolidated SHA256SUMS (over the binaries, the .deb packages, and the CycloneDX SBOM), a cargo-auditable SBOM (ironbus.sbom.json), a syft CycloneDX SBOM (ironbus.cyclonedx.json, scannable with syft/grype), and a keyless Sigstore build-provenance attestation over every artifact. Verify integrity with: sha256sum -c SHA256SUMS, and provenance with: gh attestation verify <artifact> --repo $REPO. The fail-closed installer (scripts/install.sh) verifies the checksum before installing; the distroless container image is built and (opt-in) published by the release workflow. See docs/DISTRIBUTION.md for all four channels and CHANGELOG.md for changes." \
+            --notes-file dist/release-notes.md \
             dist/ironbus-linux-amd64 \
             dist/ironbus-linux-amd64.sha256 \
             dist/ironbus-linux-arm64 \

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -24,30 +24,76 @@ runs unproven steps.
 
 ## Cut a release
 
-The release workflow has a `changelog Unreleased is non-empty` gate (#128) that runs first and
-FAILS the whole release if `## [Unreleased]` in `CHANGELOG.md` has no content, so a release can
-never ship without an audit-trail entry. Tag a release only after the entries are present.
+Cutting a release is one command to prepare the tree, one reviewed PR, and one tag push. The
+`prepare-release.sh` script does the mechanical prep; the `Release` workflow does the build +
+publish. Nothing is published until you push the tag.
 
-1. Land all changes for the release via the normal PR flow (CI green, self-reviewed, merged).
-2. In a final PR: move the `## [Unreleased]` section of `CHANGELOG.md` under a new `## [vX.Y.Z]`
-   heading (the changelog gate matches that heading EXACTLY, so keep it `## [vX.Y.Z]` with no
-   trailing date — put the release date on a line under the heading), bump the workspace `version`
-   in the top-level `Cargo.toml` (`cargo build` reconciles `Cargo.lock`), and archive the release's
-   perf + coverage baselines under `docs/benchmarks/baselines/vX.Y.Z/` (see
-   [Regression-gate baselines](#regression-gate-baselines-perf--coverage) below).
-3. After it merges, tag the merge commit and push the tag:
+```sh
+# 1. Prepare the tree (edits only — no commit, no tag, no push):
+scripts/prepare-release.sh 0.2.0
+```
 
-   ```sh
-   git tag -s vX.Y.Z -m "vX.Y.Z"   # signed tag (or -a for annotated)
-   git push origin vX.Y.Z
-   ```
+`scripts/prepare-release.sh <X.Y.Z>` (validates the version is semver; idempotent):
 
-   The `Release` workflow can also be run from the Actions tab (`workflow_dispatch`) against an
-   existing tag.
+1. bumps `[workspace.package] version` in the top-level `Cargo.toml`,
+2. bumps the internal path-dependency `version = "..."` pins in every crate manifest so cargo's
+   published-version requirement stays in lockstep,
+3. reconciles `Cargo.lock` (`cargo update --workspace`; a deterministic in-place patch if `cargo` is
+   not on `PATH`),
+4. rolls `CHANGELOG.md`: moves `## [Unreleased]` under a new `## [vX.Y.Z]` heading with a
+   `_Released <date>._` sub-line, and inserts a fresh empty `## [Unreleased]`. The version heading is
+   kept EXACTLY `## [vX.Y.Z]` (no in-heading date) so the #128 changelog gate and the release-notes
+   extractor both match it; the date lives on the sub-line,
+5. scaffolds `docs/benchmarks/baselines/vX.Y.Z/` from the previous release's baselines (retagged, the
+   coverage number reset to the pending `null`), and
+6. prints the remaining steps.
 
-   Re-running the workflow for a tag that already has a published release fails at the
-   `gh release create` step (it does not clobber); delete the existing release first
-   (`gh release delete vX.Y.Z`) to rebuild it.
+Then, still by hand (the two owner decisions the script cannot make for you):
+
+- **Fill in the changelog** under `## [vX.Y.Z]` if it is empty. The release workflow's
+  `changelog Unreleased is non-empty` gate (#128) runs first and FAILS the whole release if the
+  section has no content, so a release can never ship without an audit-trail entry.
+- **Re-anchor the baselines** if you have fresh numbers — the scaffolded perf runs are carried over
+  from the previous tag for you to replace, and the coverage number is reset to the pending `null`
+  (see [Regression-gate baselines](#regression-gate-baselines-perf--coverage) below and the
+  scaffolded `docs/benchmarks/baselines/vX.Y.Z/README.md`). Also point the perf gate's `--baseline`
+  in `ci.yml` at the new tag's file.
+
+```sh
+# 2. Commit on a branch, open the release PR (CI green, reviewed, merged):
+git switch -c chore/release-v0.2.0
+git add -A
+git commit -s -m "chore(release): prepare v0.2.0"    # -s: DCO sign-off, per CONTRIBUTING.md
+gh pr create --fill
+
+# 3. After the PR merges, tag the merge commit and push the tag — this triggers the release:
+git tag -s v0.2.0 -m "v0.2.0"                          # signed tag (or -a for annotated)
+git push origin v0.2.0
+```
+
+Pushing the `v*` tag triggers the `Release` workflow (`.github/workflows/release.yml`), which:
+
+1. asserts the tag version equals the `[workspace.package]` version (`version-gate`, via
+   `scripts/ci/assert-tag-version.sh`) and the changelog section is non-empty (`changelog-gate`,
+   #128) — either failing loudly BEFORE any binary is built;
+2. cross-builds the three static musl binaries (the same `cross` matrix the CI `musl build` jobs
+   prove on every PR), packages a `.deb` per triple, and builds/pushes the distroless container;
+3. publishes the GitHub Release with the SHA256SUMS, both SBOMs, and the Sigstore attestation, using
+   release notes **extracted from the `## [vX.Y.Z]` CHANGELOG section** (`scripts/ci/release-notes.sh`).
+   If that section exceeds GitHub's 125000-char body limit, the notes are truncated at a line
+   boundary with a link to the full `CHANGELOG.md` at the tag.
+
+The `Release` workflow can also be run from the Actions tab (`workflow_dispatch`) against an existing
+tag. Re-running it for a tag that already has a published release fails at the `gh release create`
+step (it does not clobber); delete the existing release first (`gh release delete vX.Y.Z`) to rebuild
+it.
+
+> **crates.io.** IronBus does NOT publish its library crates to crates.io — it ships a single binary
+> over the four channels below, `docs/CLIENT_SDKS.md` pins the Rust crates "by git until a crates.io
+> release", and `[patch.crates-io] raft-proto` redirects a dependency to a vendored build-script-free
+> codec that a real `cargo publish` would not carry. The release workflow documents the enable path
+> (a `CRATES_IO_TOKEN` secret + a `cargo publish` job in dependency order) inline, next to the
+> `create the GitHub Release` step, for when that decision is made.
 
 ## Regression-gate baselines (perf + coverage)
 

--- a/scripts/ci/assert-tag-version.sh
+++ b/scripts/ci/assert-tag-version.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+# SPDX-License-Identifier: MIT OR Apache-2.0
+#
+# Release precondition: the pushed tag's version MUST equal the workspace version (#128 sibling gate).
+#
+# A `v*` tag whose version does not match `[workspace.package] version` in the top-level Cargo.toml
+# means the release PR forgot to bump the manifest (or the wrong tag was pushed): the shipped binary
+# would report one version while the tag/release claims another. The release workflow runs this
+# BEFORE it builds anything, and the build jobs `needs:` it, so a mismatch FAILS the whole release
+# loudly instead of publishing a mislabeled artifact. `scripts/prepare-release.sh` is the tool that
+# keeps the two in lockstep in the first place; this gate is the belt-and-suspenders check at tag time.
+#
+# Usage:
+#   scripts/ci/assert-tag-version.sh <tag-or-version> [path-to-Cargo.toml]
+#
+# `<tag-or-version>` may be `vX.Y.Z` or `X.Y.Z` (a single leading `v` is stripped). Deterministic and
+# history-free: it reads only the manifest. Needs only POSIX `awk`.
+set -eu
+
+tag="${1:?usage: assert-tag-version.sh <tag-or-version> [Cargo.toml]}"
+manifest="${2:-Cargo.toml}"
+
+if [ ! -f "$manifest" ]; then
+	echo "::error::version check: $manifest not found" >&2
+	exit 2
+fi
+
+# Normalize the tag to a bare version: strip a single leading `v` so `v1.2.3` and `1.2.3` both match.
+tag_version="${tag#v}"
+
+# Read the FIRST `version = "..."` inside the `[workspace.package]` table, and stop at the next table
+# header so a later `version =` (a dependency's) can never be picked up by mistake.
+ws_version="$(
+	awk '
+    /^\[workspace\.package\]/ { in_sec = 1; next }
+    /^\[/                     { in_sec = 0 }
+    in_sec && /^[[:space:]]*version[[:space:]]*=/ {
+      line = $0
+      sub(/^[^"]*"/, "", line)   # drop everything up to the opening quote
+      sub(/".*$/, "", line)       # drop the closing quote and the rest
+      print line
+      exit
+    }
+  ' "$manifest"
+)"
+
+if [ -z "$ws_version" ]; then
+	echo "::error::version check: could not read [workspace.package] version from $manifest" >&2
+	exit 2
+fi
+
+if [ "$tag_version" != "$ws_version" ]; then
+	echo "::error::tag/version mismatch: tag is '${tag}' (version '${tag_version}') but ${manifest} [workspace.package] version is '${ws_version}'. Bump the manifest to match the tag (see scripts/prepare-release.sh) or push the correct tag." >&2
+	exit 1
+fi
+
+echo "ok: tag '${tag}' matches [workspace.package] version '${ws_version}'"

--- a/scripts/ci/release-notes.sh
+++ b/scripts/ci/release-notes.sh
@@ -1,0 +1,155 @@
+#!/bin/sh
+# SPDX-License-Identifier: MIT OR Apache-2.0
+#
+# Build the GitHub Release body for a tagged release FROM the CHANGELOG, so the release notes are the
+# curated `## [vX.Y.Z]` changelog section (the audit trail #128 already gates as non-empty) plus a
+# short, fixed artifact/verification footer — never a hand-maintained string that drifts from the log.
+#
+# GitHub caps a release body at 125000 characters. This script counts bytes and, if the assembled
+# notes would exceed a safe budget, truncates the CHANGELOG portion at a line boundary and appends a
+# link to the full CHANGELOG.md at the tag, so a very large release still posts a short summary + link
+# instead of failing the `gh release create` call.
+#
+# Usage:
+#   scripts/ci/release-notes.sh <tag> [changelog] [repo] [out-file]
+#
+#   <tag>        vX.Y.Z (or X.Y.Z); selects the `## [vX.Y.Z]` section (leading `v` optional).
+#   [changelog]  path to CHANGELOG.md (default: CHANGELOG.md).
+#   [repo]        owner/name for the "full changelog" link + verify hint (default: ELares/IronBus).
+#   [out-file]    write the notes here (default: stdout).
+#
+# Deterministic and history-free: reads only the changelog. Needs only POSIX `awk`/`wc`. The section
+# extraction matches the `## [vX.Y.Z]` heading as a LITERAL string, the same rule as the #128 gate
+# (scripts/ci/changelog-unreleased.sh), so both agree on which section a tag maps to.
+set -eu
+
+tag="${1:?usage: release-notes.sh <tag> [changelog] [repo] [out-file]}"
+changelog="${2:-CHANGELOG.md}"
+repo="${3:-ELares/IronBus}"
+out="${4:-}"
+
+if [ ! -f "$changelog" ]; then
+	echo "::error::release-notes: $changelog not found" >&2
+	exit 2
+fi
+
+# GitHub's hard limit is 125000 chars; leave headroom for multi-byte counting and safety.
+LIMIT=125000
+BUDGET=123000
+
+bare_version="${tag#v}"
+
+# Extract the body between the exact `## [<heading>]` line and the next `## ` heading. The heading is
+# matched as a LITERAL string (awk `==`), so the dots/brackets in a version need no escaping.
+extract_section() {
+	awk -v target="$1" '
+    $0 == target { if (in_section) exit; in_section = 1; next }
+    /^## /       { if (in_section) exit }
+    in_section   { print }
+  ' "$changelog"
+}
+
+heading_present() {
+	awk -v target="$1" '$0 == target { found = 1 } END { exit(found ? 0 : 1) }' "$changelog"
+}
+
+# Prefer `## [vX.Y.Z]`, then `## [X.Y.Z]` (accept either, mirroring the #128 gate's tolerance).
+heading=""
+for hdr in "## [v${bare_version}]" "## [${bare_version}]"; do
+	if heading_present "$hdr"; then
+		heading="$hdr"
+		break
+	fi
+done
+
+if [ -z "$heading" ]; then
+	echo "::error::release-notes: no '## [v${bare_version}]' or '## [${bare_version}]' section in $changelog" >&2
+	exit 1
+fi
+
+body="$(extract_section "$heading")"
+
+# The fixed footer: what every IronBus release ships and how to verify it. Kept short and stable so
+# the variable-length CHANGELOG body is the only thing that can push the notes over budget.
+footer="$(
+	cat <<EOF
+
+---
+
+### Artifacts
+
+Static \`musl\` binaries for the three edge triples (x86_64, aarch64, armv7) and a \`.deb\` package per
+triple, each with a SHA256; a consolidated \`SHA256SUMS\` (over the binaries, the \`.deb\` packages, and
+the CycloneDX SBOM); a \`cargo-auditable\` SBOM (\`ironbus.sbom.json\`); a syft CycloneDX SBOM
+(\`ironbus.cyclonedx.json\`, scannable with syft/grype); and a keyless Sigstore build-provenance
+attestation over every artifact.
+
+### Verify
+
+\`\`\`sh
+sha256sum -c SHA256SUMS
+gh attestation verify <artifact> --repo ${repo}
+\`\`\`
+
+The fail-closed installer (\`scripts/install.sh\`) verifies the checksum before installing. See
+[docs/DISTRIBUTION.md](https://github.com/${repo}/blob/${tag}/docs/DISTRIBUTION.md) for all four
+distribution channels and [CHANGELOG.md](https://github.com/${repo}/blob/${tag}/CHANGELOG.md) for the
+full history.
+EOF
+)"
+
+changelog_link="https://github.com/${repo}/blob/${tag}/CHANGELOG.md"
+
+# byte_len <string> prints the byte length (chars for ASCII), the metric GitHub's limit is expressed
+# in. Uses `wc -c`; printf %s avoids a trailing newline being counted.
+byte_len() { printf '%s' "$1" | wc -c | tr -d ' '; }
+
+assemble() {
+	# $1 is the (possibly truncated) changelog body.
+	printf '%s\n%s\n' "$1" "$footer"
+}
+
+full="$(assemble "$body")"
+
+if [ "$(byte_len "$full")" -le "$LIMIT" ]; then
+	notes="$full"
+else
+	# Too long: keep as many leading CHANGELOG lines as fit under BUDGET (minus the footer and the
+	# truncation notice), then append the notice + a link to the full CHANGELOG at the tag. This posts
+	# a short summary plus a link rather than failing the release.
+	# shellcheck disable=SC2016  # the backticks are literal Markdown in the printf format, not a subshell
+	notice="$(
+		printf '\n> The full changelog for this release is large and was truncated here. Read the complete `## [%s]` entry: %s\n' "$tag" "$changelog_link"
+	)"
+	overhead="$(byte_len "$(printf '%s\n%s\n%s\n' '' "$notice" "$footer")")"
+	room=$((BUDGET - overhead))
+	if [ "$room" -lt 0 ]; then room=0; fi
+
+	truncated=""
+	acc=0
+	# Accumulate whole lines until the next line would blow the budget.
+	while IFS= read -r line; do
+		# +1 for the newline that rejoins the line.
+		add=$(($(byte_len "$line") + 1))
+		if [ $((acc + add)) -gt "$room" ]; then
+			break
+		fi
+		if [ -z "$truncated" ]; then
+			truncated="$line"
+		else
+			truncated="$(printf '%s\n%s' "$truncated" "$line")"
+		fi
+		acc=$((acc + add))
+	done <<EOF
+$body
+EOF
+
+	notes="$(printf '%s\n%s\n%s\n' "$truncated" "$notice" "$footer")"
+fi
+
+if [ -n "$out" ]; then
+	printf '%s\n' "$notes" >"$out"
+	echo "ok: wrote release notes for '${heading}' to ${out} ($(byte_len "$notes") bytes)" >&2
+else
+	printf '%s\n' "$notes"
+fi

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT OR Apache-2.0
+#
+# prepare-release.sh <X.Y.Z> — do the mechanical release-prep edits in one shot, so cutting a release
+# is `scripts/prepare-release.sh X.Y.Z` -> review + merge the PR -> `git tag vX.Y.Z && git push`, and
+# the Release workflow (.github/workflows/release.yml) builds + publishes automatically. It:
+#
+#   1. bumps `[workspace.package] version` in the top-level Cargo.toml,
+#   2. bumps the internal path-dependency `version = "..."` pins in every crate manifest so cargo's
+#      published-version requirement stays in lockstep with the new workspace version,
+#   3. reconciles Cargo.lock (via `cargo update --workspace`; a deterministic in-place patch if cargo
+#      is unavailable),
+#   4. rolls CHANGELOG.md: moves `## [Unreleased]` under a new `## [vX.Y.Z]` heading (with a
+#      `_Released <date>._` sub-line, keeping the heading EXACTLY `## [vX.Y.Z]` so the #128 changelog
+#      gate matches it) and inserts a fresh empty `## [Unreleased]`,
+#   5. scaffolds docs/benchmarks/baselines/vX.Y.Z/ from the previous release's baselines (retagged,
+#      coverage number reset to the pending `null`), and
+#   6. prints the remaining manual steps (fill in the changelog if empty, re-anchor baselines, open
+#      the PR, then tag + push).
+#
+# It makes NO commit, NO tag, and NO push — it only edits the working tree for review. It is
+# idempotent: re-running for the same version is a no-op on the parts already done. See RELEASING.md.
+set -euo pipefail
+
+die() {
+	printf 'error: %s\n' "$*" >&2
+	exit 1
+}
+info() { printf '  %s\n' "$*" >&2; }
+warn() { printf 'warning: %s\n' "$*" >&2; }
+
+# --- 1. validate the version argument -------------------------------------------------------------
+[ "$#" -eq 1 ] || die "usage: scripts/prepare-release.sh <X.Y.Z>"
+VERSION="${1#v}" # tolerate a leading `v` (`v0.2.0` -> `0.2.0`)
+# Semver: MAJOR.MINOR.PATCH with an optional -prerelease and +build (per semver.org).
+if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'; then
+	die "not a valid semver version: '$1' (expected X.Y.Z, e.g. 0.2.0)"
+fi
+TAG="v${VERSION}"
+
+# --- repo root + a portable, in-place file rewriter -----------------------------------------------
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+MANIFEST="Cargo.toml"
+[ -f "$MANIFEST" ] || die "no Cargo.toml at repo root ($ROOT)"
+grep -q '^\[workspace\.package\]' "$MANIFEST" || die "$MANIFEST has no [workspace.package] table; is this the IronBus repo root?"
+
+# rewrite <file> <awk-program> [awk-args...] — run awk over a file and replace it atomically. Avoids
+# `sed -i`, whose flag differs between BSD (macOS) and GNU (Linux) sed.
+rewrite() {
+	local file="$1"
+	shift
+	local tmp
+	tmp="$(mktemp "${file}.XXXXXX")"
+	awk "$@" "$file" >"$tmp"
+	mv "$tmp" "$file"
+}
+
+# regex-escape a literal string for use in an awk ERE (only `.` matters for a version).
+# shellcheck disable=SC2016  # the sed program is a literal char class, it must not shell-expand
+esc() { printf '%s' "$1" | sed 's/[.[\*^$()+?{|]/\\&/g'; }
+
+# --- read the current workspace version -----------------------------------------------------------
+CUR="$(
+	awk '
+    /^\[workspace\.package\]/ { in_sec = 1; next }
+    /^\[/                     { in_sec = 0 }
+    in_sec && /^[[:space:]]*version[[:space:]]*=/ {
+      line = $0; sub(/^[^"]*"/, "", line); sub(/".*$/, "", line); print line; exit
+    }
+  ' "$MANIFEST"
+)"
+[ -n "$CUR" ] || die "could not read [workspace.package] version from $MANIFEST"
+
+# Guard against an accidental downgrade; allow equal (idempotent re-run).
+if [ "$VERSION" != "$CUR" ]; then
+	lowest="$(printf '%s\n%s\n' "$VERSION" "$CUR" | sort -V | head -n1)"
+	[ "$lowest" = "$CUR" ] || die "refusing to prepare $VERSION: it is older than the current $CUR"
+fi
+
+TODAY="$(date -u +%Y-%m-%d)"
+echo "Preparing release ${TAG} (current workspace version: ${CUR})" >&2
+
+# --- 2a. bump [workspace.package] version ---------------------------------------------------------
+if [ "$VERSION" = "$CUR" ]; then
+	info "[workspace.package] version already ${VERSION}, leaving as-is"
+else
+	rewrite "$MANIFEST" -v new="$VERSION" '
+    /^\[workspace\.package\]/ { in_sec = 1; print; next }
+    /^\[/                     { in_sec = 0 }
+    in_sec && !done && /^[[:space:]]*version[[:space:]]*=/ {
+      sub(/"[^"]*"/, "\"" new "\""); done = 1
+    }
+    { print }
+  '
+	info "bumped [workspace.package] version ${CUR} -> ${VERSION} in ${MANIFEST}"
+fi
+
+# --- 2b. bump the internal path-dep version pins --------------------------------------------------
+# Lines like `ironbus-core = { path = "../ironbus-core", version = "0.1.0" }` carry a version
+# requirement that must equal the (new) published version, so bump every `version = "<CUR>"` that
+# sits on a `path = "../ironbus..."` line. Only crate manifests have these pins.
+if [ "$VERSION" = "$CUR" ]; then
+	info "internal path-dep version pins already ${VERSION}, leaving as-is"
+else
+	CUR_RE="$(esc "$CUR")"
+	pin_changed=0
+	for f in crates/*/Cargo.toml; do
+		[ -f "$f" ] || continue
+		before="$(grep -c "path = \"\.\./ironbus.*version = \"${CUR}\"" "$f" || true)"
+		if [ "$before" -gt 0 ]; then
+			rewrite "$f" -v newpin="version = \"${VERSION}\"" -v oldre="version = \"${CUR_RE}\"" '
+        /path = "\.\.\/ironbus/ { gsub(oldre, newpin) }
+        { print }
+      '
+			pin_changed=$((pin_changed + before))
+		fi
+	done
+	info "bumped ${pin_changed} internal path-dep version pin(s) ${CUR} -> ${VERSION}"
+fi
+
+# --- 3. reconcile Cargo.lock ----------------------------------------------------------------------
+# `cargo update --workspace` rewrites ONLY the workspace members' versions in the lock (it leaves
+# every third-party dep pinned), which is exactly the reconciliation a version bump needs.
+if command -v cargo >/dev/null 2>&1; then
+	if cargo update --workspace --offline >/dev/null 2>&1 ||
+		cargo update --workspace >/dev/null 2>&1; then
+		info "reconciled Cargo.lock with 'cargo update --workspace'"
+	else
+		warn "'cargo update --workspace' failed; patching Cargo.lock directly"
+		patch_lock=1
+	fi
+else
+	warn "cargo not found; patching Cargo.lock directly (run 'cargo build --locked' later to confirm)"
+	patch_lock=1
+fi
+
+if [ "${patch_lock:-0}" = 1 ]; then
+	# Fallback: set the version of each workspace-member package block in Cargo.lock. Workspace members
+	# carry no checksum line and are referenced by bare name in `dependencies`, so a version rewrite is
+	# self-consistent. Collect the member names from their manifests so io-free-check (which also
+	# inherits version.workspace) is covered, not just the ironbus-* crates.
+	members=""
+	for f in crates/*/Cargo.toml tools/*/Cargo.toml; do
+		[ -f "$f" ] || continue
+		grep -q '^version.workspace = true' "$f" || continue
+		name="$(awk -F'"' '/^name[[:space:]]*=/ { print $2; exit }' "$f")"
+		[ -n "$name" ] && members="${members} ${name}"
+	done
+	# shellcheck disable=SC2016  # $0/$1 are awk fields inside the awk program, not shell expansions
+	rewrite Cargo.lock -v members=" ${members} " -v cur="$CUR" -v new="$VERSION" '
+    /^name = "/ { name = $0; sub(/^name = "/, "", name); sub(/"$/, "", name) }
+    /^version = "/ && index(members, " " name " ") > 0 {
+      if ($0 == "version = \"" cur "\"") { print "version = \"" new "\""; next }
+    }
+    { print }
+  '
+	info "patched Cargo.lock workspace-member versions ${CUR} -> ${VERSION}"
+fi
+
+# --- 4. roll the CHANGELOG ------------------------------------------------------------------------
+CHANGELOG="CHANGELOG.md"
+if [ ! -f "$CHANGELOG" ]; then
+	warn "no $CHANGELOG to roll; skipping"
+elif grep -q "^## \[${TAG}\]\$" "$CHANGELOG"; then
+	info "CHANGELOG already has a '## [${TAG}]' section, leaving as-is"
+elif ! grep -q '^## \[Unreleased\]$' "$CHANGELOG"; then
+	warn "CHANGELOG has no '## [Unreleased]' heading; not rolling it (add the section manually)"
+else
+	# Rename the `## [Unreleased]` heading to `## [vX.Y.Z]` + a `_Released <date>._` sub-line, its body
+	# stays in place under the new version, and insert a fresh empty `## [Unreleased]` above it. The new
+	# version heading stays EXACTLY `## [vX.Y.Z]` (no in-heading date) so the #128 changelog gate and
+	# the release-notes extractor both match it; the date goes on the sub-line, as v0.1.0 did.
+	# shellcheck disable=SC2016  # $0 is an awk field inside the awk program, not a shell expansion
+	rewrite "$CHANGELOG" -v ver="$VERSION" -v date="$TODAY" '
+    $0 == "## [Unreleased]" && !done {
+      print "## [Unreleased]"; print ""
+      print "## [v" ver "]"; print ""
+      print "_Released " date "._"
+      done = 1; next
+    }
+    { print }
+  '
+	info "rolled CHANGELOG: '## [Unreleased]' -> '## [${TAG}]' (dated ${TODAY}) + fresh '## [Unreleased]'"
+fi
+
+# --- 5. scaffold this release's baseline directory ------------------------------------------------
+BASE_ROOT="docs/benchmarks/baselines"
+NEW_DIR="${BASE_ROOT}/${TAG}"
+if [ ! -d "$BASE_ROOT" ]; then
+	warn "no ${BASE_ROOT} directory; skipping baseline scaffold"
+elif [ -d "$NEW_DIR" ]; then
+	info "baseline dir ${NEW_DIR} already exists, leaving as-is"
+else
+	# Prefer the CURRENT (previous-release) version's baseline dir; else the highest-versioned one.
+	PREV_DIR="${BASE_ROOT}/v${CUR}"
+	if [ ! -d "$PREV_DIR" ]; then
+		PREV_DIR="$(find "$BASE_ROOT" -mindepth 1 -maxdepth 1 -type d -name 'v*' | sort -V | tail -n1)"
+	fi
+	if [ -z "${PREV_DIR:-}" ] || [ ! -d "$PREV_DIR" ]; then
+		warn "no previous baseline dir to scaffold ${NEW_DIR} from; create it by hand (see RELEASING.md)"
+	else
+		PREV_TAG="$(basename "$PREV_DIR")"
+		PREV_RE="$(esc "$PREV_TAG")"
+		cp -R "$PREV_DIR" "$NEW_DIR"
+		# Retag every "tag" field / heading / prose reference to the new tag, and reset the coverage
+		# number to the pending `null` (it is re-recorded from the first post-tag nightly; see the dir's
+		# README + RELEASING.md). The perf runs are carried over for the owner to re-anchor.
+		for jf in "$NEW_DIR"/*.json "$NEW_DIR"/README.md; do
+			[ -f "$jf" ] || continue
+			rewrite "$jf" -v oldre="$PREV_RE" -v new="$TAG" '{ gsub(oldre, new); print }'
+		done
+		if [ -f "$NEW_DIR/coverage-baseline.json" ]; then
+			rewrite "$NEW_DIR/coverage-baseline.json" '
+        /"line_coverage_pct"[[:space:]]*:/ { sub(/:[[:space:]]*[^,]*/, ": null") }
+        { print }
+      '
+		fi
+		info "scaffolded ${NEW_DIR} from ${PREV_DIR} (retagged; coverage reset to pending null)"
+	fi
+fi
+
+# --- 6. print the remaining steps -----------------------------------------------------------------
+cat >&2 <<EOF
+
+Prepared ${TAG}. NOTHING was committed, tagged, or pushed. Next:
+
+  1. Review the working-tree changes:
+       git diff --stat
+     - Fill in CHANGELOG.md under '## [${TAG}]' if it is empty (the #128 gate FAILS an empty release).
+     - Re-anchor the perf/coverage baselines if you have fresh numbers
+       (see ${NEW_DIR}/README.md and RELEASING.md).
+
+  2. Commit on a branch and open the release PR (sign off per CONTRIBUTING.md/DCO):
+       git switch -c chore/release-${TAG}
+       git add -A
+       git commit -s -m "chore(release): prepare ${TAG}"
+       gh pr create --fill
+
+  3. After the PR is reviewed + merged, tag the merge commit and push it:
+       git tag -s ${TAG} -m "${TAG}"   # signed (or -a for annotated)
+       git push origin ${TAG}
+
+  The Release workflow (.github/workflows/release.yml) then asserts the tag matches the manifest
+  version, checks the changelog is non-empty, builds the static musl binaries + .deb + container,
+  and publishes the GitHub Release (notes from the '## [${TAG}]' changelog section) automatically.
+EOF


### PR DESCRIPTION
## What

Make cutting a release **one command + a tag push** instead of the manual dance behind `v0.1.0`:

```
scripts/prepare-release.sh X.Y.Z   →   review + merge the prep PR   →   git tag vX.Y.Z && git push origin vX.Y.Z
```

`release.yml` already cross-built the static musl matrix, packaged the `.deb`, built the container, and published the signed/attested GitHub Release. This PR closes the two steps that were still manual and adds the missing prep tooling.

## Added

- **`scripts/prepare-release.sh <X.Y.Z>`** — one-shot, idempotent, `set -euo pipefail`, shellcheck-clean. Bumps `[workspace.package] version` + every internal path-dep `version` pin, reconciles `Cargo.lock` (`cargo update --workspace`, with a deterministic in-place lock patch fallback if `cargo` is absent), rolls `CHANGELOG.md` (`## [Unreleased]` → `## [vX.Y.Z]` + `_Released <date>._` sub-line, keeping the heading exactly `## [vX.Y.Z]` for the #128 gate, and re-opens an empty `## [Unreleased]`), and scaffolds `docs/benchmarks/baselines/vX.Y.Z/` from the previous release (retagged, coverage reset to the pending `null`). Makes **no** commit/tag/push.
- **`scripts/ci/assert-tag-version.sh`** — fail-loud gate that the pushed `v*` tag equals the `[workspace.package]` version.
- **`scripts/ci/release-notes.sh`** — renders the GitHub Release body from the `## [vX.Y.Z]` CHANGELOG section, truncating at a line boundary + linking to the full CHANGELOG at the tag if it would exceed GitHub's 125000-char body limit.

## Changed

- **`.github/workflows/release.yml`** — new `version-gate` job (needs-ed by `build`) asserting tag == manifest version; the `publish` job now derives release notes from the CHANGELOG (`--notes-file`) instead of a hardcoded string, and documents the deliberate crates.io skip + its enable path.
- **`RELEASING.md`** — documents the new end-to-end flow; keeps the owner-decision notes (changelog fill-in, perf/coverage re-anchor).

## crates.io

Intentionally **not** published: IronBus is a single-binary product, `docs/CLIENT_SDKS.md` pins the Rust crates "by git until a crates.io release", there is no `CRATES_IO_TOKEN`, and `[patch.crates-io] raft-proto` redirects a dependency to a vendored build-script-free codec a real `cargo publish` would not carry. The enable path (token + `cargo publish` in dependency order) is documented inline in the workflow.

## Validation

- `shellcheck` clean on all three scripts; `actionlint` clean on `release.yml` (both run in a `rust:1-bookworm` container).
- Dry-runs to `9.9.9` and `0.2.0` on scratch git copies (not this branch): `cargo metadata --locked` passes; only the 9 workspace members bumped in `Cargo.lock` (zero third-party deps touched); CHANGELOG roll + baseline scaffold correct; `assert-tag-version` passes on match / fails on mismatch; `release-notes` exercises both the normal and the 125k-truncation paths; a second `prepare-release.sh` run is a clean no-op (idempotent).

## Not done here

No real tag/release was created and nothing was merged. Draft for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01McmNfYNWPmohVS8umY9Lkp
