### PR TITLE
perf(delivery): write-before-checkpoint + DeliverBatch fast path (L5+L6)

### DIFF
--- a/crates/ironbus-proto/src/message.rs
+++ b/crates/ironbus-proto/src/message.rs
@@ -603,6 +603,53 @@ pub fn encode_deliver(msg: &DeliverBody<'_>, out: &mut Vec<u8>) -> Result<(), Bo
     Ok(())
 }
 
+/// Encodes a COMPLETE `Deliver` FRAME — the `[len:u32][type][body]` envelope — directly onto `out`,
+/// with NO intermediate frame-body `Vec` (#812's direct-into-out pattern, extended from the batch path
+/// to the per-record leased `Deliver`). Byte-identical to
+/// `encode_frame(FrameType::Deliver, &{a Vec built by encode_deliver(msg)})`, so the on-wire frame (and
+/// the record's payload bytes) is unchanged; it merely DROPS the redundant per-record memcpy into a
+/// temporary body `Vec`. On the hot leased-delivery path (`handle_flow` / `handle_fetch`) this saves one
+/// copy of each delivered record's `(offset, generation, flags, ts, key, headers, payload)` body.
+///
+/// The frame LENGTH is not known until the variable-length body (u16-framed key/headers, then payload)
+/// is written, so it is BACKPATCHED: a 4-byte placeholder is reserved, the body is appended via the
+/// single-source-of-truth [`encode_deliver`], then the measured length is written into the placeholder.
+/// This keeps the body layout owned solely by [`encode_deliver`] (no duplicated field arithmetic to
+/// drift), unlike the fixed-size [`encode_deliver_batch_frame`] header which can precompute its length.
+///
+/// # Errors
+/// Returns [`BodyError::FieldTooLarge`] if the key or headers exceed `u16::MAX` (exactly as
+/// [`encode_deliver`]); on that error the partial frame is rolled back off `out`, leaving the buffer
+/// byte-for-byte as it was on entry.
+pub fn encode_deliver_frame(msg: &DeliverBody<'_>, out: &mut Vec<u8>) -> Result<(), BodyError> {
+    let frame_start = out.len();
+    // Reserve the 4-byte length prefix; patched once the body length below is known. The type byte
+    // follows it, exactly as `encode_frame`'s `[len:u32][type][body]` envelope.
+    out.extend_from_slice(&[0u8; 4]);
+    out.push(crate::frame::FrameType::Deliver.as_u8());
+    let body_start = out.len();
+    if let Err(e) = encode_deliver(msg, out) {
+        // A failed body encode leaves `out` untouched: roll the reserved prefix + type byte + any
+        // partial body off, so the caller sees the buffer exactly as before (it then stops the batch).
+        out.truncate(frame_start);
+        return Err(e);
+    }
+    // The frame length is the type byte plus the body just written. A delivered record's frame is the
+    // produced record's frame plus a tiny fixed prefix, and produce enforces the same `MAX_FRAME_LEN`
+    // cap on ingest, so this can never exceed the cap in practice; a `debug_assert` catches a violated
+    // invariant in test, matching `reply`/`encode_frame`'s debug-assert-only cap contract.
+    let body_len = out.len() - body_start;
+    let frame_len = 1 + body_len;
+    debug_assert!(
+        frame_len as u64 <= u64::from(crate::frame::MAX_FRAME_LEN),
+        "Deliver frame exceeded the frame cap"
+    );
+    // `frame_len <= MAX_FRAME_LEN` (a u32) in practice, so this conversion never truncates a real frame.
+    let frame_len = u32::try_from(frame_len).unwrap_or(u32::MAX);
+    out[frame_start..frame_start + 4].copy_from_slice(&frame_len.to_le_bytes());
+    Ok(())
+}
+
 /// Decodes a DELIVER body. The payload is whatever remains after the framed fields, so
 /// `body` MUST be exactly one frame's body.
 ///
@@ -3853,6 +3900,95 @@ mod tests {
         let (eh, eb) = decode_deliver_batch(&ebuf).unwrap();
         assert_eq!(eh, empty_header);
         assert!(eb.is_empty());
+    }
+
+    #[test]
+    fn encode_deliver_frame_is_byte_identical_to_the_two_copy_path() {
+        // L6 / #812: the single-pass per-record `Deliver` frame encoder must be byte-for-byte identical
+        // to the old `reply` path — `encode_frame(Deliver, &encode_deliver(...))` — so the on-wire frame
+        // is unchanged; it merely drops the intermediate frame-body Vec and one per-record memcpy.
+        use crate::frame::{decode_frame, encode_frame, FrameDecode, FrameType};
+        // Cover a non-empty key, non-empty headers, and a payload — the full variable-length body — plus
+        // a distinctive generation so the fencing token round-trips.
+        let cases: &[DeliverBody<'_>] = &[
+            DeliverBody {
+                offset: 0xDEAD_BEEF_0102_0304,
+                generation: 0x0A0B_0C0D_0E0F_1011,
+                flags: 0x5A,
+                timestamp_ms: 0x0011_2233_4455_6677,
+                key: b"routing-key",
+                headers: b"content-type=app/x",
+                payload: b"the-delivered-payload-bytes",
+            },
+            // The all-empty variable fields (no key, no headers, empty payload): the minimal body.
+            DeliverBody {
+                offset: 0,
+                generation: 0,
+                flags: 0,
+                timestamp_ms: 0,
+                key: b"",
+                headers: b"",
+                payload: b"",
+            },
+        ];
+        for msg in cases {
+            // OLD path: build the body Vec, then frame it.
+            let mut body = Vec::new();
+            encode_deliver(msg, &mut body).unwrap();
+            let mut old_frame = Vec::new();
+            encode_frame(FrameType::Deliver, &body, &mut old_frame).unwrap();
+
+            // NEW path: one pass directly into the buffer.
+            let mut new_frame = Vec::new();
+            encode_deliver_frame(msg, &mut new_frame).unwrap();
+
+            assert_eq!(
+                new_frame, old_frame,
+                "the single-pass Deliver frame is byte-identical to the two-copy path"
+            );
+
+            // And it decodes back through the normal frame + body path, unchanged.
+            let FrameDecode::Frame {
+                type_tag,
+                body: decoded_body,
+                consumed,
+            } = decode_frame(&new_frame).unwrap()
+            else {
+                panic!("a complete frame must decode");
+            };
+            assert_eq!(consumed, new_frame.len());
+            assert_eq!(FrameType::from_u8(type_tag), Some(FrameType::Deliver));
+            assert_eq!(&decode_deliver(decoded_body).unwrap(), msg);
+
+            // Appending into a NON-EMPTY buffer appends the frame without disturbing the existing bytes.
+            let mut buf = vec![0xAA, 0xBB];
+            encode_deliver_frame(msg, &mut buf).unwrap();
+            assert_eq!(&buf[..2], &[0xAA, 0xBB]);
+            assert_eq!(&buf[2..], new_frame.as_slice());
+        }
+
+        // A key over u16::MAX is a FieldTooLarge error, and it rolls the partial frame off `out`, leaving
+        // any pre-existing bytes untouched (byte-for-byte the `encode_deliver` FieldTooLarge behavior).
+        let huge = vec![0u8; usize::from(u16::MAX) + 1];
+        let msg = DeliverBody {
+            offset: 1,
+            generation: 2,
+            flags: 3,
+            timestamp_ms: 4,
+            key: &huge,
+            headers: b"",
+            payload: b"",
+        };
+        let mut buf = vec![0x11, 0x22];
+        assert!(matches!(
+            encode_deliver_frame(&msg, &mut buf),
+            Err(BodyError::FieldTooLarge)
+        ));
+        assert_eq!(
+            buf,
+            vec![0x11, 0x22],
+            "a failed encode leaves `out` untouched"
+        );
     }
 
     #[test]

--- a/crates/ironbus-server/src/server.rs
+++ b/crates/ironbus-server/src/server.rs
@@ -868,6 +868,18 @@ where
                     return Ok(());
                 };
                 inbuf.drain(..progress.consumed);
+                // Remember how many bytes the trailing partial frame needs before the next pass.
+                needed = progress.needed;
+                // LEVER 5 — WRITE BEFORE THE CHECKPOINT HOP (median latency): put the response BYTES on
+                // the wire FIRST, then fire the checkpoint actor round-trip. The checkpoint is a lagging
+                // at-least-once optimization — it only bounds how many already-processed messages a crash
+                // REDELIVERS on restart, never correctness — so nothing in the response depends on it, and
+                // the byte can safely hit the wire before it. Writing first removes one cross-thread actor
+                // round-trip from directly in front of the client-visible response, shaving it off the
+                // delivery/ack median (the hop still runs every committing pass, just AFTER the write).
+                if !out.is_empty() {
+                    stream.write_all(&out)?;
+                }
                 // Persist the session's work-group cursor on the configured interval so a crash
                 // redelivers a bounded tail. ONLY when this pass actually advanced a committed cursor (an
                 // ack/flow/unsub): a ping- or connect-only pass skips the checkpoint entirely, so it
@@ -881,11 +893,6 @@ where
                     let _ = engine.with(move |e| {
                         let _ = e.maybe_checkpoint_group(&group);
                     });
-                }
-                // Remember how many bytes the trailing partial frame needs before the next pass.
-                needed = progress.needed;
-                if !out.is_empty() {
-                    stream.write_all(&out)?;
                 }
             }
             // A NON-BLOCKING read found no new bytes while the window is non-empty (#1045): a

--- a/crates/ironbus-server/src/session.rs
+++ b/crates/ironbus-server/src/session.rs
@@ -44,13 +44,13 @@ use ironbus_proto::message::{
     decode_pub, decode_pub_subject, decode_pub_to, decode_stream_commit, decode_stream_declare,
     decode_stream_fetch, decode_stream_info, decode_sub, decode_sub_subject, decode_sub_to,
     decode_txn_check_result, decode_txn_listen, decode_txn_prepare, decode_txn_resolve,
-    encode_dead_letter, encode_deliver, encode_deliver_batch_frame, encode_gap_marker, encode_info,
-    encode_not_leader, encode_produce_confirm, encode_pub_ack, encode_stream_info_response,
-    encode_truncated, encode_txn_resolve, gap_reason, parse_connect_auth, produce_confirm_status,
-    pub_ack_level, AckLevel, AckOp, ConsumeTier, CreditAdvert, DeadLetterBody, DeliverBatchHeader,
-    DeliverBody, GapMarkerBody, InfoBody, NotLeaderBody, ProduceConfirmBody, PubAckBody,
-    StreamInfoResponseBody, TruncatedBody, TxnResolveBody, DEAD_LETTER_MAX_DELIVER,
-    PUB_WIRE_ONLY_FLAGS,
+    encode_dead_letter, encode_deliver, encode_deliver_batch_frame, encode_deliver_frame,
+    encode_gap_marker, encode_info, encode_not_leader, encode_produce_confirm, encode_pub_ack,
+    encode_stream_info_response, encode_truncated, encode_txn_resolve, gap_reason,
+    parse_connect_auth, produce_confirm_status, pub_ack_level, AckLevel, AckOp, ConsumeTier,
+    CreditAdvert, DeadLetterBody, DeliverBatchHeader, DeliverBody, GapMarkerBody, InfoBody,
+    NotLeaderBody, ProduceConfirmBody, PubAckBody, StreamInfoResponseBody, TruncatedBody,
+    TxnResolveBody, DEAD_LETTER_MAX_DELIVER, PUB_WIRE_ONLY_FLAGS,
 };
 use ironbus_storage::fs::Filesystem;
 use ironbus_storage::log::Append;
@@ -2245,13 +2245,14 @@ impl Session {
                             headers: &d.record.headers,
                             payload: wire_payload.as_ref(),
                         };
-                        frame_body.clear();
-                        // The record's key/headers came through PUB (u16-bounded), so this cannot
-                        // exceed the field limit; on the impossible error, stop the batch.
-                        if encode_deliver(&msg, &mut frame_body).is_err() {
+                        // L6 direct-into-out (#812): frame the `Deliver` DIRECTLY onto `out` in one pass,
+                        // dropping the per-record memcpy through the `frame_body` scratch. Byte-identical
+                        // to the old `encode_deliver` + `reply` path. The record's key/headers came through
+                        // PUB (u16-bounded), so this cannot exceed the field limit; on the impossible
+                        // error the partial frame is rolled off `out` and the batch stops.
+                        if encode_deliver_frame(&msg, out).is_err() {
                             break;
                         }
-                        reply(out, FrameType::Deliver, &frame_body);
                         // Record ownership so only this session can later act on this lease (#175), and
                         // the message's byte size so the byte budget (#275) is derived from `leased`. The
                         // size is key + headers + payload, matching the engine's produced-bytes accounting.
@@ -2541,11 +2542,12 @@ impl Session {
                             headers: &d.record.headers,
                             payload: wire_payload.as_ref(),
                         };
-                        frame_body.clear();
-                        if encode_deliver(&msg, &mut frame_body).is_err() {
+                        // L6 direct-into-out (#812): frame the `Deliver` DIRECTLY onto `out`, dropping the
+                        // per-record memcpy through `frame_body`. Byte-identical to the old `encode_deliver`
+                        // + `reply` path; a failed encode rolls the partial frame off `out` and stops.
+                        if encode_deliver_frame(&msg, out).is_err() {
                             break;
                         }
-                        reply(out, FrameType::Deliver, &frame_body);
                         // Lease ownership and byte accounting are IDENTICAL to `handle_flow`: only this
                         // session can later act on the lease (#175), and the byte size feeds the byte budget
                         // (#275). At-least-once holds because the record stays leased until acked.


### PR DESCRIPTION
Draft — do NOT merge yet. Two small durability-preserving delivery-write-path perf levers (L5 + L6) from the IronBus-vs-Zenoh gap analysis, bundled because both touch the delivery-write path.

## L5 — write before the checkpoint hop (median)
In `connection_loop` (`server.rs`), the per-pass `stream.write_all(&out)` now runs **before** the `maybe_checkpoint_group` actor round-trip, not after. The checkpoint is a lagging at-least-once optimization — it only bounds how many already-processed messages a crash redelivers on restart, never correctness — so nothing in the response depends on it, and the byte can safely hit the wire first. This removes one cross-thread actor hop from directly in front of the client-visible response. The checkpoint still runs on **every** committing pass (ack/flow/unsub), just after the write; `#177` invariant 4 (ping/connect-only passes never touch the actor) is preserved.

*(The optional session-side "only hop when it would actually checkpoint" skip was deliberately **not** done — it would need the engine's committed-offset delta threaded back through `Progress` per pass, which is not clean. The reorder alone captures the latency win: the hop is off the critical path whether or not it fires.)*

## L6 — DeliverBatch verify + direct-into-out
**VERIFY (the key measurement question):** the streaming-consume bench connects with `understands_deliver_batch: true`, so server-side `deliver_batch_enabled` is set and it takes the raw `serve_stream_fetch_batch` path (tag-26 `DeliverBatch`), **not** the `serve_stream_fetch_per_record` fallback. Its sealed prefix is already framed direct-into-`out` via `encode_deliver_batch_frame` (#812). So the hypothesized "+30-50% by routing the bench to DeliverBatch" does **not** apply — it is already on the fast path.

**What changed:** a new `encode_deliver_frame` (proto) frames a per-record `Deliver` directly onto `out` in one pass — it backpatches the 4-byte length prefix after appending the body via the single-source-of-truth `encode_deliver`, so it is byte-identical to the old `encode_deliver` + `reply` two-copy path (covered by a new unit test). It replaces the `frame_body.clear(); encode_deliver(..); reply(..)` sequence on the **leased** `handle_flow` / `handle_fetch` delivery paths, dropping one per-record memcpy there.

## Tests / CI
- `cargo test -p ironbus-server`: **1112 passed**, plus proto byte-identity + integration suites.
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`: clean.
- `cargo fmt --all --check`: clean.

## Benchmarks (colima Linux VM on macOS — see caveat)
A/B branch vs `origin/main` (4eac3b3, includes L1+L2+L3), release, back-to-back.

**Environment caveat:** the open-loop harness's sender is synchronous durable produce (`fire_and_forget: false`), so throughput is fsync-bound; this VM sustains only ~1000/s and **2000/s saturates it** (latency becomes unbounded queue wait — p50 in the tens of seconds). Numbers below are at sustainable rates; p50 is dominated by the ~1ms VM produce-fsync, and p99/p999 carry heavy VM-scheduler outliers on **both** sides. The `#1100` 2000/s tail number should be taken from the Linux/AWS bench box, not this VM.

1. **Combined tail (push-on, `--consume-longpoll-ms 1000`, 256B):** at 500/s, clean-run p50 ~1.3ms / p99 ~5.5ms / p999 ~7.6ms; at 800/s p50 ~1.17ms / p999 ~7.3ms (clean runs). **Branch ≈ main** (statistically identical) — L5+L6 do not regress the L1+L2+L3 tail. Absolute values are VM-fsync-bound, so this does not reproduce the prior ~2ms and cannot be used to close `#1100` directly; re-measure on the bench box.
2. **L5 median:** branch p50 ~1330us vs main ~1279us — **within noise** (a ~10-30us reorder is unresolvable against a ~1.3ms fsync-bound p50). Mechanistically, in this fetch+ack harness the checkpoint hop sits in front of the **ack** response, not the measured **deliver** frame, so the delivery-latency metric would not isolate L5 even without the fsync floor. L5 remains correct and safe; its clearest benefit is the ack/commit response round-trip (and pipelined ack+deliver passes).
3. **L6 throughput (stream-consume-bench, batched msg/s):** branch median ~2.22M vs main ~2.07M — overlapping ranges, **within noise**. Expected: the bench is on the already-direct DeliverBatch path; L6's change is on the leased per-record path the bench does not exercise.

**Honest summary:** all three deltas are within VM noise. The changes are correctness-neutral (byte-identical wire, checkpoint semantics preserved) micro-optimizations that remove a real actor round-trip (L5) and a real per-record memcpy (L6) from the leased delivery-write path; the payoff is below this VM's fsync/scheduler noise floor and should be re-measured on the Linux bench box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
