### PR TITLE
feat(streams): per-stream consumer metrics with bounded cardinality (#681 follow-up, closes #600)

### DIFF
--- a/crates/ironbus-bench/src/inproc.rs
+++ b/crates/ironbus-bench/src/inproc.rs
@@ -87,6 +87,7 @@ fn engine_config_with_credit(consumer_credit: u32, max_in_flight: u32) -> Engine
         max_groups: DEFAULT_MAX_GROUPS,
         // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
         max_streams: 0,
+        max_metric_streams: 1024,
         group_idle_evict_ms: DEFAULT_GROUP_IDLE_EVICT_MS,
         disk_full_policy: DiskFullPolicy::DropNew,
         // The RAM-headroom ceiling is off in the bench broker (#118): the bench samples real RSS

--- a/crates/ironbus-cli/src/admin.rs
+++ b/crates/ironbus-cli/src/admin.rs
@@ -684,6 +684,7 @@ mod tests {
                 max_messages: 0,
                 max_groups: 1024,
                 max_streams: 0,
+                max_metric_streams: 1024,
                 group_idle_evict_ms: 0,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,

--- a/crates/ironbus-cli/src/main.rs
+++ b/crates/ironbus-cli/src/main.rs
@@ -251,6 +251,15 @@ const DEFAULT_MAX_GROUPS: usize = ironbus_server::engine::DEFAULT_MAX_GROUPS;
 /// never counted against it.
 const DEFAULT_MAX_STREAMS: usize = ironbus_server::engine::DEFAULT_MAX_STREAMS;
 
+/// The default per-NAMED-stream CONSUMER-METRIC cardinality cap for `serve` (#600, the #681
+/// named-stream metrics follow-up), aliased to the engine's
+/// [`ironbus_server::engine::DEFAULT_MAX_METRIC_STREAMS`] so the CLI default and the engine default are
+/// a single source of truth. It bounds how many distinct named streams get their own per-stream
+/// consumer series on `/metrics` before folding into `{stream="__other__"}`, keeping the scrape
+/// cardinality bounded no matter how many streams exist. `0` resolves to (and any value is clamped to)
+/// the engine's hard backstop; the default is 1024.
+const DEFAULT_MAX_METRIC_STREAMS: usize = ironbus_server::engine::DEFAULT_MAX_METRIC_STREAMS;
+
 /// The default idle window after which an idle, fully-caught-up, lease-free NAMED work-group is
 /// evicted for `serve` (refs #277, #240), in MILLISECONDS, aliased to the engine's
 /// [`ironbus_server::engine::DEFAULT_GROUP_IDLE_EVICT_MS`] so the CLI and engine default are a single
@@ -9925,6 +9934,7 @@ fn open_engine_with<F: Filesystem + Clone>(
             // group past the cap is rejected by the engine before it allocates.
             max_groups: config.max_groups,
             max_streams: config.max_streams,
+            max_metric_streams: DEFAULT_MAX_METRIC_STREAMS,
             // Idle named-group eviction (refs #277, #240): the lifecycle reclaim that completes the
             // #240 cap. `0` = disabled (off, the default), a non-zero value is the idle window in ms
             // after which a fully-caught-up, lease-free named group is reclaimed. Never deletes a
@@ -15521,6 +15531,7 @@ mod tests {
                 max_messages: 0,
                 max_groups: DEFAULT_MAX_GROUPS,
                 max_streams: DEFAULT_MAX_STREAMS,
+                max_metric_streams: DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: 0,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,
@@ -16471,6 +16482,7 @@ mod tests {
                 max_messages: 0,
                 max_groups: DEFAULT_MAX_GROUPS,
                 max_streams: DEFAULT_MAX_STREAMS,
+                max_metric_streams: DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: 0,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,
@@ -16558,6 +16570,7 @@ mod tests {
                 max_messages: 0,
                 max_groups: DEFAULT_MAX_GROUPS,
                 max_streams: DEFAULT_MAX_STREAMS,
+                max_metric_streams: DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: 0,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,
@@ -20806,6 +20819,7 @@ eImsLe+T6lqrpgIgENKsK8qL9U5HkY7evGZM+CZNPHezUtmVVeASiOLgQO8=
                 max_messages: 0,
                 max_groups: DEFAULT_MAX_GROUPS,
                 max_streams: DEFAULT_MAX_STREAMS,
+                max_metric_streams: DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: 0,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,
@@ -20892,6 +20906,7 @@ eImsLe+T6lqrpgIgENKsK8qL9U5HkY7evGZM+CZNPHezUtmVVeASiOLgQO8=
                 max_messages: 0,
                 max_groups: DEFAULT_MAX_GROUPS,
                 max_streams: DEFAULT_MAX_STREAMS,
+                max_metric_streams: DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: 0,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,

--- a/crates/ironbus-cli/src/main.rs
+++ b/crates/ironbus-cli/src/main.rs
@@ -251,14 +251,11 @@ const DEFAULT_MAX_GROUPS: usize = ironbus_server::engine::DEFAULT_MAX_GROUPS;
 /// never counted against it.
 const DEFAULT_MAX_STREAMS: usize = ironbus_server::engine::DEFAULT_MAX_STREAMS;
 
-/// The default per-NAMED-stream CONSUMER-METRIC cardinality cap for `serve` (#600, the #681
-/// named-stream metrics follow-up), aliased to the engine's
-/// [`ironbus_server::engine::DEFAULT_MAX_METRIC_STREAMS`] so the CLI default and the engine default are
-/// a single source of truth. It bounds how many distinct named streams get their own per-stream
-/// consumer series on `/metrics` before folding into `{stream="__other__"}`, keeping the scrape
-/// cardinality bounded no matter how many streams exist. `0` resolves to (and any value is clamped to)
-/// the engine's hard backstop; the default is 1024.
-const DEFAULT_MAX_METRIC_STREAMS: usize = ironbus_server::engine::DEFAULT_MAX_METRIC_STREAMS;
+// The per-NAMED-stream CONSUMER-METRIC cardinality cap default (#600, the #681 named-stream metrics
+// follow-up) is referenced directly as `ironbus_server::engine::DEFAULT_MAX_METRIC_STREAMS` at each
+// EngineConfig construction (a single source of truth). No local alias: unlike `DEFAULT_MAX_STREAMS`
+// (used in the non-gated presets), the only non-test use is the `#[cfg(unix)]` `open_engine_with`, so a
+// local alias would be `dead_code` in the Windows bin build — the engine's `pub const` is never dead.
 
 /// The default idle window after which an idle, fully-caught-up, lease-free NAMED work-group is
 /// evicted for `serve` (refs #277, #240), in MILLISECONDS, aliased to the engine's
@@ -9934,7 +9931,7 @@ fn open_engine_with<F: Filesystem + Clone>(
             // group past the cap is rejected by the engine before it allocates.
             max_groups: config.max_groups,
             max_streams: config.max_streams,
-            max_metric_streams: DEFAULT_MAX_METRIC_STREAMS,
+            max_metric_streams: ironbus_server::engine::DEFAULT_MAX_METRIC_STREAMS,
             // Idle named-group eviction (refs #277, #240): the lifecycle reclaim that completes the
             // #240 cap. `0` = disabled (off, the default), a non-zero value is the idle window in ms
             // after which a fully-caught-up, lease-free named group is reclaimed. Never deletes a
@@ -15531,7 +15528,7 @@ mod tests {
                 max_messages: 0,
                 max_groups: DEFAULT_MAX_GROUPS,
                 max_streams: DEFAULT_MAX_STREAMS,
-                max_metric_streams: DEFAULT_MAX_METRIC_STREAMS,
+                max_metric_streams: ironbus_server::engine::DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: 0,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,
@@ -16482,7 +16479,7 @@ mod tests {
                 max_messages: 0,
                 max_groups: DEFAULT_MAX_GROUPS,
                 max_streams: DEFAULT_MAX_STREAMS,
-                max_metric_streams: DEFAULT_MAX_METRIC_STREAMS,
+                max_metric_streams: ironbus_server::engine::DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: 0,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,
@@ -16570,7 +16567,7 @@ mod tests {
                 max_messages: 0,
                 max_groups: DEFAULT_MAX_GROUPS,
                 max_streams: DEFAULT_MAX_STREAMS,
-                max_metric_streams: DEFAULT_MAX_METRIC_STREAMS,
+                max_metric_streams: ironbus_server::engine::DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: 0,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,
@@ -20819,7 +20816,7 @@ eImsLe+T6lqrpgIgENKsK8qL9U5HkY7evGZM+CZNPHezUtmVVeASiOLgQO8=
                 max_messages: 0,
                 max_groups: DEFAULT_MAX_GROUPS,
                 max_streams: DEFAULT_MAX_STREAMS,
-                max_metric_streams: DEFAULT_MAX_METRIC_STREAMS,
+                max_metric_streams: ironbus_server::engine::DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: 0,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,
@@ -20906,7 +20903,7 @@ eImsLe+T6lqrpgIgENKsK8qL9U5HkY7evGZM+CZNPHezUtmVVeASiOLgQO8=
                 max_messages: 0,
                 max_groups: DEFAULT_MAX_GROUPS,
                 max_streams: DEFAULT_MAX_STREAMS,
-                max_metric_streams: DEFAULT_MAX_METRIC_STREAMS,
+                max_metric_streams: ironbus_server::engine::DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: 0,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,

--- a/crates/ironbus-client-async/tests/roundtrip.rs
+++ b/crates/ironbus-client-async/tests/roundtrip.rs
@@ -46,6 +46,7 @@ fn open_engine() -> Engine<InMemoryFs, SystemClock> {
             max_groups: DEFAULT_MAX_GROUPS,
             // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
             max_streams: 0,
+            max_metric_streams: 1024,
             group_idle_evict_ms: DEFAULT_GROUP_IDLE_EVICT_MS,
             ram_ceiling_bytes: 0,
             disk_full_policy: DiskFullPolicy::DropNew,

--- a/crates/ironbus-client/src/lib.rs
+++ b/crates/ironbus-client/src/lib.rs
@@ -4241,6 +4241,7 @@ mod tests {
                 max_groups: DEFAULT_MAX_GROUPS,
                 // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
                 max_streams: 0,
+                max_metric_streams: 1024,
                 group_idle_evict_ms: DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,
@@ -4304,6 +4305,7 @@ mod tests {
                 max_groups: DEFAULT_MAX_GROUPS,
                 // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
                 max_streams: 0,
+                max_metric_streams: 1024,
                 group_idle_evict_ms: DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,
@@ -4394,6 +4396,7 @@ mod tests {
                 max_messages: 0,
                 max_groups: DEFAULT_MAX_GROUPS,
                 max_streams: 0,
+                max_metric_streams: 1024,
                 group_idle_evict_ms: DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,
@@ -8075,6 +8078,7 @@ toYtkjmdU2eQ2pK/3gM=
                 max_groups: DEFAULT_MAX_GROUPS,
                 // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
                 max_streams: 0,
+                max_metric_streams: 1024,
                 group_idle_evict_ms: DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,
@@ -8397,6 +8401,7 @@ toYtkjmdU2eQ2pK/3gM=
             max_groups: DEFAULT_MAX_GROUPS,
             // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
             max_streams: 0,
+            max_metric_streams: 1024,
             group_idle_evict_ms: DEFAULT_GROUP_IDLE_EVICT_MS,
             ram_ceiling_bytes: 0,
             disk_full_policy: DiskFullPolicy::DropNew,

--- a/crates/ironbus-server/src/actor.rs
+++ b/crates/ironbus-server/src/actor.rs
@@ -3337,6 +3337,7 @@ mod tests {
             max_groups: DEFAULT_MAX_GROUPS,
             // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
             max_streams: 0,
+            max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
             group_idle_evict_ms: DEFAULT_GROUP_IDLE_EVICT_MS,
             ram_ceiling_bytes: 0,
             disk_full_policy: DiskFullPolicy::DropNew,

--- a/crates/ironbus-server/src/engine.rs
+++ b/crates/ironbus-server/src/engine.rs
@@ -387,6 +387,19 @@ pub struct EngineConfig {
     /// default stream are always allowed (the default does not count). `0` means UNLIMITED, matching the
     /// other `0` = off bounds; the default is [`DEFAULT_MAX_STREAMS`] (1024), an edge profile lowers it.
     pub max_streams: usize,
+    /// The per-NAMED-stream CONSUMER-METRIC cardinality cap (#600, the #681 named-stream metrics
+    /// follow-up): how many distinct NAMED streams each get their own labelled per-stream consumer
+    /// series (`ironbus_stream_{delivered,acked,dead_lettered,filtered}_total{stream}`) on `/metrics`
+    /// before further streams fold into ONE `{stream="__other__"}` bucket, so the `/metrics` series
+    /// count stays bounded no matter how many streams exist. A SEPARATE knob from `max_streams` so an
+    /// operator can allow many streams yet keep the scrape/TSDB cardinality independently bounded.
+    /// UNLIKE the `0 = unlimited` resource caps, `0` here resolves to (and any value is CLAMPED to) the
+    /// hard [`crate::registry::MAX_METRIC_STREAM_SERIES`] backstop — an unbounded metric cardinality is
+    /// the exact OOM this bounds, so the cap can only LOWER the fold threshold, never unbound it; the
+    /// registry's preallocated arrays are a fixed ceiling regardless. Default
+    /// [`DEFAULT_MAX_METRIC_STREAMS`] (1024). The DEFAULT stream is never labelled here (its global
+    /// counters are byte-for-byte unchanged), so a deployment that never names a stream costs nothing.
+    pub max_metric_streams: usize,
     /// How long a NAMED, NON-default work-group may sit IDLE before it is EVICTED (reclaimed from
     /// memory), in MILLISECONDS (refs #277, #240, #9): the deferred lifecycle half of #240. The cap
     /// (`max_groups`) BOUNDS the number of live groups; this RECLAIMS the idle ones, so a long-lived
@@ -2025,6 +2038,19 @@ pub const DEFAULT_MAX_GROUPS: usize = 1024;
 /// lowers it. See [`EngineConfig::max_streams`].
 pub const DEFAULT_MAX_STREAMS: usize = 1024;
 
+/// The default per-NAMED-stream CONSUMER-METRIC cardinality cap (#600, closing the #681 named-stream
+/// metrics follow-up): the number of distinct NAMED streams that each get their own labelled
+/// `ironbus_stream_{delivered,acked,dead_lettered,filtered}_total{stream}` series before further
+/// streams fold into ONE `{stream="__other__"}` bucket, bounding the `/metrics` series count. It is a
+/// SEPARATE knob from [`DEFAULT_MAX_STREAMS`] so an operator can allow many streams yet keep the
+/// metric cardinality (the TSDB / scrape cost) independently in check. UNLIKE the `0 = unlimited`
+/// resource caps, an unbounded metric cardinality is the OOM footgun this exists to prevent, so `0`
+/// resolves to (and every value is clamped to) the hard [`crate::registry::MAX_METRIC_STREAM_SERIES`]
+/// backstop — the cap can only LOWER the fold threshold, never unbound it. Default matches
+/// [`DEFAULT_MAX_STREAMS`] so a default deployment gets a per-stream series for every stream it
+/// allows; an edge profile lowers it.
+pub const DEFAULT_MAX_METRIC_STREAMS: usize = 1024;
+
 /// The default idle window after which a fully-caught-up, lease-free NAMED work-group is evicted
 /// from memory (refs #277, #240), in MILLISECONDS. `0` means DISABLED (never evict), the default:
 /// named groups are only just becoming wire-reachable, eviction is a reclaim not a correctness
@@ -3436,7 +3462,12 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
             fsync: LatencyHistogram::default(),
             // The bounded metric registry (#97), from the clock seam; its head and per-consumer
             // floors are seeded from the recovered state after construction.
-            registry: MetricRegistry::new(crate_version(), start_time_unix_seconds, opened_at),
+            registry: MetricRegistry::new(
+                crate_version(),
+                start_time_unix_seconds,
+                opened_at,
+                config.max_metric_streams,
+            ),
             last_dead_lettered: None,
             dlq,
             dlq_config,
@@ -5681,6 +5712,9 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
                 if d.deliveries > 1 {
                     self.counters.redelivered = self.counters.redelivered.saturating_add(1);
                 }
+                // Per-stream metric parity (#600): mirror the global delivered bump onto this NAMED
+                // stream's own bounded series (the default stream never reaches this path).
+                self.registry.record_stream_delivered(id.name().as_bytes());
                 return Ok(Poll::Message(d));
             }
             Setup::Scan {
@@ -5752,6 +5786,8 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
                             g.cursor.ack(off);
                         }
                         self.counters.filtered = self.counters.filtered.saturating_add(1);
+                        // Per-stream metric parity (#600): this NAMED stream's own filtered count.
+                        self.registry.record_stream_filtered(id.name().as_bytes());
                         offset += 1;
                         continue;
                     }
@@ -5795,6 +5831,8 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
                         if deliveries > 1 {
                             self.counters.redelivered += 1;
                         }
+                        // Per-stream metric parity (#600): this NAMED stream's own delivered count.
+                        self.registry.record_stream_delivered(id.name().as_bytes());
                         return Ok(Poll::Message(Delivery {
                             offset: off,
                             token,
@@ -5857,6 +5895,8 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
                         g.cursor.ack(off);
                     }
                     self.counters.filtered = self.counters.filtered.saturating_add(1);
+                    // Per-stream metric parity (#600): this NAMED stream's own filtered count.
+                    self.registry.record_stream_filtered(id.name().as_bytes());
                     if filtered_from.is_none() {
                         filtered_from = Some(offset);
                     }
@@ -5898,6 +5938,8 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
                     if deliveries > 1 {
                         self.counters.redelivered += 1;
                     }
+                    // Per-stream metric parity (#600): this NAMED stream's own delivered count.
+                    self.registry.record_stream_delivered(id.name().as_bytes());
                     return Ok(Poll::Message(Delivery {
                         offset: off,
                         token,
@@ -6039,6 +6081,9 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         };
         self.counters.dead_lettered = self.counters.dead_lettered.saturating_add(1);
         self.last_dead_lettered = Some(off);
+        // Per-stream metric parity (#600): this NAMED stream's own dead-lettered (poison) count.
+        self.registry
+            .record_stream_dead_lettered(id.name().as_bytes());
         // #800: prune this stream's DLQ dedup set below the group's committed watermark — those source
         // offsets can never redeliver or re-poison, bounding the per-group set by the in-flight window.
         if let Some(sink) = self.named_dlq.get_mut(id) {
@@ -6089,6 +6134,9 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
                     r.clear_offset(token.offset);
                 }
                 self.counters.acks += 1;
+                // Per-stream metric parity (#600): this NAMED stream's own acked count (the default
+                // stream returned early above, so this only ever records a named stream).
+                self.registry.record_stream_acked(id.name().as_bytes());
                 AckResult::Acked
             }
             AckOutcome::Fenced => AckResult::Fenced,
@@ -10631,6 +10679,7 @@ mod tests {
             disk_full_policy: DiskFullPolicy::DropNew,
             max_groups: DEFAULT_MAX_GROUPS,
             max_streams: DEFAULT_MAX_STREAMS,
+            max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
             // Eviction OFF by default in the shared test config (#277); the eviction tests build a
             // config with a non-zero window explicitly so the golden-path tests stay unaffected.
             group_idle_evict_ms: DEFAULT_GROUP_IDLE_EVICT_MS,
@@ -19527,6 +19576,162 @@ mod tests {
             e.poll_in_stream("orders", "g", 0).unwrap(),
             Poll::Idle
         ));
+    }
+
+    // Collects the per-NAMED-stream consumer metric registry (#600) into a name -> (delivered, acked,
+    // dead_lettered, filtered) map for the wiring assertions below.
+    fn stream_metric_counts<C: ironbus_core::clock::Clock + Clone>(
+        e: &Engine<InMemoryFs, C>,
+    ) -> std::collections::BTreeMap<String, (u64, u64, u64, u64)> {
+        let mut seen = std::collections::BTreeMap::new();
+        e.registry().stream_consumers().for_each_series(
+            |label, delivered, acked, dead_lettered, filtered| {
+                seen.insert(
+                    label.to_string(),
+                    (delivered, acked, dead_lettered, filtered),
+                );
+            },
+        );
+        seen
+    }
+
+    #[test]
+    fn named_stream_deliver_and_ack_record_per_stream_metrics_while_default_stays_global_only() {
+        // #600 (closes the #681 named-stream metrics follow-up): a named stream's deliver + ack bump
+        // ITS OWN per-stream consumer series, while the DEFAULT stream ("") is NEVER labelled — its
+        // global counters stay byte-for-byte unchanged. Every stream still bumps the SHARED global
+        // counters (so the aggregate behavior the default stream contributes to is untouched).
+        let mut e = open(config(10, 5));
+        // Named stream `orders`: produce 2, deliver + ack both.
+        produce_to(&mut e, "orders", b"o0");
+        produce_to(&mut e, "orders", b"o1");
+        let d0 = message(e.poll_in_stream("orders", "g", 0).unwrap());
+        assert_eq!(e.ack_in_stream("orders", "g", &d0.token), AckResult::Acked);
+        let d1 = message(e.poll_in_stream("orders", "g", 0).unwrap());
+        assert_eq!(e.ack_in_stream("orders", "g", &d1.token), AckResult::Acked);
+        // Default stream "" through the SAME id-routed entry points: produce 1, deliver + ack.
+        produce_to(&mut e, "", b"d0");
+        let dd = message(e.poll_in_stream("", "g", 0).unwrap());
+        assert_eq!(e.ack_in_stream("", "g", &dd.token), AckResult::Acked);
+
+        // The GLOBAL counters count every stream's deliveries/acks exactly as before (default
+        // unchanged): 2 named + 1 default = 3 delivered, 3 acked.
+        let c = e.counters();
+        assert_eq!(
+            c.delivered, 3,
+            "global delivered counts default AND named, unchanged"
+        );
+        assert_eq!(c.acks, 3, "global acks counts default AND named, unchanged");
+
+        // The per-stream registry (#600) has ONLY the NAMED stream's own counts; the default stream is
+        // never given a per-stream series.
+        let seen = stream_metric_counts(&e);
+        assert_eq!(
+            seen.get("orders"),
+            Some(&(2, 2, 0, 0)),
+            "the named stream carries its own delivered/acked"
+        );
+        assert_eq!(
+            seen.get(""),
+            None,
+            "the DEFAULT stream is never labelled per-stream"
+        );
+        assert_eq!(e.registry().stream_consumers().series_len(), 1);
+        assert!(!e.registry().stream_consumers().has_overflow());
+    }
+
+    #[test]
+    fn a_named_stream_filtered_skip_records_a_per_stream_filtered_metric() {
+        // #600: a per-subject filtered consumer on a NAMED stream records the skip in THAT stream's own
+        // `filtered` metric (the per-stream twin of the global `ironbus_filtered_total`).
+        let mut e = open(config(100, 5));
+        // offset 0: a 3-token subject that does NOT match `orders.*`; offset 1: a matching 2-token one.
+        e.produce_in_stream_with_subject(
+            "orders",
+            &Append {
+                timestamp_ms: 0,
+                flags: RecordFlags::EMPTY,
+                key: b"",
+                headers: b"",
+                payload: b"skip",
+            },
+            b"orders.audit.x",
+        )
+        .unwrap();
+        e.produce_in_stream_with_subject(
+            "orders",
+            &Append {
+                timestamp_ms: 0,
+                flags: RecordFlags::EMPTY,
+                key: b"",
+                headers: b"",
+                payload: b"take",
+            },
+            b"orders.a",
+        )
+        .unwrap();
+        e.set_subject_filter_in_stream("orders", "w", Some("orders.*"))
+            .unwrap();
+        // Drain: the non-match is filtered (skip), the match is delivered + acked.
+        loop {
+            match e.poll_in_stream("orders", "w", 0).unwrap() {
+                Poll::Message(d) => {
+                    assert_eq!(e.ack_in_stream("orders", "w", &d.token), AckResult::Acked);
+                }
+                Poll::Filtered { .. } => {}
+                Poll::Idle => break,
+                other => panic!("unexpected poll outcome: {other:?}"),
+            }
+        }
+        let seen = stream_metric_counts(&e);
+        assert_eq!(
+            seen.get("orders"),
+            Some(&(1, 1, 0, 1)),
+            "the named stream records 1 delivered, 1 acked, 1 filtered (the skipped non-match)"
+        );
+    }
+
+    #[test]
+    fn a_named_stream_dead_letter_records_a_per_stream_dead_lettered_metric() {
+        // #600: a poison message dead-lettered on a NAMED stream records it in THAT stream's own
+        // `dead_lettered` metric (the per-stream twin of the global `ironbus_dead_lettered_total`).
+        let clock = std::sync::Arc::new(ManualClock::new());
+        let mut e = Engine::open(
+            InMemoryFs::new(),
+            std::sync::Arc::clone(&clock),
+            config(10, 1),
+        )
+        .unwrap();
+        e.produce_in_stream(
+            "orders",
+            &Append {
+                timestamp_ms: 0,
+                flags: RecordFlags::EMPTY,
+                key: b"k",
+                headers: b"",
+                payload: b"poison",
+            },
+        )
+        .unwrap();
+        // Attempt 1 delivers within max_deliver = 1; expire the lease; attempt 2 exceeds it and is
+        // dead-lettered (surfaced as Poll::Parked).
+        let _d = message(e.poll_in_stream("orders", "g", e.now_monotonic()).unwrap());
+        clock.advance_monotonic_nanos(40);
+        assert!(matches!(
+            e.poll_in_stream("orders", "g", e.now_monotonic()).unwrap(),
+            Poll::Parked { .. }
+        ));
+        assert_eq!(
+            e.counters().dead_lettered,
+            1,
+            "the global counter is unchanged"
+        );
+        let seen = stream_metric_counts(&e);
+        assert_eq!(
+            seen.get("orders"),
+            Some(&(1, 0, 1, 0)),
+            "the named stream records 1 delivered (attempt 1) and 1 dead-lettered"
+        );
     }
 
     // A config with an explicit named-stream cap (#863), so a test exercises the bound without

--- a/crates/ironbus-server/src/health.rs
+++ b/crates/ironbus-server/src/health.rs
@@ -1618,6 +1618,7 @@ fn registry_body(registry: &crate::registry::MetricRegistry, now_monotonic: u64)
     );
     consumer_lag_lines(&mut s, registry);
     throughput_lines(&mut s, registry);
+    stream_consumer_lines(&mut s, registry);
     ack_level_lines(&mut s, registry);
     self_monitoring_lines(&mut s, registry, now_monotonic);
     s
@@ -1687,6 +1688,122 @@ fn throughput_lines(s: &mut String, registry: &crate::registry::MetricRegistry) 
         s,
         "ironbus_throughput_labels_dropped_total {}",
         tp.labels_dropped()
+    );
+}
+
+/// Renders the per-NAMED-stream CONSUMER series (#600, closing the #681 named-stream metrics
+/// follow-up): records DELIVERED / ACKED / DEAD-LETTERED / FILTERED per NAMED stream
+/// (`ironbus_stream_{delivered,acked,dead_lettered,filtered}_total{stream}`) — the per-stream parity
+/// of the counters the default stream emits GLOBALLY (`ironbus_delivered_total` etc.). The DEFAULT
+/// stream is never recorded here, so its global counters stay byte-for-byte unchanged.
+///
+/// BOUNDED CARDINALITY (the #600 crux): up to the CONFIGURED `max_metric_streams` distinct streams
+/// each get their own labelled series, then further streams fold into ONE `{stream="__other__"}`
+/// bucket (emitted only once a stream has been dropped, so a healthy broker omits it), plus the
+/// unlabeled `ironbus_stream_consumer_labels_dropped_total` cardinality-pressure counter. The `stream`
+/// label is a bounded, overflow-folded STREAM NAME (never a per-message / per-offset value), so the
+/// cardinality is firewall-safe. Each of the four labelled `_total` families is emitted as a whole
+/// block (one HELP/TYPE then every sample, then its `__other__` fold), so a family is CONTIGUOUS in
+/// the exposition. All four labelled sample lines carry a label, so they are pinned only in
+/// `FROZEN_METRIC_TYPES` (the unlabeled-`_total` resilience-taxonomy test excludes them by
+/// construction); the unlabeled `*_labels_dropped_total` is a never-silent cardinality-cap event, so
+/// it is ALSO in `FROZEN_RESILIENCE_COUNTERS`, exactly like `ironbus_throughput_labels_dropped_total`.
+fn stream_consumer_lines(s: &mut String, registry: &crate::registry::MetricRegistry) {
+    let sc = registry.stream_consumers();
+    let (other_delivered, other_acked, other_dead_lettered, other_filtered) = sc.overflow_counts();
+    let other = crate::registry::OTHER_STREAM_LABEL;
+    let has_overflow = sc.has_overflow();
+
+    // Each family is one HELP/TYPE + every per-stream sample + the `__other__` fold, emitted as a
+    // whole block so the family stays contiguous (a strict Prometheus parser requires it).
+    let _ = writeln!(
+        s,
+        "# HELP ironbus_stream_delivered_total Message deliveries handed out per NAMED stream (a redelivery counts again; capped cardinality, over-cap streams fold into stream=\"__other__\")."
+    );
+    let _ = writeln!(s, "# TYPE ironbus_stream_delivered_total counter");
+    sc.for_each_series(|label, delivered, _acked, _dead, _filtered| {
+        let _ = writeln!(
+            s,
+            "ironbus_stream_delivered_total{{stream=\"{}\"}} {delivered}",
+            escape_label(label)
+        );
+    });
+    if has_overflow {
+        let _ = writeln!(
+            s,
+            "ironbus_stream_delivered_total{{stream=\"{other}\"}} {other_delivered}"
+        );
+    }
+
+    let _ = writeln!(
+        s,
+        "# HELP ironbus_stream_acked_total Commits via ack per NAMED stream (capped cardinality, over-cap streams fold into stream=\"__other__\")."
+    );
+    let _ = writeln!(s, "# TYPE ironbus_stream_acked_total counter");
+    sc.for_each_series(|label, _delivered, acked, _dead, _filtered| {
+        let _ = writeln!(
+            s,
+            "ironbus_stream_acked_total{{stream=\"{}\"}} {acked}",
+            escape_label(label)
+        );
+    });
+    if has_overflow {
+        let _ = writeln!(
+            s,
+            "ironbus_stream_acked_total{{stream=\"{other}\"}} {other_acked}"
+        );
+    }
+
+    let _ = writeln!(
+        s,
+        "# HELP ironbus_stream_dead_lettered_total Poison messages dead-lettered per NAMED stream (capped cardinality, over-cap streams fold into stream=\"__other__\")."
+    );
+    let _ = writeln!(s, "# TYPE ironbus_stream_dead_lettered_total counter");
+    sc.for_each_series(|label, _delivered, _acked, dead_lettered, _filtered| {
+        let _ = writeln!(
+            s,
+            "ironbus_stream_dead_lettered_total{{stream=\"{}\"}} {dead_lettered}",
+            escape_label(label)
+        );
+    });
+    if has_overflow {
+        let _ = writeln!(
+            s,
+            "ironbus_stream_dead_lettered_total{{stream=\"{other}\"}} {other_dead_lettered}"
+        );
+    }
+
+    let _ = writeln!(
+        s,
+        "# HELP ironbus_stream_filtered_total Records skipped by a per-subject filtered consumer per NAMED stream (capped cardinality, over-cap streams fold into stream=\"__other__\")."
+    );
+    let _ = writeln!(s, "# TYPE ironbus_stream_filtered_total counter");
+    sc.for_each_series(|label, _delivered, _acked, _dead, filtered| {
+        let _ = writeln!(
+            s,
+            "ironbus_stream_filtered_total{{stream=\"{}\"}} {filtered}",
+            escape_label(label)
+        );
+    });
+    if has_overflow {
+        let _ = writeln!(
+            s,
+            "ironbus_stream_filtered_total{{stream=\"{other}\"}} {other_filtered}"
+        );
+    }
+
+    let _ = writeln!(
+        s,
+        "# HELP ironbus_stream_consumer_labels_dropped_total NAMED-stream consumer-metric stream labels refused a distinct series at the configured max_metric_streams cap (folded into __other__)."
+    );
+    let _ = writeln!(
+        s,
+        "# TYPE ironbus_stream_consumer_labels_dropped_total counter"
+    );
+    let _ = writeln!(
+        s,
+        "ironbus_stream_consumer_labels_dropped_total {}",
+        sc.labels_dropped()
     );
 }
 
@@ -2595,6 +2712,7 @@ mod tests {
             max_groups: crate::engine::DEFAULT_MAX_GROUPS,
             // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
             max_streams: 0,
+            max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
             group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
             ram_ceiling_bytes: 0,
             disk_full_policy: DiskFullPolicy::DropNew,
@@ -3033,6 +3151,7 @@ mod tests {
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
                 // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
                 max_streams: 0,
+                max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,
@@ -3729,7 +3848,7 @@ mod tests {
     fn metrics_renders_the_overflow_saturated_gauge() {
         use crate::registry::{MetricRegistry, MAX_CONSUMER_SERIES, MAX_OVERFLOW_LEDGER};
 
-        let mut registry = MetricRegistry::new(env!("CARGO_PKG_VERSION"), 0, 0);
+        let mut registry = MetricRegistry::new(env!("CARGO_PKG_VERSION"), 0, 0, 0);
         registry.seed_head(1);
 
         // A fresh registry has not saturated: the gauge renders 0 with a `gauge` TYPE line and no
@@ -3780,6 +3899,110 @@ mod tests {
         );
     }
 
+    #[test]
+    #[allow(clippy::too_many_lines)] // one exposition test asserting many per-stream metric lines.
+    fn metrics_renders_per_named_stream_consumer_series_with_bounded_cardinality() {
+        // #600 (closes the #681 named-stream metrics follow-up): the per-stream consumer families carry
+        // a `stream` label per NAMED stream with the right values, and streams past the CONFIGURED
+        // `max_metric_streams` cap fold into ONE `{stream="__other__"}` bucket so the series count stays
+        // bounded (the #600 crux) — driven straight through the private `registry_body` renderer.
+        use crate::registry::{MetricRegistry, OTHER_STREAM_LABEL};
+
+        // A registry with a configured cap of just 2 distinct streams.
+        let mut registry = MetricRegistry::new(env!("CARGO_PKG_VERSION"), 0, 0, 2);
+
+        // AT REST: the HELP/TYPE lines are present, but there is NO per-stream sample and NO `__other__`
+        // fold yet (a broker that never named a stream emits none), and the cap counter reads 0.
+        let at_rest = registry_body(&registry, 0);
+        for ty in [
+            "ironbus_stream_delivered_total",
+            "ironbus_stream_acked_total",
+            "ironbus_stream_dead_lettered_total",
+            "ironbus_stream_filtered_total",
+        ] {
+            assert!(
+                at_rest.contains(&format!("# TYPE {ty} counter")),
+                "missing TYPE line for {ty}: {at_rest}"
+            );
+        }
+        assert!(
+            at_rest.contains("\nironbus_stream_consumer_labels_dropped_total 0\n"),
+            "{at_rest}"
+        );
+        // No `__other__` fold SAMPLE line yet (the HELP text mentions the label, so match the sample
+        // line shape specifically, not the descriptive prose).
+        assert!(
+            !at_rest.contains("ironbus_stream_delivered_total{stream=\"__other__\"}"),
+            "no __other__ fold until a stream is dropped: {at_rest}"
+        );
+        assert!(
+            !at_rest.contains("ironbus_stream_delivered_total{stream="),
+            "no per-stream sample at rest: {at_rest}"
+        );
+
+        // Two IN-CAP streams get their own labelled series with the correct values.
+        for _ in 0..2 {
+            registry.record_stream_delivered(b"orders");
+        }
+        registry.record_stream_acked(b"orders");
+        registry.record_stream_filtered(b"orders");
+        registry.record_stream_dead_lettered(b"orders");
+        registry.record_stream_delivered(b"billing");
+        // Two OVER-CAP streams (past the cap of 2) fold into `__other__`: delivered 1 + 1 = 2, acked 1.
+        registry.record_stream_delivered(b"audit");
+        registry.record_stream_acked(b"audit");
+        registry.record_stream_delivered(b"telemetry");
+
+        let body = registry_body(&registry, 0);
+        // In-cap per-stream values.
+        assert!(
+            body.contains("ironbus_stream_delivered_total{stream=\"orders\"} 2"),
+            "{body}"
+        );
+        assert!(
+            body.contains("ironbus_stream_acked_total{stream=\"orders\"} 1"),
+            "{body}"
+        );
+        assert!(
+            body.contains("ironbus_stream_filtered_total{stream=\"orders\"} 1"),
+            "{body}"
+        );
+        assert!(
+            body.contains("ironbus_stream_dead_lettered_total{stream=\"orders\"} 1"),
+            "{body}"
+        );
+        assert!(
+            body.contains("ironbus_stream_delivered_total{stream=\"billing\"} 1"),
+            "{body}"
+        );
+        // The over-cap streams fold into ONE `__other__` bucket, and get NO series of their own.
+        assert!(
+            body.contains(&format!(
+                "ironbus_stream_delivered_total{{stream=\"{OTHER_STREAM_LABEL}\"}} 2"
+            )),
+            "{body}"
+        );
+        assert!(
+            body.contains(&format!(
+                "ironbus_stream_acked_total{{stream=\"{OTHER_STREAM_LABEL}\"}} 1"
+            )),
+            "{body}"
+        );
+        assert!(
+            !body.contains("stream=\"audit\""),
+            "an over-cap stream must NOT get its own series (bounded cardinality): {body}"
+        );
+        assert!(
+            !body.contains("stream=\"telemetry\""),
+            "an over-cap stream must NOT get its own series (bounded cardinality): {body}"
+        );
+        // Exactly TWO distinct streams were dropped at the cap.
+        assert!(
+            body.contains("\nironbus_stream_consumer_labels_dropped_total 2\n"),
+            "{body}"
+        );
+    }
+
     /// Like [`start`] but with a hard durable-log byte cap, so the rejection path is exercised.
     fn start_with_cap(
         max_total_bytes: u64,
@@ -3808,6 +4031,7 @@ mod tests {
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
                 // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
                 max_streams: 0,
+                max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,
@@ -3956,6 +4180,7 @@ mod tests {
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
                 // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
                 max_streams: 0,
+                max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes,
                 disk_full_policy: DiskFullPolicy::DropNew,
@@ -4037,6 +4262,7 @@ mod tests {
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
                 // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
                 max_streams: 0,
+                max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,
@@ -4315,6 +4541,7 @@ mod tests {
                     max_groups: crate::engine::DEFAULT_MAX_GROUPS,
                     // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
                     max_streams: 0,
+                    max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
                     group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                     ram_ceiling_bytes: 0,
                     disk_full_policy: DiskFullPolicy::DropNew,
@@ -4374,6 +4601,7 @@ mod tests {
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
                 // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
                 max_streams: 0,
+                max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,
@@ -4536,6 +4764,7 @@ mod tests {
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
                 // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
                 max_streams: 0,
+                max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,
@@ -4678,6 +4907,7 @@ mod tests {
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
                 // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
                 max_streams: 0,
+                max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,
@@ -4899,6 +5129,7 @@ mod tests {
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
                 // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
                 max_streams: 0,
+                max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropOldest,
@@ -5274,6 +5505,15 @@ mod tests {
         // sample lines are excluded from this unlabeled-`_total` set by construction and pinned only in
         // `FROZEN_METRIC_TYPES`.
         "ironbus_throughput_labels_dropped_total",
+        // The per-NAMED-stream consumer-metric cardinality-cap counter (#600, the #681 named-stream
+        // metrics follow-up): a stream label refused a distinct series at the CONFIGURED
+        // `max_metric_streams` cap was folded into `{stream="__other__"}`. A cardinality-pressure
+        // signal, never a silent drop, so it belongs in the frozen taxonomy, exactly like
+        // `ironbus_throughput_labels_dropped_total`. The four labelled per-stream consumer SAMPLE
+        // counters (`ironbus_stream_{delivered,acked,dead_lettered,filtered}_total{stream}`) all carry
+        // a LABEL, so their sample lines are excluded from this unlabeled-`_total` set by construction
+        // and pinned only in `FROZEN_METRIC_TYPES`.
+        "ironbus_stream_consumer_labels_dropped_total",
     ];
 
     #[test]
@@ -5470,6 +5710,17 @@ mod tests {
         ("ironbus_group_consumed_total", "counter"),
         ("ironbus_throughput_labels_dropped_total", "counter"),
         ("ironbus_produce_ack_level_total", "counter"),
+        // Per-NAMED-stream consumer counters (#600, the #681 named-stream metrics follow-up): the four
+        // labelled per-stream sample counters (delivered/acked/dead_lettered/filtered — the `stream`
+        // label is a bounded, `__other__`-folded NAME, never a per-message value) mirroring what the
+        // default stream emits globally, plus the unlabeled cardinality-cap counter (ALSO in
+        // FROZEN_RESILIENCE_COUNTERS). The DEFAULT stream is never labelled here, so its global
+        // counters are byte-for-byte unchanged.
+        ("ironbus_stream_delivered_total", "counter"),
+        ("ironbus_stream_acked_total", "counter"),
+        ("ironbus_stream_dead_lettered_total", "counter"),
+        ("ironbus_stream_filtered_total", "counter"),
+        ("ironbus_stream_consumer_labels_dropped_total", "counter"),
         // Connection signals (connz, #572): one LABELED counter family
         // `ironbus_connections_total{state}` (the `state` label is a fixed four-value enum, so the
         // cardinality is bounded by construction — NEVER a per-connection-id label) plus the open
@@ -5949,6 +6200,7 @@ mod tests {
                 max_groups: 100,
                 // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
                 max_streams: 0,
+                max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: 0,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropOldest,
@@ -6163,6 +6415,7 @@ mod tests {
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
                 // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
                 max_streams: 0,
+                max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,
@@ -6383,6 +6636,7 @@ mod tests {
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
                 // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
                 max_streams: 0,
+                max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,
@@ -6699,6 +6953,7 @@ mod tests {
                 max_groups: 100,
                 // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
                 max_streams: 0,
+                max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: 0,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropOldest,

--- a/crates/ironbus-server/src/registry.rs
+++ b/crates/ironbus-server/src/registry.rs
@@ -900,6 +900,316 @@ impl ThroughputRegistry {
     }
 }
 
+/// The HARD allocation cap on the number of distinct per-stream CONSUMER metric series
+/// [`StreamConsumerRegistry`] preallocates (#600, the #681 named-stream metrics follow-up). It is
+/// the fixed backstop that keeps the registry's memory a compile-time constant regardless of the
+/// operator's `max_metric_streams` setting: the configured cardinality cap is CLAMPED to this, so a
+/// misconfigured huge value can never grow the preallocated arrays past this ceiling (the exact OOM
+/// the whole bounded registry exists to prevent). The configured cap can only LOWER the fold
+/// threshold below this, never raise the allocation. Sized to match [`MAX_CONSUMER_SERIES`] so the
+/// per-stream metric surface has the same generous-but-finite ceiling as the lag / throughput ones.
+pub const MAX_METRIC_STREAM_SERIES: usize = MAX_CONSUMER_SERIES;
+
+/// The synthetic `stream` label every over-cap per-stream consumer series folds into (#600), so the
+/// TOTAL delivered/acked/dead-lettered/filtered across the un-labelled streams stays visible even
+/// once distinct stream labels are refused at the configured cap. A DISTINCT spelling from the
+/// throughput/lag `__overflow__` fold on purpose: this fold is driven by the CONFIGURABLE
+/// `max_metric_streams` cap (an operator's cardinality budget), not the fixed 1024-series backstop,
+/// so `__other__` reads as "streams past your metric budget" rather than "past the hard ceiling".
+pub const OTHER_STREAM_LABEL: &str = "__other__";
+
+/// One per-stream CONSUMER metric series (#600): the inline (heap-free) stream label plus the four
+/// monotonic counts mirroring what the DEFAULT stream emits globally — records DELIVERED, ACKED,
+/// DEAD-LETTERED (poison), and FILTERED (per-subject skip) for one NAMED stream. Fixed size, so an
+/// array of these has a fixed memory cost, exactly like [`ThroughputSeries`] / [`ConsumerSeries`].
+#[derive(Clone, Copy)]
+struct StreamConsumerSeries {
+    /// The stream label, stored inline as a fixed byte buffer (no heap allocation).
+    label: [u8; MAX_CONSUMER_LABEL_BYTES],
+    /// The used length of `label` (a fixed-width `u16` for a portable per-series size).
+    label_len: u16,
+    /// Whether this slot is occupied.
+    used: bool,
+    /// Message deliveries handed out to this stream's consumers (a redelivery counts again),
+    /// monotonic — the per-stream twin of the global `ironbus_delivered_total`.
+    delivered: u64,
+    /// Commits via ack in this stream's work-groups (monotonic) — the per-stream
+    /// `ironbus_acks_total`.
+    acked: u64,
+    /// Poison messages dead-lettered to this stream's own DLQ (monotonic) — the per-stream
+    /// `ironbus_dead_lettered_total`.
+    dead_lettered: u64,
+    /// Records skipped by a per-subject filtered consumer on this stream (monotonic) — the
+    /// per-stream `ironbus_filtered_total`.
+    filtered: u64,
+}
+
+impl StreamConsumerSeries {
+    const EMPTY: StreamConsumerSeries = StreamConsumerSeries {
+        label: [0u8; MAX_CONSUMER_LABEL_BYTES],
+        label_len: 0,
+        used: false,
+        delivered: 0,
+        acked: 0,
+        dead_lettered: 0,
+        filtered: 0,
+    };
+
+    /// Copies `name`'s (possibly truncated) stored key into the inline label buffer and marks used.
+    /// Allocation-free (a fixed-size `copy_from_slice` into the preallocated buffer).
+    fn store_label(&mut self, name: &[u8]) {
+        let key = stored_key(name);
+        let n = key.len().min(MAX_CONSUMER_LABEL_BYTES);
+        if let (Some(dst), Some(src)) = (self.label.get_mut(..n), key.get(..n)) {
+            dst.copy_from_slice(src);
+        }
+        self.label_len = u16::try_from(n).unwrap_or(u16::MAX);
+        self.used = true;
+    }
+
+    /// The rendered label as a `&str` (the stored bytes are a prefix of a validated graphic-ASCII
+    /// stream name, so valid UTF-8; a defensive failure renders empty rather than panicking).
+    fn label_str(&self) -> &str {
+        let stored = self.label.get(..usize::from(self.label_len)).unwrap_or(&[]);
+        core::str::from_utf8(stored).unwrap_or("")
+    }
+}
+
+/// The per-NAMED-stream CONSUMER metric registry (#600, closing the #681 named-stream metrics
+/// follow-up): records DELIVERED / ACKED / DEAD-LETTERED / FILTERED per NAMED stream, as monotonic
+/// counters keyed by the stream LABEL, so an operator sees each named stream's consumer activity —
+/// the per-stream parity of the counters the default stream already emits globally.
+///
+/// # BOUNDED CARDINALITY (the #600 crux)
+///
+/// Adding a per-stream label MUST NOT let an unbounded number of stream names explode the metric
+/// series count and OOM the very node the metrics protect. Two nested bounds enforce this:
+///
+/// - A CONFIGURABLE cap (`cap`, from [`crate::engine::EngineConfig::max_metric_streams`]): the first
+///   `cap` distinct streams each get their OWN labelled series; every stream past it folds into ONE
+///   `{stream="__other__"}` bucket (its four counts add into the shared overflow ledger), so the
+///   total labelled series is `cap + 1` REGARDLESS of how many distinct streams exist. A brand-new
+///   over-cap stream bumps `labels_dropped` once (the cardinality-pressure signal), never per record.
+/// - A HARD backstop ([`MAX_METRIC_STREAM_SERIES`]): `cap` is CLAMPED to it at construction and the
+///   two series arrays are PREALLOCATED at it, so the registry's memory is a fixed compile-time
+///   ceiling even if an operator misconfigures a huge `max_metric_streams`. The config can only LOWER
+///   the fold threshold, never grow the allocation.
+///
+/// Like the throughput registry these are pure MONOTONIC COUNTERS (each event adds one), so the
+/// over-cap fold is the trivially-idempotent case — an over-cap stream's increments just add into the
+/// bounded overflow ledger, whose per-label slots also make `labels_dropped` count each DISTINCT
+/// refused stream exactly once (up to the ledger capacity, then a documented coarse fallback). The
+/// `{stream="__other__"}` line renders the SUM over that ledger.
+///
+/// Allocation-free on the steady-state record path (an existing stream resolves O(1) via the
+/// label->slot side-index, the #486 pattern); the once-per-new-stream claim records the mapping off
+/// the hot path. Never walks the log or the disk. The DEFAULT stream ("") is NEVER recorded here — it
+/// keeps its byte-for-byte-unchanged global counters — so a deployment that never names a stream
+/// costs nothing and emits no per-stream series.
+pub struct StreamConsumerRegistry {
+    /// The fixed-capacity primary series array (a boxed slice of exactly [`MAX_METRIC_STREAM_SERIES`]
+    /// slots), allocated ONCE at construction. A new stream takes the first free slot until `cap`;
+    /// past `cap` it folds into the overflow ledger.
+    series: Box<[StreamConsumerSeries]>,
+    /// The number of occupied primary slots in `series` (at most `cap`).
+    len: usize,
+    /// The CONFIGURED cardinality cap: the number of distinct streams that get their own labelled
+    /// series before the `__other__` fold begins. Clamped to `[1, MAX_METRIC_STREAM_SERIES]` at
+    /// construction (a `0`/over-cap setting resolves to the safe default backstop), so it is always a
+    /// valid primary index bound and never exceeds the preallocated array.
+    cap: usize,
+    /// A label->slot side-index so a record for an existing stream resolves O(1), preallocated at the
+    /// hard cap so a claim never resizes it on the hot path. One entry per occupied primary series,
+    /// plus one per distinct over-cap stream tracked in the bounded overflow ledger (mapped via
+    /// [`OVERFLOW_INDEX_BASE`](StreamConsumerRegistry::OVERFLOW_INDEX_BASE)).
+    slot_index: HashMap<Box<[u8]>, usize>,
+    /// The BOUNDED overflow fold-ledger (mirrors [`ThroughputRegistry`]'s): up to
+    /// [`MAX_METRIC_STREAM_SERIES`] inline entries, one per DISTINCT over-cap stream, so a re-record of
+    /// a folded stream adds into ITS slot and `labels_dropped` counts each distinct stream ONCE on its
+    /// first fold. Allocated once; part of the fixed memory ceiling, NOT an unbounded per-stream map.
+    overflow_ledger: Box<[StreamConsumerSeries]>,
+    /// The number of occupied slots in `overflow_ledger` (the count of DISTINCT folded streams).
+    overflow_ledger_len: usize,
+    /// `ironbus_stream_consumer_labels_dropped_total`: the number of DISTINCT streams refused a
+    /// primary series at `cap`. Bumps only on the FIRST fold of a distinct stream, NEVER per record.
+    labels_dropped: u64,
+}
+
+impl StreamConsumerRegistry {
+    /// The `slot_index` value offset that distinguishes an OVERFLOW-LEDGER slot from a primary-series
+    /// slot: a stored value `>= OVERFLOW_INDEX_BASE` is `OVERFLOW_INDEX_BASE + ledger_slot`. Sized at
+    /// the HARD backstop (not the configured `cap`), so the two index spaces never collide even when
+    /// `cap` is lowered by config.
+    const OVERFLOW_INDEX_BASE: usize = MAX_METRIC_STREAM_SERIES;
+
+    /// Builds the registry with a configured cardinality cap of `max_metric_streams`. The cap is
+    /// CLAMPED into `[1, MAX_METRIC_STREAM_SERIES]`: `0` (or any value at/above the backstop) resolves
+    /// to the hard cap, so per-stream labels are always BOUNDED — unlike the `0 = unlimited`
+    /// convention of the resource caps, an unbounded metric cardinality is the footgun this exists to
+    /// prevent. The two series arrays are preallocated at the hard backstop, so the memory is a fixed
+    /// ceiling regardless of the configured cap.
+    #[must_use]
+    pub fn new(max_metric_streams: usize) -> StreamConsumerRegistry {
+        let cap = if max_metric_streams == 0 {
+            MAX_METRIC_STREAM_SERIES
+        } else {
+            max_metric_streams.min(MAX_METRIC_STREAM_SERIES)
+        };
+        StreamConsumerRegistry {
+            series: vec![StreamConsumerSeries::EMPTY; MAX_METRIC_STREAM_SERIES].into_boxed_slice(),
+            len: 0,
+            cap,
+            slot_index: HashMap::with_capacity(MAX_METRIC_STREAM_SERIES + MAX_OVERFLOW_LEDGER),
+            overflow_ledger: vec![StreamConsumerSeries::EMPTY; MAX_OVERFLOW_LEDGER]
+                .into_boxed_slice(),
+            overflow_ledger_len: 0,
+            labels_dropped: 0,
+        }
+    }
+
+    /// Resolves (or claims, or folds) the series for stream `name` and applies `apply` to its counts.
+    /// O(1) and allocation-free for an EXISTING stream — a primary series OR an already-folded over-cap
+    /// stream. A brand-new stream claims a free primary slot below `cap`, then a bounded
+    /// overflow-ledger slot past it (the only allocations, once per distinct stream, off the
+    /// steady-state path); `labels_dropped` counts each DISTINCT refused stream ONCE. The closure
+    /// receives `&mut StreamConsumerSeries` so it can bump any of the four counters.
+    fn record(&mut self, name: &[u8], apply: impl Fn(&mut StreamConsumerSeries)) {
+        let key = stored_key(name);
+        // An EXISTING stream — a primary series OR an already-folded over-cap stream — resolves O(1).
+        if let Some(&idx) = self.slot_index.get(key) {
+            if idx >= Self::OVERFLOW_INDEX_BASE {
+                if let Some(slot) = self
+                    .overflow_ledger
+                    .get_mut(idx - Self::OVERFLOW_INDEX_BASE)
+                {
+                    apply(slot);
+                    return;
+                }
+            } else if let Some(slot) = self.series.get_mut(idx) {
+                apply(slot);
+                return;
+            }
+        }
+        // A brand-new stream with a free primary slot (below the CONFIGURED cap): claim it and record
+        // its key->slot mapping so the next record resolves it in O(1).
+        if self.len < self.cap {
+            if let Some(slot) = self.series.get_mut(self.len) {
+                slot.store_label(name);
+                apply(slot);
+                self.slot_index.insert(Box::from(key), self.len);
+                self.len += 1;
+                return;
+            }
+        }
+        // At the configured cap: a brand-new DISTINCT over-cap stream folds into the bounded overflow
+        // ledger (counted ONCE), so a re-record of it resolves O(1) above next time.
+        if self.overflow_ledger_len < MAX_OVERFLOW_LEDGER {
+            if let Some(slot) = self.overflow_ledger.get_mut(self.overflow_ledger_len) {
+                slot.store_label(name);
+                apply(slot);
+                self.slot_index.insert(
+                    Box::from(key),
+                    Self::OVERFLOW_INDEX_BASE + self.overflow_ledger_len,
+                );
+                self.overflow_ledger_len += 1;
+                self.labels_dropped = self.labels_dropped.saturating_add(1);
+                return;
+            }
+        }
+        // Even the bounded ledger is saturated (more distinct over-cap streams than its capacity over
+        // the broker's life): count the distinct drop, but do NOT fold its counts (it cannot be tracked
+        // without a slot). The `__other__` totals are then a documented LOWER BOUND; `labels_dropped`
+        // still flags the pressure. The same coarse, monotonic, never-grows-wrong fallback the
+        // throughput / lag registries use.
+        self.labels_dropped = self.labels_dropped.saturating_add(1);
+    }
+
+    /// Records one message DELIVERED to stream `name`'s consumers (#600). Allocation-free for an
+    /// existing stream.
+    pub fn record_delivered(&mut self, name: &[u8]) {
+        self.record(name, |s| s.delivered = s.delivered.saturating_add(1));
+    }
+
+    /// Records one ACK committed in stream `name` (#600). Allocation-free for an existing stream.
+    pub fn record_acked(&mut self, name: &[u8]) {
+        self.record(name, |s| s.acked = s.acked.saturating_add(1));
+    }
+
+    /// Records one poison message DEAD-LETTERED for stream `name` (#600). Allocation-free for an
+    /// existing stream.
+    pub fn record_dead_lettered(&mut self, name: &[u8]) {
+        self.record(name, |s| {
+            s.dead_lettered = s.dead_lettered.saturating_add(1)
+        });
+    }
+
+    /// Records one record FILTERED (per-subject skip) on stream `name` (#600). Allocation-free for an
+    /// existing stream.
+    pub fn record_filtered(&mut self, name: &[u8]) {
+        self.record(name, |s| s.filtered = s.filtered.saturating_add(1));
+    }
+
+    /// Invokes `f(label, delivered, acked, dead_lettered, filtered)` for each occupied DISTINCT
+    /// primary series. O(number of series), allocation-free; the `__other__` fold is emitted by the
+    /// caller via the accessors below.
+    pub fn for_each_series<F: FnMut(&str, u64, u64, u64, u64)>(&self, mut f: F) {
+        for slot in self.series.iter().take(self.len) {
+            if slot.used {
+                f(
+                    slot.label_str(),
+                    slot.delivered,
+                    slot.acked,
+                    slot.dead_lettered,
+                    slot.filtered,
+                );
+            }
+        }
+    }
+
+    /// Whether the `__other__` fold is in use (at least one stream refused a primary series at `cap`).
+    #[must_use]
+    pub fn has_overflow(&self) -> bool {
+        self.overflow_ledger_len > 0 || self.labels_dropped > 0
+    }
+
+    /// The folded (`{stream="__other__"}`) delivered/acked/dead-lettered/filtered counts: the sum over
+    /// the bounded overflow ledger. A documented LOWER BOUND if the ledger ever saturated.
+    #[must_use]
+    pub fn overflow_counts(&self) -> (u64, u64, u64, u64) {
+        self.overflow_ledger
+            .iter()
+            .take(self.overflow_ledger_len)
+            .fold((0u64, 0u64, 0u64, 0u64), |(d, a, dl, f), s| {
+                (
+                    d.saturating_add(s.delivered),
+                    a.saturating_add(s.acked),
+                    dl.saturating_add(s.dead_lettered),
+                    f.saturating_add(s.filtered),
+                )
+            })
+    }
+
+    /// The count of DISTINCT streams refused a primary series at `cap` (the
+    /// `ironbus_stream_consumer_labels_dropped_total` cardinality-pressure signal). Counts each
+    /// distinct stream once (on its first fold), never per record.
+    #[must_use]
+    pub fn labels_dropped(&self) -> u64 {
+        self.labels_dropped
+    }
+
+    /// The number of occupied distinct primary series (for the cap/overflow tests and operators).
+    #[must_use]
+    pub fn series_len(&self) -> usize {
+        self.len
+    }
+
+    /// The CONFIGURED cardinality cap (clamped), for the tests and operators.
+    #[must_use]
+    pub fn cap(&self) -> usize {
+        self.cap
+    }
+}
+
 /// The per-ack-level (Level 0/1/2) produce counters (#571): a FIXED three-slot array indexed by
 /// [`AckLevel::as_u8`], so the cardinality is bounded BY CONSTRUCTION (a closed three-value enum, no
 /// overflow fold needed). Each slot is the count of records accepted at that ack level
@@ -960,6 +1270,11 @@ pub struct MetricRegistry {
     /// The per-stream/per-group THROUGHPUT registry (#571): records produced per stream and consumed
     /// per group, bounded at [`MAX_CONSUMER_SERIES`] distinct labels with an `__overflow__` fold.
     throughput: ThroughputRegistry,
+    /// The per-NAMED-stream CONSUMER metric registry (#600): delivered/acked/dead-lettered/filtered per
+    /// named stream, bounded at the configured `max_metric_streams` cap (clamped to
+    /// [`MAX_METRIC_STREAM_SERIES`]) with an `{stream="__other__"}` fold. The DEFAULT stream is never
+    /// recorded here (its global counters stay unchanged).
+    stream_consumers: StreamConsumerRegistry,
     /// The per-ack-level (0/1/2) produce counters (#571): a fixed three-slot array, bounded by the
     /// closed [`AckLevel`] enum (no overflow fold needed).
     ack_levels: AckLevelCounters,
@@ -979,11 +1294,15 @@ impl MetricRegistry {
     /// Builds the registry, capturing the build version and the open-time wall/monotonic instants
     /// from the clock seam. `start_time_unix_seconds` and `start_monotonic_nanos` come from the
     /// caller's [`ironbus_core::clock::Clock`] read, never a raw `now()`.
+    ///
+    /// `max_metric_streams` is the CONFIGURABLE per-stream consumer-metric cardinality cap (#600),
+    /// clamped to [`MAX_METRIC_STREAM_SERIES`] and defaulted from `0`; see [`StreamConsumerRegistry`].
     #[must_use]
     pub fn new(
         build_version: &'static str,
         start_time_unix_seconds: u64,
         start_monotonic_nanos: u64,
+        max_metric_streams: usize,
     ) -> MetricRegistry {
         MetricRegistry {
             fsync_duration: FixedHistogram::default(),
@@ -993,6 +1312,7 @@ impl MetricRegistry {
             consume_latency: FixedHistogram::default(),
             consumer_lag: ConsumerLagRegistry::default(),
             throughput: ThroughputRegistry::default(),
+            stream_consumers: StreamConsumerRegistry::new(max_metric_streams),
             ack_levels: AckLevelCounters::default(),
             build_version,
             start_time_unix_seconds,
@@ -1061,6 +1381,30 @@ impl MetricRegistry {
         self.throughput.record_consumed(name);
     }
 
+    /// Records one message DELIVERED to NAMED stream `name`'s consumers (#600). Allocation-free for an
+    /// existing stream; a brand-new stream claims a bounded series slot (or folds into `__other__` at
+    /// the configured `max_metric_streams` cap). The DEFAULT stream is never recorded here.
+    pub fn record_stream_delivered(&mut self, name: &[u8]) {
+        self.stream_consumers.record_delivered(name);
+    }
+
+    /// Records one ACK committed in NAMED stream `name` (#600). Allocation-free for an existing stream.
+    pub fn record_stream_acked(&mut self, name: &[u8]) {
+        self.stream_consumers.record_acked(name);
+    }
+
+    /// Records one poison DEAD-LETTERED for NAMED stream `name` (#600). Allocation-free for an existing
+    /// stream.
+    pub fn record_stream_dead_lettered(&mut self, name: &[u8]) {
+        self.stream_consumers.record_dead_lettered(name);
+    }
+
+    /// Records one record FILTERED (per-subject skip) on NAMED stream `name` (#600). Allocation-free
+    /// for an existing stream.
+    pub fn record_stream_filtered(&mut self, name: &[u8]) {
+        self.stream_consumers.record_filtered(name);
+    }
+
     /// Records one record accepted at ack level `level` (#571). Allocation-free (a fixed-index bump).
     pub fn record_ack_level(&mut self, level: AckLevel) {
         self.ack_levels.record(level);
@@ -1107,6 +1451,13 @@ impl MetricRegistry {
     #[must_use]
     pub fn throughput(&self) -> &ThroughputRegistry {
         &self.throughput
+    }
+
+    /// The per-NAMED-stream consumer metric registry (#600), for the scrape rendering and the
+    /// cap/`__other__` tests.
+    #[must_use]
+    pub fn stream_consumers(&self) -> &StreamConsumerRegistry {
+        &self.stream_consumers
     }
 
     /// The per-ack-level (0/1/2) produce counters (#571), for the scrape rendering.
@@ -1160,10 +1511,24 @@ pub fn registry_memory_ceiling_bytes() -> usize {
     // of the hard ceiling, not open-ended terms.
     let throughput_series = MAX_CONSUMER_SERIES * core::mem::size_of::<ThroughputSeries>();
     let throughput_overflow = MAX_OVERFLOW_LEDGER * core::mem::size_of::<ThroughputSeries>();
+    // The per-NAMED-stream consumer arrays (#600): a primary series array plus a bounded overflow
+    // fold-ledger, BOTH preallocated at the HARD [`MAX_METRIC_STREAM_SERIES`] backstop (NOT the
+    // configured `max_metric_streams`, which only lowers the fold threshold), so the memory is a fixed
+    // ceiling regardless of the operator's cardinality setting.
+    let stream_consumer_series =
+        MAX_METRIC_STREAM_SERIES * core::mem::size_of::<StreamConsumerSeries>();
+    let stream_consumer_overflow =
+        MAX_OVERFLOW_LEDGER * core::mem::size_of::<StreamConsumerSeries>();
     // The fixed core state held inline in MetricRegistry (the two histograms plus the scalar
     // self-info and lag-registry bookkeeping). This is the fixed sub-100-series core cost.
     let core = core::mem::size_of::<MetricRegistry>();
-    consumer_series + overflow_ledger + throughput_series + throughput_overflow + core
+    consumer_series
+        + overflow_ledger
+        + throughput_series
+        + throughput_overflow
+        + stream_consumer_series
+        + stream_consumer_overflow
+        + core
 }
 
 #[cfg(test)]
@@ -1501,7 +1866,7 @@ mod tests {
     fn the_overflow_fold_path_does_not_allocate() {
         // The engine drives the fold on every ack, so the fold (claim + re-commit update) must be
         // allocation-free just like the under-cap commit path.
-        let mut reg = MetricRegistry::new("0.0.0", 0, 0);
+        let mut reg = MetricRegistry::new("0.0.0", 0, 0, 0);
         reg.record_appended();
         // Fill the distinct-series cap OUTSIDE the counted window.
         for i in 0..MAX_CONSUMER_SERIES {
@@ -1534,7 +1899,7 @@ mod tests {
 
     #[test]
     fn uptime_is_monotonic_derived() {
-        let reg = MetricRegistry::new("9.9.9", 1_700_000_000, 5_000_000_000);
+        let reg = MetricRegistry::new("9.9.9", 1_700_000_000, 5_000_000_000, 0);
         // 8 s after the open-time monotonic origin (5 s).
         assert_eq!(reg.uptime_seconds(13_000_000_000), 8);
         // A monotonic reading before the origin (cannot happen for a real clock) saturates to 0.
@@ -1575,30 +1940,49 @@ mod tests {
             per_throughput <= MAX_CONSUMER_LABEL_BYTES + 24,
             "per-throughput-series cost drifted above label[64] + three words: {per_throughput}"
         );
+        // The per-NAMED-stream consumer series (#600) is a parallel capped array (four monotonic
+        // consumer counts per stream), preallocated at the HARD [`MAX_METRIC_STREAM_SERIES`] backstop
+        // with its own bounded overflow ledger, all fixed-width so it is identical across targets. The
+        // configured `max_metric_streams` only lowers the FOLD threshold; it never grows the allocation
+        // past this backstop, so the ceiling stays a compile-time constant.
+        let per_stream_consumer = core::mem::size_of::<StreamConsumerSeries>();
+        assert!(
+            per_stream_consumer >= MAX_CONSUMER_LABEL_BYTES,
+            "the inline per-stream consumer label buffer must be stored, not heaped: {per_stream_consumer}"
+        );
+        assert!(
+            per_stream_consumer <= MAX_CONSUMER_LABEL_BYTES + 40,
+            "per-stream-consumer-series cost drifted above label[64] + five words: {per_stream_consumer}"
+        );
         // The overflow fold-ledgers are SECOND capped arrays of the same per-entry cost, also
         // preallocated at their caps, so they too are fixed terms independent of live-label count. The
-        // ceiling is exactly the four capped arrays (lag series + lag overflow + throughput series +
-        // throughput overflow) plus the fixed core.
+        // ceiling is exactly the six capped arrays (lag series + lag overflow + throughput series +
+        // throughput overflow + stream-consumer series + stream-consumer overflow) plus the fixed core.
         assert_eq!(
             ceiling,
             MAX_CONSUMER_SERIES * per_series
                 + MAX_OVERFLOW_LEDGER * per_series
                 + MAX_CONSUMER_SERIES * per_throughput
                 + MAX_OVERFLOW_LEDGER * per_throughput
+                + MAX_METRIC_STREAM_SERIES * per_stream_consumer
+                + MAX_OVERFLOW_LEDGER * per_stream_consumer
                 + core::mem::size_of::<MetricRegistry>()
         );
-        // The signed-off ceiling: the four capped series arrays (the lag series + its overflow ledger,
-        // the throughput series + its overflow ledger) are the dominant terms and together are well
-        // under 512 KiB, so the whole registry is a small fixed slice of the 64 MiB edge RAM budget,
-        // INDEPENDENT of record count or disk size. (~80-88 bytes/series x 1024 x 4 arrays ~= 340 KiB.)
+        // The signed-off ceiling: the six capped series arrays (the lag series + its overflow ledger,
+        // the throughput series + its overflow ledger, the per-stream consumer series + its overflow
+        // ledger) are the dominant terms and together are well under 768 KiB, so the whole registry is
+        // a small fixed slice of the 64 MiB edge RAM budget, INDEPENDENT of record count, disk size, or
+        // the number of live streams. (~80-104 bytes/series x 1024 x 6 arrays ~= 550 KiB.)
         assert!(
-            ceiling < 512 * 1024,
-            "registry ceiling {ceiling} bytes exceeded the documented 512 KiB sign-off"
+            ceiling < 768 * 1024,
+            "registry ceiling {ceiling} bytes exceeded the documented 768 KiB sign-off"
         );
-        // The core (non-consumer-series) state is a fixed sub-100-series cost: a handful of
-        // histograms and scalars, well under 1 KiB.
+        // The core (non-consumer-series) INLINE state is a fixed sub-100-series cost: a handful of
+        // fixed-bucket histograms, the four bounded registries' fat-pointer/HashMap bookkeeping (the
+        // big series arrays live on the heap, counted above — NOT here), and a few scalars. Well under
+        // 2 KiB, and independent of any live-label count.
         assert!(
-            core::mem::size_of::<MetricRegistry>() < 1024,
+            core::mem::size_of::<MetricRegistry>() < 2048,
             "core registry state is not the fixed small term it is documented as"
         );
     }
@@ -1608,7 +1992,7 @@ mod tests {
         // Build the registry and pre-touch its consumer series OUTSIDE the counted window (claiming a
         // series slot copies the label into the preallocated array; the test asserts the STEADY-STATE
         // hot path, where the series already exists, allocates nothing).
-        let mut reg = MetricRegistry::new("0.0.0", 0, 0);
+        let mut reg = MetricRegistry::new("0.0.0", 0, 0, 0);
         reg.set_consumer_committed(b"orders", 0);
         reg.set_consumer_committed(b"billing", 0);
         // The steady-state append + commit + observe hot path: advance the head, observe both
@@ -1634,7 +2018,7 @@ mod tests {
         // must be allocation-free on the STEADY-STATE hot path (an existing label), so leaving them on
         // is affordable on the edge box, exactly like the lag registry. Pre-touch the labels OUTSIDE
         // the counted window (claiming a series slot copies the label into the preallocated array).
-        let mut reg = MetricRegistry::new("0.0.0", 0, 0);
+        let mut reg = MetricRegistry::new("0.0.0", 0, 0, 0);
         reg.record_stream_produced(b""); // the default stream
         reg.record_group_consumed(b"orders");
         let allocs = count_allocs(|| {
@@ -1667,7 +2051,7 @@ mod tests {
         // #571: past MAX_CONSUMER_SERIES distinct labels, a new label is REFUSED its own series and its
         // counts FOLD into `__overflow__`, bounding the series memory (the cardinality firewall the
         // registry enforces). `labels_dropped` counts each DISTINCT refused label once.
-        let mut reg = MetricRegistry::new("0.0.0", 0, 0);
+        let mut reg = MetricRegistry::new("0.0.0", 0, 0, 0);
         // Fill exactly to the cap with distinct stream labels, each produced once.
         for i in 0..MAX_CONSUMER_SERIES {
             reg.record_stream_produced(format!("stream-{i}").as_bytes());
@@ -1705,10 +2089,144 @@ mod tests {
     fn the_throughput_overflow_label_is_invisible_until_a_label_is_dropped() {
         // #571: a healthy broker (under the cap) emits NO `__overflow__` throughput series, so the
         // overflow line only appears once cardinality pressure forced a fold.
-        let mut reg = MetricRegistry::new("0.0.0", 0, 0);
+        let mut reg = MetricRegistry::new("0.0.0", 0, 0, 0);
         reg.record_stream_produced(b"orders");
         reg.record_group_consumed(b"orders");
         assert!(!reg.throughput().has_overflow());
+    }
+
+    #[test]
+    fn the_stream_consumer_registry_records_the_four_counts_per_named_stream() {
+        // #600: each NAMED stream gets its own delivered/acked/dead-lettered/filtered counts, keyed by
+        // stream label, mirroring what the default stream emits globally. Two streams are independent.
+        let mut reg = MetricRegistry::new("0.0.0", 0, 0, 0);
+        reg.record_stream_delivered(b"orders");
+        reg.record_stream_delivered(b"orders");
+        reg.record_stream_acked(b"orders");
+        reg.record_stream_filtered(b"orders");
+        reg.record_stream_dead_lettered(b"orders");
+        reg.record_stream_delivered(b"billing");
+        reg.record_stream_acked(b"billing");
+        reg.record_stream_acked(b"billing");
+        let mut seen: std::collections::BTreeMap<String, (u64, u64, u64, u64)> =
+            std::collections::BTreeMap::new();
+        reg.stream_consumers().for_each_series(
+            |label, delivered, acked, dead_lettered, filtered| {
+                seen.insert(
+                    label.to_string(),
+                    (delivered, acked, dead_lettered, filtered),
+                );
+            },
+        );
+        assert_eq!(seen.get("orders"), Some(&(2, 1, 1, 1)));
+        assert_eq!(seen.get("billing"), Some(&(1, 2, 0, 0)));
+        assert_eq!(reg.stream_consumers().series_len(), 2);
+        assert!(!reg.stream_consumers().has_overflow());
+        assert_eq!(reg.stream_consumers().labels_dropped(), 0);
+    }
+
+    #[test]
+    fn the_stream_consumer_cardinality_is_bounded_by_the_configured_cap_and_folds_into_other() {
+        // #600 CRUX: with a CONFIGURED cap of 3, the first 3 distinct streams get their own labelled
+        // series and every stream past the cap folds into ONE `__other__` bucket, so the total labelled
+        // series stays `cap + 1` REGARDLESS of how many distinct streams exist. `labels_dropped` counts
+        // each DISTINCT refused stream once (never per record). This is the bound that stops a per-
+        // stream label from exploding the series count and OOMing the node.
+        let mut reg = MetricRegistry::new("0.0.0", 0, 0, 3);
+        assert_eq!(
+            reg.stream_consumers().cap(),
+            3,
+            "the configured cap is honored"
+        );
+        // The 3 in-cap streams each get their own series.
+        for s in ["a", "b", "c"] {
+            reg.record_stream_delivered(s.as_bytes());
+        }
+        assert_eq!(reg.stream_consumers().series_len(), 3);
+        assert!(
+            !reg.stream_consumers().has_overflow(),
+            "at the cap exactly, no fold yet"
+        );
+        // 200 MORE distinct over-cap streams, each delivered+acked twice: all fold into __other__.
+        for i in 0..200 {
+            let name = format!("over-{i}");
+            reg.record_stream_delivered(name.as_bytes());
+            reg.record_stream_delivered(name.as_bytes());
+            reg.record_stream_acked(name.as_bytes());
+            reg.record_stream_acked(name.as_bytes());
+        }
+        let sc = reg.stream_consumers();
+        assert_eq!(
+            sc.series_len(),
+            3,
+            "the labelled series array NEVER grows past the configured cap, whatever the stream count"
+        );
+        assert!(sc.has_overflow());
+        assert_eq!(
+            sc.labels_dropped(),
+            200,
+            "each DISTINCT over-cap stream is counted once, never per record"
+        );
+        let (delivered, acked, dead_lettered, filtered) = sc.overflow_counts();
+        assert_eq!(
+            delivered, 400,
+            "200 streams x 2 deliveries fold into __other__"
+        );
+        assert_eq!(acked, 400, "200 streams x 2 acks fold into __other__");
+        assert_eq!(dead_lettered, 0);
+        assert_eq!(filtered, 0);
+    }
+
+    #[test]
+    fn the_stream_consumer_other_bucket_is_invisible_until_a_stream_is_dropped() {
+        // #600: under the cap, NO `__other__` bucket is emitted, so a healthy broker's exposition only
+        // grows the fold line once cardinality pressure forced it.
+        let mut reg = MetricRegistry::new("0.0.0", 0, 0, 2);
+        reg.record_stream_delivered(b"a");
+        reg.record_stream_delivered(b"b");
+        assert!(!reg.stream_consumers().has_overflow());
+        reg.record_stream_delivered(b"c"); // third distinct stream, cap is 2
+        assert!(reg.stream_consumers().has_overflow());
+    }
+
+    #[test]
+    fn the_configured_stream_metric_cap_is_clamped_to_the_hard_backstop() {
+        // #600: `0` resolves to the hard backstop (never 0-series or unlimited), and an over-backstop
+        // value is clamped down, so the preallocated arrays — and thus the memory — are ALWAYS bounded
+        // by MAX_METRIC_STREAM_SERIES regardless of what an operator configures.
+        assert_eq!(
+            StreamConsumerRegistry::new(0).cap(),
+            MAX_METRIC_STREAM_SERIES
+        );
+        assert_eq!(
+            StreamConsumerRegistry::new(usize::MAX).cap(),
+            MAX_METRIC_STREAM_SERIES,
+            "a misconfigured huge cap is clamped to the hard backstop"
+        );
+        assert_eq!(StreamConsumerRegistry::new(10).cap(), 10);
+    }
+
+    #[test]
+    fn the_stream_consumer_record_path_is_allocation_free_for_existing_streams() {
+        // #600: after each distinct stream's first record (which claims a slot), the steady-state record
+        // path is allocation-free (an O(1) side-index lookup + a borrowed count bump), so leaving the
+        // per-stream consumer metrics on is affordable on the edge box, exactly like the throughput one.
+        let mut reg = MetricRegistry::new("0.0.0", 0, 0, 0);
+        for s in ["orders", "billing", "audit"] {
+            reg.record_stream_delivered(s.as_bytes()); // first touch claims the slot (may allocate)
+        }
+        let allocs = count_allocs(|| {
+            for _ in 0..1000u64 {
+                reg.record_stream_delivered(b"orders");
+                reg.record_stream_acked(b"billing");
+                reg.record_stream_filtered(b"audit");
+                reg.record_stream_dead_lettered(b"orders");
+            }
+        });
+        assert_eq!(
+            allocs, 0,
+            "the steady-state per-stream consumer record path allocated {allocs} times"
+        );
     }
 
     #[test]
@@ -1716,7 +2234,7 @@ mod tests {
         // #570: the produce->ack / deliver / consume request-path histograms record into the SAME
         // fixed bucket set, and their observe is allocation-free just like fsync/append (so leaving
         // the request-path latency metrics on is affordable on the edge box).
-        let mut reg = MetricRegistry::new("0.0.0", 0, 0);
+        let mut reg = MetricRegistry::new("0.0.0", 0, 0, 0);
         let allocs = count_allocs(|| {
             for _ in 0..1000u64 {
                 reg.observe_produce_ack_nanos(250_000); // <= 0.0005 s bucket 0
@@ -1747,7 +2265,7 @@ mod tests {
         // for_each_series visit plus the cumulative-bucket reads) must allocate nothing. (The
         // string formatting the real /metrics body does is a separate, already-bounded concern; this
         // pins that the registry's read side is allocation-free.)
-        let mut reg = MetricRegistry::new("0.0.0", 0, 0);
+        let mut reg = MetricRegistry::new("0.0.0", 0, 0, 0);
         reg.record_appended();
         for i in 0..500u64 {
             reg.set_consumer_committed(format!("c{i}").as_bytes(), 0);

--- a/crates/ironbus-server/src/registry.rs
+++ b/crates/ironbus-server/src/registry.rs
@@ -1139,7 +1139,7 @@ impl StreamConsumerRegistry {
     /// existing stream.
     pub fn record_dead_lettered(&mut self, name: &[u8]) {
         self.record(name, |s| {
-            s.dead_lettered = s.dead_lettered.saturating_add(1)
+            s.dead_lettered = s.dead_lettered.saturating_add(1);
         });
     }
 

--- a/crates/ironbus-server/src/server.rs
+++ b/crates/ironbus-server/src/server.rs
@@ -958,6 +958,7 @@ mod tests {
             max_groups: crate::engine::DEFAULT_MAX_GROUPS,
             // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
             max_streams: 0,
+            max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
             group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
             ram_ceiling_bytes: 0,
             disk_full_policy: DiskFullPolicy::DropNew,

--- a/crates/ironbus-server/src/session.rs
+++ b/crates/ironbus-server/src/session.rs
@@ -5324,6 +5324,7 @@ mod tests {
             max_groups: crate::engine::DEFAULT_MAX_GROUPS,
             // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
             max_streams: 0,
+            max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
             group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
             ram_ceiling_bytes: 0,
             disk_full_policy: DiskFullPolicy::DropNew,
@@ -5429,6 +5430,7 @@ mod tests {
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
                 // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
                 max_streams: 0,
+                max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,
@@ -5490,6 +5492,7 @@ mod tests {
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
                 // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
                 max_streams: 0,
+                max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropOldest,
@@ -5810,6 +5813,7 @@ mod tests {
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
                 // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
                 max_streams: 0,
+                max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,
@@ -8414,6 +8418,7 @@ mod tests {
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
                 // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
                 max_streams: 0,
+                max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,
@@ -9607,6 +9612,7 @@ mod tests {
                     max_groups: crate::engine::DEFAULT_MAX_GROUPS,
                     // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
                     max_streams: 0,
+                    max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
                     group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                     ram_ceiling_bytes: 0,
                     disk_full_policy: DiskFullPolicy::DropNew,
@@ -10013,6 +10019,7 @@ mod tests {
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
                 // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
                 max_streams: 0,
+                max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,
@@ -10073,6 +10080,7 @@ mod tests {
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
                 // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
                 max_streams: 0,
+                max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,
@@ -10286,6 +10294,7 @@ mod tests {
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
                 // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
                 max_streams: 0,
+                max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
                 disk_full_policy: DiskFullPolicy::DropNew,
@@ -11332,6 +11341,7 @@ mod tests {
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
                 // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
                 max_streams: 0,
+                max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: 10, // eviction ON; the explicit-Unsub path ignores the window
                 disk_full_policy: DiskFullPolicy::DropNew,
                 ram_ceiling_bytes: 0,

--- a/crates/ironbus-server/tests/conformance_vectors.rs
+++ b/crates/ironbus-server/tests/conformance_vectors.rs
@@ -658,6 +658,8 @@ fn build_config(setup: &Setup) -> EngineConfig {
         // Named-stream cap OFF (#863, `0` = unlimited): the conformance vectors assume the
         // historical unbounded behavior, so the golden bytes are unchanged by the cap.
         max_streams: 0,
+        // Per-stream consumer-metric cap (#600): observability only, does not affect the golden bytes.
+        max_metric_streams: 1024,
         group_idle_evict_ms: 0,
         ram_ceiling_bytes: 0,
         dedup: DedupConfig {

--- a/crates/ironbus-server/tests/determinism.rs
+++ b/crates/ironbus-server/tests/determinism.rs
@@ -38,6 +38,7 @@ fn config() -> EngineConfig {
         max_groups: DEFAULT_MAX_GROUPS,
         // Named-stream cap OFF (#863, `0` = unlimited): the determinism image is unchanged by the cap.
         max_streams: 0,
+        max_metric_streams: 1024,
         // Idle named-group eviction OFF (#277), the default: the determinism image is unchanged.
         group_idle_evict_ms: DEFAULT_GROUP_IDLE_EVICT_MS,
         ram_ceiling_bytes: 0,

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -590,6 +590,43 @@ in a bounded ledger so `*_labels_dropped_total` counts each distinct dropped lab
 label (an O(1) side-index lookup); the registry's memory ceiling now covers the
 throughput series array and its overflow ledger too (signed off below).
 
+### Per-NAMED-stream consumer counters (#600, the #681 named-stream metrics follow-up)
+
+```
+ironbus_stream_delivered_total{stream=...}            message deliveries handed out per NAMED stream (a redelivery counts again)
+ironbus_stream_acked_total{stream=...}                commits via ack per NAMED stream
+ironbus_stream_dead_lettered_total{stream=...}        poison messages dead-lettered per NAMED stream
+ironbus_stream_filtered_total{stream=...}             per-subject filtered-consumer skips per NAMED stream
+ironbus_stream_consumer_labels_dropped_total          distinct streams refused a series at the max_metric_streams cap (folded into __other__)
+```
+
+The per-stream parity of the counters the **default** stream emits globally
+(`ironbus_delivered_total` / `ironbus_acks_total` / `ironbus_dead_lettered_total` /
+`ironbus_filtered_total`), keyed by the NAMED stream. The **DEFAULT stream is never
+labelled here** — its global counters stay byte-for-byte unchanged, and every stream
+still contributes to those globals exactly as before.
+
+**Bounded cardinality (the #600 crux).** Adding a per-stream label must not let an
+unbounded number of stream names explode the series count and OOM the node. Two nested
+bounds enforce it:
+
+- A **configurable** cap, `EngineConfig::max_metric_streams` (default 1024): the first
+  `max_metric_streams` distinct streams each get their own labelled series; every stream
+  past it folds into ONE `{stream="__other__"}` bucket, so the total labelled series is
+  `cap + 1` regardless of how many distinct streams exist. A new over-cap stream bumps
+  `ironbus_stream_consumer_labels_dropped_total` once (never per record).
+- A **hard backstop**, `MAX_METRIC_STREAM_SERIES` (1024): the cap is clamped to it and
+  the series arrays are preallocated at it, so the registry memory is a fixed ceiling
+  even if an operator misconfigures a huge value (the cap can only LOWER the fold
+  threshold, never grow the allocation). Unlike the `0 = unlimited` resource caps, `0`
+  here resolves to the backstop — an unbounded metric cardinality is the exact OOM this
+  bounds.
+
+The `stream` label is a bounded, `__other__`-folded NAME (never a per-message / per-offset
+value), so it is firewall-safe (the #576 allowlist). Recording is allocation-free for an
+existing stream (an O(1) side-index lookup); the registry's memory ceiling covers this
+registry's series array and its overflow ledger too (signed off below).
+
 ### Connection signals — "connz" (#572)
 
 ```


### PR DESCRIPTION
Completes named-stream metric parity with the default stream (durable cursor / DLQ / key-shared / Tier-S already shipped for named). The final piece of the #681 follow-up; **closes #600** ("Multi-stream metrics/CLI hooks with BOUNDED CARDINALITY").

## What

Named-stream consumers had no per-stream label on their consumer metrics — deliver/ack/dead-letter/filter on a named stream folded into the global counters with no per-stream visibility. This adds the per-stream label, keyed by stream name, mirroring what the default stream emits globally:

| new metric | default-stream twin |
|---|---|
| `ironbus_stream_delivered_total{stream=...}` | `ironbus_delivered_total` |
| `ironbus_stream_acked_total{stream=...}` | `ironbus_acks_total` |
| `ironbus_stream_dead_lettered_total{stream=...}` | `ironbus_dead_lettered_total` |
| `ironbus_stream_filtered_total{stream=...}` | `ironbus_filtered_total` |
| `ironbus_stream_consumer_labels_dropped_total` | cardinality-pressure signal (unlabeled) |

Reuses the existing `MetricRegistry` + `health.rs` Prometheus exporter — no new metrics system.

## Bounded cardinality (the #600 crux)

A new `StreamConsumerRegistry` mirrors the reviewed #571 `ThroughputRegistry` (same bounded-ledger + `label->slot` side-index pattern), with two nested bounds:

- **Configurable cap** — `EngineConfig::max_metric_streams` (default **1024**). The first `cap` distinct streams each get their own labelled series; every stream past it folds into ONE `{stream="__other__"}` bucket, so total labelled series is **`cap + 1` regardless of stream count**. A new over-cap stream bumps `..._labels_dropped_total` once (never per record).
- **Hard backstop** — `MAX_METRIC_STREAM_SERIES` (1024): the cap is clamped to it and the arrays are preallocated at it, so registry memory is a **fixed compile-time ceiling** even if an operator misconfigures a huge value (the cap can only LOWER the fold threshold, never grow the allocation). Unlike the `0 = unlimited` resource caps, `0` here resolves to the backstop — unbounded metric cardinality is the exact OOM this prevents.

The `stream` label is a bounded, `__other__`-folded NAME (never a per-message/offset value), so it passes the #576 cardinality firewall (the `stream` key is already allowlisted; family fits the 1100/family cap).

## Default stream unchanged

The default stream is **never** recorded in this registry — its global counters are byte-for-byte unchanged. The named consume paths (`deliver_from_named_stream` / `ack_in_stream` / `named_dead_letter_in`, all named-stream-only) only ADD the per-stream record calls next to the existing global increments; the default (`""`) routes elsewhere and returns byte-for-byte as before.

## Scope note

The cap is a real, safe-defaulted config knob at the engine's configuration surface (`EngineConfig::max_metric_streams`); the CLI serve path passes the default. A dedicated `--max-metric-streams` CLI flag (mirroring `--max-streams`) is a trivial, separate follow-up and was kept out to bound the blast radius of this PR.

## For review

- **Bounded-cardinality holds**: `cap + 1` labelled series max, hard-clamped allocation ceiling, `__other__` fold + distinct-`labels_dropped`. Tested directly (`>cap` distinct streams stay capped and fold).
- **Default unchanged**: named paths only add record calls next to existing global increments; default never enters the registry. Tested (global counters count both; no per-stream series for `""`).
- Frozen metric-type / resilience-taxonomy contracts and the registry memory-ceiling sign-off are updated deliberately.

## Tests (all in-container, `rust:1-bookworm`)

- `cargo test --workspace --locked` — **0 failed** (server lib: `1155 passed; 0 failed; 1 ignored`).
- `cargo test -p ironbus-cli --locked --test acceptance -- --exact golden_path_acceptance_install_to_recovery_to_upgrade` — **ok, 1 passed**.
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — clean.
- `cargo fmt --all --check` — clean.
- `scripts/check-format-registry.sh` — ok.

Refs #681, #600.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01McmNfYNWPmohVS8umY9Lkp
