### PR TITLE
feat(streams): max_open_streams hot-set LRU with evict/reopen (#565)

### DIFF
--- a/crates/ironbus-bench/src/inproc.rs
+++ b/crates/ironbus-bench/src/inproc.rs
@@ -87,6 +87,7 @@ fn engine_config_with_credit(consumer_credit: u32, max_in_flight: u32) -> Engine
         max_groups: DEFAULT_MAX_GROUPS,
         // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
         max_streams: 0,
+        max_open_streams: 0,
         max_metric_streams: 1024,
         group_idle_evict_ms: DEFAULT_GROUP_IDLE_EVICT_MS,
         disk_full_policy: DiskFullPolicy::DropNew,

--- a/crates/ironbus-cli/src/admin.rs
+++ b/crates/ironbus-cli/src/admin.rs
@@ -684,6 +684,7 @@ mod tests {
                 max_messages: 0,
                 max_groups: 1024,
                 max_streams: 0,
+                max_open_streams: 0,
                 max_metric_streams: 1024,
                 group_idle_evict_ms: 0,
                 ram_ceiling_bytes: 0,

--- a/crates/ironbus-cli/src/main.rs
+++ b/crates/ironbus-cli/src/main.rs
@@ -251,6 +251,15 @@ const DEFAULT_MAX_GROUPS: usize = ironbus_server::engine::DEFAULT_MAX_GROUPS;
 /// never counted against it.
 const DEFAULT_MAX_STREAMS: usize = ironbus_server::engine::DEFAULT_MAX_STREAMS;
 
+/// The default cap on the number of OPEN (fd-resident) NAMED streams for `serve` — the
+/// `max_open_streams` hot-set LRU (#565), aliased to the engine's
+/// [`ironbus_server::engine::DEFAULT_MAX_OPEN_STREAMS`] so the CLI default and the engine default are a
+/// single source of truth and cannot drift. Bounds the RESIDENT file descriptors + segment buffers to
+/// the hot working set (the least-recently-used stream's log is closed, and reopened from disk on
+/// demand), ORTHOGONAL to `DEFAULT_MAX_STREAMS` (which bounds how many streams may EXIST). `0` =
+/// unlimited (never evict); the default is non-zero (1024). The default stream is never evicted.
+const DEFAULT_MAX_OPEN_STREAMS: usize = ironbus_server::engine::DEFAULT_MAX_OPEN_STREAMS;
+
 // The per-NAMED-stream CONSUMER-METRIC cardinality cap default (#600, the #681 named-stream metrics
 // follow-up) is referenced directly as `ironbus_server::engine::DEFAULT_MAX_METRIC_STREAMS` at each
 // EngineConfig construction (a single source of truth). No local alias: unlike `DEFAULT_MAX_STREAMS`
@@ -687,6 +696,12 @@ struct ProfilePreset {
     /// `edge-tiny` LOWERS it (a tiny node should pin few logs); `balanced`/`throughput` mirror their
     /// group budgets. `0` = unlimited.
     max_streams: usize,
+    /// `backpressure.max_open_streams` (`--max-open-streams`): the OPEN (fd-resident) NAMED-stream
+    /// hot-set LRU cap (#565). Bounds resident fds/buffers to the hot working set, closing + reopening
+    /// per-stream logs on demand; ORTHOGONAL to `max_streams` (which bounds how many streams may
+    /// EXIST). `edge-tiny` LOWERS it (a tiny node keeps few logs open); `balanced`/`throughput` mirror
+    /// their group budgets. `0` = unlimited (never evict).
+    max_open_streams: usize,
     /// `backpressure.max_in_flight` (`--max-in-flight`).
     max_in_flight: u32,
     /// `backpressure.disk_full_policy` (`--disk-full-policy`).
@@ -730,6 +745,10 @@ const EDGE_TINY_PRESET: ProfilePreset = ProfilePreset {
     // LOWERED named-stream cap (#863): a tiny edge node should pin only a handful of logs (each a
     // distinct fd/inode/buffer set), so 64 named streams — matching its group budget — is the bound.
     max_streams: 64,
+    // LOWERED open-stream hot-set cap (#565): a tiny edge node keeps only a small working set of logs
+    // OPEN at once (each an fd + buffers), evicting + reopening the rest on demand. Matching its
+    // `max_streams` bound (64) keeps every allowed stream resident while still capping resident fds.
+    max_open_streams: 64,
     max_in_flight: 256,
     disk_full_policy: DiskFullPolicyArg::DropNew,
     checkpoint_interval: 1024,
@@ -768,6 +787,7 @@ const BALANCED_PRESET: ProfilePreset = ProfilePreset {
     max_connections: DEFAULT_MAX_CONNECTIONS,
     max_groups: DEFAULT_MAX_GROUPS,
     max_streams: DEFAULT_MAX_STREAMS,
+    max_open_streams: DEFAULT_MAX_OPEN_STREAMS,
     max_in_flight: DEFAULT_MAX_IN_FLIGHT,
     disk_full_policy: DiskFullPolicyArg::DropNew,
     checkpoint_interval: DEFAULT_CHECKPOINT_INTERVAL,
@@ -798,6 +818,7 @@ const THROUGHPUT_PRESET: ProfilePreset = ProfilePreset {
     max_connections: 1024,
     max_groups: 4096,
     max_streams: 4096,
+    max_open_streams: 4096,
     max_in_flight: 8192,
     disk_full_policy: DiskFullPolicyArg::DropOldest,
     checkpoint_interval: 4096,
@@ -900,7 +921,8 @@ USAGE:
                   [--consumer-credit <n>] [--consumer-credit-bytes <n>]
                   [--max-segment-bytes <n>] [--max-total-bytes <bytes>]
                   [--max-retained-bytes <bytes>] [--max-age-ms <ms>] [--max-messages <n>]
-                  [--max-groups <n>] [--max-streams <n>] [--group-idle-evict-ms <ms>]
+                  [--max-groups <n>] [--max-streams <n>] [--max-open-streams <n>]
+                  [--group-idle-evict-ms <ms>]
                   [--disk-full-policy <drop-new|drop-oldest>]
                   [--key-shared-group <name>]... [--broadcast-group <name>]...
                   [--visibility-timeout-ms <n>] [--health-addr <host:port>] [--enable-admin]
@@ -1041,6 +1063,12 @@ Notes:
     stream pins its own log: an open file descriptor, an inode/directory entry, and per-stream
     buffers, so once the wire can name streams a client cannot exhaust fds/inodes/RAM by naming
     endless streams. A new named stream past the cap is rejected; the default stream is never counted.
+    --max-open-streams (default 1024, 0 = unlimited) caps the number of OPEN (fd-resident) NAMED
+    streams — the hot-set LRU. When opening one more would exceed it, the least-recently-used stream's
+    log is CLOSED (freeing its fd + buffers) and reopened from disk on demand, so a broker can serve a
+    large stream catalog on modest hardware. Orthogonal to --max-streams (which bounds how many streams
+    may EXIST): an evicted stream still exists and still counts against --max-streams. Never evicts the
+    default stream.
     --group-idle-evict-ms (default 0 = disabled) evicts an idle NAMED work-group from memory after
     it has been idle this many milliseconds, reclaiming its slot against --max-groups. Only a
     fully-caught-up (committed at the head, no acked-ahead set), lease-free, non-key-shared named
@@ -2333,6 +2361,10 @@ struct ServeFlags {
     max_groups: Option<usize>,
     /// The resident NAMED-stream cap (#863); `None` falls back to the profile preset. `0` = unlimited.
     max_streams: Option<usize>,
+    /// The OPEN (fd-resident) NAMED-stream hot-set LRU cap (#565); `None` falls back to the profile
+    /// preset. `0` = unlimited (never evict). Bounds resident fds/buffers to the hot working set,
+    /// closing + reopening logs on demand; orthogonal to `max_streams` (which bounds EXISTENCE).
+    max_open_streams: Option<usize>,
     group_idle_evict_ms: Option<u64>,
     /// The refuse-to-boot RAM ceiling in bytes (#115); `None` falls back to the profile preset (`0`
     /// = off for `balanced`/`throughput`, 64 MiB for `edge-tiny`). When set, the broker refuses to
@@ -2654,6 +2686,9 @@ fn collect_serve_flags(args: &[String]) -> Result<ServeFlags, CliError> {
             }
             "--max-groups" => f.max_groups = Some(take_number("--max-groups", args, &mut i)?),
             "--max-streams" => f.max_streams = Some(take_number("--max-streams", args, &mut i)?),
+            "--max-open-streams" => {
+                f.max_open_streams = Some(take_number("--max-open-streams", args, &mut i)?);
+            }
             "--group-idle-evict-ms" => {
                 f.group_idle_evict_ms = Some(take_number("--group-idle-evict-ms", args, &mut i)?);
             }
@@ -3258,6 +3293,12 @@ fn parse_serve_flags_with_env_and_reader(
             compact: resolve_bool("--compact", f.compact, env)?,
             max_groups: resolve_number("--max-groups", f.max_groups, env, preset.max_groups)?,
             max_streams: resolve_number("--max-streams", f.max_streams, env, preset.max_streams)?,
+            max_open_streams: resolve_number(
+                "--max-open-streams",
+                f.max_open_streams,
+                env,
+                preset.max_open_streams,
+            )?,
             group_idle_evict_ms: resolve_number(
                 "--group-idle-evict-ms",
                 f.group_idle_evict_ms,
@@ -5058,6 +5099,13 @@ struct ServeConfig {
     /// unlimited (the cap is off); the default is non-zero (1024). The default stream is never
     /// counted. A new named stream past the cap is rejected by the engine.
     max_streams: usize,
+    /// The cap on the number of OPEN (fd-resident) NAMED streams — the `max_open_streams` hot-set LRU
+    /// (#565), wired into [`EngineConfig::max_open_streams`]. Bounds resident fds/buffers to the hot
+    /// working set: the least-recently-used stream's log is closed (and reopened from disk on demand)
+    /// when opening one more would exceed this. `0` = unlimited (never evict); the default is non-zero
+    /// (1024). ORTHOGONAL to `max_streams` (which bounds how many streams may EXIST). The default stream
+    /// is never evicted.
+    max_open_streams: usize,
     /// The idle window after which an idle, fully-caught-up, lease-free NAMED work-group is evicted
     /// from memory (refs #277, #240), in MILLISECONDS: the lifecycle reclaim that complements the
     /// `max_groups` cap. `0` = DISABLED (never evict), the default; a non-zero value opts in. The
@@ -5316,6 +5364,7 @@ impl ServeConfig {
             compact: false,
             max_groups: DEFAULT_MAX_GROUPS,
             max_streams: DEFAULT_MAX_STREAMS,
+            max_open_streams: DEFAULT_MAX_OPEN_STREAMS,
             group_idle_evict_ms: DEFAULT_GROUP_IDLE_EVICT_MS,
             ram_ceiling_bytes: DEFAULT_RAM_CEILING_BYTES,
             disk_full_policy: DiskFullPolicyArg::DropNew,
@@ -6825,7 +6874,7 @@ fn materialized_config_line(config: &ServeConfig, addr: &str, data_dir: Option<&
         "materialized-config profile={} profile_schema_version={} addr={addr} \
          data_dir={data_dir} max_connections={} max_segment_bytes={} max_total_bytes={} \
          consumer_credit={} consumer_credit_bytes={} max_in_flight={} max_groups={} \
-         max_streams={} \
+         max_streams={} max_open_streams={} \
          group_idle_evict_ms={} checkpoint_interval={} max_deliver={} \
          allow_unlimited_deliver={} disk_full_policy={policy} visibility_timeout_ms={} \
          max_retained_bytes={} max_age_ms={} max_messages={} health_liveness_window_ms={} \
@@ -6847,6 +6896,7 @@ fn materialized_config_line(config: &ServeConfig, addr: &str, data_dir: Option<&
         config.max_in_flight,
         config.max_groups,
         config.max_streams,
+        config.max_open_streams,
         config.group_idle_evict_ms,
         config.checkpoint_interval,
         config.max_deliver,
@@ -9659,6 +9709,7 @@ fn cmd_serve(
         config.compact,
         config.max_groups,
         config.max_streams,
+        config.max_open_streams,
         config.group_idle_evict_ms,
         // The #115 refuse-to-boot RAM ceiling is read only on the Unix serve path (it wires the
         // engine's ram_ceiling_bytes and drives the boot guard), so the non-Unix stub must consume it
@@ -9931,6 +9982,7 @@ fn open_engine_with<F: Filesystem + Clone>(
             // group past the cap is rejected by the engine before it allocates.
             max_groups: config.max_groups,
             max_streams: config.max_streams,
+            max_open_streams: config.max_open_streams,
             max_metric_streams: ironbus_server::engine::DEFAULT_MAX_METRIC_STREAMS,
             // Idle named-group eviction (refs #277, #240): the lifecycle reclaim that completes the
             // #240 cap. `0` = disabled (off, the default), a non-zero value is the idle window in ms
@@ -13604,6 +13656,7 @@ mod tests {
             compact: false,
             max_groups: DEFAULT_MAX_GROUPS,
             max_streams: DEFAULT_MAX_STREAMS,
+            max_open_streams: DEFAULT_MAX_OPEN_STREAMS,
             group_idle_evict_ms: DEFAULT_GROUP_IDLE_EVICT_MS,
             ram_ceiling_bytes: DEFAULT_RAM_CEILING_BYTES,
             disk_full_policy: DiskFullPolicyArg::DropNew,
@@ -15528,6 +15581,7 @@ mod tests {
                 max_messages: 0,
                 max_groups: DEFAULT_MAX_GROUPS,
                 max_streams: DEFAULT_MAX_STREAMS,
+                max_open_streams: DEFAULT_MAX_OPEN_STREAMS,
                 max_metric_streams: ironbus_server::engine::DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: 0,
                 ram_ceiling_bytes: 0,
@@ -16479,6 +16533,7 @@ mod tests {
                 max_messages: 0,
                 max_groups: DEFAULT_MAX_GROUPS,
                 max_streams: DEFAULT_MAX_STREAMS,
+                max_open_streams: DEFAULT_MAX_OPEN_STREAMS,
                 max_metric_streams: ironbus_server::engine::DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: 0,
                 ram_ceiling_bytes: 0,
@@ -16567,6 +16622,7 @@ mod tests {
                 max_messages: 0,
                 max_groups: DEFAULT_MAX_GROUPS,
                 max_streams: DEFAULT_MAX_STREAMS,
+                max_open_streams: DEFAULT_MAX_OPEN_STREAMS,
                 max_metric_streams: ironbus_server::engine::DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: 0,
                 ram_ceiling_bytes: 0,
@@ -17051,6 +17107,7 @@ mod tests {
             compact: false,
             max_groups: DEFAULT_MAX_GROUPS,
             max_streams: DEFAULT_MAX_STREAMS,
+            max_open_streams: DEFAULT_MAX_OPEN_STREAMS,
             group_idle_evict_ms: DEFAULT_GROUP_IDLE_EVICT_MS,
             ram_ceiling_bytes: DEFAULT_RAM_CEILING_BYTES,
             disk_full_policy: DiskFullPolicyArg::DropNew,
@@ -17160,6 +17217,7 @@ mod tests {
             consumer_credit_bytes: 256 * 1024,
             max_groups: 64,
             max_streams: 64,
+            max_open_streams: 64,
             max_in_flight: 256,
             ram_ceiling_bytes: EDGE_TINY_RAM_CEILING,
             // The edge-tiny preset lowers these (#878); with the shipped 4096 * 100_000 defaults the
@@ -17193,6 +17251,7 @@ mod tests {
             consumer_credit_bytes: 256 * 1024,
             max_groups: 64,
             max_streams: 64,
+            max_open_streams: 64,
             max_in_flight: 256,
             ram_ceiling_bytes: EDGE_TINY_RAM_CEILING,
             dedup_max_ids: 256,
@@ -17225,6 +17284,7 @@ mod tests {
             consumer_credit_bytes: 256 * 1024,
             max_groups: 64,
             max_streams: 64,
+            max_open_streams: 64,
             max_in_flight: 256,
             ram_ceiling_bytes: EDGE_TINY_RAM_CEILING,
             ..validation_config()
@@ -17276,6 +17336,7 @@ mod tests {
             consumer_credit_bytes: 256 * 1024,
             max_groups: 64,
             max_streams: 64,
+            max_open_streams: 64,
             max_in_flight: 256,
             ram_ceiling_bytes: EDGE_TINY_RAM_CEILING,
             // The edge-tiny preset LOWERS the dedup caps (#878) so the charged dedup term (~11 MiB)
@@ -18778,6 +18839,65 @@ mod tests {
         assert!(
             USAGE.contains("--max-streams"),
             "USAGE must document --max-streams"
+        );
+    }
+
+    // ----- max_open_streams hot-set LRU flag (#565) -----
+
+    #[test]
+    fn serve_accepts_a_zero_max_open_streams_meaning_unlimited() {
+        // `0` = unlimited (never evict), matching the `0` = off convention of the other bounds. An
+        // explicit 0 must parse the same as the default, so the only failure is the unrelated bind
+        // path, never EXIT_USAGE.
+        let mut buf = Vec::new();
+        let e = run(
+            &[
+                "serve".to_string(),
+                "--data-dir".to_string(),
+                "/tmp/ironbus-cli-mos0-never-served".to_string(),
+                "--max-open-streams".to_string(),
+                "0".to_string(),
+                "--addr".to_string(),
+                "127.0.0.1:1".to_string(),
+            ],
+            &mut buf,
+        )
+        .unwrap_err();
+        assert_ne!(
+            e.exit_code(),
+            EXIT_USAGE,
+            "an explicit --max-open-streams 0 (unlimited) parses and validates: {e}"
+        );
+        let _ = std::fs::remove_dir_all("/tmp/ironbus-cli-mos0-never-served");
+    }
+
+    #[test]
+    fn max_open_streams_resolves_flag_over_preset_over_default() {
+        // The resolution precedence (#565, flag > preset > default): the flag wins; absent the flag the
+        // edge-tiny preset's LOWERED 64 flows through; absent any profile the balanced default (1024).
+        let c = parse_serve_flags(&serve_args(&["--max-open-streams", "9"]))
+            .unwrap()
+            .config;
+        assert_eq!(c.max_open_streams, 9, "the flag value wins");
+        let c = parse_serve_flags(&serve_args(&["--profile", "edge-tiny"]))
+            .unwrap()
+            .config;
+        assert_eq!(
+            c.max_open_streams, 64,
+            "edge-tiny lowers the open-stream hot-set cap"
+        );
+        let c = parse_serve_flags(&serve_args(&[])).unwrap().config;
+        assert_eq!(
+            c.max_open_streams, DEFAULT_MAX_OPEN_STREAMS,
+            "the balanced default (1024)"
+        );
+    }
+
+    #[test]
+    fn usage_lists_the_max_open_streams_flag() {
+        assert!(
+            USAGE.contains("--max-open-streams"),
+            "USAGE must document --max-open-streams"
         );
     }
 
@@ -20816,6 +20936,7 @@ eImsLe+T6lqrpgIgENKsK8qL9U5HkY7evGZM+CZNPHezUtmVVeASiOLgQO8=
                 max_messages: 0,
                 max_groups: DEFAULT_MAX_GROUPS,
                 max_streams: DEFAULT_MAX_STREAMS,
+                max_open_streams: DEFAULT_MAX_OPEN_STREAMS,
                 max_metric_streams: ironbus_server::engine::DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: 0,
                 ram_ceiling_bytes: 0,
@@ -20903,6 +21024,7 @@ eImsLe+T6lqrpgIgENKsK8qL9U5HkY7evGZM+CZNPHezUtmVVeASiOLgQO8=
                 max_messages: 0,
                 max_groups: DEFAULT_MAX_GROUPS,
                 max_streams: DEFAULT_MAX_STREAMS,
+                max_open_streams: DEFAULT_MAX_OPEN_STREAMS,
                 max_metric_streams: ironbus_server::engine::DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: 0,
                 ram_ceiling_bytes: 0,

--- a/crates/ironbus-client-async/tests/roundtrip.rs
+++ b/crates/ironbus-client-async/tests/roundtrip.rs
@@ -46,6 +46,7 @@ fn open_engine() -> Engine<InMemoryFs, SystemClock> {
             max_groups: DEFAULT_MAX_GROUPS,
             // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
             max_streams: 0,
+            max_open_streams: 0,
             max_metric_streams: 1024,
             group_idle_evict_ms: DEFAULT_GROUP_IDLE_EVICT_MS,
             ram_ceiling_bytes: 0,

--- a/crates/ironbus-client/src/lib.rs
+++ b/crates/ironbus-client/src/lib.rs
@@ -4241,6 +4241,7 @@ mod tests {
                 max_groups: DEFAULT_MAX_GROUPS,
                 // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
                 max_streams: 0,
+                max_open_streams: 0,
                 max_metric_streams: 1024,
                 group_idle_evict_ms: DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
@@ -4305,6 +4306,7 @@ mod tests {
                 max_groups: DEFAULT_MAX_GROUPS,
                 // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
                 max_streams: 0,
+                max_open_streams: 0,
                 max_metric_streams: 1024,
                 group_idle_evict_ms: DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
@@ -4396,6 +4398,7 @@ mod tests {
                 max_messages: 0,
                 max_groups: DEFAULT_MAX_GROUPS,
                 max_streams: 0,
+                max_open_streams: 0,
                 max_metric_streams: 1024,
                 group_idle_evict_ms: DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
@@ -8078,6 +8081,7 @@ toYtkjmdU2eQ2pK/3gM=
                 max_groups: DEFAULT_MAX_GROUPS,
                 // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
                 max_streams: 0,
+                max_open_streams: 0,
                 max_metric_streams: 1024,
                 group_idle_evict_ms: DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
@@ -8401,6 +8405,7 @@ toYtkjmdU2eQ2pK/3gM=
             max_groups: DEFAULT_MAX_GROUPS,
             // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
             max_streams: 0,
+            max_open_streams: 0,
             max_metric_streams: 1024,
             group_idle_evict_ms: DEFAULT_GROUP_IDLE_EVICT_MS,
             ram_ceiling_bytes: 0,

--- a/crates/ironbus-core/src/lease.rs
+++ b/crates/ironbus-core/src/lease.rs
@@ -208,6 +208,29 @@ impl LeaseTable {
             .collect()
     }
 
+    /// The FULL durable attempt state: the live leases' delivery counts unioned with the CARRIED
+    /// (recovered-but-not-yet-re-claimed) attempt counts (#358/#565), as `(offset, attempt)` pairs in
+    /// ascending-offset order. Unlike [`attempt_counts`](Self::attempt_counts) — which snapshots the
+    /// live leases ONLY — this ALSO includes `carried`, so a snapshot written while a poison count is
+    /// still carried (a stream RECOVERED from its `attempts.ckpt` but NOT yet re-polled, so the count
+    /// sits in `carried` with `leases` empty) does not silently drop that count to zero.
+    ///
+    /// This is the snapshot the hot-set-LRU EVICTION path persists (#565): an evict must never LOWER a
+    /// group's durable attempt count, or a poison could reset its delivery count and escape its
+    /// `MaxDeliver` cap. A carried entry and a live lease for the SAME offset are disjoint in practice
+    /// (the first re-claim moves an offset out of `carried` into `leases`); if both ever held a count
+    /// the MAXIMUM is kept, so the persisted count can only rise, never regress. Bounded by
+    /// `max_in_flight` like both inputs.
+    #[must_use]
+    pub fn all_attempt_counts(&self) -> Vec<(u64, u32)> {
+        let mut merged: BTreeMap<u64, u32> = self.carried.clone();
+        for (&off, lease) in &self.leases {
+            let slot = merged.entry(off).or_insert(0);
+            *slot = (*slot).max(lease.deliveries);
+        }
+        merged.into_iter().collect()
+    }
+
     /// The number of messages currently tracked as in-flight (granted but not yet acked,
     /// whether or not their visibility has expired).
     #[must_use]
@@ -866,6 +889,39 @@ mod tests {
             counts,
             vec![(2, 2)],
             "an acked offset clears its durable count"
+        );
+    }
+
+    #[test]
+    fn all_attempt_counts_unions_live_leases_with_carried_and_never_drops_a_carried_count() {
+        // #565: the eviction-safe snapshot must include CARRIED (recovered-but-not-yet-re-claimed)
+        // counts, not just live leases — else evicting a recovered-not-repolled poison would persist an
+        // EMPTY snapshot and reset its delivery count, letting it escape MaxDeliver.
+        let mut t = LeaseTable::new(cfg());
+        // Two poison counts recovered from disk into `carried`, with NO live lease yet.
+        t.resume_attempts([(off(0).get(), 4), (off(5).get(), 2)]);
+        // The live-leases-only snapshot is EMPTY here — persisting IT would clobber the durable counts.
+        assert!(
+            t.attempt_counts().is_empty(),
+            "no live lease yet — the clobber-risk state the eviction path must not persist blindly"
+        );
+        // The union snapshot preserves BOTH carried counts.
+        let mut all = t.all_attempt_counts();
+        all.sort_unstable();
+        assert_eq!(all, vec![(0, 4), (5, 2)]);
+        // Claim offset 0: it moves from `carried` to a live lease at deliveries = 4 + 1 = 5 (and its
+        // carried entry is consumed). Offset 5 stays carried.
+        match t.claim(off(0), 0) {
+            Claim::Granted { deliveries, .. } => assert_eq!(deliveries, 5),
+            other => panic!("expected Granted, got {other:?}"),
+        }
+        // The union now reflects the live lease (offset 0 -> 5) AND the still-carried offset 5 -> 2.
+        let mut all = t.all_attempt_counts();
+        all.sort_unstable();
+        assert_eq!(
+            all,
+            vec![(0, 5), (5, 2)],
+            "leases ∪ carried: a claimed offset's live count and an un-claimed offset's carried count"
         );
     }
 

--- a/crates/ironbus-server/src/actor.rs
+++ b/crates/ironbus-server/src/actor.rs
@@ -3337,6 +3337,7 @@ mod tests {
             max_groups: DEFAULT_MAX_GROUPS,
             // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
             max_streams: 0,
+            max_open_streams: 0,
             max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
             group_idle_evict_ms: DEFAULT_GROUP_IDLE_EVICT_MS,
             ram_ceiling_bytes: 0,

--- a/crates/ironbus-server/src/engine.rs
+++ b/crates/ironbus-server/src/engine.rs
@@ -387,6 +387,24 @@ pub struct EngineConfig {
     /// default stream are always allowed (the default does not count). `0` means UNLIMITED, matching the
     /// other `0` = off bounds; the default is [`DEFAULT_MAX_STREAMS`] (1024), an edge profile lowers it.
     pub max_streams: usize,
+    /// The cap on the number of OPEN (fd-resident) NAMED streams — the `max_open_streams` hot-set LRU
+    /// (#565, M2-I4). A broker with many named streams cannot keep every per-stream log open (each pins
+    /// a file descriptor + its active-segment write buffers); this bounds the OPEN working set. When
+    /// opening (or reopening) a named stream would exceed this cap, the engine EVICTS the
+    /// least-recently-used open stream — flushing its durable state (its committed cursor #681, its DLQ
+    /// #1110, its in-flight attempt counts) and CLOSING its `Log` (releasing the fd + buffers) — while
+    /// leaving its on-disk `streams/<hex>/` subtree fully intact, then LAZILY REOPENS + per-stream
+    /// recovers it on its next access. An evict/reopen cycle is behaviorally identical to a per-stream
+    /// restart: no committed record is lost, re-delivered, or double-dead-lettered.
+    ///
+    /// ORTHOGONAL to [`EngineConfig::max_streams`]: `max_streams` bounds how many distinct streams may
+    /// EXIST (inodes/dirs — a fail-closed REJECT of a NEW stream), while `max_open_streams` bounds how
+    /// many are RESIDENT at once (fds/RAM — a transparent EVICT-and-reopen), so a deployment can allow a
+    /// large stream catalog yet keep only a bounded hot set open. The DEFAULT stream `""` is served by
+    /// the root [`Engine::log`] and is NEVER evicted (it is not counted here). `0` means UNLIMITED
+    /// (never evict — every declared stream stays resident, the pre-#565 behavior), matching the other
+    /// `0` = off bounds; the default is [`DEFAULT_MAX_OPEN_STREAMS`] (1024), an edge profile lowers it.
+    pub max_open_streams: usize,
     /// The per-NAMED-stream CONSUMER-METRIC cardinality cap (#600, the #681 named-stream metrics
     /// follow-up): how many distinct NAMED streams each get their own labelled per-stream consumer
     /// series (`ironbus_stream_{delivered,acked,dead_lettered,filtered}_total{stream}`) on `/metrics`
@@ -1727,6 +1745,12 @@ pub struct EngineConfigSnapshot {
     /// [`EngineError::TooManyStreams`] BEFORE any `Log` is opened; an already-resident stream and the
     /// default stream are always allowed. The default stream does not count toward the cap.
     pub max_streams: usize,
+    /// The cap on the number of OPEN (fd-resident) NAMED streams — the `max_open_streams` hot-set LRU
+    /// (#565, `0` = unlimited / never evict). Bounds the resident file descriptors + segment buffers to
+    /// the hot working set; the least-recently-used stream's log is closed (and reopened from disk on
+    /// demand) when opening one more would exceed this. Orthogonal to `max_streams` (which bounds how
+    /// many streams may EXIST); the default stream is never evicted and does not count.
+    pub max_open_streams: usize,
     /// The idle-eviction window for a named group in NANOSECONDS (`0` = disabled).
     pub group_idle_evict_nanos: u64,
     /// The lease visibility timeout in nanoseconds.
@@ -2037,6 +2061,19 @@ pub const DEFAULT_MAX_GROUPS: usize = 1024;
 /// an fd + dir + `Log` per name until fds/inodes/RAM are exhausted. `0` = unlimited; an edge profile
 /// lowers it. See [`EngineConfig::max_streams`].
 pub const DEFAULT_MAX_STREAMS: usize = 1024;
+
+/// The default cap on the number of OPEN (fd-resident) NAMED streams — the `max_open_streams` hot-set
+/// LRU bound (#565, M2-I4). A broker with many named streams cannot keep every per-stream log open
+/// (each pins a file descriptor + segment write buffers); this bounds the OPEN working set and closes
+/// the least-recently-used stream's log when opening one more would exceed the cap, reopening it from
+/// disk on demand. It is ORTHOGONAL to [`DEFAULT_MAX_STREAMS`]: `max_streams` bounds how many distinct
+/// streams may EXIST (inodes/dirs, a fail-closed REJECT), while `max_open_streams` bounds how many are
+/// RESIDENT at once (fds/RAM, a transparent EVICT-and-reopen), so a deployment can allow a very large
+/// stream catalog yet keep only a bounded hot set open. `0` = UNLIMITED (never evict — every declared
+/// stream stays resident, the pre-#565 behavior), matching the `0` = off convention of the other
+/// bounds. The default matches [`DEFAULT_MAX_STREAMS`] (1024); an edge profile lowers it. See
+/// [`EngineConfig::max_open_streams`].
+pub const DEFAULT_MAX_OPEN_STREAMS: usize = 1024;
 
 /// The default per-NAMED-stream CONSUMER-METRIC cardinality cap (#600, closing the #681 named-stream
 /// metrics follow-up): the number of distinct NAMED streams that each get their own labelled
@@ -2403,53 +2440,74 @@ fn recover_named_stream_groups<F: Filesystem, C: Clock>(
         let Some(log) = streams.get(&id) else {
             continue;
         };
-        let flushed = log.flushed_offset().get();
-        let fs = log.filesystem();
-        let mut ns = NamedStream::new();
-        // Discover every durable group of THIS stream from BOTH its cursor file AND its attempts file
-        // (the #681 DLQ follow-up brings the default stream's #358 union to the named path): a group
-        // whose poison was in flight but never committed has an `attempts-<hex>.ckpt` yet no
-        // `cursor-<hex>.ckpt` (the cursor write is gated on the watermark advancing), so iterating only
-        // cursor files would orphan its durable attempt counts and re-poison from attempt 1 after a
-        // crash. The union of the two filename sets, with a fresh cursor for an attempts-only group,
-        // recovers both — exactly as `recover_named_groups` does for the default stream's named groups.
-        let mut names = std::collections::BTreeSet::new();
-        for file in fs.list()? {
-            if let Some(group) = ironbus_storage::naming::parse_cursor_checkpoint_name(&file) {
-                names.insert(group);
-            } else if let Some(group) = parse_group_attempts_name(&file) {
-                names.insert(group);
-            }
-        }
-        for group in names {
-            // A named-stream group is always non-empty (`poll_in_stream` validates it), so a bare
-            // `cursor.ckpt` / `attempts.ckpt` (empty group) in a stream subdir is foreign — skip
-            // anything that fails the group-name rule rather than resurrect it.
-            if validate_group_name(&group).is_err() {
-                continue;
-            }
-            // Resume the cursor from `cursor-<hex>.ckpt` if present, else start fresh at offset 0 (the
-            // attempts-only case, a poison in flight but never committed). Then seed the durable
-            // per-message attempt counts from `attempts-<hex>.ckpt`, clamped exactly like the default
-            // stream (#358), so `MaxDeliver` and the poison-cap survive a restart in every named stream.
-            let cursor_name = group_checkpoint_name(&group);
-            let cursor = if fs.exists(&cursor_name)? {
-                let (_, recovered) = Checkpoint::open(fs.open(&cursor_name)?)?;
-                resume_cursor_from_snapshot(recovered.as_deref(), flushed)
-            } else {
-                AckCursor::new()
-            };
-            let committed = cursor.committed().get();
-            let recovered_a = read_group_attempts(fs, &group)?;
-            let g = resume_work_group(cursor, recovered_a.as_deref(), lease, opened_at, flushed);
-            ns.group_last_checkpointed.insert(group.clone(), committed);
-            ns.groups.insert(group, g);
-        }
+        let ns = recover_one_named_stream(log, lease, opened_at)?;
+        // A stream only ever produced-to (no cursor/attempts files) recovers an EMPTY `NamedStream`; it
+        // stays absent from the map (lazy-on-first-consume) exactly as before.
         if !ns.groups.is_empty() {
             out.insert(id, ns);
         }
     }
     Ok(out)
+}
+
+/// Recovers ONE named stream's durable per-group consumer state (committed cursor #681 + in-flight
+/// attempt counts #358) from that stream's own `streams/<hex(name)>/` subdir — the per-stream body of
+/// [`recover_named_stream_groups`], factored out so the hot-set LRU REOPEN path (#565) resumes an
+/// evicted stream's cursors by EXACTLY the same recovery boot runs. A reopen is therefore behaviorally
+/// a per-stream restart: the returned [`NamedStream`] carries the committed watermark (so committed
+/// records never redeliver) and the carried attempt counts (so a poison never re-counts from 1), and an
+/// empty result (a produce-only / genuinely-new stream) is a fresh, no-groups `NamedStream`.
+///
+/// # Errors
+/// Propagates a storage error from listing the stream's subdir or opening/reading a checkpoint file.
+fn recover_one_named_stream<F: Filesystem, C: Clock>(
+    log: &Log<F, C>,
+    lease: LeaseConfig,
+    opened_at: u64,
+) -> Result<NamedStream, EngineError> {
+    let flushed = log.flushed_offset().get();
+    let fs = log.filesystem();
+    let mut ns = NamedStream::new();
+    // Discover every durable group of THIS stream from BOTH its cursor file AND its attempts file
+    // (the #681 DLQ follow-up brings the default stream's #358 union to the named path): a group
+    // whose poison was in flight but never committed has an `attempts-<hex>.ckpt` yet no
+    // `cursor-<hex>.ckpt` (the cursor write is gated on the watermark advancing), so iterating only
+    // cursor files would orphan its durable attempt counts and re-poison from attempt 1 after a
+    // crash. The union of the two filename sets, with a fresh cursor for an attempts-only group,
+    // recovers both — exactly as `recover_named_groups` does for the default stream's named groups.
+    let mut names = std::collections::BTreeSet::new();
+    for file in fs.list()? {
+        if let Some(group) = ironbus_storage::naming::parse_cursor_checkpoint_name(&file) {
+            names.insert(group);
+        } else if let Some(group) = parse_group_attempts_name(&file) {
+            names.insert(group);
+        }
+    }
+    for group in names {
+        // A named-stream group is always non-empty (`poll_in_stream` validates it), so a bare
+        // `cursor.ckpt` / `attempts.ckpt` (empty group) in a stream subdir is foreign — skip
+        // anything that fails the group-name rule rather than resurrect it.
+        if validate_group_name(&group).is_err() {
+            continue;
+        }
+        // Resume the cursor from `cursor-<hex>.ckpt` if present, else start fresh at offset 0 (the
+        // attempts-only case, a poison in flight but never committed). Then seed the durable
+        // per-message attempt counts from `attempts-<hex>.ckpt`, clamped exactly like the default
+        // stream (#358), so `MaxDeliver` and the poison-cap survive a restart in every named stream.
+        let cursor_name = group_checkpoint_name(&group);
+        let cursor = if fs.exists(&cursor_name)? {
+            let (_, recovered) = Checkpoint::open(fs.open(&cursor_name)?)?;
+            resume_cursor_from_snapshot(recovered.as_deref(), flushed)
+        } else {
+            AckCursor::new()
+        };
+        let committed = cursor.committed().get();
+        let recovered_a = read_group_attempts(fs, &group)?;
+        let g = resume_work_group(cursor, recovered_a.as_deref(), lease, opened_at, flushed);
+        ns.group_last_checkpointed.insert(group.clone(), committed);
+        ns.groups.insert(group, g);
+    }
+    Ok(ns)
 }
 
 /// Reconstructs a group's carried attempt counts from a recovered `attempts.ckpt` payload, clamped
@@ -2907,6 +2965,22 @@ pub struct Engine<F: Filesystem, C: Clock> {
     /// with [`EngineError::TooManyStreams`] before its `Log` is opened, bounding the fds/inodes/RAM one
     /// client can pin. `0` means unlimited. See [`EngineConfig::max_streams`].
     max_streams: usize,
+    /// The cap on the number of OPEN (fd-resident) NAMED streams — the `max_open_streams` hot-set LRU
+    /// (#565): when opening one more would exceed this, the least-recently-used open stream is EVICTED
+    /// (its durable state flushed, its `Log` closed) and reopened from disk on demand. `0` = unlimited
+    /// (never evict). ORTHOGONAL to `max_streams` (which bounds how many streams may EXIST, tracked by
+    /// `known_named_streams`); this bounds only the RESIDENT set. See [`EngineConfig::max_open_streams`],
+    /// [`Engine::ensure_named_stream_open`], and [`Engine::evict_named_stream`].
+    max_open_streams: usize,
+    /// The set of EVERY named stream that has ever been declared (produced-to / declared / bound),
+    /// whether or not it is currently OPEN (#565): the authoritative "does this stream EXIST" set that
+    /// SURVIVES a hot-set LRU eviction (which closes the `Log` but leaves the on-disk subtree and this
+    /// entry). It decouples the two caps: `max_streams` (#863) is enforced against `known_named_streams.len()`
+    /// (distinct streams that EXIST), NOT the shrinking OPEN count, so eviction can never let a flood of
+    /// distinct stream names slip past the existence cap; and a consume/ack of an EVICTED stream is
+    /// recognized as KNOWN (reopen it) rather than UNKNOWN (reject it). Seeded at open from every
+    /// recovered named stream and bounded by `max_streams`. The default stream `""` is never a member.
+    known_named_streams: std::collections::BTreeSet<StreamId>,
     /// The idle window in NANOSECONDS after which a fully-caught-up, lease-free NAMED group is
     /// evicted from memory (#277): the configured `group_idle_evict_ms` converted to nanoseconds at
     /// open (the clock seam is in nanoseconds). `0` means DISABLED (never evict). The sweep
@@ -3405,6 +3479,15 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         // evaluated in source order (a later read of `config` would then be a
         // borrow-after-partial-move). All knobs default to inert.
         let backpressure = Backpressure::from_engine_config(&config);
+        // Seed the "which named streams EXIST" set (#565) from every recovered named stream, so the
+        // existence cap (`max_streams`) and the reopen-vs-reject decision are correct BEFORE any client
+        // touches a stream. This survives a hot-set LRU eviction (which drops the open `Log`), so an
+        // evicted-then-consumed stream is recognized as KNOWN (reopened), never UNKNOWN (rejected).
+        let known_named_streams: std::collections::BTreeSet<StreamId> = streams
+            .stream_ids()
+            .into_iter()
+            .filter(|id| !id.is_default())
+            .collect();
         let mut engine = Engine {
             log,
             // The per-named-stream LOG substrate (#676), opened above; recovered named streams (if
@@ -3448,6 +3531,11 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
             disk_full_policy: config.disk_full_policy,
             max_groups: config.max_groups,
             max_streams: config.max_streams,
+            // The hot-set LRU open cap (#565); `0` = unlimited (never evict). Boot-time recovery below
+            // opens EVERY on-disk named stream, so if that exceeds the cap the engine immediately evicts
+            // the least-recently-used ones down to it (their state is already durable on disk).
+            max_open_streams: config.max_open_streams,
+            known_named_streams,
             // The idle-eviction window (#277), converted from milliseconds to the clock seam's
             // nanoseconds and saturated rather than overflowed. `0` (disabled) stays 0, so the
             // sweep is a no-op unless an operator opts in.
@@ -3564,6 +3652,15 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         // past a record the log actually holds (a snapshot written slightly ahead of a torn-tail
         // recovery degrades to at-least-once for that producer rather than returning a phantom offset).
         engine.seed_producer_seq_from_recovered(recovered_seq.as_deref(), flushed, opened_at);
+
+        // ENFORCE the hot-set LRU open cap at boot (#565): recovery above opened EVERY on-disk named
+        // stream, which may exceed `max_open_streams`. Evict the least-recently-used ones down to the
+        // cap so the resident-fd invariant (`open named streams <= max_open_streams`) holds immediately
+        // after open, not only once runtime traffic drives an eviction. Each victim's state was just
+        // recovered from disk and is already durable, so eviction here just re-checkpoints (a no-op when
+        // unchanged) and releases the fd + buffers; the stream reopens from disk on its next access.
+        engine.evict_open_streams_down_to_cap()?;
+
         Ok(engine)
     }
 
@@ -4709,14 +4806,13 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
             });
         }
         let id = StreamId::named(stream)?;
-        // #863: cap the resident-stream COUNT before opening a new stream's log (fd/inode/RAM bound).
+        // #863: cap the DISTINCT-stream count before materializing a NEW stream (inode/dir bound).
         self.check_stream_cap(&id)?;
-        // Declare-on-first-produce: open the named stream's independent log under `streams/<hex>/`
-        // (idempotent — a no-op if already open) and mirror it in the per-stream consumer state.
-        self.streams.declare(&id).map_err(EngineError::Storage)?;
-        self.named_streams
-            .entry(id.clone())
-            .or_insert_with(NamedStream::new);
+        // Declare-on-first-produce THROUGH the hot-set LRU (#565): open (or lazily REOPEN + per-stream
+        // recover) this named stream's independent log under `streams/<hex>/`, evicting the
+        // least-recently-used open stream first if opening one more would exceed `max_open_streams`, and
+        // mark it most-recently-used. Idempotent for an already-open stream (just refreshes its recency).
+        self.ensure_named_stream_open(&id)?;
         // Append to THIS stream's log (a single-`Log` append; appending to X never touches Y, so
         // per-record cost stays flat as streams grow), PERSISTING the subject (#594-B) so a filtered
         // consumer on this named stream can match it, then make it durable with the cross-stream
@@ -5508,22 +5604,27 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
             return Ok(false);
         }
         let id = StreamId::named(stream)?;
-        // #863: cap the resident-stream COUNT before opening a new stream's log (fd/inode/RAM bound).
+        // #863: cap the DISTINCT-stream count before materializing a NEW stream (inode/dir bound).
         self.check_stream_cap(&id)?;
-        let created = self.streams.declare(&id).map_err(EngineError::Storage)?;
-        // Mirror the per-stream consumer state so a subsequent consume resolves the same way a
-        // produce-declared stream does (idempotent: an existing entry is left untouched).
-        self.named_streams
-            .entry(id)
-            .or_insert_with(NamedStream::new);
+        // Open (or reopen) through the hot-set LRU (#565); `created` is whether this is the stream's
+        // FIRST-ever declaration — a re-declare of an existing stream (including one the LRU evicted) is
+        // `false`, since reopening an evicted stream creates no new distinct stream.
+        let created = self.ensure_named_stream_open(&id)?;
         Ok(created)
     }
 
-    /// Whether the named stream `stream` EXISTS (is open) (#588): the engine-side of the `StreamInfo`
-    /// wire verb's existence bit. The default stream (the EMPTY name) ALWAYS exists. A named stream
-    /// exists once it has been declared (via [`Engine::declare_stream`] or declare-on-first-produce).
-    /// A malformed named name reports `false` (it can never have been declared), never an error — the
-    /// wire layer fails a malformed id closed before this is reached, so this is a pure existence read.
+    /// Whether the named stream `stream` EXISTS (#588): the engine-side of the `StreamInfo` wire verb's
+    /// existence bit AND the filtered-subscribe existence gate. The default stream (the EMPTY name)
+    /// ALWAYS exists. A named stream exists once it has been declared (via [`Engine::declare_stream`] or
+    /// declare-on-first-produce). A malformed named name reports `false` (it can never have been
+    /// declared), never an error — the wire layer fails a malformed id closed before this is reached, so
+    /// this is a pure existence read.
+    ///
+    /// Tested against `known_named_streams` (existence), NOT the OPEN set (#565): a stream the hot-set
+    /// LRU EVICTED still EXISTS (its on-disk subtree is intact, it reopens on next access), so it must
+    /// report `true` — else a subscribe or `StreamInfo` on an evicted stream would wrongly see it as
+    /// gone. Use [`is_named_stream_resident`](Self::is_named_stream_resident) for the narrower "is its
+    /// log currently OPEN" question.
     #[must_use]
     pub fn stream_exists(&self, stream: &str) -> bool {
         if stream.is_empty() {
@@ -5532,7 +5633,24 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         let Ok(id) = StreamId::named(stream) else {
             return false;
         };
-        self.streams.get(&id).is_some()
+        self.known_named_streams.contains(&id)
+    }
+
+    /// Whether the named stream `stream`'s log is currently OPEN (fd-resident) rather than evicted by
+    /// the `max_open_streams` hot-set LRU (#565). The default stream is always resident. Distinct from
+    /// [`stream_exists`](Self::stream_exists): an EVICTED stream still EXISTS (reopening on next access)
+    /// but is not resident. This is the clean seam the #566 per-stream retention respects (retention
+    /// acts on the OPEN working set), and it is what the resident-stream tests observe. A malformed or
+    /// never-declared name is not resident.
+    #[must_use]
+    pub fn is_named_stream_resident(&self, stream: &str) -> bool {
+        if stream.is_empty() {
+            return true;
+        }
+        let Ok(id) = StreamId::named(stream) else {
+            return false;
+        };
+        self.streams.is_open(&id)
     }
 
     /// Polls the stream named `stream` in work-group `group` (#676): the default stream routes to
@@ -5606,6 +5724,14 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         now: u64,
     ) -> Result<(StreamId, u64), EngineError> {
         let id = StreamId::named(stream)?;
+        // Reopen a KNOWN stream the hot-set LRU evicted (resuming its durable cursors/attempts from
+        // disk), or reject a never-declared one (#565). A consume never CREATES a stream (only a
+        // produce/declare/bind does), so an unknown stream is a typed reject, never a silent empty read.
+        if !self.ensure_named_stream_resident(&id)? {
+            return Err(EngineError::UnknownStream {
+                name: stream.to_string(),
+            });
+        }
         let Some(flushed) = self.streams.get(&id).map(|log| log.flushed_offset().get()) else {
             return Err(EngineError::UnknownStream {
                 name: stream.to_string(),
@@ -6115,6 +6241,13 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         let Ok(id) = StreamId::named(stream) else {
             return AckResult::Fenced;
         };
+        // An ack IS an access: keep an actively-acked OPEN stream hot in the hot-set LRU (#565). We do
+        // NOT reopen on ack — an ack of an EVICTED stream is Fenced below because its in-flight lease was
+        // dropped on eviction (exactly as a restart drops in-flight leases), so the message simply
+        // redelivers on the stream's next poll rather than committing against a stale token.
+        if self.streams.is_open(&id) {
+            self.streams.touch(&id);
+        }
         let now = self.streams.get(&id).map_or(0, Log::now_monotonic);
         let Some(named) = self.named_streams.get_mut(&id) else {
             return AckResult::Fenced;
@@ -6206,23 +6339,201 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
     /// new resource); `max_streams == 0` disables the cap. The caller passes the NAMED stream id (the
     /// default stream is materialized at open and never routed through here).
     ///
-    /// Residency is tested against `self.streams` (the authoritative open-stream map that
-    /// [`named_stream_count`](Self::named_stream_count) also counts), NOT the lazily-populated
-    /// `self.named_streams` consumer-state cache: a stream RECOVERED at open lives in `self.streams`
-    /// but is absent from `named_streams` until first touched. Reading `named_streams` here would count
-    /// a recovered stream against the cap yet treat a produce TO it as "new", so an operator who
-    /// restarted with `max_streams`-or-more on-disk streams could never produce to them again (the
-    /// produce is rejected BEFORE the `or_insert` that would register it — a permanent wedge). Reading
-    /// the same map the count comes from keeps the exemption and the count consistent.
+    /// Existence is tested against `self.known_named_streams` — the set of every named stream that has
+    /// ever been declared, whether or not it is currently OPEN (#565) — NOT the shrinking OPEN count
+    /// ([`named_stream_count`](Self::named_stream_count)). This is what keeps the two caps ORTHOGONAL:
+    /// once the hot-set LRU can CLOSE a stream's log, the open count no longer equals the number of
+    /// distinct streams that EXIST, so counting the open set would let a flood of distinct stream names
+    /// slip past the existence cap (each one evicting a predecessor yet leaving its `streams/<hex>/`
+    /// subtree on disk — unbounded inode growth, the exact #863 attack). Counting `known_named_streams`
+    /// bounds distinct EXISTENCE (inodes/dirs) while `max_open_streams` independently bounds RESIDENCE
+    /// (fds/RAM). An ALREADY-KNOWN stream (including one the LRU evicted) is always allowed — reopening
+    /// it creates no new distinct stream. `max_streams == 0` disables the cap.
     fn check_stream_cap(&self, id: &StreamId) -> Result<(), EngineError> {
         if self.max_streams != 0
-            && self.streams.get(id).is_none()
-            && self.named_stream_count() >= self.max_streams
+            && !self.known_named_streams.contains(id)
+            && self.known_named_streams.len() >= self.max_streams
         {
             return Err(EngineError::TooManyStreams {
                 max: self.max_streams,
             });
         }
+        Ok(())
+    }
+
+    // ===================================================================================
+    // THE max_open_streams HOT-SET LRU (#565, M2-I4): open-on-demand / evict-LRU / reopen-from-disk.
+    //
+    // A broker with many named streams cannot keep every per-stream log open (each pins an fd + its
+    // active-segment write buffers). `max_open_streams` bounds the OPEN working set: opening one more
+    // stream than the cap allows EVICTS the least-recently-used open stream — flushing its durable
+    // state (cursor #681, DLQ #1110, attempt counts #358) and closing its `Log` — then that stream
+    // REOPENS from disk on its next access. An evict/reopen cycle is behaviorally a per-stream restart:
+    // no committed record is lost, redelivered, or double-dead-lettered. The DEFAULT stream `""` is
+    // served by `self.log` and is NEVER evicted. `max_open_streams == 0` disables eviction entirely
+    // (every declared stream stays resident, the pre-#565 behavior).
+    // ===================================================================================
+
+    /// Ensures NAMED stream `id` is OPEN and marks it MOST-recently-used (#565), OPENING it if needed —
+    /// which for a KNOWN (previously-declared) stream the LRU evicted is a lazy REOPEN + per-stream
+    /// recovery from disk, and for a genuinely-new stream is a first open. When opening would exceed
+    /// `max_open_streams`, the least-recently-used open stream is EVICTED first (durable state flushed,
+    /// log closed) to make room. Returns whether the stream was NEWLY created (its first-ever open) vs
+    /// already-existing (already open, or a reopen of an evicted stream).
+    ///
+    /// This is the single choke point every CREATE path (produce / declare / bind) routes through, so
+    /// the open-set invariant, the LRU order, and the existence set (`known_named_streams`) are
+    /// maintained in exactly one place. The caller has already enforced the EXISTENCE cap
+    /// ([`check_stream_cap`](Self::check_stream_cap)) for a new stream.
+    ///
+    /// # Errors
+    /// Propagates a storage error from evicting a victim, opening the stream's log, or re-recovering
+    /// its durable groups.
+    fn ensure_named_stream_open(&mut self, id: &StreamId) -> Result<bool, EngineError> {
+        debug_assert!(
+            !id.is_default(),
+            "the default stream is never routed through the LRU"
+        );
+        if self.streams.is_open(id) {
+            // Already resident: just refresh its recency so an actively-used stream is not the next
+            // eviction victim (the LRU-reorders-on-access property).
+            self.streams.touch(id);
+            return Ok(false);
+        }
+        // A KNOWN stream that is not open was EVICTED; its durable consumer state must be re-recovered
+        // from disk on reopen (else its committed cursor would reset to 0 and mass-redeliver — the exact
+        // bug this feature must not introduce). A genuinely-new stream has no such state.
+        let known = self.known_named_streams.contains(id);
+        // Make room BEFORE opening: evict the LRU until opening one more stays within the cap.
+        self.evict_to_open_cap()?;
+        // Open (first open) or REOPEN (recovering the durable log from disk) the stream's `Log`.
+        self.streams.declare(id).map_err(EngineError::Storage)?;
+        // Rebuild the per-stream consumer state: recover the durable cursors/attempts for a reopened
+        // KNOWN stream (resume exactly where it left off), or a fresh empty `NamedStream` for a new one.
+        let ns = if known {
+            let now = self.log.now_monotonic();
+            let log = self
+                .streams
+                .get(id)
+                .ok_or(EngineError::MissingRecord { offset: 0 })?;
+            recover_one_named_stream(log, self.lease_config, now)?
+        } else {
+            NamedStream::new()
+        };
+        self.named_streams.insert(id.clone(), ns);
+        self.known_named_streams.insert(id.clone());
+        self.streams.touch(id);
+        Ok(!known)
+    }
+
+    /// Ensures a KNOWN named stream `id` is RESIDENT for a CONSUME/ACK access (#565): reopening +
+    /// re-recovering it from disk if the LRU evicted it, and marking it most-recently-used. Returns
+    /// `Ok(true)` if the stream is now open, or `Ok(false)` if it was NEVER declared — the consume path
+    /// turns that into [`EngineError::UnknownStream`] (a consume never CREATES a stream, unlike a
+    /// produce). Unlike [`ensure_named_stream_open`](Self::ensure_named_stream_open) this refuses to
+    /// materialize a brand-new stream.
+    ///
+    /// # Errors
+    /// Propagates a storage error from a reopen (eviction of a victim, log open, or group recovery).
+    fn ensure_named_stream_resident(&mut self, id: &StreamId) -> Result<bool, EngineError> {
+        if !self.streams.is_open(id) && !self.known_named_streams.contains(id) {
+            return Ok(false); // never declared -> UnknownStream at the call site
+        }
+        // Open (touch) or evicted-but-known (reopen): `ensure_named_stream_open` takes the reopen branch
+        // because the stream is known, so it never creates a new distinct stream here.
+        self.ensure_named_stream_open(id)?;
+        Ok(true)
+    }
+
+    /// Evicts least-recently-used open named streams until opening ONE more would stay within
+    /// `max_open_streams` (#565): a no-op when the cap is unlimited (`0`) or the open set is already
+    /// below it. Called before opening/reopening a named stream.
+    ///
+    /// # Errors
+    /// Propagates a storage error from flushing an evicted stream's durable state or closing its log.
+    fn evict_to_open_cap(&mut self) -> Result<(), EngineError> {
+        if self.max_open_streams == 0 {
+            return Ok(());
+        }
+        // At/over the cap means adding one more would exceed it: evict down to `cap - 1` so the imminent
+        // open lands the open count at exactly the cap.
+        while self.streams.open_named_count() >= self.max_open_streams {
+            let Some(victim) = self.streams.lru_victim() else {
+                break; // no named stream open to evict (only possible when the cap is 0-ish)
+            };
+            self.evict_named_stream(&victim)?;
+        }
+        Ok(())
+    }
+
+    /// Evicts least-recently-used open named streams until the open count is AT OR BELOW
+    /// `max_open_streams` (#565): the boot-time enforcement, called once after open (recovery opens
+    /// every on-disk named stream, which may exceed the cap). A no-op when the cap is unlimited or the
+    /// recovered open set already fits.
+    ///
+    /// # Errors
+    /// Propagates a storage error from flushing an evicted stream's durable state or closing its log.
+    fn evict_open_streams_down_to_cap(&mut self) -> Result<(), EngineError> {
+        if self.max_open_streams == 0 {
+            return Ok(());
+        }
+        while self.streams.open_named_count() > self.max_open_streams {
+            let Some(victim) = self.streams.lru_victim() else {
+                break;
+            };
+            self.evict_named_stream(&victim)?;
+        }
+        Ok(())
+    }
+
+    /// Evicts one NAMED stream from the OPEN set (#565): the flush-before-close eviction step. In order:
+    ///   1. SYNC the stream's log so every appended record is durable on disk (dropping the `Log`
+    ///      discards its unflushed `pending` buffer, so an un-synced tail would be lost);
+    ///   2. persist EVERY group's committed cursor (#681) AND in-flight attempt counts (#358) at the
+    ///      current watermark, UNCONDITIONALLY (like the idle-group eviction #277), BEFORE dropping the
+    ///      in-memory consumer state — else the committed position / poison-cap would be lost and reopen
+    ///      would redeliver / re-poison;
+    ///   3. DROP the in-memory consumer state and the DLQ sink handle (the DLQ's records are already
+    ///      durable — `append_poison` fsyncs in-band — and its per-group idempotency set rebuilds
+    ///      lazily from those records on the next reopen, so a poison is never double-dead-lettered);
+    ///   4. CLOSE the log, releasing the fd + segment buffers, leaving `streams/<hex>/` intact on disk.
+    ///
+    /// The stream stays in `known_named_streams` (it still EXISTS), so a later access reopens + recovers
+    /// it. The default stream is never a victim (it is not in the LRU). A sync/checkpoint error
+    /// propagates WITHOUT dropping the stream, so a disk fault never costs a committed position — the
+    /// stream stays open and a later eviction retries.
+    ///
+    /// # Errors
+    /// Propagates a storage error from the log sync or a checkpoint write.
+    fn evict_named_stream(&mut self, id: &StreamId) -> Result<(), EngineError> {
+        debug_assert!(!id.is_default(), "the default stream is never evicted");
+        if !self.streams.is_open(id) {
+            return Ok(());
+        }
+        // 1) Flush-before-close: make the log's appended records durable BEFORE the fd is dropped.
+        self.streams.sync_stream(id).map_err(EngineError::Storage)?;
+        // 2) Persist each group's committed cursor + attempt counts at the current watermark, before the
+        //    in-memory state is dropped. Unconditional (not the interval gate) so the LATEST committed
+        //    position is durable even if no interval checkpoint fired since the last ack.
+        let groups: Vec<String> = self
+            .named_streams
+            .get(id)
+            .map(|s| s.groups.keys().cloned().collect())
+            .unwrap_or_default();
+        for group in &groups {
+            let committed = self
+                .named_streams
+                .get(id)
+                .and_then(|s| s.groups.get(group))
+                .map_or(0, |g| g.cursor.committed().get());
+            self.write_named_group_checkpoint(id, group, committed)?;
+            self.write_named_group_attempts(id, group)?;
+        }
+        // 3) Drop the in-memory consumer state + DLQ handle (both are reconstructable from disk).
+        self.named_streams.remove(id);
+        self.named_dlq.remove(id);
+        // 4) Close the log (release fd + buffers); the on-disk subtree is untouched, so a reopen recovers.
+        self.streams.close(id);
         Ok(())
     }
 
@@ -6263,14 +6574,12 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
             StreamId::default_stream()
         } else {
             let id = StreamId::named(stream)?;
-            // #863: cap the resident-stream COUNT before opening a new stream's log (fd/inode/RAM bound).
+            // #863: cap the DISTINCT-stream count before materializing a NEW stream (inode/dir bound).
             self.check_stream_cap(&id)?;
-            // Declare-on-bind: the stream must have a log to receive a subject-addressed publish later,
-            // exactly as declare-on-first-produce gives the id-routed path one (idempotent).
-            self.streams.declare(&id).map_err(EngineError::Storage)?;
-            self.named_streams
-                .entry(id.clone())
-                .or_insert_with(NamedStream::new);
+            // Declare-on-bind THROUGH the hot-set LRU (#565): the stream must have a log to receive a
+            // subject-addressed publish later, exactly as declare-on-first-produce gives the id-routed
+            // path one (idempotent; evicts the least-recently-used open stream first if over the cap).
+            self.ensure_named_stream_open(&id)?;
             id
         };
         // Register + rebuild + swap (advances the generation; rolls back on a fork-bound rejection).
@@ -9779,8 +10088,10 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
             return self.stream_fetch_in(group, member, start_offset, max_records, max_bytes);
         }
         let id = StreamId::named(stream)?;
-        // The stream must be resident: consuming an unknown (never-declared) stream is a typed reject.
-        if self.streams.get(&id).is_none() {
+        // Reopen a KNOWN stream the hot-set LRU evicted (resuming its durable cursor from disk), else
+        // reject a never-declared one (#565): a streaming fetch is a consume, so it resumes an evicted
+        // stream but never creates a new one.
+        if !self.ensure_named_stream_resident(&id)? {
             return Err(EngineError::UnknownStream {
                 name: stream.to_string(),
             });
@@ -10085,6 +10396,14 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
             return self.stream_commit_in(group, up_to);
         }
         let id = StreamId::named(stream)?;
+        // Reopen a KNOWN stream the hot-set LRU evicted (resuming its durable cursor from disk), else
+        // reject a never-declared one (#565): a streaming commit is a consumer-managed-offset access, so
+        // it resumes an evicted stream but never creates a new one.
+        if !self.ensure_named_stream_resident(&id)? {
+            return Err(EngineError::UnknownStream {
+                name: stream.to_string(),
+            });
+        }
         // Read THIS stream's durable window + monotonic clock in one scoped borrow, copying the values
         // out so the borrow of `self.streams` ends before the group cursor mutation below.
         let (durable_head, earliest_retained, now) = match self.streams.get(&id) {
@@ -10604,6 +10923,7 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
             max_deliver: self.delivery.max_deliver(),
             max_groups: self.max_groups,
             max_streams: self.max_streams,
+            max_open_streams: self.max_open_streams,
             group_idle_evict_nanos: self.group_idle_evict_nanos,
             visibility_nanos: self.lease_config.visibility_nanos,
             hard_cap_nanos: self.lease_config.hard_cap_nanos,
@@ -10679,6 +10999,10 @@ mod tests {
             disk_full_policy: DiskFullPolicy::DropNew,
             max_groups: DEFAULT_MAX_GROUPS,
             max_streams: DEFAULT_MAX_STREAMS,
+            // Hot-set LRU OFF by default in the shared test config (#565, `0` = unlimited / never
+            // evict): the pre-#565 behavior (every declared stream stays resident), so existing tests
+            // are byte-for-byte unchanged. The LRU tests build a config with a small explicit cap.
+            max_open_streams: 0,
             max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
             // Eviction OFF by default in the shared test config (#277); the eviction tests build a
             // config with a non-zero window explicitly so the golden-path tests stay unaffected.
@@ -20110,6 +20434,266 @@ mod tests {
             matches!(e2.poll_in_stream("orders", "g", 0).unwrap(), Poll::Idle),
             "the stream is fully drained after the resumed consume"
         );
+    }
+
+    // ======================= M2-I4 (#565): the max_open_streams hot-set LRU =======================
+
+    /// With the open cap at N, opening the (N+1)th named stream evicts the least-recently-used one, so
+    /// the OPEN set never exceeds N. The DEFAULT stream is served by the root log — never counted, never
+    /// evicted — and its own data/consume path is unaffected by the named-stream churn.
+    #[test]
+    fn max_open_streams_lru_bounds_the_open_set_and_never_evicts_the_default() {
+        let mut e = open(EngineConfig {
+            max_open_streams: 2,
+            ..config(10, 5)
+        });
+        // The default stream stays resident throughout, independent of the named hot set.
+        e.produce(&append_at(b"d0")).unwrap();
+        produce_to(&mut e, "a", b"a0");
+        produce_to(&mut e, "b", b"b0");
+        assert_eq!(e.named_stream_count(), 2, "a and b fill the open cap");
+        assert!(e.is_named_stream_resident("a") && e.is_named_stream_resident("b"));
+
+        // Opening a THIRD named stream evicts the least-recently-used (a) to stay within the cap.
+        produce_to(&mut e, "c", b"c0");
+        assert_eq!(
+            e.named_stream_count(),
+            2,
+            "the open set stays <= the cap after opening a 3rd stream"
+        );
+        assert!(
+            !e.is_named_stream_resident("a"),
+            "the LRU stream (a) was evicted"
+        );
+        assert!(e.is_named_stream_resident("b") && e.is_named_stream_resident("c"));
+        // The evicted stream still EXISTS (it reopens on demand); the default is always resident.
+        assert!(e.stream_exists("a"), "an evicted stream still exists");
+        assert!(
+            e.is_named_stream_resident(""),
+            "the default stream is never evicted"
+        );
+
+        // The default stream's OWN data + consume path is byte-for-byte unaffected by the eviction churn.
+        let dd = message(e.poll_in_stream("", "g", 0).unwrap());
+        assert_eq!(dd.record.payload.as_ref(), b"d0");
+        assert_eq!(e.ack_in_stream("", "g", &dd.token), AckResult::Acked);
+    }
+
+    /// THE KEY DURABILITY TEST: evicting + reopening a stream is behaviorally identical to a per-stream
+    /// restart — its committed cursor AND its uncommitted tail resume exactly from disk, with NO
+    /// committed record redelivered and NO uncommitted record lost. The eviction is the ONLY thing that
+    /// persists the cursor here (no interval checkpoint fired), so this directly exercises the
+    /// flush-before-close ordering.
+    #[test]
+    fn a_named_stream_survives_evict_and_reopen_like_a_per_stream_restart() {
+        let mut e = open(EngineConfig {
+            max_open_streams: 1,
+            ..config(10, 5)
+        });
+        // Stream A: four durable records; consume + ack the first two (committing its cursor to 2).
+        for p in [&b"a0"[..], b"a1", b"a2", b"a3"] {
+            produce_to(&mut e, "A", p);
+        }
+        for expected in [&b"a0"[..], b"a1"] {
+            let d = message(e.poll_in_stream("A", "g", 0).unwrap());
+            assert_eq!(d.record.payload.as_ref(), expected);
+            assert_eq!(e.ack_in_stream("A", "g", &d.token), AckResult::Acked);
+        }
+        assert_eq!(e.committed_offset_in_stream("A", "g"), Offset::new(2));
+        assert!(e.is_named_stream_resident("A"));
+
+        // EVICT A by opening a sibling B (cap is 1): A's cursor is flushed, then its log is closed.
+        produce_to(&mut e, "B", b"b0");
+        assert!(
+            !e.is_named_stream_resident("A"),
+            "A was evicted to make room for B"
+        );
+        assert!(e.is_named_stream_resident("B"));
+
+        // REOPEN A by consuming it — it recovers from disk exactly where it left off. The FIRST poll
+        // resumes at the committed cursor (offset 2 = a2), NOT from 0: the acked a0/a1 never redeliver.
+        let d2 = message(e.poll_in_stream("A", "g", 0).unwrap());
+        assert!(e.is_named_stream_resident("A"), "A reopened on access");
+        assert_eq!(
+            e.committed_offset_in_stream("A", "g"),
+            Offset::new(2),
+            "the committed cursor survived the evict/reopen"
+        );
+        assert_eq!(d2.offset, Offset::new(2));
+        assert_eq!(
+            d2.record.payload.as_ref(),
+            b"a2",
+            "resumes at the committed cursor, not from 0 — no committed record redelivered"
+        );
+        assert_eq!(e.ack_in_stream("A", "g", &d2.token), AckResult::Acked);
+        // The uncommitted TAIL (a3) survived the close/reopen intact and delivers in order.
+        let d3 = message(e.poll_in_stream("A", "g", 0).unwrap());
+        assert_eq!(d3.offset, Offset::new(3));
+        assert_eq!(
+            d3.record.payload.as_ref(),
+            b"a3",
+            "the uncommitted tail is intact"
+        );
+        assert_eq!(e.ack_in_stream("A", "g", &d3.token), AckResult::Acked);
+        assert_eq!(e.committed_offset_in_stream("A", "g"), Offset::new(4));
+        assert!(
+            matches!(e.poll_in_stream("A", "g", 0).unwrap(), Poll::Idle),
+            "A is fully drained — nothing lost, nothing redelivered across the evict/reopen"
+        );
+    }
+
+    /// Accessing a stream promotes it to most-recently-used, so a recently-touched stream is NOT the
+    /// next eviction victim — the LRU reorders on access (the hot working set is retained).
+    #[test]
+    fn accessing_a_named_stream_reorders_the_lru_so_it_is_not_the_next_victim() {
+        let mut e = open(EngineConfig {
+            max_open_streams: 2,
+            ..config(10, 5)
+        });
+        produce_to(&mut e, "a", b"a0"); // open a           -> LRU order [a, b] after next line
+        produce_to(&mut e, "b", b"b0"); // open b           -> [a(lru), b]
+        produce_to(&mut e, "a", b"a1"); // touch a          -> [b(lru), a]
+                                        // Opening c evicts the LRU (b), NOT the recently-touched a.
+        produce_to(&mut e, "c", b"c0");
+        assert!(
+            e.is_named_stream_resident("a"),
+            "the recently-touched a is NOT evicted"
+        );
+        assert!(!e.is_named_stream_resident("b"), "the LRU b is evicted");
+        assert!(e.is_named_stream_resident("c"));
+        assert_eq!(e.named_stream_count(), 2);
+    }
+
+    /// A poison already dead-lettered + committed-past on a stream is NEVER re-dead-lettered or
+    /// redelivered across an evict/reopen: the DLQ's durable records + the per-group idempotency set are
+    /// reconstructed from disk on reopen exactly as a restart reconstructs them (the DLQ/attempts half
+    /// of the round-trip invariant — no double-dead-letter).
+    #[test]
+    fn a_dead_lettered_named_stream_is_not_double_dead_lettered_across_evict_reopen() {
+        use ironbus_storage::dlq::{read_dead_letter_entries, DLQ_SUBDIR};
+        use ironbus_storage::layout::STREAMS_SUBDIR;
+        use ironbus_storage::naming::stream_subdir_name;
+
+        let clock = std::sync::Arc::new(ManualClock::new());
+        let fs = InMemoryFs::new();
+        let probe = fs.clone();
+        // max_deliver = 1 so the 2nd attempt poisons; open cap = 1 so a sibling produce evicts A.
+        let mut e = Engine::open(
+            fs,
+            std::sync::Arc::clone(&clock),
+            EngineConfig {
+                max_open_streams: 1,
+                ..config(10, 1)
+            },
+        )
+        .unwrap();
+        let off = e
+            .produce_in_stream(
+                "A",
+                &Append {
+                    timestamp_ms: 7,
+                    flags: RecordFlags::EMPTY,
+                    key: b"",
+                    headers: b"",
+                    payload: b"poison",
+                },
+            )
+            .unwrap();
+        // Deliver once (attempt 1), expire the lease, re-deliver: attempt 2 exceeds max_deliver and is
+        // dead-lettered + committed past.
+        let d = message(e.poll_in_stream("A", "g", e.now_monotonic()).unwrap());
+        assert_eq!(d.offset, off);
+        clock.advance_monotonic_nanos(40);
+        match e.poll_in_stream("A", "g", e.now_monotonic()).unwrap() {
+            Poll::Parked { offset, .. } => assert_eq!(offset, off),
+            other => panic!("expected the poison to dead-letter (Parked), got {other:?}"),
+        }
+        assert_eq!(e.counters().dead_lettered, 1);
+        assert_eq!(e.dlq_records(), 1, "one poison in A's DLQ before eviction");
+        assert_eq!(
+            e.committed_offset_in_stream("A", "g"),
+            Offset::new(off.get() + 1)
+        );
+
+        // EVICT A (flush cursor + attempts, close log; the DLQ records stay on disk) by producing to B.
+        e.produce_in_stream("B", &append_at(b"b0")).unwrap();
+        assert!(!e.is_named_stream_resident("A"), "A was evicted");
+
+        // REOPEN A by consuming it: it recovers cursor-past-the-poison from disk, so the poison is NOT
+        // redelivered and therefore NOT re-dead-lettered.
+        assert!(
+            matches!(
+                e.poll_in_stream("A", "g", e.now_monotonic()).unwrap(),
+                Poll::Idle
+            ),
+            "the committed-past poison is not redelivered after reopen"
+        );
+        assert_eq!(
+            e.committed_offset_in_stream("A", "g"),
+            Offset::new(off.get() + 1),
+            "A's cursor resumed past the poison"
+        );
+        assert_eq!(
+            e.counters().dead_lettered,
+            1,
+            "no second dead-letter across the evict/reopen"
+        );
+
+        // The DLQ on DISK still holds EXACTLY ONE record for A — no duplicate was ever written.
+        let stream_fs = probe
+            .subdir(STREAMS_SUBDIR)
+            .unwrap()
+            .subdir(&stream_subdir_name("A"))
+            .unwrap();
+        let entries = read_dead_letter_entries(&stream_fs, DLQ_SUBDIR).unwrap();
+        assert_eq!(
+            entries.len(),
+            1,
+            "exactly one durable DLQ record — never double-dead-lettered"
+        );
+    }
+
+    /// Boot-time enforcement: recovery opens EVERY on-disk named stream, so if that exceeds
+    /// `max_open_streams` the engine evicts the least-recently-used ones down to the cap at open — the
+    /// resident-fd invariant holds immediately after a restart, not only once runtime traffic drives an
+    /// eviction. The evicted streams still EXIST and reopen (recovering their data) on demand.
+    #[test]
+    fn boot_evicts_recovered_streams_down_to_the_open_cap() {
+        let fs = InMemoryFs::new();
+        {
+            // Create three named streams with no open cap (all resident), each with its own record.
+            let mut e = Engine::open(fs.clone(), ManualClock::new(), config(10, 5)).unwrap();
+            for (s, p) in [("a", &b"a0"[..]), ("b", b"b0"), ("c", b"c0")] {
+                produce_to(&mut e, s, p);
+            }
+            assert_eq!(e.named_stream_count(), 3);
+            e.checkpoint_all_groups().unwrap();
+        }
+        // Reopen with an open cap of 1: recovery opens all three, then boot-eviction closes two.
+        let mut e2 = Engine::open(
+            fs,
+            ManualClock::new(),
+            EngineConfig {
+                max_open_streams: 1,
+                ..config(10, 5)
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            e2.named_stream_count(),
+            1,
+            "boot evicted the recovered streams down to the open cap"
+        );
+        // All three still EXIST and reopen on demand with their durable data intact.
+        for (s, p) in [("a", &b"a0"[..]), ("b", b"b0"), ("c", b"c0")] {
+            assert!(e2.stream_exists(s), "{s} still exists after boot eviction");
+            let d = message(e2.poll_in_stream(s, "g", 0).unwrap());
+            assert_eq!(
+                d.record.payload.as_ref(),
+                p,
+                "{s} reopened with its own data"
+            );
+        }
     }
 
     #[test]

--- a/crates/ironbus-server/src/engine.rs
+++ b/crates/ironbus-server/src/engine.rs
@@ -4497,7 +4497,49 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
             Some(g) => g.leases.attempt_counts(),
             None => return Ok(()),
         };
-        let payload = attempts_snapshot_payload(&pairs);
+        self.write_named_group_attempt_pairs(id, group, &pairs)
+    }
+
+    /// The EVICTION-safe attempt-count writer (#565): persists the FULL attempt state — live leases
+    /// UNION carried (recovered-but-not-yet-re-claimed) counts, via [`LeaseTable::all_attempt_counts`]
+    /// — rather than the live leases ONLY. This is what [`evict_named_stream`](Self::evict_named_stream)
+    /// uses so evicting a stream whose poison counts are still CARRIED (recovered from disk but not yet
+    /// re-polled, so `leases` is empty) does NOT overwrite `attempts-<hex>.ckpt` with an empty snapshot
+    /// — which would reset the poison's delivery count to zero and let it escape its `MaxDeliver` cap.
+    /// The periodic checkpoint keeps [`write_named_group_attempts`](Self::write_named_group_attempts)
+    /// (live leases only), gated on cursor-advance / in-flight so it never fires in the
+    /// recovered-not-repolled state. A no-op for an absent stream/group.
+    ///
+    /// # Errors
+    /// Propagates a storage error from opening or writing the checkpoint file.
+    fn write_named_group_attempts_full(
+        &mut self,
+        id: &StreamId,
+        group: &str,
+    ) -> Result<(), EngineError> {
+        let pairs = match self.named_streams.get(id).and_then(|s| s.groups.get(group)) {
+            Some(g) => g.leases.all_attempt_counts(),
+            None => return Ok(()),
+        };
+        self.write_named_group_attempt_pairs(id, group, &pairs)
+    }
+
+    /// Durably writes `pairs` as NAMED stream `id`'s work-group `group` attempt snapshot to
+    /// `streams/<hex(name)>/attempts-<hex(group)>.ckpt` — the shared file-write behind
+    /// [`write_named_group_attempts`](Self::write_named_group_attempts) (live leases, periodic) and
+    /// [`write_named_group_attempts_full`](Self::write_named_group_attempts_full) (leases ∪ carried,
+    /// eviction). Reopened per write so the crash-safe two-slot sequence continues. A no-op if the
+    /// stream's log is not open.
+    ///
+    /// # Errors
+    /// Propagates a storage error from opening or writing the checkpoint file.
+    fn write_named_group_attempt_pairs(
+        &mut self,
+        id: &StreamId,
+        group: &str,
+        pairs: &[(u64, u32)],
+    ) -> Result<(), EngineError> {
+        let payload = attempts_snapshot_payload(pairs);
         let name = group_attempts_name(group);
         let file = {
             let Some(log) = self.streams.get(id) else {
@@ -6489,10 +6531,19 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
     /// Evicts one NAMED stream from the OPEN set (#565): the flush-before-close eviction step. In order:
     ///   1. SYNC the stream's log so every appended record is durable on disk (dropping the `Log`
     ///      discards its unflushed `pending` buffer, so an un-synced tail would be lost);
-    ///   2. persist EVERY group's committed cursor (#681) AND in-flight attempt counts (#358) at the
-    ///      current watermark, UNCONDITIONALLY (like the idle-group eviction #277), BEFORE dropping the
-    ///      in-memory consumer state — else the committed position / poison-cap would be lost and reopen
-    ///      would redeliver / re-poison;
+    ///   2. persist EVERY group's committed cursor (#681) AND FULL attempt counts (#358) at the current
+    ///      watermark, unconditionally, BEFORE dropping the in-memory consumer state — else the
+    ///      committed position / poison-cap would be lost and reopen would redeliver / re-poison. The
+    ///      cursor write is unconditional so the LATEST committed position is durable even if no interval
+    ///      checkpoint fired since the last ack. The attempts write uses
+    ///      [`write_named_group_attempts_full`](Self::write_named_group_attempts_full) (live leases UNION
+    ///      CARRIED counts), NOT the live-leases-only periodic writer: a stream RECOVERED from disk but
+    ///      not yet re-polled holds its poison counts in `carried` with `leases` EMPTY, so the
+    ///      live-leases-only snapshot would be empty and OVERWRITE the durable `attempts.ckpt` to zero —
+    ///      resetting the poison's delivery count and letting it escape its `MaxDeliver` cap. The union
+    ///      guarantees the persisted count NEVER drops below what is already on disk. (This is unlike the
+    ///      idle-group eviction #277, which writes only the cursor and only for caught-up, lease-free
+    ///      groups.)
     ///   3. DROP the in-memory consumer state and the DLQ sink handle (the DLQ's records are already
     ///      durable — `append_poison` fsyncs in-band — and its per-group idempotency set rebuilds
     ///      lazily from those records on the next reopen, so a poison is never double-dead-lettered);
@@ -6512,9 +6563,12 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         }
         // 1) Flush-before-close: make the log's appended records durable BEFORE the fd is dropped.
         self.streams.sync_stream(id).map_err(EngineError::Storage)?;
-        // 2) Persist each group's committed cursor + attempt counts at the current watermark, before the
-        //    in-memory state is dropped. Unconditional (not the interval gate) so the LATEST committed
-        //    position is durable even if no interval checkpoint fired since the last ack.
+        // 2) Persist each group's committed cursor + FULL attempt counts at the current watermark, before
+        //    the in-memory state is dropped. The cursor write is unconditional so the LATEST committed
+        //    position is durable even if no interval checkpoint fired since the last ack; the attempts
+        //    write persists leases UNION carried (`write_named_group_attempts_full`) so a
+        //    recovered-not-yet-repolled poison's durable count is never clobbered to zero (its count sits
+        //    in `carried` with `leases` empty — the live-leases-only writer would erase it).
         let groups: Vec<String> = self
             .named_streams
             .get(id)
@@ -6527,7 +6581,7 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
                 .and_then(|s| s.groups.get(group))
                 .map_or(0, |g| g.cursor.committed().get());
             self.write_named_group_checkpoint(id, group, committed)?;
-            self.write_named_group_attempts(id, group)?;
+            self.write_named_group_attempts_full(id, group)?;
         }
         // 3) Drop the in-memory consumer state + DLQ handle (both are reconstructable from disk).
         self.named_streams.remove(id);
@@ -20884,6 +20938,123 @@ mod tests {
         assert_eq!(
             entries[0].attempt, 4,
             "the poison attempt is MaxDeliver + 1 = 4, counted across the restart"
+        );
+    }
+
+    /// #565 REGRESSION: an evicted poison whose durable attempt count sits in `carried`
+    /// (RECOVERED-but-not-yet-re-polled) must NOT have that count clobbered to zero by the eviction.
+    /// The eviction persists leases UNION carried, so on reopen the poison resumes at its true attempt
+    /// number and dead-letters at exactly `MaxDeliver` TOTAL. Exercises the BOOT-evict path (restart with
+    /// `max_open_streams` below the on-disk stream count). Before the fix, `evict_named_stream` wrote the
+    /// live-leases-only snapshot — EMPTY for a recovered-not-repolled stream — overwriting
+    /// `attempts.ckpt` to zero, so the poison reset to attempt 1 and escaped its `MaxDeliver` cap.
+    #[test]
+    fn an_evicted_poison_resumes_its_attempt_count_and_dead_letters_at_max_deliver_not_reset() {
+        use ironbus_storage::dlq::{read_dead_letter_entries, DLQ_SUBDIR};
+        use ironbus_storage::layout::STREAMS_SUBDIR;
+        use ironbus_storage::naming::stream_subdir_name;
+
+        let clock = std::sync::Arc::new(ManualClock::new());
+        let fs = InMemoryFs::new();
+        let probe = fs.clone();
+        // max_deliver = 5: the 6th claim poisons. Deliver the poison on stream `a` THREE times pre-crash
+        // (attempts 1..3), leaving it IN FLIGHT (cursor NOT past it), and durably checkpoint its attempt
+        // count. Create a sibling `b` on disk so a restart with open cap 1 must evict one of the two.
+        {
+            let mut e = Engine::open(fs, std::sync::Arc::clone(&clock), config(10, 5)).unwrap();
+            e.produce_in_stream(
+                "a",
+                &Append {
+                    timestamp_ms: 0,
+                    flags: RecordFlags::EMPTY,
+                    key: b"",
+                    headers: b"",
+                    payload: b"poison",
+                },
+            )
+            .unwrap();
+            e.produce_in_stream("b", &append_at(b"b0")).unwrap();
+            for attempt in 1..=3u32 {
+                let d = message(e.poll_in_stream("a", "g", e.now_monotonic()).unwrap());
+                assert_eq!(d.deliveries, attempt);
+                clock.advance_monotonic_nanos(40);
+            }
+            // Clean-shutdown flush: durable attempts-<g>.ckpt for `a` now carries {offset 0 -> 3}.
+            e.checkpoint_in_stream("a", "g").unwrap();
+            drop(e);
+        }
+
+        // RESTART with the open cap at 1: boot recovery opens BOTH a and b (loading a's count 3 into
+        // `carried`, `leases` EMPTY), then boot eviction evicts the LRU (`a`, the lowest-keyed) BEFORE it
+        // is ever re-polled — the exact recovered-not-repolled state the clobber bug corrupts.
+        let clock2 = std::sync::Arc::new(ManualClock::new());
+        let mut e = Engine::open(
+            probe.clone(),
+            std::sync::Arc::clone(&clock2),
+            EngineConfig {
+                max_open_streams: 1,
+                ..config(10, 5)
+            },
+        )
+        .unwrap();
+        assert!(
+            !e.is_named_stream_resident("a"),
+            "a was evicted at boot in the recovered-not-repolled state"
+        );
+        assert_eq!(e.named_stream_count(), 1);
+
+        // REOPEN a by polling it: it recovers the PRESERVED count (3) from disk, so the first redelivery
+        // is attempt 4 (3 + 1), NOT 1. Poll until it dead-letters, counting the DELIVERIES: exactly
+        // MaxDeliver - 3 = 2 more (attempts 4, 5), then the 6th claim dead-letters. The BUG would reset to
+        // 0 and deliver 5 more times (attempts 1..5) — failing the first-redelivery assertion below.
+        let mut post_reopen_deliveries = 0u32;
+        let deliveries_before_dead_letter = loop {
+            match e.poll_in_stream("a", "g", e.now_monotonic()).unwrap() {
+                Poll::Message(d) => {
+                    post_reopen_deliveries += 1;
+                    if post_reopen_deliveries == 1 {
+                        assert_eq!(
+                            d.deliveries, 4,
+                            "resumed at attempt 4 (3 carried + 1), NOT reset to 1 by the eviction"
+                        );
+                    }
+                    clock2.advance_monotonic_nanos(40);
+                }
+                Poll::Parked { offset, .. } => {
+                    assert_eq!(offset, Offset::ZERO);
+                    break post_reopen_deliveries;
+                }
+                other => panic!("unexpected poll {other:?}"),
+            }
+        };
+        assert_eq!(
+            deliveries_before_dead_letter, 2,
+            "the poison was delivered exactly MaxDeliver - 3 = 2 more times before dead-lettering — \
+             the durable count survived the evict/reopen (a reset would redeliver it 5 more times)"
+        );
+        assert_eq!(
+            e.dlq_records(),
+            1,
+            "reaches the DLQ after MaxDeliver TOTAL, exactly once"
+        );
+        assert_eq!(
+            e.committed_offset_in_stream("a", "g"),
+            Offset::new(1),
+            "committed past the poison"
+        );
+        drop(e);
+
+        // The single DLQ entry records attempt 6 (MaxDeliver + 1) — TOTAL across the evict/reopen.
+        let stream_fs = probe
+            .subdir(STREAMS_SUBDIR)
+            .unwrap()
+            .subdir(&stream_subdir_name("a"))
+            .unwrap();
+        let entries = read_dead_letter_entries(&stream_fs, DLQ_SUBDIR).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(
+            entries[0].attempt, 6,
+            "the poison attempt is MaxDeliver + 1 = 6, counted across the evict/reopen — not reset"
         );
     }
 

--- a/crates/ironbus-server/src/health.rs
+++ b/crates/ironbus-server/src/health.rs
@@ -2712,6 +2712,7 @@ mod tests {
             max_groups: crate::engine::DEFAULT_MAX_GROUPS,
             // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
             max_streams: 0,
+            max_open_streams: 0,
             max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
             group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
             ram_ceiling_bytes: 0,
@@ -3151,6 +3152,7 @@ mod tests {
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
                 // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
                 max_streams: 0,
+                max_open_streams: 0,
                 max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
@@ -4031,6 +4033,7 @@ mod tests {
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
                 // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
                 max_streams: 0,
+                max_open_streams: 0,
                 max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
@@ -4180,6 +4183,7 @@ mod tests {
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
                 // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
                 max_streams: 0,
+                max_open_streams: 0,
                 max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes,
@@ -4262,6 +4266,7 @@ mod tests {
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
                 // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
                 max_streams: 0,
+                max_open_streams: 0,
                 max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
@@ -4541,6 +4546,7 @@ mod tests {
                     max_groups: crate::engine::DEFAULT_MAX_GROUPS,
                     // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
                     max_streams: 0,
+                    max_open_streams: 0,
                     max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
                     group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                     ram_ceiling_bytes: 0,
@@ -4601,6 +4607,7 @@ mod tests {
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
                 // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
                 max_streams: 0,
+                max_open_streams: 0,
                 max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
@@ -4764,6 +4771,7 @@ mod tests {
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
                 // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
                 max_streams: 0,
+                max_open_streams: 0,
                 max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
@@ -4907,6 +4915,7 @@ mod tests {
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
                 // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
                 max_streams: 0,
+                max_open_streams: 0,
                 max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
@@ -5129,6 +5138,7 @@ mod tests {
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
                 // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
                 max_streams: 0,
+                max_open_streams: 0,
                 max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
@@ -6200,6 +6210,7 @@ mod tests {
                 max_groups: 100,
                 // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
                 max_streams: 0,
+                max_open_streams: 0,
                 max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: 0,
                 ram_ceiling_bytes: 0,
@@ -6415,6 +6426,7 @@ mod tests {
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
                 // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
                 max_streams: 0,
+                max_open_streams: 0,
                 max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
@@ -6608,6 +6620,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::too_many_lines)] // +1 line for the #565 `max_open_streams` EngineConfig field
     fn admin_resilience_reports_frozen_after_an_integrity_freeze() {
         // The resilience sub-resource surfaces the integrity freeze (#16: never silent). Drive a real
         // writer freeze (an armed fatal fsync on the fault filesystem) and assert `/admin` reports
@@ -6636,6 +6649,7 @@ mod tests {
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
                 // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
                 max_streams: 0,
+                max_open_streams: 0,
                 max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
@@ -6953,6 +6967,7 @@ mod tests {
                 max_groups: 100,
                 // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
                 max_streams: 0,
+                max_open_streams: 0,
                 max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: 0,
                 ram_ceiling_bytes: 0,
@@ -7251,6 +7266,7 @@ mod tests {
                 max_groups: 100,
                 // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
                 max_streams: 0,
+                max_open_streams: 0,
                 group_idle_evict_nanos: 0,
                 visibility_nanos: 1234,
                 hard_cap_nanos: 5678,

--- a/crates/ironbus-server/src/server.rs
+++ b/crates/ironbus-server/src/server.rs
@@ -958,6 +958,7 @@ mod tests {
             max_groups: crate::engine::DEFAULT_MAX_GROUPS,
             // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
             max_streams: 0,
+            max_open_streams: 0,
             max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
             group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
             ram_ceiling_bytes: 0,

--- a/crates/ironbus-server/src/session.rs
+++ b/crates/ironbus-server/src/session.rs
@@ -5324,6 +5324,7 @@ mod tests {
             max_groups: crate::engine::DEFAULT_MAX_GROUPS,
             // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
             max_streams: 0,
+            max_open_streams: 0,
             max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
             group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
             ram_ceiling_bytes: 0,
@@ -5430,6 +5431,7 @@ mod tests {
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
                 // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
                 max_streams: 0,
+                max_open_streams: 0,
                 max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
@@ -5492,6 +5494,7 @@ mod tests {
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
                 // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
                 max_streams: 0,
+                max_open_streams: 0,
                 max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
@@ -5813,6 +5816,7 @@ mod tests {
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
                 // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
                 max_streams: 0,
+                max_open_streams: 0,
                 max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
@@ -8418,6 +8422,7 @@ mod tests {
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
                 // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
                 max_streams: 0,
+                max_open_streams: 0,
                 max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
@@ -9612,6 +9617,7 @@ mod tests {
                     max_groups: crate::engine::DEFAULT_MAX_GROUPS,
                     // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
                     max_streams: 0,
+                    max_open_streams: 0,
                     max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
                     group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                     ram_ceiling_bytes: 0,
@@ -10019,6 +10025,7 @@ mod tests {
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
                 // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
                 max_streams: 0,
+                max_open_streams: 0,
                 max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
@@ -10080,6 +10087,7 @@ mod tests {
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
                 // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
                 max_streams: 0,
+                max_open_streams: 0,
                 max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
@@ -10294,6 +10302,7 @@ mod tests {
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
                 // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
                 max_streams: 0,
+                max_open_streams: 0,
                 max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: crate::engine::DEFAULT_GROUP_IDLE_EVICT_MS,
                 ram_ceiling_bytes: 0,
@@ -11341,6 +11350,7 @@ mod tests {
                 max_groups: crate::engine::DEFAULT_MAX_GROUPS,
                 // Named-stream cap OFF (#863, `0` = unlimited): preserves the historical unbounded behavior.
                 max_streams: 0,
+                max_open_streams: 0,
                 max_metric_streams: crate::engine::DEFAULT_MAX_METRIC_STREAMS,
                 group_idle_evict_ms: 10, // eviction ON; the explicit-Unsub path ignores the window
                 disk_full_policy: DiskFullPolicy::DropNew,

--- a/crates/ironbus-server/tests/conformance_vectors.rs
+++ b/crates/ironbus-server/tests/conformance_vectors.rs
@@ -658,6 +658,7 @@ fn build_config(setup: &Setup) -> EngineConfig {
         // Named-stream cap OFF (#863, `0` = unlimited): the conformance vectors assume the
         // historical unbounded behavior, so the golden bytes are unchanged by the cap.
         max_streams: 0,
+        max_open_streams: 0,
         // Per-stream consumer-metric cap (#600): observability only, does not affect the golden bytes.
         max_metric_streams: 1024,
         group_idle_evict_ms: 0,

--- a/crates/ironbus-server/tests/determinism.rs
+++ b/crates/ironbus-server/tests/determinism.rs
@@ -38,6 +38,7 @@ fn config() -> EngineConfig {
         max_groups: DEFAULT_MAX_GROUPS,
         // Named-stream cap OFF (#863, `0` = unlimited): the determinism image is unchanged by the cap.
         max_streams: 0,
+        max_open_streams: 0,
         max_metric_streams: 1024,
         // Idle named-group eviction OFF (#277), the default: the determinism image is unchanged.
         group_idle_evict_ms: DEFAULT_GROUP_IDLE_EVICT_MS,

--- a/crates/ironbus-storage/src/streamset.rs
+++ b/crates/ironbus-storage/src/streamset.rs
@@ -281,6 +281,17 @@ pub struct StreamSet<F: Filesystem, C: Clock> {
     /// budget, daily write budget). Per-stream config overrides are a future concern (per-stream
     /// retention is M2-I5); here one config governs all streams, matching the single-log broker.
     config: LogConfig,
+    /// The access-ordered list of OPEN NAMED streams for the `max_open_streams` hot-set LRU (M2-I4,
+    /// #565): the FRONT is the least-recently-used named stream (the next eviction victim) and the
+    /// BACK is the most-recently-used. The DEFAULT stream `""` is NEVER a member (it is the root log
+    /// and is never evicted). Kept in lockstep with the named entries of `streams`: [`StreamSet::open`]
+    /// seeds it from the recovered named streams, [`StreamSet::declare`] pushes a newly-opened stream
+    /// to the MRU end, [`StreamSet::touch`] promotes an accessed stream to the MRU end, and
+    /// [`StreamSet::close`] removes an evicted stream. So `lru.len() == self.len() - 1` (the open named
+    /// count) always. The engine reads [`StreamSet::lru_victim`] to pick the stream to evict when
+    /// opening one more would exceed the cap; the CAP itself is engine policy (an `EngineConfig` knob),
+    /// so a bare `StreamSet` (cap unset) simply never evicts and this list is pure bookkeeping.
+    lru: Vec<StreamId>,
 }
 
 impl<F: Filesystem, C: Clock> std::fmt::Debug for StreamSet<F, C> {
@@ -380,16 +391,36 @@ impl<F: Filesystem + Clone, C: Clock + Clone> StreamSet<F, C> {
             }
         }
 
+        // Seed the hot-set LRU (#565) from the recovered NAMED streams in deterministic (BTreeMap key)
+        // order — the default stream `""` is excluded (it is never evicted). A freshly recovered stream
+        // has no runtime access history, so key order is the arbitrary-but-reproducible initial LRU
+        // order; the engine's boot-time evict-to-cap (if the recovered named count exceeds the cap)
+        // therefore evicts the lowest-keyed streams first, deterministically.
+        let lru: Vec<StreamId> = streams
+            .keys()
+            .filter(|id| !id.is_default())
+            .cloned()
+            .collect();
+
         Ok((
             StreamSet {
                 streams,
                 clock,
                 config,
+                lru,
             },
             recoveries,
         ))
     }
+}
 
+// `declare` (open-or-reopen a single named stream's log) needs only the CLOCK to be `Clone` (it clones
+// the clock seam into the new `Log`) — NOT the filesystem, since [`Filesystem::subdir`] borrows `&self`
+// and [`Log::open`] takes an owned subdir handle. Splitting it out of the `F: Clone` block above is what
+// lets the ENGINE'S CONSUME/ACK paths (which are generic over an `F` that need not be `Clone`) REOPEN a
+// stream the hot-set LRU evicted (#565): a lazy reopen is exactly a `declare`, so it must be reachable
+// without the `F: Clone` bound that only [`StreamSet::open`]'s parallel cold-open needs.
+impl<F: Filesystem, C: Clock + Clone> StreamSet<F, C> {
     /// Declares (creating its `streams/<hex(name)>/` directory + a fresh [`Log`] on first use, or
     /// returning the already-open one) the NAMED stream `id`, so it can be appended to and read. The
     /// default stream is always already open (it is the root log), so declaring it is a no-op that
@@ -398,7 +429,13 @@ impl<F: Filesystem + Clone, C: Clock + Clone> StreamSet<F, C> {
     /// On first declaration of a named stream this materializes `streams/` (and `streams/<hex>/`) on
     /// disk via [`Filesystem::subdir`] and opens a fresh independent [`Log`] there. Re-declaring an
     /// open stream is idempotent: it does not reopen or disturb the existing log. Returns whether the
-    /// stream was NEWLY created (`true`) versus already open (`false`).
+    /// stream was NEWLY OPENED (`true`) versus already open (`false`).
+    ///
+    /// This is ALSO the hot-set LRU REOPEN path (#565): a stream the LRU evicted (its log closed, its
+    /// on-disk `streams/<hex>/` subtree intact) is reopened here by exactly the same [`Log::open`] that
+    /// a first declaration runs, which recovers its durable records from disk — so a reopen is
+    /// behaviorally a per-stream restart. A newly-opened stream is pushed to the MRU end of the hot-set
+    /// LRU (it is the most-recently-touched stream by definition).
     ///
     /// # Errors
     /// Propagates a [`StorageError`] from creating the subdir or opening the stream's log.
@@ -416,6 +453,10 @@ impl<F: Filesystem + Clone, C: Clock + Clone> StreamSet<F, C> {
             .map_err(StorageError::Io)?;
         let log = Log::open(this_stream_dir, self.clock.clone(), self.config)?;
         self.streams.insert(id.clone(), log);
+        // A newly-opened (or reopened) named stream is the most-recently-used by definition: push it to
+        // the MRU end of the hot-set LRU so it is the LAST to be evicted (#565). `declare` returns early
+        // above when the stream is already open, so this never double-inserts an id.
+        self.lru.push(id.clone());
         Ok(true)
     }
 
@@ -720,6 +761,74 @@ impl<F: Filesystem, C: Clock> StreamSet<F, C> {
     #[must_use]
     pub fn is_open(&self, id: &StreamId) -> bool {
         self.streams.contains_key(id)
+    }
+
+    // ======================= M2-I4 (#565): the max_open_streams hot-set LRU =======================
+    //
+    // These methods maintain the OPEN-set access order and close/evict a stream's log on demand. The
+    // CAP is engine policy (`EngineConfig::max_open_streams`), and eviction's flush-of-durable-state
+    // (the per-stream cursor #681, the DLQ #1110, the attempt counts) lives in the engine (it owns that
+    // state). The `StreamSet` owns only the MECHANISM here: the LRU order, the victim pick, and the
+    // log close (fd + segment-buffer release). A reopen is a `declare` (above), which recovers the
+    // stream from disk — so an evict/reopen cycle is behaviorally a per-stream restart.
+
+    /// Promotes OPEN named stream `id` to the MOST-recently-used end of the hot-set LRU (#565), so it
+    /// is the LAST to be evicted. Called on every access (produce / consume / ack) of a named stream.
+    /// A no-op for the default stream (never in the LRU) or an id that is not currently open (nothing
+    /// to promote — a reopen re-adds it at the MRU end via [`StreamSet::declare`]). O(open named
+    /// streams), which is bounded by the cap.
+    pub fn touch(&mut self, id: &StreamId) {
+        if id.is_default() || !self.streams.contains_key(id) {
+            return;
+        }
+        if let Some(pos) = self.lru.iter().position(|x| x == id) {
+            // Already tracked: move it from wherever it is to the MRU (back) end. `remove` is O(n) but
+            // n is bounded by the open cap, and this keeps the vector a true recency order.
+            let existing = self.lru.remove(pos);
+            self.lru.push(existing);
+        } else {
+            // Open but somehow untracked (defensive — every open goes through `declare`, which tracks
+            // it): record it at the MRU end so the invariant `lru == open named set` self-heals.
+            self.lru.push(id.clone());
+        }
+    }
+
+    /// The LEAST-recently-used OPEN named stream — the next eviction victim — or `None` when no named
+    /// stream is open (#565). The default stream is never a candidate (it is not in the LRU). The
+    /// engine calls this when opening one more stream would exceed `max_open_streams`, evicts the
+    /// returned victim (flushing its durable state and closing its log), and repeats until under cap.
+    #[must_use]
+    pub fn lru_victim(&self) -> Option<StreamId> {
+        self.lru.first().cloned()
+    }
+
+    /// The number of OPEN NAMED streams, EXCLUDING the always-present default stream (#565): the
+    /// quantity the `max_open_streams` cap bounds. Equal to `self.len() - 1` (the default is always
+    /// open) and to `self.lru.len()` (the LRU tracks exactly the open named streams).
+    #[must_use]
+    pub fn open_named_count(&self) -> usize {
+        self.streams.len().saturating_sub(1)
+    }
+
+    /// CLOSES (evicts from the open set) NAMED stream `id`: drops its [`Log`] — releasing the file
+    /// descriptor and the in-memory segment/pending buffers — and removes it from the hot-set LRU
+    /// (#565). Its ON-DISK `streams/<hex>/` subtree is left fully intact, so a later [`StreamSet::declare`]
+    /// REOPENS and recovers it from disk exactly like a per-stream restart. Returns whether a stream
+    /// was actually closed (`false` if `id` was not open).
+    ///
+    /// The caller MUST have already made the stream's records durable ([`StreamSet::sync_stream`]) and
+    /// checkpointed any engine-side per-stream state (cursor / DLQ / attempts) BEFORE calling this —
+    /// dropping the `Log` discards its unflushed `pending` buffer, so an un-synced tail would be lost.
+    /// The default stream is NEVER closable (it is the root log): a request to close it is a no-op
+    /// `false`, so the default stream can never be evicted.
+    pub fn close(&mut self, id: &StreamId) -> bool {
+        if id.is_default() {
+            return false;
+        }
+        if let Some(pos) = self.lru.iter().position(|x| x == id) {
+            self.lru.remove(pos);
+        }
+        self.streams.remove(id).is_some()
     }
 }
 
@@ -1522,6 +1631,93 @@ mod tests {
             let read_b = set_b.read_range(id, Offset::ZERO, 1000, None).unwrap();
             assert_eq!(read.len(), read_b.len());
             assert_eq!(&*read[i].payload, &*read_b[i].payload);
+        }
+    }
+
+    // ======================= M2-I4 (#565): the max_open_streams hot-set LRU =======================
+
+    /// `declare` tracks each newly-opened named stream at the MRU end and the default stream is NEVER
+    /// in the LRU, so `lru_victim` returns the first-declared named stream and `open_named_count`
+    /// excludes the default.
+    #[test]
+    fn declare_tracks_the_open_set_and_default_is_never_a_victim() {
+        let fs = InMemoryFs::new();
+        let (mut set, _) = open(&fs);
+        // No named stream open yet: nothing to evict, and the default is not counted.
+        assert_eq!(set.open_named_count(), 0);
+        assert_eq!(set.lru_victim(), None);
+
+        let a = StreamId::named("a").unwrap();
+        let b = StreamId::named("b").unwrap();
+        let c = StreamId::named("c").unwrap();
+        for id in [&a, &b, &c] {
+            set.declare(id).unwrap();
+        }
+        assert_eq!(set.open_named_count(), 3);
+        // Declared a, b, c in order -> a is the LRU (first-declared), the eviction victim.
+        assert_eq!(set.lru_victim(), Some(a.clone()));
+    }
+
+    /// `touch` promotes an accessed stream to the MRU end, so a recently-touched stream is NOT the next
+    /// victim — the LRU reorders on access.
+    #[test]
+    fn touch_reorders_the_lru_so_a_hot_stream_is_not_evicted_next() {
+        let fs = InMemoryFs::new();
+        let (mut set, _) = open(&fs);
+        let a = StreamId::named("a").unwrap();
+        let b = StreamId::named("b").unwrap();
+        let c = StreamId::named("c").unwrap();
+        for id in [&a, &b, &c] {
+            set.declare(id).unwrap();
+        }
+        // Order is [a, b, c]; a is LRU. Touch a -> order becomes [b, c, a], so b is now the victim.
+        assert_eq!(set.lru_victim(), Some(a.clone()));
+        set.touch(&a);
+        assert_eq!(set.lru_victim(), Some(b.clone()));
+        // Touch b -> [c, a, b], c is the victim.
+        set.touch(&b);
+        assert_eq!(set.lru_victim(), Some(c.clone()));
+        // Touching the default stream is a no-op (it is never in the LRU).
+        set.touch(&StreamId::default_stream());
+        assert_eq!(set.lru_victim(), Some(c.clone()));
+    }
+
+    /// `close` releases a named stream's log + LRU slot but leaves its on-disk subtree intact, so a
+    /// later `declare` REOPENS it recovering its durable records — an evict/reopen cycle is a per-stream
+    /// restart, losing no committed data. The default stream is never closable.
+    #[test]
+    fn close_then_reopen_recovers_the_streams_durable_records() {
+        let fs = InMemoryFs::new();
+        let a = StreamId::named("a").unwrap();
+        {
+            let (mut set, _) = open(&fs);
+            set.declare(&a).unwrap();
+            set.append_to(&a, &rec(b"a0")).unwrap();
+            set.append_to(&a, &rec(b"a1")).unwrap();
+            set.sync_all().unwrap();
+
+            // Close (evict) a: it leaves the open set + LRU, but its bytes stay on disk.
+            assert!(set.close(&a));
+            assert!(!set.is_open(&a));
+            assert_eq!(set.open_named_count(), 0);
+            assert_eq!(set.lru_victim(), None);
+            // The default stream is never closable.
+            assert!(!set.close(&StreamId::default_stream()));
+            assert!(set.is_open(&StreamId::default_stream()));
+
+            // Reopen a via declare: `Log::open` recovers its two durable records from disk.
+            assert!(set.declare(&a).unwrap());
+            assert!(set.is_open(&a));
+            let read = set.read_range(&a, Offset::ZERO, 100, None).unwrap();
+            assert_eq!(
+                read.len(),
+                2,
+                "the reopened stream recovered its durable records"
+            );
+            assert_eq!(&*read[0].payload, b"a0");
+            assert_eq!(&*read[1].payload, b"a1");
+            // Reopen re-tracked it at the MRU end (it is the only named stream, so it is the victim).
+            assert_eq!(set.lru_victim(), Some(a.clone()));
         }
     }
 }


### PR DESCRIPTION
## What

Implements V2-M2-I4 (#565): a `max_open_streams` hot-set LRU over the OPEN named-stream logs. A broker with many named streams cannot keep every per-stream log open (each pins an fd + segment write buffers); this bounds the OPEN working set and closes the least-recently-used stream's log when opening one more would exceed the cap, reopening it from disk on demand — with ALL durable state surviving the close/reopen.

Closes #565.

## Mechanism

- **StreamSet** (`streamset.rs`) owns the LRU mechanism: an access-ordered `lru: Vec<StreamId>` of open named streams, with `touch` (promote to MRU), `lru_victim` (LRU pick), `open_named_count`, and `close` (drop the `Log`, release the fd + buffers, leave the on-disk subtree intact). `declare` (the reopen path) was moved to a `C: Clone`-only impl block so the engine's consume/ack paths — generic over an `F` that need not be `Clone` — can reopen an evicted stream.
- **Engine** (`engine.rs`) owns the policy: `EngineConfig::max_open_streams` (default 1024, `0` = unlimited/never-evict) drives `ensure_named_stream_open` (open-or-reopen-or-touch, evicting the LRU first when over cap) and `evict_named_stream` (the flush-before-close eviction). Boot-time `evict_open_streams_down_to_cap` enforces the cap after recovery opens every on-disk stream.

## The durability invariant (evict/reopen = per-stream restart)

`evict_named_stream` order: (1) `sync_stream` — flush the log's appended records to disk BEFORE the fd is dropped; (2) persist EVERY group's committed cursor (#681) + attempt counts (#358) unconditionally at the current watermark, BEFORE dropping the in-memory state; (3) drop the in-memory consumer state + DLQ sink handle (records already durable, idempotency set rebuilds lazily); (4) close the log. Reopen re-recovers cursor/attempts from disk via `recover_one_named_stream` (shared with boot recovery), so committed records never redeliver, the uncommitted tail is intact, and a committed-past poison is never double-dead-lettered.

## Two orthogonal caps

`known_named_streams` decouples them: `max_streams` (#863) bounds how many streams may **EXIST** (inodes/dirs — fail-closed REJECT), `max_open_streams` (#565) bounds how many are **RESIDENT** (fds/RAM — transparent EVICT + reopen). So a large stream catalog can run on a bounded hot set. `stream_exists` now reports existence (known), not residence, so a subscribe/`StreamInfo` on an evicted stream is not wrongly rejected; `is_named_stream_resident` is the clean seam #566 retention will respect.

## Config + CLI

`--max-open-streams` mirrors `--max-streams` end-to-end (flag/env/preset resolution, usage, echo). Presets: edge-tiny 64, balanced 1024, throughput 4096.

## Tests

- StreamSet: `declare` tracks the open set (default never a victim), `touch` reorders the LRU, `close`→`declare` recovers durable records.
- Engine: LRU bounds the open set (default never evicted/counted); **round-trip durability** (produce+commit to A, evict A, reopen A → committed cursor + uncommitted tail intact, nothing redelivered); access reorders the LRU; no double-dead-letter across evict/reopen; boot evicts recovered streams down to the cap.
- CLI: flag resolves flag > preset > default, `0` = unlimited, usage lists it.

Full CI-equivalent gate green: `cargo test --workspace --locked` **3175 passed / 0 failed**; acceptance `golden_path_acceptance_install_to_recovery_to_upgrade` **ok**; `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` clean; `cargo fmt --all --check` clean; `scripts/check-format-registry.sh` ok (no format change — in-memory open-set management).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01McmNfYNWPmohVS8umY9Lkp