### PR TITLE
perf(consume): per-stream commit-notify wakeup (kill thundering-herd + named-stream floor) — #1100

### DIFF
--- a/crates/ironbus-server/src/actor.rs
+++ b/crates/ironbus-server/src/actor.rs
@@ -49,7 +49,7 @@
 //! - No lost replies / no deadlock: every command gets exactly one reply; a closed channel is a typed
 //!   [`ActorGone`], never a panic, so neither side hangs forever if the other dies.
 
-use crate::commit_notify::CommitNotify;
+use crate::commit_notify::{CommitNotify, StreamCell};
 use crate::engine::{AsyncCommit, DiskFullPolicy, Engine, EngineError};
 use crate::flusher::{spawn_flusher, FlushJob, SyncDone};
 use crate::liveness::ActorWatchdog;
@@ -59,6 +59,7 @@ use ironbus_core::clock::Clock;
 use ironbus_core::types::Offset;
 use ironbus_storage::fs::Filesystem;
 use ironbus_storage::log::Append;
+use std::collections::HashMap;
 use std::collections::VecDeque;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{sync_channel, Receiver, RecvTimeoutError, SyncSender, TryRecvError};
@@ -1900,34 +1901,96 @@ struct PipelineRig<File> {
     max_dirty_bytes: u64,
 }
 
-/// Signals the commit-notify wakeup seam (push delivery) IFF the DURABLE poll frontier advanced since
-/// `last_notified`. Pure observation on the actor thread: it reads [`Engine::flushed_offset`] — the
-/// exact head [`Engine::poll_now_in_member`] serves up to, which under the sync tier advances only at
-/// barrier completion — and, only when it grew, records the new head and [`CommitNotify::bump`]s every
-/// idle long-polling consumer awake to re-poll. Called STRICTLY AFTER the durability work that may have
-/// advanced the frontier, so it never reorders any commit/append/release. OVER-bumping is harmless (a
-/// woken waiter that still finds nothing re-waits or times out); UNDER-bumping only costs a consumer a
-/// little latency (it falls back to its long-poll timeout). Cheap on the steady-state path: one offset
-/// read + compare, and the `bump` (a short lock + `notify_all`) runs only on a real advance.
-///
-/// SCOPE (v1): this observes ONLY the DEFAULT/root log's `flushed_offset`. A commit to a NAMED stream
-/// (#588 — its OWN per-stream log, served by `poll_in_stream`) does NOT advance this frontier, so a
-/// consumer long-polling a named stream gets NO early wakeup; it is TIMEOUT-BACKSTOPPED (still correct —
-/// it re-polls and delivers when its budget elapses, exactly the pre-push-delivery behavior for that
-/// consumer). Observing per-stream frontiers (a bump keyed by the stream that committed) is the
-/// documented per-stream-granularity refinement, deferred with the global-granularity note.
-fn notify_frontier_advance<F, C>(
-    engine: &Engine<F, C>,
-    commit_notify: &CommitNotify,
-    last_notified: &mut u64,
-) where
-    F: Filesystem,
-    C: Clock + Clone,
-{
-    let head = engine.flushed_offset().get();
-    if head > *last_notified {
-        *last_notified = head;
-        commit_notify.bump();
+/// One tracked stream in the actor's [`FrontierTracker`]: the last durable head it has already
+/// signalled for this stream, plus a CACHED handle to that stream's [`StreamCell`] so a per-batch
+/// advance bumps it WITHOUT re-locking the commit-notify registry each commit.
+struct TrackedStream {
+    /// The last durable poll frontier already signalled to this stream's long-polling consumers. Only
+    /// a head STRICTLY GREATER than this bumps (and then advances this), so a re-observation of an
+    /// unchanged head is a no-op.
+    last_notified: u64,
+    /// This stream's wakeup cell (get-or-created from the registry once, then cached here). Bumped
+    /// directly on advance — no registry lock on the steady path.
+    cell: Arc<StreamCell>,
+}
+
+/// The append actor's PER-STREAM commit-notify frontier tracker (push delivery, #1100 L2). For each
+/// stream it has observed — the default `""` and every named stream (#588) — it holds the last durable
+/// head it signalled and a cached [`StreamCell`] handle, so a per-batch advance scan bumps ONLY the
+/// streams whose frontier actually grew (the default log AND any named-stream log that advanced),
+/// waking only those streams' waiters. Built ONCE per actor when long-poll is enabled and NEVER touched
+/// on a default-off broker, so the produce hot path is byte-for-byte unchanged when push delivery is
+/// off. Replaces L1's single `last_notified: u64` (which only ever observed the root log).
+struct FrontierTracker {
+    /// stream name -> its last-signalled head + cached wakeup cell.
+    per_stream: HashMap<Arc<str>, TrackedStream>,
+}
+
+impl FrontierTracker {
+    /// Seed the tracker with EVERY currently-open stream's RECOVERED head, WITHOUT bumping — so a
+    /// broker that recovered a non-empty log does not spuriously wake (there are no waiters at spawn
+    /// anyway); only advances AFTER spawn signal. Called once at actor entry when long-poll is enabled.
+    fn seed<F, C>(engine: &Engine<F, C>, commit_notify: &CommitNotify) -> FrontierTracker
+    where
+        F: Filesystem,
+        C: Clock + Clone,
+    {
+        let mut per_stream: HashMap<Arc<str>, TrackedStream> = HashMap::new();
+        engine.for_each_poll_frontier(|name, head| {
+            let cell = commit_notify.cell(name);
+            per_stream.insert(
+                Arc::from(name),
+                TrackedStream {
+                    last_notified: head,
+                    cell,
+                },
+            );
+        });
+        FrontierTracker { per_stream }
+    }
+
+    /// Signal every stream whose DURABLE poll frontier advanced since it was last signalled: scan the
+    /// default log AND every named-stream log, and for each one whose head grew, record the new head
+    /// and [`StreamCell::bump`] THAT stream's cell (waking only its waiters). Called STRICTLY AFTER the
+    /// durability work that may have advanced any frontier, so it never reorders a commit/append/
+    /// release. OVER-bumping a stream is harmless (a woken waiter that still finds nothing re-waits or
+    /// times out); UNDER-bumping only costs that stream's waiters a little latency (they fall back to
+    /// their long-poll timeout). Cheap on the steady state: one head read + compare per open stream,
+    /// and a `bump` (a short per-cell lock + `notify_all`) only on a real advance.
+    ///
+    /// A stream FIRST observed here (declared + produced during the run, so it was absent from the
+    /// spawn-time seed) is registered on the spot with `last_notified = 0`; because its first records
+    /// jump the head to `> 0`, it BUMPS immediately, so a consumer already parked on the freshly
+    /// declared stream wakes on its first commit rather than eating its full budget (over-bump is
+    /// harmless if there is no waiter yet).
+    fn notify_advances<F, C>(&mut self, engine: &Engine<F, C>, commit_notify: &CommitNotify)
+    where
+        F: Filesystem,
+        C: Clock + Clone,
+    {
+        let per_stream = &mut self.per_stream;
+        engine.for_each_poll_frontier(|name, head| {
+            if let Some(tracked) = per_stream.get_mut(name) {
+                if head > tracked.last_notified {
+                    tracked.last_notified = head;
+                    tracked.cell.bump();
+                }
+            } else {
+                let cell = commit_notify.cell(name);
+                // First observation post-seed: seed at 0 so a stream that committed its first records
+                // this very batch (head > 0) still wakes any already-parked waiter. Over-bump is safe.
+                if head > 0 {
+                    cell.bump();
+                }
+                per_stream.insert(
+                    Arc::from(name),
+                    TrackedStream {
+                        last_notified: head,
+                        cell,
+                    },
+                );
+            }
+        });
     }
 }
 
@@ -1983,13 +2046,11 @@ where
     // (no `flushed_offset` read, no lock, no `notify_all` per commit). Only a long-poll-enabled broker
     // seeds the last-signalled frontier and bumps on advance.
     let longpoll_enabled = consume_longpoll_ms != 0;
-    // The last durable poll frontier this actor has already signalled to long-polling consumers: seeded
-    // to the recovered head so only real ADVANCES bump the seam. Unused (and unread) when off.
-    let mut last_notified = if longpoll_enabled {
-        engine.flushed_offset().get()
-    } else {
-        0
-    };
+    // The PER-STREAM commit-notify frontier tracker (#1100 L2): seeded to every open stream's recovered
+    // head so only real ADVANCES bump, and it bumps ONLY the cells whose stream advanced (the default
+    // log AND any named-stream log). `None` (and never built) when long-poll is off, so the group-commit
+    // hot path never touches it. Replaces L1's single root-log `last_notified`.
+    let mut frontiers = longpoll_enabled.then(|| FrontierTracker::seed(&engine, commit_notify));
     // The per-pass command batch, hoisted and reused across drains exactly like `pending` above (#828):
     // each pass `clear()`s it and `drain(..)`s it empty, so its backing capacity is retained instead of
     // freed and regrown-from-zero every batch. This actor is the single serialization point for all
@@ -2097,9 +2158,10 @@ where
         // Push delivery (OPT-IN): only when long-poll is enabled does the covering commit's frontier
         // advance wake an idle long-polling consumer. When off this branch is skipped entirely, so the
         // group-commit boundary stays byte-for-byte the historical path. STRICTLY AFTER the flush (pure
-        // observation; a bump reads the now-current `flushed_offset`), never reordered with it.
-        if longpoll_enabled {
-            notify_frontier_advance(&engine, commit_notify, &mut last_notified);
+        // observation; a bump reads the now-current per-stream `flushed_offset`s), never reordered with
+        // it. Bumps ONLY the streams that advanced this batch (#1100 L2), not every idle consumer.
+        if let Some(frontiers) = frontiers.as_mut() {
+            frontiers.notify_advances(&engine, commit_notify);
         }
         // The batch just changed the durable byte total (an append grows it; a post-commit retention
         // reap can shrink it), so refresh the connection-thread fast-reject gate with the now-current
@@ -2167,14 +2229,11 @@ where
     // so the pipelined group-commit path is byte-for-byte the historical one (no `flushed_offset` probe,
     // no lock, no `notify_all`). Only a long-poll-enabled broker seeds the frontier and bumps on advance.
     let longpoll_enabled = consume_longpoll_ms != 0;
-    // The last durable poll frontier already signalled to long-polling consumers: in this (sync) tier
+    // The PER-STREAM commit-notify frontier tracker (#1100 L2): in this (sync) tier a stream's
     // `flushed_offset` advances only at barrier completion, so a bump means a record just became
-    // poll-visible. Seeded to the recovered head so only real advances signal; unused when off.
-    let mut last_notified = if longpoll_enabled {
-        engine.flushed_offset().get()
-    } else {
-        0
-    };
+    // poll-visible on THAT stream. Seeded to every open stream's recovered head so only real advances
+    // signal; `None` (never built) when off. Replaces L1's single root-log `last_notified`.
+    let mut frontiers = longpoll_enabled.then(|| FrontierTracker::seed(&engine, commit_notify));
     let mut pipeline = Pipeline {
         parked: VecDeque::new(),
         in_flight: None,
@@ -2211,9 +2270,9 @@ where
                     // frontier advances while the command channel is idle, so wake any long-polling
                     // consumer to re-poll the moment the barrier completes. Skipped entirely when off, so
                     // the idle-wait path is unchanged. STRICTLY AFTER the completion is folded in — pure
-                    // observation of the now-current `flushed_offset`.
-                    if longpoll_enabled {
-                        notify_frontier_advance(&engine, commit_notify, &mut last_notified);
+                    // observation of the now-current per-stream `flushed_offset`s (#1100 L2).
+                    if let Some(frontiers) = frontiers.as_mut() {
+                        frontiers.notify_advances(&engine, commit_notify);
                     }
                     continue;
                 }
@@ -2320,9 +2379,10 @@ where
         // `finish_pass` would miss it and strand the consumer until its timeout. An ASYNC barrier instead
         // leaves the frontier unchanged now (this is a no-op) and is caught by the `wait_one_completion`
         // bump when it completes. Skipped entirely when off, so the pass-end path is unchanged. Pure
-        // observation of the now-current `flushed_offset`; never reorders the durability work above.
-        if longpoll_enabled {
-            notify_frontier_advance(&engine, commit_notify, &mut last_notified);
+        // observation of the now-current per-stream `flushed_offset`s; never reorders the durability
+        // work above. Bumps ONLY the streams that advanced this pass (#1100 L2).
+        if let Some(frontiers) = frontiers.as_mut() {
+            frontiers.notify_advances(&engine, commit_notify);
         }
         refresh_cap_gate(cap_gate, &mut engine);
         engine.codel_queue_empty();

--- a/crates/ironbus-server/src/commit_notify.rs
+++ b/crates/ironbus-server/src/commit_notify.rs
@@ -9,23 +9,37 @@
 //! additive overlay on the unchanged consume path: it never reorders, leases, or emits anything; it
 //! only decides WHEN the existing poll runs again.
 //!
-//! GRANULARITY IS GLOBAL for v1 (one counter per engine, not per stream/group): any commit wakes every
-//! waiter. A spurious cross-stream wakeup simply re-polls empty and (if still within budget) waits
-//! again, which is byte-for-byte what a timer-driven re-poll does today, so global granularity is
-//! correct, only slightly less selective than a future per-stream refinement. The counter is a
-//! monotonically-increasing generation, so a bump that lands BETWEEN a waiter's snapshot and its wait
-//! can never be lost (the predicate `*seq == snapshot` is already false, so `wait_timeout_while`
-//! returns without parking) — the standard lost-wakeup-safe condvar protocol.
+//! GRANULARITY IS PER-STREAM (#1100 L2): the seam is NOT one global counter but a small registry of
+//! per-stream [`StreamCell`]s, keyed by stream identity (`""` for the DEFAULT/root log, each named
+//! stream #588 by its name). A commit on stream A bumps ONLY stream A's cell, so it wakes ONLY the
+//! consumers waiting on A — not every idle consumer in the broker. This kills two L1 costs at once: the
+//! `O(N-idle)` THUNDERING HERD (a single global `notify_all` woke every parked consumer on any commit,
+//! each to re-poll empty and re-park); and the LOCK CONVOY on the one global `seq` mutex (every waiter
+//! and the actor contended on it). A commit now touches exactly the committing stream's cell (its own
+//! mutex + condvar), and consumers of unrelated streams never wake. It also lifts the L1 NAMED-STREAM
+//! FLOOR: a named-stream commit bumps that stream's cell, so its long-poller wakes promptly instead of
+//! always eating its full budget (L1 only observed the root log's frontier, so a named-stream consumer
+//! never got an early wake).
 //!
-//! NAMED-STREAM SCOPE (v1): the actor bumps only on the DEFAULT/root log's `flushed_offset` advancing,
-//! so a consumer long-polling a NAMED stream (#588 — its own per-stream log) gets NO early wakeup and
-//! falls back to its budget timeout. That is correct (it re-polls and delivers on timeout, exactly the
-//! pre-push-delivery behavior) and is the same per-stream-granularity refinement noted above.
+//! LOST-WAKEUP SAFETY IS PRESERVED PER STREAM. Each cell's generation is a monotonically-increasing
+//! counter; a waiter snapshots ITS stream's generation BEFORE it polls, so a bump that lands BETWEEN
+//! the snapshot and the wait can never be lost — the wait predicate observes the advanced counter and
+//! returns without parking (the standard lost-wakeup-safe condvar protocol, now keyed to the
+//! consumer's own stream). Over-bumping a stream is harmless (a woken waiter that still finds nothing
+//! re-waits or times out); under-bumping only costs THAT stream's waiters a little latency.
+//!
+//! BROADCAST CORRECTNESS. The cell key is the STREAM (log), NOT the work-group or member: every
+//! consumer of stream S — competing-group members AND broadcast subscribers alike — snapshots and
+//! waits on the SAME cell for S, so one commit to S wakes ALL of them. Each then re-polls its own
+//! group's cursor; a consumer whose group already drained simply re-waits (a harmless over-wake within
+//! the stream, the same benign re-poll the global seam did, now scoped to the one stream).
 
-use std::sync::{Arc, Condvar, Mutex};
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Condvar, Mutex, PoisonError};
 use std::time::{Duration, Instant};
 
-/// The bounded busy-poll window a [`wait_for_change`](CommitNotify::wait_for_change) spins BEFORE
+/// The bounded busy-poll window a [`wait_for_change`](StreamCell::wait_for_change) spins BEFORE
 /// parking on the condvar (#1100), in microseconds — the exact parallel of the produce path's
 /// `REPLY_SPIN_MICROS` (#1032, `actor.rs`). On the no-pre-ack-fsync tiers (memory backend or a relaxed
 /// `interval`/`async`/`none` level) a produce becomes poll-visible within tens of microseconds, but a
@@ -38,64 +52,73 @@ use std::time::{Duration, Instant};
 /// nothing before it parks exactly as the historical path did.
 const WAIT_SPIN_MICROS: u64 = 100;
 
-/// The engine-wide commit-notify wakeup counter (#push-delivery). ONE per append actor, shared (via
-/// `Arc`) between the actor thread (which [`bump`](CommitNotify::bump)s it whenever the durable poll
-/// frontier advances) and every consumer connection thread (which
-/// [`wait_for_change`](CommitNotify::wait_for_change)es on it while idle-long-polling).
+/// ONE stream's wakeup cell (#1100 L2): the per-stream generation + condvar the append actor bumps
+/// when THAT stream's durable poll frontier advances, and the consumers of THAT stream wait on. Shared
+/// via `Arc` between the actor (which caches the handle and [`bump`](StreamCell::bump)s it) and every
+/// connection long-polling the stream (which [`wait_for_change`](StreamCell::wait_for_change)es on it).
 ///
-/// The `seq` is a generation counter, not the frontier offset itself: the actor need not know any
-/// waiter's cursor, and over-bumping is harmless (a woken waiter that finds nothing re-waits), so the
-/// actor bumps on ANY frontier advance. Under-bumping would only cost latency (the waiter falls back to
-/// its timeout), never correctness.
-pub struct CommitNotify {
-    /// The monotic wakeup generation. Bumped under the lock on every durable-frontier advance; read
-    /// (snapshotted) by a waiter before it polls, and compared inside the wait predicate.
-    seq: Mutex<u64>,
-    /// Signalled on every [`bump`](CommitNotify::bump) so a parked waiter re-checks the predicate.
+/// The generation is an [`AtomicU64`] so a waiter's spin-before-park re-check (#1100) reads it
+/// LOCK-FREE — resolving L1's noted follow-up (L1 re-read the counter through the mutex) — while the
+/// mutex/condvar back the park. It is written ONLY under `lock` (in [`bump`](StreamCell::bump)), which
+/// is what keeps the condvar lost-wakeup protocol intact despite the lock-free read (see `bump`).
+pub struct StreamCell {
+    /// The monotonic wakeup generation for THIS stream. Read LOCK-FREE by the spin and the park
+    /// predicate; incremented ONLY under `lock` (in `bump`). A `wrapping`/`fetch_add` bump between a
+    /// waiter's snapshot and its wait can never be lost — the predicate observes `gen != snapshot`.
+    gen: AtomicU64,
+    /// The mutex the condvar pairs with. It guards NO data (the generation lives in `gen`); it exists
+    /// solely to make a `bump`'s increment and a waiter's predicate-check mutually exclusive, which
+    /// closes the lost-wakeup window: a bump can only land BEFORE a waiter checks the predicate (so the
+    /// waiter sees the new generation and never parks) or AFTER the waiter has atomically parked (so
+    /// the `notify_all` wakes it) — never in between, because both hold this lock around the
+    /// increment / the predicate-and-park.
+    lock: Mutex<()>,
+    /// Signalled on every [`bump`](StreamCell::bump) of THIS cell, so ONLY this stream's parked
+    /// waiters re-check their predicate.
     cv: Condvar,
 }
 
-impl CommitNotify {
-    /// A fresh notify at generation 0, wrapped in an `Arc` so the actor and every connection share the
-    /// one instance.
-    #[must_use]
-    pub fn new() -> Arc<Self> {
-        Arc::new(CommitNotify {
-            seq: Mutex::new(0),
+impl StreamCell {
+    /// A fresh cell at generation 0.
+    fn new() -> Arc<StreamCell> {
+        Arc::new(StreamCell {
+            gen: AtomicU64::new(0),
+            lock: Mutex::new(()),
             cv: Condvar::new(),
         })
     }
 
-    /// The CURRENT wakeup generation, snapshotted by a waiter BEFORE it runs its poll batch so a bump
-    /// that lands between the snapshot and the wait is not lost (the wait predicate observes the
-    /// advanced counter and returns immediately).
+    /// The CURRENT wakeup generation of this stream (lock-free), snapshotted by a waiter BEFORE it runs
+    /// its poll batch so a bump that lands between the snapshot and the wait is not lost (the wait
+    /// predicate observes the advanced counter and returns immediately).
     #[must_use]
     pub fn seq(&self) -> u64 {
-        *self
-            .seq
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
+        self.gen.load(Ordering::Acquire)
     }
 
-    /// Advance the generation and wake every parked waiter. Called by the append actor STRICTLY AFTER
-    /// the durability work that advanced the poll-visible frontier (pure observation — it never
-    /// reorders the actor's own statements). Over-bumping is harmless.
+    /// Advance THIS stream's generation and wake ITS parked waiters. Called by the append actor
+    /// STRICTLY AFTER the durability work that advanced this stream's poll-visible frontier (pure
+    /// observation — it never reorders the actor's own statements). Over-bumping is harmless.
+    ///
+    /// The increment runs UNDER `lock` even though `gen` is an atomic: that is the lost-wakeup
+    /// invariant. A waiter checks its predicate (`gen == snapshot`) while holding `lock` and only then
+    /// atomically parks (releasing `lock`); because this increment also holds `lock`, it cannot slip
+    /// between that check and the park — so the waiter either sees the new generation (and never parks)
+    /// or is already parked when `notify_all` fires. `notify_all` is issued AFTER dropping the lock so
+    /// a woken waiter does not immediately contend on it.
     pub fn bump(&self) {
         {
-            let mut seq = self
-                .seq
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            *seq = seq.wrapping_add(1);
+            let _guard = self.lock.lock().unwrap_or_else(PoisonError::into_inner);
+            self.gen.fetch_add(1, Ordering::Release);
         }
-        // Notify AFTER dropping the lock so a woken waiter does not immediately contend on it.
         self.cv.notify_all();
     }
 
-    /// Block until the generation moves off `snapshot` (a commit happened) or `timeout` elapses,
-    /// whichever comes first. Returns as soon as the predicate is false, so a bump racing the snapshot
-    /// is never lost. A spurious condvar wake with an unchanged generation simply re-parks until the
-    /// deadline — the caller re-polls at most once regardless.
+    /// Block until this stream's generation moves off `snapshot` (a commit to THIS stream happened) or
+    /// `timeout` elapses, whichever comes first. Returns as soon as the predicate is false, so a bump
+    /// racing the snapshot is never lost. A spurious condvar wake with an unchanged generation simply
+    /// re-parks until the deadline — the caller re-polls at most once regardless. A commit to a
+    /// DIFFERENT stream bumps a DIFFERENT cell and never wakes this wait.
     ///
     /// `spin` gates a bounded busy-poll BEFORE the condvar park (#1100), threaded from the caller as the
     /// produce path's spin discriminant (`!commit_syncs_before_ack()`, #1032/#1026): `true` on the
@@ -105,17 +128,17 @@ impl CommitNotify {
     /// core and this is byte-for-byte the historical straight-to-park.
     pub fn wait_for_change(&self, snapshot: u64, timeout: Duration, spin: bool) {
         let start = Instant::now();
-        // Bounded spin-before-park (#1100). This is a PURE optimization layered on the unchanged
-        // condvar park below: the spin only re-reads `seq` — the SAME generation the wait predicate
-        // checks — so a bump it MISSES is still caught by the predicate (which then returns without
-        // parking), and a bump it SEES returns immediately with no park at all. Lost-wakeup safety is
-        // therefore identical to the pure-park path; the spin can only ever SHORTEN the wait.
+        // Bounded spin-before-park (#1100), now LOCK-FREE (#1100 L2 resolves L1's follow-up): the spin
+        // re-reads `gen` with a plain atomic load — the SAME generation the wait predicate checks — so
+        // a bump it MISSES is still caught by the predicate (which then returns without parking), and a
+        // bump it SEES returns immediately with no park and no mutex at all. Lost-wakeup safety is
+        // identical to the pure-park path; the spin can only ever SHORTEN the wait.
         if spin {
             let spin_deadline = start + Duration::from_micros(WAIT_SPIN_MICROS);
             loop {
-                // Re-read the generation under the same lock the predicate uses. A move off `snapshot`
-                // means a commit landed during the spin: return WITHOUT parking (the caller re-polls).
-                if self.seq() != snapshot {
+                // A move off `snapshot` means a commit to THIS stream landed during the spin: return
+                // WITHOUT parking (the caller re-polls).
+                if self.gen.load(Ordering::Acquire) != snapshot {
                     return;
                 }
                 if Instant::now() >= spin_deadline {
@@ -126,19 +149,87 @@ impl CommitNotify {
         }
         // Park for the REMAINING budget (the spin, if any, already burned `start.elapsed()`). The
         // condvar backstops every wake the spin did not catch: `wait_timeout_while` re-checks the
-        // predicate on entry and on every (spurious or real) wake, so a generation that already
-        // advanced past `snapshot` — including a bump that raced the snapshot or landed just after the
-        // spin window — returns without parking. The returned guard/timeout result is not needed: the
-        // caller re-polls unconditionally after this returns.
+        // predicate on entry and on every (spurious or real) wake, reading `gen` UNDER `lock` — the
+        // same lock `bump` holds around its increment — so a generation that already advanced past
+        // `snapshot` (a bump that raced the snapshot or landed just after the spin window) returns
+        // without parking. The returned guard/timeout result is not needed: the caller re-polls
+        // unconditionally after this returns.
         let remaining = timeout.saturating_sub(start.elapsed());
-        let guard = self
-            .seq
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let guard = self.lock.lock().unwrap_or_else(PoisonError::into_inner);
         let _ = self
             .cv
-            .wait_timeout_while(guard, remaining, |seq| *seq == snapshot)
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
+            .wait_timeout_while(guard, remaining, |()| {
+                self.gen.load(Ordering::Acquire) == snapshot
+            })
+            .unwrap_or_else(PoisonError::into_inner);
+    }
+}
+
+/// The engine-wide commit-notify registry (#push-delivery, per-stream since #1100 L2). ONE per append
+/// actor, shared (via `Arc`) between the actor thread (which [`bump`](CommitNotify::bump)s a stream's
+/// cell whenever THAT stream's durable poll frontier advances) and every consumer connection thread
+/// (which [`wait_for_change`](CommitNotify::wait_for_change)es on its OWN stream's cell while idle
+/// long-polling).
+///
+/// It is a get-or-insert map from stream identity to that stream's [`StreamCell`]. The registry mutex
+/// is held ONLY for the brief `HashMap` lookup/insert — NEVER across a park, a poll, or a bump's
+/// `notify_all` — so a commit on stream A and an idle waiter on stream B contend here for nanoseconds
+/// at most and then operate on DISJOINT per-cell mutexes/condvars (the L1 global-condvar thundering
+/// herd and lock convoy are both gone). Cells are never removed (bounded by `max_streams` + 1), so a
+/// [`cell`](CommitNotify::cell) handle for a given stream is stable for the life of the actor.
+pub struct CommitNotify {
+    /// Per-stream wakeup cells, keyed by stream name: `""` for the DEFAULT/root stream, each NAMED
+    /// stream (#588) by its validated name. Get-or-insert under this ONE mutex.
+    cells: Mutex<HashMap<Arc<str>, Arc<StreamCell>>>,
+}
+
+impl CommitNotify {
+    /// A fresh, empty registry, wrapped in an `Arc` so the actor and every connection share the one
+    /// instance. Cells are materialized lazily on first use per stream.
+    #[must_use]
+    pub fn new() -> Arc<Self> {
+        Arc::new(CommitNotify {
+            cells: Mutex::new(HashMap::new()),
+        })
+    }
+
+    /// Get-or-create the wakeup cell for `stream` (`""` = the default/root stream). A brief
+    /// registry-lock lookup that inserts a fresh generation-0 cell the first time a stream is seen by
+    /// EITHER a producer (the actor's bump) or a consumer (a wait). Returns an owned `Arc` so a caller
+    /// can HOLD the handle — the actor caches it to bump without re-locking the registry each commit; a
+    /// consumer holds it across one consume batch to snapshot then wait on the SAME cell. Because cells
+    /// are never removed, repeated calls for the same stream return the same cell.
+    #[must_use]
+    pub fn cell(&self, stream: &str) -> Arc<StreamCell> {
+        let mut cells = self.cells.lock().unwrap_or_else(PoisonError::into_inner);
+        if let Some(cell) = cells.get(stream) {
+            return Arc::clone(cell);
+        }
+        let cell = StreamCell::new();
+        cells.insert(Arc::from(stream), Arc::clone(&cell));
+        cell
+    }
+
+    /// The CURRENT wakeup generation of `stream`, a convenience over [`cell`](CommitNotify::cell) +
+    /// [`StreamCell::seq`].
+    #[must_use]
+    pub fn seq(&self, stream: &str) -> u64 {
+        self.cell(stream).seq()
+    }
+
+    /// Advance `stream`'s generation and wake ONLY that stream's parked waiters (the per-stream
+    /// targeted wakeup). A convenience over [`cell`](CommitNotify::cell) + [`StreamCell::bump`]; the
+    /// actor prefers caching the [`cell`](CommitNotify::cell) handle and bumping it directly to skip
+    /// the registry lock on the steady path.
+    pub fn bump(&self, stream: &str) {
+        self.cell(stream).bump();
+    }
+
+    /// Block until `stream`'s generation moves off `snapshot` or `timeout` elapses. A convenience over
+    /// [`cell`](CommitNotify::cell) + [`StreamCell::wait_for_change`]; waits on THAT stream's cell only,
+    /// so a commit to a different stream never wakes this waiter.
+    pub fn wait_for_change(&self, stream: &str, snapshot: u64, timeout: Duration, spin: bool) {
+        self.cell(stream).wait_for_change(snapshot, timeout, spin);
     }
 }
 
@@ -152,10 +243,10 @@ mod tests {
     #[test]
     fn spin_returns_immediately_when_the_generation_already_advanced() {
         let notify = CommitNotify::new();
-        let snapshot = notify.seq();
-        notify.bump(); // seq is now != snapshot BEFORE the wait
+        let snapshot = notify.seq("");
+        notify.bump(""); // seq is now != snapshot BEFORE the wait
         let start = Instant::now();
-        notify.wait_for_change(snapshot, Duration::from_secs(30), /* spin */ true);
+        notify.wait_for_change("", snapshot, Duration::from_secs(30), /* spin */ true);
         assert!(
             start.elapsed() < Duration::from_secs(1),
             "a pre-advanced generation must return at once, not park to the 30 s budget; took {:?}",
@@ -171,16 +262,16 @@ mod tests {
     fn a_generation_change_during_the_wait_is_observed_well_below_the_budget() {
         for spin in [true, false] {
             let notify = CommitNotify::new();
-            let snapshot = notify.seq();
+            let snapshot = notify.seq("");
             let bumper = Arc::clone(&notify);
             let jh = std::thread::spawn(move || {
                 // Land the commit inside the wait, after it has begun (past the ~100 us spin window on
                 // the spin path, so this also exercises the condvar backstop, not only the busy-poll).
                 std::thread::sleep(Duration::from_millis(20));
-                bumper.bump();
+                bumper.bump("");
             });
             let start = Instant::now();
-            notify.wait_for_change(snapshot, Duration::from_secs(30), spin);
+            notify.wait_for_change("", snapshot, Duration::from_secs(30), spin);
             let elapsed = start.elapsed();
             jh.join().unwrap();
             assert!(
@@ -197,10 +288,10 @@ mod tests {
     #[test]
     fn spin_still_backstops_on_the_condvar_and_times_out_without_a_commit() {
         let notify = CommitNotify::new();
-        let snapshot = notify.seq();
+        let snapshot = notify.seq("");
         let budget = Duration::from_millis(120);
         let start = Instant::now();
-        notify.wait_for_change(snapshot, budget, /* spin */ true);
+        notify.wait_for_change("", snapshot, budget, /* spin */ true);
         let elapsed = start.elapsed();
         // At least the budget minus the spin window (and a slack for coarse timer granularity): the
         // park must dominate, so this is FAR above the 100 us spin — proving the spin fell through to
@@ -209,6 +300,115 @@ mod tests {
             elapsed >= budget.saturating_sub(Duration::from_millis(20)),
             "with no commit the spin must fall into the condvar park and honor the budget; \
              took {elapsed:?} for a {budget:?} budget"
+        );
+    }
+
+    /// FAN-OUT ISOLATION (#1100 L2, the thundering-herd fix): a waiter on stream A is NOT woken by a
+    /// commit to stream B — it waits on B's WHOLE budget and times out — yet a commit to A DOES wake
+    /// it promptly. Proves a bump is scoped to the committing stream's cell, so an idle consumer on
+    /// one stream is never disturbed by commits on unrelated streams (the O(N-idle) herd L2 kills).
+    #[test]
+    fn a_commit_to_another_stream_does_not_wake_a_waiter() {
+        // Part 1: a commit to "B" must NOT wake a waiter on "A" — it must time out on its own budget.
+        let notify = CommitNotify::new();
+        let snapshot_a = notify.seq("a");
+        let bumper = Arc::clone(&notify);
+        let jh = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(20));
+            bumper.bump("b"); // a DIFFERENT stream
+        });
+        let budget = Duration::from_millis(200);
+        let start = Instant::now();
+        notify.wait_for_change("a", snapshot_a, budget, /* spin */ false);
+        let elapsed = start.elapsed();
+        jh.join().unwrap();
+        assert!(
+            elapsed >= budget.saturating_sub(Duration::from_millis(20)),
+            "a commit to stream B must NOT wake a waiter on stream A; it must wait out its budget, \
+             but it returned after {elapsed:?} (budget {budget:?})"
+        );
+
+        // Part 2: a commit to "A" DOES wake the same-keyed waiter promptly (the cell works for A).
+        let notify = CommitNotify::new();
+        let snapshot_a = notify.seq("a");
+        let bumper = Arc::clone(&notify);
+        let jh = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(20));
+            bumper.bump("a"); // the SAME stream
+        });
+        let start = Instant::now();
+        notify.wait_for_change(
+            "a",
+            snapshot_a,
+            Duration::from_secs(30),
+            /* spin */ false,
+        );
+        let elapsed = start.elapsed();
+        jh.join().unwrap();
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "a commit to stream A must wake its own waiter well below the budget; took {elapsed:?}"
+        );
+    }
+
+    /// NAMED-STREAM EARLY WAKE (#1100 L2, the named-stream floor fix): a waiter on a NAMED stream wakes
+    /// on a commit to THAT named stream — far below its budget — where L1 (which only bumped on the
+    /// root log) would have stranded it until timeout. The named cell is just another key, so this is
+    /// the same mechanism as the default stream, now reaching named-stream long-pollers.
+    #[test]
+    fn a_named_stream_waiter_wakes_on_its_own_commit() {
+        let notify = CommitNotify::new();
+        let snapshot = notify.seq("orders");
+        let bumper = Arc::clone(&notify);
+        let jh = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(20));
+            bumper.bump("orders");
+        });
+        let start = Instant::now();
+        notify.wait_for_change(
+            "orders",
+            snapshot,
+            Duration::from_secs(30),
+            /* spin */ true,
+        );
+        let elapsed = start.elapsed();
+        jh.join().unwrap();
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "a named-stream waiter must wake on its own stream's commit, not eat the full budget; \
+             took {elapsed:?}"
+        );
+    }
+
+    /// BROADCAST CORRECTNESS (#1100 L2): TWO waiters on the SAME stream (the competing-group member +
+    /// broadcast-subscriber case — the key is the stream, not the group) are BOTH woken by ONE commit
+    /// to that stream. Each snapshots and waits on the same cell, so a single `notify_all` releases
+    /// both well below the budget.
+    #[test]
+    fn two_waiters_on_the_same_stream_both_wake_on_one_commit() {
+        let notify = CommitNotify::new();
+        let snap1 = notify.seq("s");
+        let snap2 = notify.seq("s");
+        let n1 = Arc::clone(&notify);
+        let n2 = Arc::clone(&notify);
+        let w1 = std::thread::spawn(move || {
+            let start = Instant::now();
+            n1.wait_for_change("s", snap1, Duration::from_secs(30), /* spin */ false);
+            start.elapsed()
+        });
+        let w2 = std::thread::spawn(move || {
+            let start = Instant::now();
+            n2.wait_for_change("s", snap2, Duration::from_secs(30), /* spin */ false);
+            start.elapsed()
+        });
+        // Let both threads reach the park, then fire ONE commit to the shared stream.
+        std::thread::sleep(Duration::from_millis(40));
+        notify.bump("s");
+        let e1 = w1.join().unwrap();
+        let e2 = w2.join().unwrap();
+        assert!(
+            e1 < Duration::from_secs(5) && e2 < Duration::from_secs(5),
+            "one commit to a shared stream must wake BOTH waiters; took {e1:?} and {e2:?}"
         );
     }
 }

--- a/crates/ironbus-server/src/engine.rs
+++ b/crates/ironbus-server/src/engine.rs
@@ -5203,6 +5203,18 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
             .map_or(Offset::ZERO, Log::flushed_offset)
     }
 
+    /// Visit the durable poll frontier (`flushed_offset`) of the DEFAULT stream AND every open NAMED
+    /// stream (#1100 L2): calls `f("", head)` first — the ROOT log's authoritative head, exactly what
+    /// [`Engine::flushed_offset`] reports and what a default-stream consumer polls, since the
+    /// [`StreamSet`]'s own `""` slot is an inert never-written re-open — then `f(name, head)` for each
+    /// named stream in deterministic order. A pure read used by the append actor's PER-STREAM
+    /// commit-notify to bump only the cells whose frontier advanced. O(open streams); a default-only
+    /// deployment visits exactly one entry, so the common path stays a single atomic head read.
+    pub fn for_each_poll_frontier<G: FnMut(&str, u64)>(&self, mut f: G) {
+        f("", self.log.flushed_offset().get());
+        self.streams.for_each_named_frontier(f);
+    }
+
     /// The number of OPEN named streams (#676), EXCLUDING the always-present default stream: `0` for
     /// a deployment that never named a stream. (The [`StreamSet`] always carries its `""` slot, so we
     /// subtract it to report the named count an operator cares about.)

--- a/crates/ironbus-server/src/session.rs
+++ b/crates/ironbus-server/src/session.rs
@@ -2160,16 +2160,21 @@ impl Session {
         // One reusable scratch buffer for this batch's per-record frame bodies (#826): cleared and
         // reused each iteration instead of allocating a fresh `Vec` per delivered record/advisory.
         let mut frame_body = Vec::with_capacity(DELIVER_FRAME_SCRATCH_CAP);
-        // Event-driven long-poll (push delivery): snapshot the commit-notify generation BEFORE the poll
-        // batch (lost-wakeup safety — a commit racing the snapshot leaves the wait predicate already
-        // false), run the delivery drain, and if it drew NOTHING and long-poll is configured, block up
-        // to the budget on the seam and re-run the drain EXACTLY ONCE. The repoll is safe from
-        // `delivered == 0`: nothing was leased, no frame was emitted, and the credit/ceiling/AIMD bounds
-        // were computed above and stay unconsumed, so a second drain is byte-for-byte a fresh batch. A
-        // `None` seam or a zero budget skips straight to the unchanged tail. Granularity is GLOBAL: a
-        // spurious cross-stream wake just re-polls empty, exactly today's timer-driven re-poll.
-        let longpoll_notify = engine.commit_notify();
-        let longpoll_snapshot = longpoll_notify.map(|n| n.seq());
+        // Event-driven long-poll (push delivery), PER-STREAM (#1100 L2): grab THIS consumer's stream
+        // cell ONCE — keyed by `self.stream` (`""` for the default/root stream, else the named stream
+        // this Flow polls) — and snapshot its generation BEFORE the poll batch (per-stream lost-wakeup
+        // safety: a commit to THIS stream racing the snapshot bumps its cell past the snapshot, so the
+        // wait predicate is already false and never parks). Run the delivery drain, and if it drew
+        // NOTHING and long-poll is configured, block up to the budget on THAT cell and re-run the drain
+        // EXACTLY ONCE. A commit to a DIFFERENT stream never wakes this waiter (the thundering-herd fix),
+        // and a named-stream commit now wakes it early instead of eating its full budget. The repoll is
+        // safe from `delivered == 0`: nothing was leased, no frame was emitted, and the
+        // credit/ceiling/AIMD bounds were computed above and stay unconsumed, so a second drain is
+        // byte-for-byte a fresh batch. A `None` seam or a zero budget skips straight to the unchanged
+        // tail. Holding the cell (not re-looking-it-up) guarantees the snapshot and the wait target the
+        // SAME cell.
+        let longpoll_cell = engine.commit_notify().map(|n| n.cell(&self.stream));
+        let longpoll_snapshot = longpoll_cell.as_ref().map(|c| c.seq());
         for longpoll_attempt in 0..2u8 {
             for _ in 0..credits {
                 // The byte budget binds (#275): stop once in-flight bytes have reached the budget, unless
@@ -2317,8 +2322,8 @@ impl Session {
             // drain, the second attempt, a zero budget, or no seam (a non-actor engine) — breaks to the
             // unchanged tail below, which runs EXACTLY once regardless.
             if longpoll_attempt == 0 && delivered == 0 && self.consume_longpoll_ms > 0 {
-                if let (Some(notify), Some(snapshot)) = (longpoll_notify, longpoll_snapshot) {
-                    notify.wait_for_change(
+                if let (Some(cell), Some(snapshot)) = (&longpoll_cell, longpoll_snapshot) {
+                    cell.wait_for_change(
                         snapshot,
                         std::time::Duration::from_millis(self.consume_longpoll_ms),
                         // Spin-before-park (#1100) on the no-pre-ack-fsync tiers only — the produce
@@ -2450,12 +2455,16 @@ impl Session {
         // One reusable scratch buffer for this batch's per-record frame bodies (#826): cleared and
         // reused each iteration instead of allocating a fresh `Vec` per delivered record/advisory.
         let mut frame_body = Vec::with_capacity(DELIVER_FRAME_SCRATCH_CAP);
-        // Event-driven long-poll (push delivery): the batch twin of the `handle_flow` wrap — snapshot
-        // the commit-notify generation BEFORE the drain, and if the drain drew NOTHING re-run it EXACTLY
-        // ONCE after waking on a commit (or the budget elapsing). A `no_wait` fetch (#489) is EXEMPT: it
-        // is contractually a single immediate pass, so the wait is skipped and it returns as today.
-        let longpoll_notify = engine.commit_notify();
-        let longpoll_snapshot = longpoll_notify.map(|n| n.seq());
+        // Event-driven long-poll (push delivery), PER-STREAM (#1100 L2): the batch twin of the
+        // `handle_flow` wrap. This batch-fetch path polls the DEFAULT/root stream (`poll_now_in_member`),
+        // so it grabs the default stream's cell (`""`) — the cell it snapshots and waits on must match
+        // the stream it polls, so a default commit wakes it and a named-stream commit does not disturb
+        // it. Snapshot the cell's generation BEFORE the drain, and if the drain drew NOTHING re-run it
+        // EXACTLY ONCE after waking on a commit (or the budget elapsing). A `no_wait` fetch (#489) is
+        // EXEMPT: it is contractually a single immediate pass, so the wait is skipped and it returns as
+        // today.
+        let longpoll_cell = engine.commit_notify().map(|n| n.cell(""));
+        let longpoll_snapshot = longpoll_cell.as_ref().map(|c| c.seq());
         for longpoll_attempt in 0..2u8 {
             for _ in 0..credits {
                 // The deadline binds (#489): once the monotonic clock has reached it, end the batch with
@@ -2579,8 +2588,8 @@ impl Session {
                 && self.consume_longpoll_ms > 0
                 && !req.no_wait
             {
-                if let (Some(notify), Some(snapshot)) = (longpoll_notify, longpoll_snapshot) {
-                    notify.wait_for_change(
+                if let (Some(cell), Some(snapshot)) = (&longpoll_cell, longpoll_snapshot) {
+                    cell.wait_for_change(
                         snapshot,
                         std::time::Duration::from_millis(self.consume_longpoll_ms),
                         // Spin-before-park (#1100) on the no-pre-ack-fsync tiers only — the produce
@@ -13013,6 +13022,174 @@ mod tests {
         assert!(
             elapsed >= std::time::Duration::from_millis(200),
             "the consumer must wait out ~the budget, took {elapsed:?}"
+        );
+        drop(s);
+        drop(handle);
+        actor.join().unwrap();
+    }
+
+    // ---- Per-stream commit-notify (#1100 L2): fan-out + named-stream early wake -----------------
+
+    /// A streams-capable consumer: connects advertising `understands_streams` so it may `SubTo` a
+    /// named stream, its long-poll budget seeded from the engine-config snapshot as the serve path does.
+    fn longpoll_streams_consumer(
+        handle: &crate::actor::EngineHandle<InMemoryFs, ManualClock>,
+    ) -> Session {
+        let mut s = Session::new().with_consume_longpoll_ms(handle.consume_longpoll_ms());
+        let mut body = Vec::new();
+        ironbus_proto::message::encode_connect(
+            &ironbus_proto::message::ConnectBody {
+                requested_credit: None,
+                requested_credit_bytes: None,
+                wants_gap_marker: false,
+                default_ack_level: None,
+                understands_streaming: false,
+                default_tier: None,
+                understands_deliver_batch: false,
+                understands_streams: true,
+                understands_compressed_delivery: false,
+            },
+            &mut body,
+        );
+        let mut out = Vec::new();
+        s.process(handle, &frame(FrameType::Connect, &body), &mut out)
+            .unwrap();
+        s
+    }
+
+    /// A `SubTo(stream, group)` wire frame.
+    fn sub_to_frame(stream: &[u8], group: &[u8]) -> Vec<u8> {
+        let mut body = Vec::new();
+        ironbus_proto::message::encode_sub_to(
+            &ironbus_proto::message::SubToBody {
+                stream_id: stream,
+                group,
+            },
+            &mut body,
+        )
+        .unwrap();
+        frame(FrameType::SubTo, &body)
+    }
+
+    /// A Level-1 owned produce to a NAMED stream through the actor's `with` job, mirroring
+    /// `longpoll_append` but routed to the named stream's own log. Returns once the produce commits.
+    fn produce_to_named_stream(
+        handle: &crate::actor::EngineHandle<InMemoryFs, ManualClock>,
+        stream: &'static str,
+        payload: &'static [u8],
+    ) {
+        handle
+            .with(move |e| {
+                e.produce_in_stream(
+                    stream,
+                    &ironbus_storage::log::Append {
+                        timestamp_ms: 0,
+                        flags: ironbus_core::types::RecordFlags::EMPTY,
+                        key: b"",
+                        headers: b"",
+                        payload,
+                    },
+                )
+            })
+            .expect("actor alive")
+            .expect("a clean named-stream produce");
+    }
+
+    #[test]
+    fn longpoll_named_stream_wakes_early_on_its_own_commit() {
+        // #1100 L2: a consumer long-polling a NAMED stream wakes on a commit to THAT stream, far below
+        // its budget — where L1 (which bumped only on the root log's frontier) stranded it to the full
+        // timeout. Proves the actor now observes per-stream frontiers and bumps the named stream's cell.
+        let budget_ms = 2_000u64;
+        let (handle, actor) = longpoll_rig(budget_ms);
+        // Declare the named stream (empty) so the consumer can bind + poll it before any record exists.
+        handle
+            .with(|e| e.declare_stream("orders"))
+            .expect("actor alive")
+            .expect("declare");
+        let mut s = longpoll_streams_consumer(&handle);
+        let mut out = Vec::new();
+        // Bind the consumer to the named stream's work-group; SubTo replies Ok.
+        s.process(&handle, &sub_to_frame(b"orders", b"g"), &mut out)
+            .unwrap();
+        assert_eq!(one_response(&out).0, FrameType::Ok, "SubTo is accepted");
+        out.clear();
+        // A producer publishes to "orders" shortly after the consumer begins long-polling it empty.
+        let producer = handle.clone();
+        let jh = std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(40));
+            produce_to_named_stream(&producer, "orders", b"hello");
+        });
+        let start = std::time::Instant::now();
+        s.process(
+            &handle,
+            &frame(FrameType::Flow, &10u32.to_le_bytes()),
+            &mut out,
+        )
+        .unwrap();
+        let elapsed = start.elapsed();
+        jh.join().unwrap();
+        assert_eq!(
+            flow_end_count(&out),
+            1,
+            "the named-stream record is delivered on the per-stream commit-notify wakeup"
+        );
+        // Well below the 2 s budget: a broken per-stream bump would only free it at the ~2 s timeout.
+        assert!(
+            elapsed < std::time::Duration::from_millis(1_500),
+            "the named-stream delivery must arrive well before the budget, took {elapsed:?}"
+        );
+        drop(s);
+        drop(handle);
+        actor.join().unwrap();
+    }
+
+    #[test]
+    fn longpoll_named_stream_waiter_is_not_woken_by_a_default_stream_commit() {
+        // #1100 L2 THUNDERING-HERD FIX, end-to-end: a consumer long-polling the named stream "orders"
+        // is NOT woken by a produce to the DEFAULT stream — that commit bumps only the default cell, so
+        // the "orders" waiter sleeps on its own cell and times out empty. Under L1's single global
+        // counter this default produce would have woken every idle consumer (the herd L2 kills).
+        let budget_ms = 400u64;
+        let (handle, actor) = longpoll_rig(budget_ms);
+        handle
+            .with(|e| e.declare_stream("orders"))
+            .expect("actor alive")
+            .expect("declare");
+        let mut s = longpoll_streams_consumer(&handle);
+        let mut out = Vec::new();
+        s.process(&handle, &sub_to_frame(b"orders", b"g"), &mut out)
+            .unwrap();
+        assert_eq!(one_response(&out).0, FrameType::Ok, "SubTo is accepted");
+        out.clear();
+        // A producer commits to the DEFAULT stream while the "orders" consumer long-polls.
+        let producer = handle.clone();
+        let jh = std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(40));
+            producer
+                .produce(longpoll_append(b"on-default"))
+                .expect("a clean default-stream produce");
+        });
+        let start = std::time::Instant::now();
+        s.process(
+            &handle,
+            &frame(FrameType::Flow, &10u32.to_le_bytes()),
+            &mut out,
+        )
+        .unwrap();
+        let elapsed = start.elapsed();
+        jh.join().unwrap();
+        assert_eq!(
+            flow_end_count(&out),
+            0,
+            "a default-stream commit must NOT deliver to a named-stream long-poller"
+        );
+        // It must have waited out ~the budget rather than being spuriously woken by the default commit.
+        // The 200 ms floor (half the 400 ms budget) is a wide, timer-granularity-safe margin.
+        assert!(
+            elapsed >= std::time::Duration::from_millis(200),
+            "a named-stream waiter must NOT wake on a default-stream commit; it must wait out its \
+             budget, took {elapsed:?}"
         );
         drop(s);
         drop(handle);

--- a/crates/ironbus-storage/src/streamset.rs
+++ b/crates/ironbus-storage/src/streamset.rs
@@ -663,6 +663,21 @@ impl<F: Filesystem, C: Clock> StreamSet<F, C> {
         self.streams.keys().cloned().collect()
     }
 
+    /// Visit each NAMED stream's durable head (`flushed_offset`), calling `f(name, head)` in
+    /// deterministic (name) order and SKIPPING the inert default `""` slot (whose authoritative head
+    /// lives on the engine's root [`Log`], not this set's default entry). Allocation-free — no
+    /// intermediate `Vec` — so the append actor's per-stream commit-notify frontier scan (push
+    /// delivery, #1100 L2) costs one atomic head read per open named stream and nothing when none
+    /// exist.
+    pub fn for_each_named_frontier<G: FnMut(&str, u64)>(&self, mut f: G) {
+        for (id, log) in &self.streams {
+            if id.is_default() {
+                continue;
+            }
+            f(id.name(), log.flushed_offset().get());
+        }
+    }
+
     /// The number of open streams, including the always-present default stream (so this is `>= 1`).
     #[must_use]
     pub fn len(&self) -> usize {


### PR DESCRIPTION
## What & why (lever #2 of the #1100 tail-latency campaign, follow-on to L1 #1102)

L1 (#1102) added a bounded spin-before-park to the commit-notify long-poll wakeup, but the seam stayed a **single global** `{ seq: Mutex<u64>, cv: Condvar }`:

- **Thundering herd:** `bump()` called `cv.notify_all()`, so ANY commit woke EVERY parked idle consumer (`O(N-idle)`), each to re-poll empty and re-park.
- **Lock convoy:** every waiter and the actor contended on the one `seq` mutex; the L1 spin also re-read the counter *through* that mutex.
- **Named-stream floor:** the actor observed ONLY the default/root log's `flushed_offset`, so a NAMED-stream consumer (#588) got NO early wake and always ate its full budget.

This PR makes the seam **per-stream**.

## Design (std only — no new deps)

- `CommitNotify` is now a get-or-insert registry `Mutex<HashMap<Arc<str>, Arc<StreamCell>>>`, keyed by stream identity (`""` = default/root log, each named stream by name). The registry lock is held ONLY for the brief lookup/insert — never across a park, poll, or `notify_all`.
- `StreamCell { gen: AtomicU64, lock: Mutex<()>, cv: Condvar }`. The generation is an **atomic** so the L1 spin re-check is now **lock-free** (resolves L1's noted follow-up); it is written **under `lock`** in `bump`, which keeps the condvar lost-wakeup protocol intact. The park backstops on the cell's own condvar.
- **Actor** tracks per-stream frontiers in a `FrontierTracker` (seeded to every open stream's recovered head, built ONLY when long-poll is enabled), and bumps ONLY the cells whose durable head advanced. New `Engine::for_each_poll_frontier` visits the root log + every named stream (`StreamSet::for_each_named_frontier`), so a bump is keyed by the committing stream.
- **Consumers** snapshot + wait on their own stream's cell: `handle_flow` keys by `self.stream`; the default-stream batch fetch keys by `""` (it polls the root).

## Correctness

- **Per-stream lost-wakeup:** a waiter snapshots ITS stream's generation before polling; a racing commit to that stream bumps its cell past the snapshot, so the wait predicate is already false (never parks). The atomic is written under the cell lock, so a bump can only land before the waiter's predicate check (seen → no park) or after it has atomically parked (`notify_all` wakes it).
- **Broadcast:** the cell key is the STREAM, not the group/member, so competing-group members AND broadcast subscribers of one stream share its cell and all wake on its commit.
- **Default-off unchanged:** `consume_longpoll_ms == 0` never builds the tracker or touches the seam — produce hot path byte-identical. A default-only broker's per-batch scan is a single head read + one cell bump (matches L1).

## Tests (all green)

- Existing lost-wakeup + longpoll integration tests pass.
- New `commit_notify` unit tests: fan-out isolation (A not woken by B, A woken by A), named-stream early wake, broadcast (two waiters / one cell / one commit).
- New session integration tests: a named-stream consumer wakes early on its own commit; a named-stream waiter is NOT woken by a default-stream commit (herd fix, end-to-end).
- `cargo test -p ironbus-server` → 1110 passed. `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` clean. `cargo fmt --all --check` clean.

## Benchmark (fan-out mechanism microbench; VM-noise caveat)

A full N-connection socket fan-out harness is impractical on the CI VM, so a std-only microbench isolates the one mechanism L2 changes (64 idle waiters, one per stream; 20,000 commits to NON-target streams):

| metric | L1 global | L2 per-stream |
|---|---|---|
| target-stream spurious wakeups | ~12,000 | ~1 |
| total herd wakeups (64 waiters) | ~750,000 | ~64 |
| per-bump p50 | ~25 us | ~0.9 us |
| per-bump p999 | ~120 us | ~12 us |
| per-bump max | ~1.8 ms | ~32 us |

The absolute ns figures carry VM noise, but the scaling (`O(N)` herd + single-mutex convoy → `O(1)` targeted wakeup) is unambiguous. Single-stream delivery latency does not regress: the per-stream path is structurally identical to L1 for one stream, with the spin now lock-free (an atomic load vs a mutex-guarded read).

Refs #1100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01McmNfYNWPmohVS8umY9Lkp