### PR TITLE
feat(streams): Tier-S streaming consume for named streams (#681 follow-up)

### DIFF
--- a/crates/ironbus-server/src/engine.rs
+++ b/crates/ironbus-server/src/engine.rs
@@ -9199,6 +9199,82 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         self.groups.get(group).is_some_and(|g| g.streaming)
     }
 
+    /// The NAMED-stream twin of [`Engine::set_streaming_in`] (#681 follow-up, Tier-S for named streams):
+    /// marks `group` OF the named `stream` a TIER-S STREAMING consumer (or clears it). A streaming named
+    /// group is served by [`Engine::stream_fetch_in_stream`] / [`Engine::stream_commit_in_stream`] off
+    /// that stream's OWN log with NO lease and NO per-record cursor write, durability coming from the
+    /// periodic named [`Engine::stream_commit_in_stream`] — the SAME lease-free contract the default
+    /// stream's streaming tier uses, keyed by `(stream, group)`. It lives on that stream's own
+    /// [`WorkGroup`] (the same per-group property as the default stream), so the same group name in two
+    /// streams carries two INDEPENDENT streaming cursors. Mirrors [`Engine::set_subject_filter_in_stream`]
+    /// / [`Engine::set_key_ordering_in_stream`]: it re-applies the mode server-side after open (never
+    /// restored from disk; the per-stream CURSOR, however, is durable, #681), creates the stream's group
+    /// if absent (validating the name and the PER-STREAM group cap), and requires the named `stream` to
+    /// already be resident (declared via produce/bind). The default stream (`""`) routes to
+    /// [`Engine::set_streaming_in`] BYTE-FOR-BYTE.
+    ///
+    /// # Errors
+    /// [`EngineError::InvalidStreamName`] for a malformed named name, [`EngineError::UnknownStream`] for
+    /// a never-declared stream, [`EngineError::InvalidGroupName`] for a malformed group name, or
+    /// [`EngineError::TooManyGroups`] if a new group would exceed the per-stream cap.
+    pub fn set_streaming_in_stream(
+        &mut self,
+        stream: &str,
+        group: &str,
+        streaming: bool,
+    ) -> Result<(), EngineError> {
+        if stream.is_empty() {
+            return self.set_streaming_in(group, streaming);
+        }
+        let id = StreamId::named(stream)?;
+        // The stream must be resident (its log open) before a streaming group can bind to it — a Tier-S
+        // mark on an unknown stream is a typed reject, never a silent bind to a stream that does not exist
+        // (matching the named filter / key-shared setters).
+        if self.streams.get(&id).is_none() {
+            return Err(EngineError::UnknownStream {
+                name: stream.to_string(),
+            });
+        }
+        validate_group_name(group)?;
+        let now = self.streams.get(&id).map_or(0, Log::now_monotonic);
+        let lease_config = self.lease_config;
+        let max_groups = self.max_groups;
+        let named = self
+            .named_streams
+            .entry(id)
+            .or_insert_with(NamedStream::new);
+        if !named.groups.contains_key(group) {
+            if max_groups != 0 && named.groups.len() >= max_groups {
+                return Err(EngineError::TooManyGroups { max: max_groups });
+            }
+            named
+                .groups
+                .insert(group.to_string(), WorkGroup::new(lease_config, now));
+        }
+        if let Some(g) = named.groups.get_mut(group) {
+            g.streaming = streaming;
+        }
+        Ok(())
+    }
+
+    /// Whether `group` OF the named `stream` is a TIER-S STREAMING consumer (#681 follow-up), the twin of
+    /// [`Engine::is_streaming_in`]: `true` when that stream's group is marked streaming, `false` for an
+    /// unknown stream/group or a plain competing named group. The default stream (`""`) reads the
+    /// default-group mode.
+    #[must_use]
+    pub fn is_streaming_in_stream(&self, stream: &str, group: &str) -> bool {
+        if stream.is_empty() {
+            return self.is_streaming_in(group);
+        }
+        let Ok(id) = StreamId::named(stream) else {
+            return false;
+        };
+        self.named_streams
+            .get(&id)
+            .and_then(|s| s.groups.get(group))
+            .is_some_and(|g| g.streaming)
+    }
+
     /// Binds a per-subject FILTER `pattern` to `group` (#594, V2-M2), or clears it (`None`). A filtered
     /// group delivers ONLY records whose stored subject matches `pattern`, emitting a
     /// `GapMarker`(`reason = FILTERED`) across each coalesced run of skipped offsets. The filter is a
@@ -9617,6 +9693,84 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         self.stream_fetch_in(DEFAULT_GROUP, member, start_offset, max_records, max_bytes)
     }
 
+    /// The NAMED-stream twin of [`Engine::stream_fetch_in`] (#681 follow-up, Tier-S for named streams):
+    /// serves a CONTIGUOUS batch of records from the named `stream`'s OWN log starting at the
+    /// consumer-managed `start_offset`, bounded by `max_records` / `max_bytes` and that stream's flushed
+    /// frontier — with NO lease grant, NO generation fence, and NO per-record cursor write, exactly the
+    /// lease-free contract the default stream's `stream_fetch_in` provides. It REUSES the SAME shared read
+    /// primitive ([`Log::read_range`]) on the per-stream log, so a named streaming fetch and a default one
+    /// differ only in WHICH log they read; the bookkeeping is byte-for-byte identical. `group` must be a
+    /// STREAMING group of `stream` (declared via [`Engine::set_streaming_in_stream`]); a fetch on a
+    /// non-streaming named group is rejected with the same wrong-mode error `stream_fetch_in` uses, so a
+    /// client cannot bypass the named Tier-W lease path by accident.
+    ///
+    /// `_member` is accepted for symmetry with the member-aware named poll and future per-member streaming
+    /// policy but is NOT used: a streaming consumer manages its own offset, so the contiguous read is not
+    /// member-routed — the SAME choice the default stream's `stream_fetch_in` makes (so a `key_shared`
+    /// named group that is ALSO marked streaming serves the full contiguous run, key routing inert on the
+    /// streaming path, matching the default). The default stream (`""`) routes to
+    /// [`Engine::stream_fetch_in`] BYTE-FOR-BYTE.
+    ///
+    /// # Errors
+    /// [`EngineError::InvalidStreamName`] for a malformed name, [`EngineError::UnknownStream`] for a
+    /// never-declared stream, [`EngineError::CumulativeAckOnWorkGroup`] if `group` is not a streaming
+    /// group of `stream`, or a storage error reading the durable prefix.
+    pub fn stream_fetch_in_stream(
+        &mut self,
+        stream: &str,
+        group: &str,
+        member: MemberId,
+        start_offset: Offset,
+        max_records: usize,
+        max_bytes: Option<usize>,
+    ) -> Result<StreamBatch, EngineError> {
+        // The DEFAULT stream ("") delegates to `stream_fetch_in` (which itself ignores the member on the
+        // contiguous read). A NAMED stream is likewise not member-routed on the streaming path (see the
+        // doc), so `member` is only forwarded to the default delegate and otherwise unreferenced below.
+        if stream.is_empty() {
+            return self.stream_fetch_in(group, member, start_offset, max_records, max_bytes);
+        }
+        let id = StreamId::named(stream)?;
+        // The stream must be resident: consuming an unknown (never-declared) stream is a typed reject.
+        if self.streams.get(&id).is_none() {
+            return Err(EngineError::UnknownStream {
+                name: stream.to_string(),
+            });
+        }
+        // A streaming fetch belongs to a STREAMING named group ONLY (the same wrong-mode guard as
+        // `stream_fetch_in`): a Tier-W named group must keep using the poll/Fetch path.
+        if !self.is_streaming_in_stream(stream, group) {
+            return Err(EngineError::CumulativeAckOnWorkGroup);
+        }
+        // A fetch IS activity: refresh the named group's idle stamp and mark it touched so its committed
+        // cursor pins the per-stream retention floor, exactly like the default streaming fetch. The
+        // `named_group_mut` borrow ends before the read below (disjoint fields), so the borrows never
+        // overlap.
+        let now = self.streams.get(&id).map_or(0, Log::now_monotonic);
+        if let Some(g) = self.named_group_mut(&id, group) {
+            g.last_activity = now;
+            g.touched = true;
+        }
+        // The contiguous read off THIS stream's durable, flushed prefix — the SAME `Log::read_range`
+        // primitive the default streaming fetch and the Tier-W named poll use. NO lease, NO cursor write.
+        let Some(log) = self.streams.get(&id) else {
+            return Err(EngineError::UnknownStream {
+                name: stream.to_string(),
+            });
+        };
+        let records = log.read_range(start_offset, max_records, max_bytes)?;
+        // Resume one past the last record served (or `start_offset` when empty), mirroring
+        // `stream_fetch_in`'s `next_offset`.
+        let next_offset = records.last().map_or(start_offset, |r| {
+            r.offset.checked_next().unwrap_or(r.offset)
+        });
+        self.counters.delivered = self.counters.delivered.saturating_add(records.len() as u64);
+        Ok(StreamBatch {
+            records,
+            next_offset,
+        })
+    }
+
     /// Serves a Tier-S STREAMING fetch as RAW on-disk frame bytes (#541, M1-I5): the zero-copy twin of
     /// [`Engine::stream_fetch_in`] used to deliver a contiguous run as ONE `DeliverBatch` frame. It runs
     /// the IDENTICAL group-mode guard, activity refresh, and `delivered`-counter accounting as
@@ -9700,6 +9854,80 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         self.stream_fetch_raw_in(DEFAULT_GROUP, member, start_offset, max_records, max_bytes)
     }
 
+    /// The NAMED-stream twin of [`Engine::stream_fetch_raw_in`] (#681 follow-up): serves a named-stream
+    /// Tier-S fetch as RAW on-disk frame bytes (the zero-copy `DeliverBatch` half), reusing the SAME
+    /// per-stream [`Log::read_range_raw`] + [`Log::read_range`] primitives on the named `stream`'s own
+    /// log. It runs the IDENTICAL existence + wrong-mode guard, activity refresh, and `delivered`-counter
+    /// accounting as [`Engine::stream_fetch_in_stream`], so the raw and per-record named streaming fetches
+    /// are interchangeable on the wire (the records reconstructed from `raw` plus `tail` are EXACTLY the
+    /// records `stream_fetch_in_stream` would return for the same window). NO lease, NO fence, NO cursor
+    /// write. The default stream (`""`) routes to [`Engine::stream_fetch_raw_in`] BYTE-FOR-BYTE.
+    ///
+    /// # Errors
+    /// [`EngineError::InvalidStreamName`] for a malformed name, [`EngineError::UnknownStream`] for a
+    /// never-declared stream, [`EngineError::CumulativeAckOnWorkGroup`] if `group` is not a streaming
+    /// group of `stream`, or a storage error reading the durable prefix.
+    pub fn stream_fetch_raw_in_stream(
+        &mut self,
+        stream: &str,
+        group: &str,
+        member: MemberId,
+        start_offset: Offset,
+        max_records: usize,
+        max_bytes: Option<usize>,
+    ) -> Result<StreamRawBatch, EngineError> {
+        // As `stream_fetch_in_stream`: `member` is only forwarded to the default-stream delegate; the
+        // named streaming raw read is not member-routed.
+        if stream.is_empty() {
+            return self.stream_fetch_raw_in(group, member, start_offset, max_records, max_bytes);
+        }
+        let id = StreamId::named(stream)?;
+        if self.streams.get(&id).is_none() {
+            return Err(EngineError::UnknownStream {
+                name: stream.to_string(),
+            });
+        }
+        // The same wrong-mode guard as `stream_fetch_raw_in`: a raw fetch is the same Tier-S streaming
+        // fetch, only the delivery encoding differs.
+        if !self.is_streaming_in_stream(stream, group) {
+            return Err(EngineError::CumulativeAckOnWorkGroup);
+        }
+        let now = self.streams.get(&id).map_or(0, Log::now_monotonic);
+        if let Some(g) = self.named_group_mut(&id, group) {
+            g.last_activity = now;
+            g.touched = true;
+        }
+        let Some(log) = self.streams.get(&id) else {
+            return Err(EngineError::UnknownStream {
+                name: stream.to_string(),
+            });
+        };
+        // The contiguous SEALED prefix as raw on-disk frame bytes (zero-copy), plus the resume point for
+        // anything this single-segment raw read did not serve — the SAME primitive the default path uses.
+        let (raw, tail_from) = log.read_range_raw(start_offset, max_records, max_bytes)?;
+        // Materialize the ACTIVE-tail remainder (if any), bounded by the records the raw run did NOT
+        // already serve and the residual byte budget, so raw + tail never exceeds the request — identical
+        // to `stream_fetch_raw_in`.
+        let raw_count = usize::try_from(raw.record_count).unwrap_or(usize::MAX);
+        let tail = match tail_from {
+            Some(from) if raw_count < max_records => {
+                let remaining = max_records - raw_count;
+                log.read_range(from, remaining, max_bytes)?
+            }
+            _ => Vec::new(),
+        };
+        let next_offset = tail.last().map_or(raw.next_offset, |r| {
+            r.offset.checked_next().unwrap_or(r.offset)
+        });
+        let total = raw.record_count.saturating_add(tail.len() as u64);
+        self.counters.delivered = self.counters.delivered.saturating_add(total);
+        Ok(StreamRawBatch {
+            raw,
+            tail,
+            next_offset,
+        })
+    }
+
     /// Commits a Tier-S STREAMING group's cursor up to the EXCLUSIVE offset `up_to` (#544, M1-I7): the
     /// consumer's PERIODIC, cumulative "everything below `up_to` is durably processed" checkpoint. It
     /// REUSES the broadcast cumulative-ack cursor primitive ([`AckCursor::commit_up_to`]) — no new
@@ -9778,6 +10006,90 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
     /// As [`Engine::stream_commit_in`].
     pub fn stream_commit(&mut self, up_to: Offset) -> Result<(), EngineError> {
         self.stream_commit_in(DEFAULT_GROUP, up_to)
+    }
+
+    /// The NAMED-stream twin of [`Engine::stream_commit_in`] (#681 follow-up): advances the streaming
+    /// `group` OF the named `stream`'s per-stream cursor up to the EXCLUSIVE offset `up_to` — the named
+    /// streaming consumer's periodic cumulative durability checkpoint. It REUSES the SAME
+    /// [`AckCursor::commit_up_to`] primitive the default streaming commit and the named per-message ack
+    /// ([`Engine::ack_in_stream`]) drive, on that stream's OWN cursor, so a committed named streaming
+    /// consumer frees its per-stream retention exactly like a named ack. Like `ack_in_stream` (and unlike
+    /// the default `stream_commit_in`) it does NOT fire the designated-confirm hook: that L2-produce
+    /// confirm path is a default-stream concern, and the named ack path already omits it. Because a
+    /// streaming group grants NO leases, the commit only advances the watermark (no `release_below`). It
+    /// is idempotent and monotonic. `up_to` is validated against THIS stream's durable, retained window
+    /// BEFORE the cursor is touched. The per-stream cursor is durably checkpointed by the SAME periodic
+    /// #681 named-cursor checkpoint (no new durability path, no on-disk format change). The default stream
+    /// (`""`) routes to [`Engine::stream_commit_in`] BYTE-FOR-BYTE.
+    ///
+    /// # Errors
+    /// [`EngineError::InvalidStreamName`] for a malformed name, [`EngineError::UnknownStream`] for a
+    /// never-declared stream, [`EngineError::CumulativeAckOnWorkGroup`] if `group` is not a streaming
+    /// group of `stream`, or [`EngineError::CumulativeAckOutOfRange`] if `up_to` is past that stream's
+    /// durable head or below its earliest retained offset.
+    pub fn stream_commit_in_stream(
+        &mut self,
+        stream: &str,
+        group: &str,
+        up_to: Offset,
+    ) -> Result<(), EngineError> {
+        if stream.is_empty() {
+            return self.stream_commit_in(group, up_to);
+        }
+        let id = StreamId::named(stream)?;
+        // Read THIS stream's durable window + monotonic clock in one scoped borrow, copying the values
+        // out so the borrow of `self.streams` ends before the group cursor mutation below.
+        let (durable_head, earliest_retained, now) = match self.streams.get(&id) {
+            Some(log) => (
+                log.flushed_offset().get(),
+                log.earliest_offset().get(),
+                log.now_monotonic(),
+            ),
+            None => {
+                return Err(EngineError::UnknownStream {
+                    name: stream.to_string(),
+                })
+            }
+        };
+        // Streaming named groups only: the verb belongs to a consumer-managed-offset group (the same
+        // wrong-mode guard as `stream_commit_in`).
+        if !self.is_streaming_in_stream(stream, group) {
+            return Err(EngineError::CumulativeAckOnWorkGroup);
+        }
+        // Validate `up_to` against the durable, retained window BEFORE touching the cursor — identical to
+        // `stream_commit_in`. Either bound leaves the committed position exactly as it was.
+        let up_to_raw = up_to.get();
+        if up_to_raw > durable_head || up_to_raw < earliest_retained {
+            return Err(EngineError::CumulativeAckOutOfRange {
+                up_to: up_to_raw,
+                earliest_retained,
+                durable_head,
+            });
+        }
+        // Resolve the per-stream group via direct field access (not `named_group_mut`, whose `&mut self`
+        // borrow would block the `self.counters` update below): the group is present because the
+        // streaming-mode guard above passed. Advance the single streaming cursor; `commit_up_to` is
+        // idempotent + monotonic (a re-commit never regresses the floor). NO `release_below`: a streaming
+        // group holds no leases. The `g` borrow (of `self.named_streams`) ends before `self.counters`.
+        let Some(g) = self
+            .named_streams
+            .get_mut(&id)
+            .and_then(|s| s.groups.get_mut(group))
+        else {
+            return Err(EngineError::CumulativeAckOnWorkGroup);
+        };
+        g.last_activity = now;
+        g.touched = true;
+        let before = g.cursor.committed().get();
+        let advanced = if g.cursor.commit_up_to(up_to) {
+            g.cursor.committed().get().saturating_sub(before)
+        } else {
+            0
+        };
+        // Count each newly-committed offset as an ack on the SAME counter the named per-message ack drives
+        // (`ack_in_stream`), so the resilience taxonomy is unchanged (no new counter).
+        self.counters.acks = self.counters.acks.saturating_add(advanced);
+        Ok(())
     }
 
     /// Nacks the message named by `token`, requeueing it for redelivery and fencing the
@@ -10383,6 +10695,180 @@ mod tests {
             Poll::Message(d) => d,
             other => panic!("expected a message, got {other:?}"),
         }
+    }
+
+    /// Produces `payload` to the NAMED stream `stream` (declares-on-first-produce), for the named Tier-S
+    /// engine tests (#681 follow-up).
+    fn produce_named(
+        e: &mut Engine<InMemoryFs, ManualClock>,
+        stream: &str,
+        payload: &[u8],
+    ) -> Offset {
+        e.produce_in_stream(
+            stream,
+            &Append {
+                timestamp_ms: 0,
+                flags: RecordFlags::EMPTY,
+                key: b"",
+                headers: b"",
+                payload,
+            },
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn named_stream_fetch_in_stream_reads_its_own_log_lease_free_and_isolated() {
+        // #681 follow-up: `stream_fetch_in_stream` serves a contiguous run off the NAMED stream's OWN log
+        // with NO lease and NO cursor write — the lease-free Tier-S contract, reusing `Log::read_range`.
+        // A fetch on a group NOT marked streaming is the wrong-mode reject; an unknown stream is typed.
+        let mut e = open(config(100, 5));
+        for i in 0..6u8 {
+            produce_named(&mut e, "orders", &[i]);
+        }
+        // A default-stream produce must NOT leak into the named fetch (cross-stream isolation).
+        produce(&mut e, b"default-only");
+
+        // Before the group is marked streaming, a streaming fetch is rejected wrong-mode.
+        assert!(matches!(
+            e.stream_fetch_in_stream("orders", "g", MemberId::default(), Offset::ZERO, 100, None),
+            Err(EngineError::CumulativeAckOnWorkGroup)
+        ));
+        e.set_streaming_in_stream("orders", "g", true).unwrap();
+        assert!(e.is_streaming_in_stream("orders", "g"));
+
+        let batch = e
+            .stream_fetch_in_stream("orders", "g", MemberId::default(), Offset::ZERO, 100, None)
+            .unwrap();
+        assert_eq!(
+            batch
+                .records
+                .iter()
+                .map(|r| r.payload.to_vec())
+                .collect::<Vec<_>>(),
+            (0..6u8).map(|i| vec![i]).collect::<Vec<_>>(),
+            "reads exactly the named stream's own records"
+        );
+        assert_eq!(
+            batch.next_offset.get(),
+            6,
+            "resumes one past the last record"
+        );
+        // NO cursor write: the named group's committed cursor stays at 0 after a lease-free fetch.
+        assert_eq!(e.committed_offset_in_stream("orders", "g").get(), 0);
+        // An unknown stream is a typed reject, never a silent empty read.
+        assert!(matches!(
+            e.stream_fetch_in_stream("missing", "g", MemberId::default(), Offset::ZERO, 100, None),
+            Err(EngineError::UnknownStream { .. })
+        ));
+        // The DEFAULT stream ("") routes to `stream_fetch_in` byte-for-byte.
+        e.set_streaming_in("dg", true).unwrap();
+        let def = e
+            .stream_fetch_in_stream("", "dg", MemberId::default(), Offset::ZERO, 100, None)
+            .unwrap();
+        assert_eq!(
+            def.records.len(),
+            1,
+            "the default-stream route reads the default log"
+        );
+    }
+
+    #[test]
+    fn named_stream_fetch_raw_in_stream_serves_the_same_window_as_the_per_record_fetch() {
+        // The raw (DeliverBatch) named fetch serves EXACTLY the records the per-record named fetch does
+        // for the same window — same total count, same resume offset, reusing `Log::read_range_raw`.
+        let mut e = open(config(100, 5));
+        for i in 0..10u8 {
+            produce_named(&mut e, "orders", &[i]);
+        }
+        e.set_streaming_in_stream("orders", "g", true).unwrap();
+        let per = e
+            .stream_fetch_in_stream(
+                "orders",
+                "g",
+                MemberId::default(),
+                Offset::new(2),
+                100,
+                None,
+            )
+            .unwrap();
+        let raw = e
+            .stream_fetch_raw_in_stream(
+                "orders",
+                "g",
+                MemberId::default(),
+                Offset::new(2),
+                100,
+                None,
+            )
+            .unwrap();
+        let raw_total = raw.raw.record_count + raw.tail.len() as u64;
+        assert_eq!(
+            raw_total,
+            per.records.len() as u64,
+            "raw + tail == the per-record window"
+        );
+        assert_eq!(raw.next_offset, per.next_offset, "same resume offset");
+        assert_eq!(per.records.len(), 8, "the window [2, 10) is served");
+    }
+
+    #[test]
+    fn named_stream_commit_in_stream_advances_only_that_cursor_and_validates_range() {
+        // `stream_commit_in_stream` advances the NAMED group's OWN cursor, validates `up_to` against THIS
+        // stream's durable window, rejects a non-streaming group wrong-mode, and is idempotent/monotonic.
+        let mut e = open(config(100, 5));
+        for i in 0..8u8 {
+            produce_named(&mut e, "orders", &[i]);
+        }
+        e.set_streaming_in_stream("orders", "g", true).unwrap();
+        // A commit on a non-streaming named group is wrong-mode (the pull path uses acks).
+        assert!(matches!(
+            e.stream_commit_in_stream("orders", "pull", Offset::new(2)),
+            Err(EngineError::CumulativeAckOnWorkGroup)
+        ));
+        // `up_to` past this stream's durable head is out-of-range (cursor untouched).
+        assert!(matches!(
+            e.stream_commit_in_stream("orders", "g", Offset::new(99)),
+            Err(EngineError::CumulativeAckOutOfRange { .. })
+        ));
+        assert_eq!(e.committed_offset_in_stream("orders", "g").get(), 0);
+        // A valid commit advances only the named cursor.
+        e.stream_commit_in_stream("orders", "g", Offset::new(5))
+            .unwrap();
+        assert_eq!(e.committed_offset_in_stream("orders", "g").get(), 5);
+        assert_eq!(
+            e.committed_offset_in_stream("", "g").get(),
+            0,
+            "the default stream's same-named cursor is untouched"
+        );
+        // A lower re-commit is an idempotent no-op success; the watermark never regresses.
+        e.stream_commit_in_stream("orders", "g", Offset::new(2))
+            .unwrap();
+        assert_eq!(e.committed_offset_in_stream("orders", "g").get(), 5);
+        // An unknown stream is a typed reject.
+        assert!(matches!(
+            e.stream_commit_in_stream("missing", "g", Offset::new(0)),
+            Err(EngineError::UnknownStream { .. })
+        ));
+    }
+
+    #[test]
+    fn set_streaming_in_stream_routes_the_default_and_rejects_an_unknown_stream() {
+        // The named streaming-mode setter routes the DEFAULT stream ("") to `set_streaming_in`
+        // byte-for-byte, and rejects a never-declared named stream (typed), mirroring the named filter /
+        // key-shared setters.
+        let mut e = open(config(100, 5));
+        e.set_streaming_in_stream("", "g", true).unwrap();
+        assert!(
+            e.is_streaming_in("g"),
+            "the default route marks the default group"
+        );
+        assert!(e.is_streaming_in_stream("", "g"));
+        assert!(matches!(
+            e.set_streaming_in_stream("missing", "g", true),
+            Err(EngineError::UnknownStream { .. })
+        ));
+        assert!(!e.is_streaming_in_stream("missing", "g"));
     }
 
     // --- The pipelined async-commit API (#1040): begin/complete/tail/fail + passthroughs ---

--- a/crates/ironbus-server/src/session.rs
+++ b/crates/ironbus-server/src/session.rs
@@ -2752,6 +2752,11 @@ impl Session {
         let start = Offset::new(req.start_offset);
         let group = self.subscription.clone();
         let member = self.member_id;
+        // The NAMED stream this streaming fetch targets (#681 follow-up), `""` for the DEFAULT stream. A
+        // named-stream streaming consumer routes its contiguous read to that stream's OWN log via the
+        // engine's `*_in_stream` twins (threaded into the serve helpers below); the default stream is
+        // byte-for-byte unchanged.
+        let stream = self.stream.clone();
         // CLUSTER FOLLOWER-READ over the wire (#735, half B): if this node FOLLOWS the partition, serve the
         // Tier-S streaming fetch from its OWN follower read plane via the #723 read-consistency tiers —
         // fail-closed by the SAFE committed watermark `min(own_flushed, known_committed_hw)`, so a follower
@@ -2763,21 +2768,31 @@ impl Session {
         // A `Some` outcome means this node follows the partition: serve from the follower run (or, for a
         // latest/dirty read above the safe bar, reply an empty batch — never a speculative unconfirmed
         // serve; the dirty-tier leader confirm over the wire is the flagged follow-up).
-        if let Some(outcome) = engine.cluster_follower_consume(
-            crate::cluster::client_ack::DEFAULT_PARTITION,
-            ReadTier::FollowerCommitted,
-            start,
-            want,
-            max_bytes,
-        ) {
-            let delivered =
-                Self::serve_follower_read_outcome(outcome, self.compressed_delivery_enabled, out);
-            // Terminate with the SAME FlowEnd a leader Tier-S batch uses, so the client frames a
-            // follower-read response exactly like any other streaming batch. No keep-up auto-tune on the
-            // follower path (the credit window is the leader engine's concern); a follower-read just serves
-            // its committed prefix.
-            reply(out, FrameType::FlowEnd, &delivered.to_le_bytes());
-            return Ok(());
+        //
+        // NAMED streams (#681 follow-up) are NOT in the cluster follower-read plane (that plane is the
+        // DEFAULT stream / DEFAULT_PARTITION concern), so only the default stream consults it — a named
+        // streaming fetch falls straight through to the local (leader/local-engine) serve below, keyed by
+        // (stream_id, group).
+        if self.stream.is_empty() {
+            if let Some(outcome) = engine.cluster_follower_consume(
+                crate::cluster::client_ack::DEFAULT_PARTITION,
+                ReadTier::FollowerCommitted,
+                start,
+                want,
+                max_bytes,
+            ) {
+                let delivered = Self::serve_follower_read_outcome(
+                    outcome,
+                    self.compressed_delivery_enabled,
+                    out,
+                );
+                // Terminate with the SAME FlowEnd a leader Tier-S batch uses, so the client frames a
+                // follower-read response exactly like any other streaming batch. No keep-up auto-tune on
+                // the follower path (the credit window is the leader engine's concern); a follower-read
+                // just serves its committed prefix.
+                reply(out, FrameType::FlowEnd, &delivered.to_le_bytes());
+                return Ok(());
+            }
         }
         // A consumer that advertised the DeliverBatch capability (#541) takes the RAW-FRAMED batch path:
         // a contiguous run ships as ONE `DeliverBatch` (the on-disk frame bytes verbatim, sendfile-ready
@@ -2794,11 +2809,11 @@ impl Session {
             // compression-capable by construction. The ACTIVE-tail per-record remainder is still gated
             // via `capable` inside the fn. (#1066)
             Self::serve_stream_fetch_batch(
-                engine, &group, member, start, want, max_bytes, capable, out,
+                engine, &stream, &group, member, start, want, max_bytes, capable, out,
             )?
         } else {
             Self::serve_stream_fetch_per_record(
-                engine, &group, member, start, want, max_bytes, capable, out,
+                engine, &stream, &group, member, start, want, max_bytes, capable, out,
             )?
         };
         let Some(delivered) = delivered else {
@@ -2932,6 +2947,7 @@ impl Session {
         E: EngineAccess<F, C>,
     >(
         engine: &E,
+        stream: &GroupName,
         group: &GroupName,
         member: MemberId,
         start: Offset,
@@ -2941,10 +2957,17 @@ impl Session {
         out: &mut Vec<u8>,
     ) -> Result<Option<u32>, SessionError> {
         let group = group.clone();
+        // Route by stream: a NAMED-stream streaming consumer (#681 follow-up) reads its OWN per-stream log
+        // via `stream_fetch_in_stream`; the DEFAULT stream (`stream` empty) routes to `stream_fetch_in`
+        // BYTE-FOR-BYTE (the engine method itself dispatches on the empty name). Both are the SAME
+        // lease-free contiguous read — only the log differs.
+        let stream = stream.clone();
         // ONE actor round-trip serves the whole contiguous batch — the heart of the Tier-S win versus
         // the N per-record round-trips the Tier-W poll loop makes. The engine reads off the shared
         // durable read path, claims no lease, and writes no cursor.
-        match engine.with(move |e| e.stream_fetch_in(&group, member, start, want, max_bytes))? {
+        match engine.with(move |e| {
+            e.stream_fetch_in_stream(&stream, &group, member, start, want, max_bytes)
+        })? {
             Ok(StreamBatch { records, .. }) => {
                 let mut delivered = 0u32;
                 // One reusable scratch buffer for this batch's per-record frame bodies (#826):
@@ -3019,6 +3042,7 @@ impl Session {
         E: EngineAccess<F, C>,
     >(
         engine: &E,
+        stream: &GroupName,
         group: &GroupName,
         member: MemberId,
         start: Offset,
@@ -3028,7 +3052,13 @@ impl Session {
         out: &mut Vec<u8>,
     ) -> Result<Option<u32>, SessionError> {
         let group = group.clone();
-        match engine.with(move |e| e.stream_fetch_raw_in(&group, member, start, want, max_bytes))? {
+        // Route by stream (#681 follow-up): a NAMED stream reads its OWN per-stream log via
+        // `stream_fetch_raw_in_stream`; the DEFAULT stream (`stream` empty) routes to `stream_fetch_raw_in`
+        // BYTE-FOR-BYTE. Same lease-free raw contiguous read — only the log differs.
+        let stream = stream.clone();
+        match engine.with(move |e| {
+            e.stream_fetch_raw_in_stream(&stream, &group, member, start, want, max_bytes)
+        })? {
             Ok(StreamRawBatch { raw, tail, .. }) => {
                 let mut delivered: u32 = 0;
                 // The contiguous SEALED prefix as ONE DeliverBatch: the on-disk frame bytes verbatim. A
@@ -3131,7 +3161,11 @@ impl Session {
         };
         let group = group.to_string();
         let up_to = Offset::new(commit.up_to);
-        match engine.with(move |e| e.stream_commit_in(&group, up_to))? {
+        // Route by stream (#681 follow-up): a NAMED-stream streaming consumer commits its OWN per-stream
+        // cursor via `stream_commit_in_stream`; the DEFAULT stream (`self.stream` empty) routes to
+        // `stream_commit_in` BYTE-FOR-BYTE (the engine method dispatches on the empty name).
+        let stream = self.stream.clone();
+        match engine.with(move |e| e.stream_commit_in_stream(&stream, &group, up_to))? {
             // A committed (or idempotent no-op) streaming commit: the generic body-less success. There
             // is no per-connection lease to release (Tier-S grants none), so unlike the broadcast
             // cumulative-ack path there is no `self.leased` bookkeeping here.
@@ -4022,6 +4056,22 @@ impl Session {
             }
         })?;
         self.joined_key_shared = joined;
+        // Apply the connection's negotiated DEFAULT consume tier (#543 / #681 follow-up) to the newly-
+        // subscribed NAMED group, the twin of the default stream's `handle_sub` marking: mark THIS stream's
+        // group streaming ONLY when the connection default is Tier-S, and NEVER clear it, so a `SubTo` that
+        // does not explicitly pick a tier consumes at the connection's Tier-S default on its OWN per-stream
+        // cursor (keyed by (stream, group)). Best-effort at SubTo time (the streaming fetch re-checks the
+        // mode and rejects a non-streaming group), so `SubTo` stays infallible for the tier selection and a
+        // transient engine error does not strand the subscription. The default tier is already gated by the
+        // streaming capability bit at Connect (a Tier-S default is forced to Tier-W when the client did not
+        // advertise the capability), so a pre-streaming client never reaches this branch.
+        if self.default_tier == ConsumeTier::Streaming {
+            let stream_name = self.stream.clone();
+            let sub = self.subscription.clone();
+            engine.with(move |e| {
+                let _ = e.set_streaming_in_stream(&stream_name, &sub, true);
+            })?;
+        }
         reply(out, FrameType::Ok, &[]);
         Ok(())
     }
@@ -7036,6 +7086,537 @@ mod tests {
             .unwrap();
         assert_eq!(one_response(&out).0, FrameType::Ok);
         s
+    }
+
+    // ===== NAMED-stream Tier-S STREAMING consume (#681 follow-up) ================================
+    //
+    // These mirror the DEFAULT-stream Tier-S suite above, but drive a NAMED stream: the same
+    // consumer-managed-offset StreamFetch / StreamCommit, served off the named stream's OWN log via the
+    // engine's `*_in_stream` twins, keyed by (stream, group). A pull/competing named consumer is
+    // unaffected (it never marks its group streaming), and the streaming path composes with the named
+    // key-shared / filter modes exactly as the default stream's streaming path does (routing/filter are
+    // INERT on the contiguous streaming read — the same choice `stream_fetch_in` makes).
+
+    /// A streams-capable + streaming-capable connect body for the named Tier-S tests: advertises
+    /// `understands_streaming` (negotiate the streaming tier), `understands_streams` (so `SubTo` binds a
+    /// named stream), an optional connection `default_tier`, and optionally the `DeliverBatch` capability.
+    fn named_streaming_connect_body(
+        default_tier: Option<ConsumeTier>,
+        understands_deliver_batch: bool,
+    ) -> Vec<u8> {
+        let mut body = Vec::new();
+        ironbus_proto::message::encode_connect(
+            &ironbus_proto::message::ConnectBody {
+                requested_credit: None,
+                requested_credit_bytes: None,
+                wants_gap_marker: false,
+                default_ack_level: None,
+                understands_streaming: true,
+                default_tier: default_tier.map(ConsumeTier::as_u8),
+                understands_deliver_batch,
+                understands_streams: true,
+                understands_compressed_delivery: false,
+                wants_subject_filter: false,
+            },
+            &mut body,
+        );
+        body
+    }
+
+    /// Produces a record with explicit key/headers/payload to a NAMED stream (declares-on-first-produce),
+    /// the named twin of `produce_kh`.
+    fn produce_named_kh<C: Clock + Clone>(
+        e: &DirectEngine<InMemoryFs, C>,
+        stream: &str,
+        key: &[u8],
+        headers: &[u8],
+        payload: &[u8],
+    ) {
+        e.engine_mut()
+            .produce_in_stream(
+                stream,
+                &Append {
+                    timestamp_ms: 42,
+                    flags: RecordFlags::EMPTY,
+                    key,
+                    headers,
+                    payload,
+                },
+            )
+            .unwrap();
+    }
+
+    /// Marks the named `stream`'s `group` streaming, connects a streams+streaming-capable session (with
+    /// the `DeliverBatch` capability iff `deliver_batch`), and `SubTo`s the named group. The named twin of
+    /// `batch_session`; the stream must already be resident (produce to it first).
+    fn named_streaming_session<C: Clock + Clone + 'static>(
+        e: &DirectEngine<InMemoryFs, C>,
+        stream: &[u8],
+        group: &[u8],
+        deliver_batch: bool,
+    ) -> Session {
+        let st = core::str::from_utf8(stream).unwrap();
+        let g = core::str::from_utf8(group).unwrap();
+        e.engine_mut().set_streaming_in_stream(st, g, true).unwrap();
+        let mut s = Session::new();
+        let mut out = Vec::new();
+        s.process(
+            e,
+            &frame(
+                FrameType::Connect,
+                &named_streaming_connect_body(None, deliver_batch),
+            ),
+            &mut out,
+        )
+        .unwrap();
+        out.clear();
+        s.process(e, &sub_to_frame(stream, group), &mut out)
+            .unwrap();
+        assert_eq!(one_response(&out).0, FrameType::Ok, "SubTo accepted");
+        s
+    }
+
+    /// A `StreamFetch` wire frame for the consumer-managed window `[start, start+max_records)`.
+    fn stream_fetch_frame(start: u64, max_records: u32, max_bytes: u64) -> Vec<u8> {
+        let mut b = Vec::new();
+        ironbus_proto::message::encode_stream_fetch(
+            &ironbus_proto::message::StreamFetchBody {
+                start_offset: start,
+                max_records,
+                max_bytes,
+            },
+            &mut b,
+        );
+        frame(FrameType::StreamFetch, &b)
+    }
+
+    /// The offsets of the per-record `Deliver` frames in `out`, in order.
+    fn delivered_offsets(out: &[u8]) -> Vec<u64> {
+        decode_all(out)
+            .iter()
+            .filter(|(ty, _)| *ty == FrameType::Deliver)
+            .map(|(_, body)| decode_deliver(body).unwrap().offset)
+            .collect()
+    }
+
+    #[test]
+    fn named_stream_tier_s_per_record_delivers_the_contiguous_run() {
+        // A NAMED-stream Tier-S consumer receives the whole contiguous run off the named stream's OWN log
+        // as per-record `Deliver` frames terminated by one FlowEnd — the streaming path, keyed by
+        // (stream, group). The DEFAULT stream's same-named group is untouched (cross-stream isolation).
+        let e = DirectEngine::new(engine());
+        for i in 0..12u8 {
+            produce_named_kh(&e, "orders", &[i, 7], &[i, 9], &[i; 5]);
+        }
+        // A record on the DEFAULT stream's `g` must NOT leak into the named consumer's run.
+        produce(&e, b"default-only");
+
+        let mut s = named_streaming_session(&e, b"orders", b"g", false);
+        let mut out = Vec::new();
+        s.process(&e, &stream_fetch_frame(0, 100, 0), &mut out)
+            .unwrap();
+        let frames = decode_all(&out);
+        // Per-record Deliver frames (no DeliverBatch: this consumer is batch-incapable) + one FlowEnd(12).
+        assert!(
+            !frames.iter().any(|(ty, _)| *ty == FrameType::DeliverBatch),
+            "a batch-incapable named consumer gets per-record Deliver frames"
+        );
+        let offs = delivered_offsets(&out);
+        assert_eq!(
+            offs,
+            (0..12).collect::<Vec<_>>(),
+            "the whole named run, in order"
+        );
+        // Payloads reconstruct exactly (proving it read the NAMED log, not the default one).
+        let payloads: Vec<Vec<u8>> = decode_all(&out)
+            .iter()
+            .filter(|(ty, _)| *ty == FrameType::Deliver)
+            .map(|(_, b)| decode_deliver(b).unwrap().payload.to_vec())
+            .collect();
+        assert_eq!(payloads, (0..12u8).map(|i| vec![i; 5]).collect::<Vec<_>>());
+        let end = frames
+            .iter()
+            .find(|(ty, _)| *ty == FrameType::FlowEnd)
+            .unwrap();
+        assert_eq!(
+            end.1,
+            12u32.to_le_bytes(),
+            "FlowEnd counts every named record"
+        );
+    }
+
+    #[test]
+    #[allow(clippy::too_many_lines)]
+    fn named_stream_tier_s_batch_matches_per_record() {
+        // #681 follow-up DIFFERENTIAL (mirrors the default `deliver_batch_yields_the_same_records...`): a
+        // batch-capable NAMED consumer's StreamFetch is answered with a `DeliverBatch` whose decoded
+        // records are BYTE-FOR-BYTE the records a per-record NAMED consumer gets as N `Deliver` frames.
+        let e = DirectEngine::new(engine());
+        for i in 0..12u8 {
+            produce_named_kh(&e, "orders", &[i, 7], &[i, 9, 9], &[i; 5]);
+        }
+        let mut batch_s = named_streaming_session(&e, b"orders", b"g", true);
+        let mut plain_s = named_streaming_session(&e, b"orders", b"g2", false);
+
+        let req = stream_fetch_frame(0, 100, 0);
+
+        let mut batch_out = Vec::new();
+        batch_s.process(&e, &req, &mut batch_out).unwrap();
+        let batch_frames = decode_all(&batch_out);
+        assert!(
+            batch_frames
+                .iter()
+                .any(|(ty, _)| *ty == FrameType::DeliverBatch),
+            "a batch-capable named consumer is served a DeliverBatch"
+        );
+        assert!(
+            !batch_frames.iter().any(|(ty, _)| *ty == FrameType::Deliver),
+            "the whole sealed named run ships as ONE batch, no per-record Deliver"
+        );
+        let batch_body = &batch_frames
+            .iter()
+            .find(|(ty, _)| *ty == FrameType::DeliverBatch)
+            .unwrap()
+            .1;
+        let from_batch = decode_batch_records(batch_body);
+
+        let mut plain_out = Vec::new();
+        plain_s.process(&e, &req, &mut plain_out).unwrap();
+        let plain_frames = decode_all(&plain_out);
+        let from_plain: Vec<_> = plain_frames
+            .iter()
+            .filter(|(ty, _)| *ty == FrameType::Deliver)
+            .map(|(_, body)| {
+                let d = decode_deliver(body).unwrap();
+                (
+                    d.offset,
+                    d.generation,
+                    d.flags,
+                    d.timestamp_ms,
+                    d.key.to_vec(),
+                    d.headers.to_vec(),
+                    d.payload.to_vec(),
+                )
+            })
+            .collect();
+
+        assert_eq!(from_batch.len(), 12, "all 12 named records delivered");
+        assert_eq!(
+            from_batch, from_plain,
+            "the named batch decodes to EXACTLY the per-record Deliver run (offsets, CRC verified)"
+        );
+        let batch_end = batch_frames
+            .iter()
+            .find(|(ty, _)| *ty == FrameType::FlowEnd)
+            .unwrap();
+        let plain_end = plain_frames
+            .iter()
+            .find(|(ty, _)| *ty == FrameType::FlowEnd)
+            .unwrap();
+        assert_eq!(batch_end.1, plain_end.1, "same FlowEnd delivered count");
+        assert_eq!(batch_end.1, 12u32.to_le_bytes());
+    }
+
+    #[test]
+    fn named_stream_tier_s_reconstructs_offsets_and_resumes_from_a_mid_run_start() {
+        // Consumer-managed offset on a NAMED stream: a batch starting at a non-zero offset reconstructs
+        // each offset positionally and a bounded fetch resumes exactly where it left off (no gap/overlap).
+        let e = DirectEngine::new(engine());
+        for i in 0..20u8 {
+            produce_named_kh(&e, "orders", b"", b"", &[i]);
+        }
+        let mut s = named_streaming_session(&e, b"orders", b"g", true);
+
+        let fetch = |s: &mut Session, start: u64, max: u32| -> Vec<u64> {
+            let mut out = Vec::new();
+            s.process(&e, &stream_fetch_frame(start, max, 0), &mut out)
+                .unwrap();
+            let mut offs = Vec::new();
+            for (ty, body) in decode_all(&out) {
+                if ty == FrameType::DeliverBatch {
+                    for r in decode_batch_records(&body) {
+                        offs.push(r.0);
+                    }
+                }
+            }
+            offs
+        };
+        assert_eq!(fetch(&mut s, 5, 5), vec![5, 6, 7, 8, 9]);
+        assert_eq!(fetch(&mut s, 10, 5), vec![10, 11, 12, 13, 14]);
+        assert_eq!(fetch(&mut s, 0, 100), (0..20).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn named_stream_tier_s_flow_control_matches_the_default() {
+        // FLOW-CONTROL / CREDIT: a named streaming fetch is bounded by the SAME per-consumer credit
+        // window as the default stream (#552/#464 floor). With more records than the initial window, a
+        // huge `max_records` still delivers only a window's worth — and the count is IDENTICAL to a
+        // default-stream consumer given the same record count, proving the credit path is shared.
+        let e = DirectEngine::new(engine());
+        for i in 0..150u32 {
+            produce(&e, &i.to_le_bytes()); // default stream `gd`
+            produce_named_kh(&e, "orders", b"", b"", &i.to_le_bytes());
+        }
+        // Default-stream streaming consumer.
+        e.engine_mut().set_streaming_in("gd", true).unwrap();
+        let mut def_s = Session::new();
+        let mut def_out = Vec::new();
+        def_s
+            .process(
+                &e,
+                &frame(
+                    FrameType::Connect,
+                    &named_streaming_connect_body(None, false),
+                ),
+                &mut def_out,
+            )
+            .unwrap();
+        def_out.clear();
+        def_s
+            .process(&e, &frame(FrameType::Sub, b"gd"), &mut def_out)
+            .unwrap();
+        def_out.clear();
+        def_s
+            .process(&e, &stream_fetch_frame(0, 100_000, 0), &mut def_out)
+            .unwrap();
+        let def_count = delivered_offsets(&def_out).len();
+
+        // Named-stream streaming consumer, identical fetch.
+        let mut nm_s = named_streaming_session(&e, b"orders", b"g", false);
+        let mut nm_out = Vec::new();
+        nm_s.process(&e, &stream_fetch_frame(0, 100_000, 0), &mut nm_out)
+            .unwrap();
+        let nm_count = delivered_offsets(&nm_out).len();
+
+        assert!(
+            def_count < 150,
+            "the credit window bound the default fetch (flow-control engaged)"
+        );
+        assert_eq!(
+            nm_count, def_count,
+            "the named streaming fetch is bounded by the SAME credit window as the default"
+        );
+        // The FlowEnd count matches the delivered count on the named path.
+        let nm_end = decode_all(&nm_out)
+            .into_iter()
+            .find(|(ty, _)| *ty == FrameType::FlowEnd)
+            .unwrap()
+            .1;
+        assert_eq!(nm_end, u32::try_from(nm_count).unwrap().to_le_bytes());
+    }
+
+    #[test]
+    fn named_stream_tier_s_commit_advances_only_that_streams_cursor() {
+        // StreamCommit on a NAMED streaming group advances THAT stream's per-stream cursor (durably
+        // pinned, #681) and NOTHING else: the default stream's same-named cursor stays at zero, and a
+        // re-commit is an idempotent no-op success.
+        let e = DirectEngine::new(engine());
+        for i in 0..10u8 {
+            produce_named_kh(&e, "orders", b"", b"", &[i]);
+        }
+        let mut s = named_streaming_session(&e, b"orders", b"g", false);
+        let mut out = Vec::new();
+        // Commit up_to = 6 (exclusive) on the named group.
+        let mut cb = Vec::new();
+        ironbus_proto::message::encode_stream_commit(
+            &ironbus_proto::message::StreamCommitBody {
+                up_to: 6,
+                group: b"g",
+            },
+            &mut cb,
+        );
+        s.process(&e, &frame(FrameType::StreamCommit, &cb), &mut out)
+            .unwrap();
+        assert_eq!(
+            one_response(&out).0,
+            FrameType::Ok,
+            "named streaming commit succeeds"
+        );
+        assert_eq!(
+            e.engine_mut()
+                .committed_offset_in_stream("orders", "g")
+                .get(),
+            6,
+            "the NAMED stream's cursor advanced to the committed offset"
+        );
+        assert_eq!(
+            e.engine_mut().committed_offset_in_stream("", "g").get(),
+            0,
+            "the DEFAULT stream's same-named cursor is untouched (cross-stream isolation)"
+        );
+        // Idempotent re-commit below the watermark: still Ok, cursor unchanged.
+        out.clear();
+        let mut cb2 = Vec::new();
+        ironbus_proto::message::encode_stream_commit(
+            &ironbus_proto::message::StreamCommitBody {
+                up_to: 3,
+                group: b"g",
+            },
+            &mut cb2,
+        );
+        s.process(&e, &frame(FrameType::StreamCommit, &cb2), &mut out)
+            .unwrap();
+        assert_eq!(
+            one_response(&out).0,
+            FrameType::Ok,
+            "a re-commit is an idempotent success"
+        );
+        assert_eq!(
+            e.engine_mut()
+                .committed_offset_in_stream("orders", "g")
+                .get(),
+            6,
+            "the cursor never regresses on a lower re-commit"
+        );
+    }
+
+    #[test]
+    fn named_stream_tier_s_rejects_a_fetch_on_a_non_streaming_group_and_pull_is_unchanged() {
+        // A pull/competing NAMED consumer is UNCHANGED: its group is never marked streaming, a StreamFetch
+        // on it is rejected wrong-mode (the client must use Flow/poll), and a plain Flow still delivers +
+        // acks byte-for-byte the historical named pull path.
+        let e = DirectEngine::new(engine());
+        for i in 0..5u8 {
+            produce_named_kh(&e, "orders", b"", b"", &[i]);
+        }
+        // A streams-capable consumer that did NOT mark its group streaming (a pull consumer).
+        let mut s = Session::new();
+        let mut out = Vec::new();
+        s.process(
+            &e,
+            &frame(
+                FrameType::Connect,
+                &named_streaming_connect_body(None, false),
+            ),
+            &mut out,
+        )
+        .unwrap();
+        out.clear();
+        s.process(&e, &sub_to_frame(b"orders", b"pull"), &mut out)
+            .unwrap();
+        assert_eq!(one_response(&out).0, FrameType::Ok);
+        out.clear();
+        // StreamFetch on the non-streaming named group is rejected (wrong-mode), never a silent serve.
+        s.process(&e, &stream_fetch_frame(0, 100, 0), &mut out)
+            .unwrap();
+        assert_eq!(
+            one_response(&out).0,
+            FrameType::Err,
+            "a streaming fetch on a NON-streaming named group is rejected"
+        );
+        assert!(
+            !e.engine_mut().is_streaming_in_stream("orders", "pull"),
+            "a pull named group is never streaming"
+        );
+        out.clear();
+        // The pull path is unchanged: a plain Flow delivers the named run.
+        s.process(&e, &frame(FrameType::Flow, &10u32.to_le_bytes()), &mut out)
+            .unwrap();
+        assert_eq!(
+            delivered_offsets(&out),
+            (0..5).collect::<Vec<_>>(),
+            "the pull named consumer still receives its run via Flow, unchanged"
+        );
+    }
+
+    #[test]
+    fn named_stream_tier_s_composes_with_key_shared_like_the_default() {
+        // COMPOSE (streaming + key-shared): a named group that is BOTH key_shared (#1111) and streaming
+        // serves the FULL contiguous run — key routing is INERT on the consumer-managed streaming read,
+        // exactly as `stream_fetch_in` ignores the member on the default stream. Distinct keys, all
+        // delivered in offset order.
+        let e = DirectEngine::new(engine());
+        for i in 0..8u8 {
+            // Distinct keys so key_shared routing WOULD split them across members on the pull path.
+            produce_named_kh(&e, "orders", &[i], b"", &[i]);
+        }
+        e.engine_mut()
+            .set_key_ordering_in_stream("orders", "g", KeyOrdering::KeyShared)
+            .unwrap();
+        let mut s = named_streaming_session(&e, b"orders", b"g", false);
+        let mut out = Vec::new();
+        s.process(&e, &stream_fetch_frame(0, 100, 0), &mut out)
+            .unwrap();
+        assert_eq!(
+            delivered_offsets(&out),
+            (0..8).collect::<Vec<_>>(),
+            "streaming serves the full contiguous run regardless of key routing (routing inert)"
+        );
+    }
+
+    #[test]
+    fn named_stream_tier_s_composes_with_filter_like_the_default() {
+        // COMPOSE (streaming + filter): a named group with a per-subject filter (#594-B) that is ALSO
+        // streaming delivers EVERY record in the contiguous window — the filter is INERT on the streaming
+        // read, matching the default stream's streaming path (which also ignores the group filter).
+        let e = DirectEngine::new(engine());
+        // Interleave matching and non-matching subjects; the pull path would skip the non-matching ones.
+        let subjects: [&[u8]; 6] = [b"a.b", b"z.z", b"a.b", b"z.z", b"a.b", b"z.z"];
+        for (i, subj) in subjects.iter().enumerate() {
+            e.engine_mut()
+                .produce_in_stream_with_subject(
+                    "orders",
+                    &Append {
+                        timestamp_ms: 0,
+                        flags: RecordFlags::EMPTY,
+                        key: b"",
+                        headers: b"",
+                        payload: &[u8::try_from(i).unwrap()],
+                    },
+                    subj,
+                )
+                .unwrap();
+        }
+        // Bind a filter that matches only "a.b" — inert on the streaming path.
+        e.engine_mut()
+            .set_subject_filter_in_stream("orders", "g", Some("a.b"))
+            .unwrap();
+        let mut s = named_streaming_session(&e, b"orders", b"g", false);
+        let mut out = Vec::new();
+        s.process(&e, &stream_fetch_frame(0, 100, 0), &mut out)
+            .unwrap();
+        assert_eq!(
+            delivered_offsets(&out),
+            (0..6).collect::<Vec<_>>(),
+            "streaming delivers EVERY record in the window; the group filter is inert on this tier"
+        );
+    }
+
+    #[test]
+    fn named_stream_tier_s_default_tier_marks_the_group_on_sub_to() {
+        // Connection DEFAULT tier (#543) on the NAMED path: a streaming-default connection that `SubTo`s a
+        // named stream WITHOUT explicitly selecting a tier has that named group marked streaming, the twin
+        // of the default stream's `handle_sub` marking — so an unmarked named SUB streams.
+        let e = DirectEngine::new(engine());
+        produce_named_kh(&e, "orders", b"", b"", b"x");
+        let mut s = Session::new();
+        let mut out = Vec::new();
+        s.process(
+            &e,
+            &frame(
+                FrameType::Connect,
+                &named_streaming_connect_body(Some(ConsumeTier::Streaming), false),
+            ),
+            &mut out,
+        )
+        .unwrap();
+        out.clear();
+        s.process(&e, &sub_to_frame(b"orders", b"g"), &mut out)
+            .unwrap();
+        assert_eq!(one_response(&out).0, FrameType::Ok, "SubTo accepted");
+        assert!(
+            e.engine_mut().is_streaming_in_stream("orders", "g"),
+            "an unmarked named SUB adopts the connection's Tier-S default"
+        );
+        // And it consumes at Tier-S: a StreamFetch is served (not wrong-mode rejected).
+        out.clear();
+        s.process(&e, &stream_fetch_frame(0, 100, 0), &mut out)
+            .unwrap();
+        assert_eq!(
+            delivered_offsets(&out),
+            vec![0],
+            "the Tier-S-default named group streams"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

Brings the low-latency **Tier-S STREAMING** consume tier (consumer-managed offset, lease-free contiguous read via `StreamFetch`/`StreamCommit`) to **NAMED streams**, at parity with the DEFAULT stream. Named streams previously supported only the pull/competing tier. Keyed by `(stream, group)`, reusing the default mechanism verbatim. Refs #681.

A pull/competing named consumer stays **byte-for-byte unchanged**.

## Reused vs added

Each new engine method routes the empty stream name to its default twin **byte-for-byte**, then serves the named case off that stream's OWN log/group using the SAME shared primitives:

| Default (reused) | Named twin (added) | Shared primitive reused |
|---|---|---|
| `set_streaming_in` / `is_streaming_in` | `set_streaming_in_stream` / `is_streaming_in_stream` | per-stream `WorkGroup.streaming` (as filter/key-shared setters) |
| `stream_fetch_in` | `stream_fetch_in_stream` | `Log::read_range` (no lease, no cursor write) |
| `stream_fetch_raw_in` | `stream_fetch_raw_in_stream` | `Log::read_range_raw` + `read_range` tail |
| `stream_commit_in` | `stream_commit_in_stream` | `AckCursor::commit_up_to` on the durable (#681) per-stream cursor |

Session: `handle_stream_fetch` / `handle_stream_commit` route by `self.stream`; `serve_stream_fetch_{per_record,batch}` take the stream and call the `*_in_stream` methods; `handle_sub_to` marks the named group streaming on a Tier-S connection default (mirrors `handle_sub`). The cluster follower-read plane stays DEFAULT-stream only.

## Composition (matches the default's composition exactly)

Tier-S is a contiguous consumer-managed-offset read, so — as on the default stream — **filter (#594-B) and key-shared (#1111) routing are INERT on the streaming path** (the member is not routed; the group cursor/filter are not consulted). The named per-stream DLQ (#1110) path is untouched. Tests pin this parity.

## Format

**No on-disk format change** — the existing `StreamFetch`/`StreamCommit`/`DeliverBatch` frames and the per-stream durable cursor are reused. `check-format-registry.sh` digest unchanged.

## Tests (all in-container, foreground)

- `cargo test --workspace --locked` — **0 failed** (ironbus_server lib: 1146 passed / 0 failed / 1 ignored)
- acceptance `golden_path_acceptance_install_to_recovery_to_upgrade` — **ok**
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — clean
- `cargo fmt --all --check` + `scripts/check-format-registry.sh` — clean

13 new tests: 9 session-level (per-record, batch differential, offset reconstruction/resume, credit/flow-control parity vs default, commit isolation + idempotency, non-streaming reject + pull unchanged, key-shared + filter composition, Tier-S-default `SubTo` marking) and 4 engine-level (fetch isolation + wrong-mode/unknown-stream, raw==per-record window, commit range/isolation, default-route + unknown reject).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01McmNfYNWPmohVS8umY9Lkp