### PR TITLE
perf(consume): spin-before-park on the commit-notify wait — fix #1100 p999 tail

### DIFF
--- a/crates/ironbus-server/src/actor.rs
+++ b/crates/ironbus-server/src/actor.rs
@@ -1215,6 +1215,20 @@ pub trait EngineAccess<F: Filesystem, C: Clock> {
         None
     }
 
+    /// Whether an idle consume long-poll should SPIN briefly before parking on the commit-notify
+    /// condvar (#1100). The SAME discriminant the produce path spins on (`reply_spin` =
+    /// `!Engine::commit_syncs_before_ack()`, #1032/#1026): `true` on the no-pre-ack-fsync tiers (memory
+    /// backend or a relaxed `interval`/`async`/`none` level) where a commit is poll-visible within
+    /// microseconds, so a bounded busy-poll catches the wake without the park/unpark round-trip whose
+    /// jitter tail is the p999 delivery regression; `false` on the fsync-barrier `sync` tier where a
+    /// commit is milliseconds away and spinning would only burn a core. The DEFAULT impl returns
+    /// `false` (the in-process test fixtures have no actor to bump the seam, so their long-poll never
+    /// waits anyway); [`EngineHandle`] overrides it with the snapshotted `reply_spin`. Consulted ONLY
+    /// alongside a live [`EngineAccess::commit_notify`] seam when `Session::consume_longpoll_ms > 0`.
+    fn consume_wait_spin(&self) -> bool {
+        false
+    }
+
     /// The CLUSTER produce-ack decision (#719) for one durable produce on connection `member`: called
     /// AFTER the local group-commit fsync returned `Appended(offset)`, with the `offset`, and the EXACT
     /// wire-`PubAck` frame bytes the session would otherwise write now.
@@ -1372,6 +1386,14 @@ impl<F: Filesystem + Clone + 'static, C: Clock + Clone + 'static> EngineAccess<F
         // The shared seam the append actor bumps on every durable-frontier advance (push delivery): an
         // idle long-polling consumer waits on this and wakes the instant a record commits.
         Some(EngineHandle::commit_notify(self))
+    }
+
+    fn consume_wait_spin(&self) -> bool {
+        // The SAME fixed-for-life discriminant the produce reply wait spins on (#1032): `reply_spin` =
+        // `!commit_syncs_before_ack()`, snapshotted at `spawn_actor`. On the no-pre-ack-fsync tiers a
+        // commit is poll-visible within microseconds, so an idle long-poll spins briefly to catch the
+        // commit-notify wake without the park round-trip (#1100); the fsync `sync` tier stays parked.
+        self.reply_spin
     }
 
     fn client_ack_disposition(

--- a/crates/ironbus-server/src/commit_notify.rs
+++ b/crates/ironbus-server/src/commit_notify.rs
@@ -23,7 +23,20 @@
 //! pre-push-delivery behavior) and is the same per-stream-granularity refinement noted above.
 
 use std::sync::{Arc, Condvar, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
+
+/// The bounded busy-poll window a [`wait_for_change`](CommitNotify::wait_for_change) spins BEFORE
+/// parking on the condvar (#1100), in microseconds — the exact parallel of the produce path's
+/// `REPLY_SPIN_MICROS` (#1032, `actor.rs`). On the no-pre-ack-fsync tiers (memory backend or a relaxed
+/// `interval`/`async`/`none` level) a produce becomes poll-visible within tens of microseconds, but a
+/// waiter that parks straight onto the condvar eats a park/unpark round-trip whose scheduler-jitter
+/// tail is the push-delivery p999 delivery regression (#1100: ~15 ms p999 vs ~1 ms push-OFF). Busy
+/// re-reading the SAME generation the wait predicate checks for this small window catches that wake
+/// WITHOUT the round-trip in the common case; the condvar park still backstops the remaining budget,
+/// so lost-wakeup safety is byte-for-byte the pure-park path. Sized (100 us) to cover the
+/// commit->frontier->bump hop on those tiers while wasting at most this much CPU on a spin that draws
+/// nothing before it parks exactly as the historical path did.
+const WAIT_SPIN_MICROS: u64 = 100;
 
 /// The engine-wide commit-notify wakeup counter (#push-delivery). ONE per append actor, shared (via
 /// `Arc`) between the actor thread (which [`bump`](CommitNotify::bump)s it whenever the durable poll
@@ -83,17 +96,119 @@ impl CommitNotify {
     /// whichever comes first. Returns as soon as the predicate is false, so a bump racing the snapshot
     /// is never lost. A spurious condvar wake with an unchanged generation simply re-parks until the
     /// deadline — the caller re-polls at most once regardless.
-    pub fn wait_for_change(&self, snapshot: u64, timeout: Duration) {
+    ///
+    /// `spin` gates a bounded busy-poll BEFORE the condvar park (#1100), threaded from the caller as the
+    /// produce path's spin discriminant (`!commit_syncs_before_ack()`, #1032/#1026): `true` on the
+    /// no-pre-ack-fsync tiers where a commit is poll-visible within microseconds — there this catches
+    /// the wake without the park/unpark round-trip that drove the p999 delivery tail — and `false` on
+    /// the fsync-barrier `sync` tier where a commit is milliseconds away, so spinning would only burn a
+    /// core and this is byte-for-byte the historical straight-to-park.
+    pub fn wait_for_change(&self, snapshot: u64, timeout: Duration, spin: bool) {
+        let start = Instant::now();
+        // Bounded spin-before-park (#1100). This is a PURE optimization layered on the unchanged
+        // condvar park below: the spin only re-reads `seq` — the SAME generation the wait predicate
+        // checks — so a bump it MISSES is still caught by the predicate (which then returns without
+        // parking), and a bump it SEES returns immediately with no park at all. Lost-wakeup safety is
+        // therefore identical to the pure-park path; the spin can only ever SHORTEN the wait.
+        if spin {
+            let spin_deadline = start + Duration::from_micros(WAIT_SPIN_MICROS);
+            loop {
+                // Re-read the generation under the same lock the predicate uses. A move off `snapshot`
+                // means a commit landed during the spin: return WITHOUT parking (the caller re-polls).
+                if self.seq() != snapshot {
+                    return;
+                }
+                if Instant::now() >= spin_deadline {
+                    break;
+                }
+                std::hint::spin_loop();
+            }
+        }
+        // Park for the REMAINING budget (the spin, if any, already burned `start.elapsed()`). The
+        // condvar backstops every wake the spin did not catch: `wait_timeout_while` re-checks the
+        // predicate on entry and on every (spurious or real) wake, so a generation that already
+        // advanced past `snapshot` — including a bump that raced the snapshot or landed just after the
+        // spin window — returns without parking. The returned guard/timeout result is not needed: the
+        // caller re-polls unconditionally after this returns.
+        let remaining = timeout.saturating_sub(start.elapsed());
         let guard = self
             .seq
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        // `wait_timeout_while` re-checks the predicate on every (spurious or real) wake and on entry,
-        // so a generation that already advanced past `snapshot` returns without parking. The returned
-        // guard/timeout result is not needed: the caller re-polls unconditionally after this returns.
         let _ = self
             .cv
-            .wait_timeout_while(guard, timeout, |seq| *seq == snapshot)
+            .wait_timeout_while(guard, remaining, |seq| *seq == snapshot)
             .unwrap_or_else(std::sync::PoisonError::into_inner);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A generation that ALREADY advanced past the snapshot returns at once on the spin path — the
+    /// first spin re-read observes `seq != snapshot` and never touches the condvar. (The pure-park
+    /// path returns immediately here too via the entry predicate; this pins the spin fast path.)
+    #[test]
+    fn spin_returns_immediately_when_the_generation_already_advanced() {
+        let notify = CommitNotify::new();
+        let snapshot = notify.seq();
+        notify.bump(); // seq is now != snapshot BEFORE the wait
+        let start = Instant::now();
+        notify.wait_for_change(snapshot, Duration::from_secs(30), /* spin */ true);
+        assert!(
+            start.elapsed() < Duration::from_secs(1),
+            "a pre-advanced generation must return at once, not park to the 30 s budget; took {:?}",
+            start.elapsed()
+        );
+    }
+
+    /// A bump that lands DURING the wait is observed and returns far below the (huge) budget — the
+    /// headline #1100 case: a commit racing an idle long-poll wakes it promptly (via the spin re-read
+    /// in the common case, or the condvar backstop if the spin window elapsed first), never at the
+    /// timeout. Runs on BOTH gate settings to prove the wake fires regardless of the spin tier.
+    #[test]
+    fn a_generation_change_during_the_wait_is_observed_well_below_the_budget() {
+        for spin in [true, false] {
+            let notify = CommitNotify::new();
+            let snapshot = notify.seq();
+            let bumper = Arc::clone(&notify);
+            let jh = std::thread::spawn(move || {
+                // Land the commit inside the wait, after it has begun (past the ~100 us spin window on
+                // the spin path, so this also exercises the condvar backstop, not only the busy-poll).
+                std::thread::sleep(Duration::from_millis(20));
+                bumper.bump();
+            });
+            let start = Instant::now();
+            notify.wait_for_change(snapshot, Duration::from_secs(30), spin);
+            let elapsed = start.elapsed();
+            jh.join().unwrap();
+            assert!(
+                elapsed < Duration::from_secs(5),
+                "a bump during the wait (spin={spin}) must wake it well below the 30 s budget, \
+                 not at the timeout; took {elapsed:?}"
+            );
+        }
+    }
+
+    /// With spin ENABLED but NO commit, the spin exhausts and the condvar park still backstops the
+    /// full budget — the wait times out at ~`timeout`, it does not busy-spin-return early. Proves the
+    /// spin never swallows the timeout contract (a broken fall-through would return in ~100 us).
+    #[test]
+    fn spin_still_backstops_on_the_condvar_and_times_out_without_a_commit() {
+        let notify = CommitNotify::new();
+        let snapshot = notify.seq();
+        let budget = Duration::from_millis(120);
+        let start = Instant::now();
+        notify.wait_for_change(snapshot, budget, /* spin */ true);
+        let elapsed = start.elapsed();
+        // At least the budget minus the spin window (and a slack for coarse timer granularity): the
+        // park must dominate, so this is FAR above the 100 us spin — proving the spin fell through to
+        // the condvar rather than returning early.
+        assert!(
+            elapsed >= budget.saturating_sub(Duration::from_millis(20)),
+            "with no commit the spin must fall into the condvar park and honor the budget; \
+             took {elapsed:?} for a {budget:?} budget"
+        );
     }
 }

--- a/crates/ironbus-server/src/session.rs
+++ b/crates/ironbus-server/src/session.rs
@@ -2321,6 +2321,9 @@ impl Session {
                     notify.wait_for_change(
                         snapshot,
                         std::time::Duration::from_millis(self.consume_longpoll_ms),
+                        // Spin-before-park (#1100) on the no-pre-ack-fsync tiers only — the produce
+                        // path's spin discriminant, so a real-fsync broker never burns a core here.
+                        engine.consume_wait_spin(),
                     );
                     continue;
                 }
@@ -2580,6 +2583,9 @@ impl Session {
                     notify.wait_for_change(
                         snapshot,
                         std::time::Duration::from_millis(self.consume_longpoll_ms),
+                        // Spin-before-park (#1100) on the no-pre-ack-fsync tiers only — the produce
+                        // path's spin discriminant, so a real-fsync broker never burns a core here.
+                        engine.consume_wait_spin(),
                     );
                     continue;
                 }


### PR DESCRIPTION
## What

Fixes the push-delivery **p999/max delivery tail** (#1100). The event-driven consume long-poll (#1098) parked straight onto the commit-notify `Condvar` with **no spin tier**, so every wake ate an un-mitigated park/unpark round-trip whose scheduler-jitter tail is the reproducible push-ON regression (~12–16 ms p999 vs push-OFF ~1 ms).

This mirrors the **already-proven produce-path pattern** (#1032 `REPLY_SPIN_MICROS` + `recv_spin_then_park`): before parking, `CommitNotify::wait_for_change` busy-re-checks the **same generation** the condvar predicate checks for a bounded ~100 µs window (`WAIT_SPIN_MICROS`), returning immediately if a commit lands during the spin, else falling into `wait_timeout_while` for the **remaining** budget.

## Lost-wakeup safety

The spin is a **pure optimization** on top of the unchanged condvar park. It only re-reads `seq` — the exact same generation the wait predicate checks — so:

- a bump the spin **sees** → returns immediately, no park;
- a bump the spin **misses** → still caught by the unchanged predicate `*seq == snapshot` (which returns without parking), and the condvar still backstops the full budget.

So correctness is byte-for-byte the pure-park path; the spin can only ever *shorten* the wait.

## Gating (so a real-fsync broker never burns a core)

`consume_wait_spin()` returns the engine's `reply_spin` = `!commit_syncs_before_ack()` — the **same** discriminant the produce spin uses. `true` on the no-pre-ack-fsync tiers (memory backend, relaxed `interval`/`async`/`none`) where a commit is poll-visible in microseconds; `false` on the fsync-barrier `sync` tier where a commit is milliseconds away, so that path stays byte-for-byte the historical straight-to-park. Threaded through the `EngineAccess` trait (default `false` for the actor-less test fixtures) and passed from both callers (`handle_flow`, `handle_fetch`).

## Re-benchmark — push-ON round-trip delivery latency

In-memory broker (`--storage memory --ephemeral-loss-ack --consume-longpoll-ms 1000`), rate 2000/s, 256 B random, single 4-vCPU colima VM, **fresh broker per run**, A/B vs `main` back-to-back, 10 runs each:

| metric | OLD (main) | NEW (this PR) | delta |
|---|---|---|---|
| **p999** median | ~19.7 ms | **~2.0 ms** | **~10× lower** (best NEW run 0.57 ms, sub-ms) |
| **max** median | ~21.4 ms | **~5.0 ms** | ~4× lower |
| **p50** | ~192 µs | ~193 µs | unchanged (no regression) |
| **p99** | comparable / tighter | comparable / tighter | no regression |

A residual **~18–21 ms wall still hits BOTH builds equally** on the ~3 noisiest of the 10 runs — a shared-VM scheduler artifact the consumer-side spin cannot address (the *wake source itself* is delayed there), consistent with `BENCH-v010.md`'s clean-host caveat. On every non-contended run the spin collapses the park-latency tail by ~10×.

*Directional / relative only — single 4-vCPU loopback VM, no core pinning.*

## Tests

- Existing commit-notify integration tests (`longpoll_wakes_on_a_concurrent_produce`, `longpoll_times_out_to_empty_without_a_producer`, `longpoll_off_returns_empty_flow_immediately`) still green.
- New `commit_notify` unit tests: pre-advanced generation returns immediately on the spin path; a bump during the wait is observed well below the budget (both gate settings); spin still backstops on the condvar and honors the timeout when no commit arrives.
- `cargo test -p ironbus-server` → **1114 passed, 0 failed**. `clippy --workspace --all-targets --all-features -D warnings` clean; `fmt --all --check` clean.

Closes #1100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01McmNfYNWPmohVS8umY9Lkp
