### PR TITLE
feat(streams): wire PartitionedStream through the engine + partition wire (#693, core)

### DIFF
--- a/crates/ironbus-client-async/src/lib.rs
+++ b/crates/ironbus-client-async/src/lib.rs
@@ -1326,6 +1326,7 @@ impl AsyncClient {
         encode_stream_declare(
             &StreamDeclareBody {
                 stream_id: stream.as_bytes(),
+                partition_count: 1,
             },
             &mut body,
         )
@@ -1434,6 +1435,7 @@ impl AsyncClient {
             &SubToBody {
                 stream_id: stream.as_bytes(),
                 group: group.as_bytes(),
+                partition: None,
             },
             &mut body,
         )

--- a/crates/ironbus-client/src/lib.rs
+++ b/crates/ironbus-client/src/lib.rs
@@ -2929,6 +2929,7 @@ impl Client {
         encode_stream_declare(
             &StreamDeclareBody {
                 stream_id: stream.as_bytes(),
+                partition_count: 1,
             },
             &mut body,
         )
@@ -3313,6 +3314,7 @@ impl Client {
             &SubToBody {
                 stream_id: stream.as_bytes(),
                 group: group.as_bytes(),
+                partition: None,
             },
             &mut body,
         )

--- a/crates/ironbus-proto/src/message.rs
+++ b/crates/ironbus-proto/src/message.rs
@@ -2377,28 +2377,47 @@ fn read_stream_id<'a>(r: &mut Reader<'a>) -> Result<&'a [u8], BodyError> {
 ///
 /// Layout (version+length framed, forward-compatible): `body_version: u8`
 /// ([`STREAM_WIRE_BODY_VERSION`]), `field_len: u16` (the length of the v1 known-field block), then the
-/// v1 block: `stream_id: u16-len + bytes`. Bytes past `field_len` (a future version's appended fields)
-/// are TOLERATED and ignored.
+/// v1 block: `stream_id: u16-len + bytes`, then — ONLY when it exceeds the default single partition —
+/// an ADDITIVE `partition_count: u32 LE` (#693, V2-M2-I11b). Bytes past `field_len` (a future
+/// version's appended fields) are TOLERATED and ignored.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct StreamDeclareBody<'a> {
     /// The name of the stream to create-or-ensure (validated server-side by `StreamId::named`).
     pub stream_id: &'a [u8],
+    /// The number of partitions `P` (`>= 1`) to back this stream with (#693): `1` (the DEFAULT) is
+    /// today's single-log stream — byte-for-byte on the wire AND on disk — and `P > 1` opts the stream
+    /// into `P` independent, key-routed sub-logs (`ironbus_storage::partitioned::PartitionedStream`).
+    /// It is an ADDITIVE wire field emitted ONLY when `> 1`, so an old client (or any single-partition
+    /// declare) is byte-for-byte the historical `StreamDeclare` body and a partitioned stream is opt-in.
+    pub partition_count: u32,
 }
 
-/// Encodes a `StreamDeclare` body onto the end of `out` (#588).
+/// Encodes a `StreamDeclare` body onto the end of `out` (#588, #693).
+///
+/// The `partition_count` is appended INSIDE the field-length block AFTER the stream id, and ONLY when
+/// it exceeds `1` (the default single partition), so a single-partition declare is byte-for-byte the
+/// pre-#693 body. It must remain the LAST additive field of the v1 block: a future field appends after
+/// it and, when set alongside a single-partition declare, must still emit `partition_count = 1` to keep
+/// the positional order the decoder reads.
 ///
 /// # Errors
-/// Returns [`BodyError::FieldTooLarge`] if the stream id exceeds the `u16` wire limit.
+/// Returns [`BodyError::FieldTooLarge`] if the stream id (or the framed block) exceeds the `u16` wire
+/// limit.
 pub fn encode_stream_declare(
     req: &StreamDeclareBody<'_>,
     out: &mut Vec<u8>,
 ) -> Result<(), BodyError> {
     let id_len = u16::try_from(req.stream_id.len()).map_err(|_| BodyError::FieldTooLarge)?;
-    let field_len = u16::try_from(2 + req.stream_id.len()).map_err(|_| BodyError::FieldTooLarge)?;
+    let extra = usize::from(req.partition_count > 1) * 4;
+    let field_len =
+        u16::try_from(2 + req.stream_id.len() + extra).map_err(|_| BodyError::FieldTooLarge)?;
     out.push(STREAM_WIRE_BODY_VERSION);
     out.extend_from_slice(&field_len.to_le_bytes());
     out.extend_from_slice(&id_len.to_le_bytes());
     out.extend_from_slice(req.stream_id);
+    if req.partition_count > 1 {
+        out.extend_from_slice(&req.partition_count.to_le_bytes());
+    }
     Ok(())
 }
 
@@ -2423,7 +2442,15 @@ pub fn decode_stream_declare(body: &[u8]) -> Result<StreamDeclareBody<'_>, BodyE
     let block = r.take(field_len)?;
     let mut fr = Reader::new(block);
     let stream_id = read_stream_id(&mut fr)?;
-    Ok(StreamDeclareBody { stream_id })
+    // The partition count is an ADDITIVE field appended after the stream id (#693): a partition-aware
+    // client emits a `> 1` count, while an old client (or any single-partition declare) omits it and it
+    // folds to the default `1`. A missing/short remainder, or an out-of-range `0`, folds to `1` (never
+    // an error), so the field stays forward-compatible and a partitioned stream is strictly opt-in.
+    let partition_count = fr.u32().ok().filter(|&p| p >= 1).unwrap_or(1);
+    Ok(StreamDeclareBody {
+        stream_id,
+        partition_count,
+    })
 }
 
 /// A client's query for a named stream (the `StreamInfo` REQUEST body, tag 29, #588): it carries the
@@ -2590,26 +2617,36 @@ pub fn decode_pub_to(body: &[u8]) -> Result<PubToBody<'_>, BodyError> {
 /// the default group.
 ///
 /// Layout (version+length framed): `body_version: u8`, `field_len: u16`, then the v1 block:
-/// `stream_id: u16-len + bytes`, `group: u16-len + bytes`. Both fields ride INSIDE the declared block
-/// (each `u16`-length-prefixed), so a future version appends after them. Trailing block bytes are
-/// tolerated.
+/// `stream_id: u16-len + bytes`, `group: u16-len + bytes`, then — ONLY when the consumer addresses a
+/// specific partition — an ADDITIVE `partition: u32 LE` (#693, V2-M2-I11b). All fields ride INSIDE the
+/// declared block, so a future version appends after them. Trailing block bytes are tolerated.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct SubToBody<'a> {
     /// The target stream name (empty selects the default stream).
     pub stream_id: &'a [u8],
     /// The work-group name (empty selects the default group), validated server-side.
     pub group: &'a [u8],
+    /// The partition of a PARTITIONED stream this consumer addresses (#693), or `None` to subscribe to
+    /// the stream as a whole (the ONLY behavior for a single-partition stream, byte-for-byte the
+    /// historical `SubTo`). `Some(i)` binds the connection's subsequent Flow/Ack to partition `i`'s
+    /// OWN sub-log + its own per-partition durable cursor — the SIMPLE/STATIC assignment (one consumer,
+    /// one explicit partition). Emitted ONLY when `Some`, so an old client's `SubTo` is unchanged.
+    pub partition: Option<u32>,
 }
 
-/// Encodes a `SubTo` body onto the end of `out` (#588): the version byte, the field-block length, then
-/// the stream id and group, each `u16`-length-prefixed.
+/// Encodes a `SubTo` body onto the end of `out` (#588, #693): the version byte, the field-block length,
+/// then the stream id and group (each `u16`-length-prefixed), and — ONLY when `partition` is `Some` —
+/// the addressed partition as a `u32 LE` appended to the block. A `None` partition emits nothing extra,
+/// so a whole-stream `SubTo` is byte-for-byte the pre-#693 body. The partition must remain the LAST
+/// additive field of the block (a future field appends after it).
 ///
 /// # Errors
 /// Returns [`BodyError::FieldTooLarge`] if the stream id or group exceeds the `u16` wire limit.
 pub fn encode_sub_to(req: &SubToBody<'_>, out: &mut Vec<u8>) -> Result<(), BodyError> {
     let id_len = u16::try_from(req.stream_id.len()).map_err(|_| BodyError::FieldTooLarge)?;
     let group_len = u16::try_from(req.group.len()).map_err(|_| BodyError::FieldTooLarge)?;
-    let field_len = u16::try_from(2 + req.stream_id.len() + 2 + req.group.len())
+    let extra = usize::from(req.partition.is_some()) * 4;
+    let field_len = u16::try_from(2 + req.stream_id.len() + 2 + req.group.len() + extra)
         .map_err(|_| BodyError::FieldTooLarge)?;
     out.push(STREAM_WIRE_BODY_VERSION);
     out.extend_from_slice(&field_len.to_le_bytes());
@@ -2617,6 +2654,9 @@ pub fn encode_sub_to(req: &SubToBody<'_>, out: &mut Vec<u8>) -> Result<(), BodyE
     out.extend_from_slice(req.stream_id);
     out.extend_from_slice(&group_len.to_le_bytes());
     out.extend_from_slice(req.group);
+    if let Some(partition) = req.partition {
+        out.extend_from_slice(&partition.to_le_bytes());
+    }
     Ok(())
 }
 
@@ -2639,7 +2679,15 @@ pub fn decode_sub_to(body: &[u8]) -> Result<SubToBody<'_>, BodyError> {
     let mut fr = Reader::new(block);
     let stream_id = read_stream_id(&mut fr)?;
     let group = fr.var()?;
-    Ok(SubToBody { stream_id, group })
+    // The addressed partition is an ADDITIVE field appended after the group (#693): a partition-aware
+    // consumer emits a `u32`, an old client omits it (folding to `None` = whole-stream subscribe). A
+    // missing/short remainder folds to `None`, never an error, so the field stays forward-compatible.
+    let partition = fr.u32().ok();
+    Ok(SubToBody {
+        stream_id,
+        group,
+        partition,
+    })
 }
 
 // ===================================================================================
@@ -4491,7 +4539,11 @@ mod tests {
 
             // SubTo: stream_id + group (both u16-len framed inside the block).
             let mut buf = Vec::new();
-            encode_sub_to(&SubToBody { stream_id: &stream_id, group: &group }, &mut buf).unwrap();
+            encode_sub_to(
+                &SubToBody { stream_id: &stream_id, group: &group, partition: None },
+                &mut buf,
+            )
+            .unwrap();
             let v = decode_sub_to(&buf).unwrap();
             prop_assert_eq!(v.stream_id, stream_id.as_slice());
             prop_assert_eq!(v.group, group.as_slice());
@@ -5653,12 +5705,24 @@ mod tests {
         // round-tripping exactly. The default-stream empty id round-trips too.
         for id in [b"orders".as_slice(), b"", b"a/b.c-1"] {
             let mut buf = Vec::new();
-            encode_stream_declare(&StreamDeclareBody { stream_id: id }, &mut buf).unwrap();
+            encode_stream_declare(
+                &StreamDeclareBody {
+                    stream_id: id,
+                    partition_count: 1,
+                },
+                &mut buf,
+            )
+            .unwrap();
             assert_eq!(
                 buf[0], STREAM_WIRE_BODY_VERSION,
                 "leads with the body version"
             );
             assert_eq!(decode_stream_declare(&buf).unwrap().stream_id, id);
+            assert_eq!(
+                decode_stream_declare(&buf).unwrap().partition_count,
+                1,
+                "a single-partition declare defaults to P=1"
+            );
 
             let mut ibuf = Vec::new();
             encode_stream_info(&StreamInfoBody { stream_id: id }, &mut ibuf).unwrap();
@@ -6067,10 +6131,12 @@ mod tests {
         fn any_sub_to_round_trips(
             stream_id in prop::collection::vec(any::<u8>(), 0..=MAX_STREAM_ID_LEN),
             group in prop::collection::vec(any::<u8>(), 0..256),
+            partition in prop::option::of(any::<u32>()),
         ) {
             let msg = SubToBody {
                 stream_id: &stream_id,
                 group: &group,
+                partition,
             };
             let mut buf = Vec::new();
             encode_sub_to(&msg, &mut buf).unwrap();
@@ -6160,6 +6226,7 @@ mod tests {
             &SubToBody {
                 stream_id: &at_stream_cap,
                 group: b"g",
+                partition: None,
             },
             &mut buf,
         )
@@ -6209,6 +6276,7 @@ mod tests {
                 &SubToBody {
                     stream_id: id,
                     group,
+                    partition: None,
                 },
                 &mut buf,
             )
@@ -6216,7 +6284,101 @@ mod tests {
             let decoded = decode_sub_to(&buf).unwrap();
             assert_eq!(decoded.stream_id, id);
             assert_eq!(decoded.group, group);
+            assert_eq!(
+                decoded.partition, None,
+                "whole-stream SubTo has no partition"
+            );
         }
+    }
+
+    #[test]
+    fn stream_declare_carries_an_additive_partition_count() {
+        // #693: a partition-aware StreamDeclare carries P > 1 as an ADDITIVE field, while a P = 1
+        // declare is byte-for-byte the historical single-partition body (the field is omitted). An old
+        // decoder tolerates the extra bytes (a v1 reader ignores the trailing block); a new decoder
+        // reads P back exactly. The P = 1 encoding is IDENTICAL to a declare that names no count.
+        let mut with_p = Vec::new();
+        encode_stream_declare(
+            &StreamDeclareBody {
+                stream_id: b"orders",
+                partition_count: 4,
+            },
+            &mut with_p,
+        )
+        .unwrap();
+        let d = decode_stream_declare(&with_p).unwrap();
+        assert_eq!(d.stream_id, b"orders");
+        assert_eq!(d.partition_count, 4);
+
+        let mut single = Vec::new();
+        encode_stream_declare(
+            &StreamDeclareBody {
+                stream_id: b"orders",
+                partition_count: 1,
+            },
+            &mut single,
+        )
+        .unwrap();
+        // P = 1 is byte-for-byte the pre-#693 body (no partition_count appended).
+        let mut legacy = vec![STREAM_WIRE_BODY_VERSION];
+        let field_len = u16::try_from(2 + "orders".len()).unwrap();
+        legacy.extend_from_slice(&field_len.to_le_bytes());
+        legacy.extend_from_slice(&u16::try_from("orders".len()).unwrap().to_le_bytes());
+        legacy.extend_from_slice(b"orders");
+        assert_eq!(
+            single, legacy,
+            "P=1 is byte-for-byte the historical declare"
+        );
+        // And an OLD-client body (no partition_count) decodes to the default P = 1.
+        assert_eq!(decode_stream_declare(&legacy).unwrap().partition_count, 1);
+        // A declared P of 0 (never emitted by the encoder) folds to 1, never an error.
+        let mut zero = vec![STREAM_WIRE_BODY_VERSION];
+        let zfl = u16::try_from(2 + "o".len() + 4).unwrap();
+        zero.extend_from_slice(&zfl.to_le_bytes());
+        zero.extend_from_slice(&1u16.to_le_bytes());
+        zero.extend_from_slice(b"o");
+        zero.extend_from_slice(&0u32.to_le_bytes());
+        assert_eq!(decode_stream_declare(&zero).unwrap().partition_count, 1);
+    }
+
+    #[test]
+    fn sub_to_carries_an_additive_partition_selector() {
+        // #693: a partition-addressed SubTo carries the target partition as an ADDITIVE field; a
+        // whole-stream SubTo omits it (byte-for-byte the historical body) and decodes to None.
+        let mut addressed = Vec::new();
+        encode_sub_to(
+            &SubToBody {
+                stream_id: b"orders",
+                group: b"w",
+                partition: Some(2),
+            },
+            &mut addressed,
+        )
+        .unwrap();
+        let d = decode_sub_to(&addressed).unwrap();
+        assert_eq!(d.stream_id, b"orders");
+        assert_eq!(d.group, b"w");
+        assert_eq!(d.partition, Some(2));
+
+        let mut whole = Vec::new();
+        encode_sub_to(
+            &SubToBody {
+                stream_id: b"orders",
+                group: b"w",
+                partition: None,
+            },
+            &mut whole,
+        )
+        .unwrap();
+        let mut legacy = vec![STREAM_WIRE_BODY_VERSION];
+        let field_len = u16::try_from(2 + "orders".len() + 2 + "w".len()).unwrap();
+        legacy.extend_from_slice(&field_len.to_le_bytes());
+        legacy.extend_from_slice(&u16::try_from("orders".len()).unwrap().to_le_bytes());
+        legacy.extend_from_slice(b"orders");
+        legacy.extend_from_slice(&u16::try_from("w".len()).unwrap().to_le_bytes());
+        legacy.extend_from_slice(b"w");
+        assert_eq!(whole, legacy, "None is byte-for-byte the historical SubTo");
+        assert_eq!(decode_sub_to(&legacy).unwrap().partition, None);
     }
 
     #[test]

--- a/crates/ironbus-proto/tests/export_go_vectors.rs
+++ b/crates/ironbus-proto/tests/export_go_vectors.rs
@@ -761,6 +761,7 @@ fn build_vectors() -> Vec<Vector> {
     encode_stream_declare(
         &StreamDeclareBody {
             stream_id: b"orders",
+            partition_count: 1,
         },
         &mut body,
     )
@@ -832,6 +833,7 @@ fn build_vectors() -> Vec<Vector> {
         &SubToBody {
             stream_id: b"orders",
             group: b"pickers",
+            partition: None,
         },
         &mut body,
     )

--- a/crates/ironbus-server/src/engine.rs
+++ b/crates/ironbus-server/src/engine.rs
@@ -35,6 +35,7 @@ use ironbus_core::keyshared::{KeyOrdering, KeyRouter, MemberId, RouteDecision};
 use ironbus_core::lease::{
     AckOutcome, Claim, ExtendOutcome, LeaseConfig, LeaseTable, LeaseToken, NackOutcome,
 };
+use ironbus_core::partition::{PartitionCount, PartitionIndex};
 use ironbus_core::producer_seq::{
     decode_seq_snapshot, encode_seq_snapshot, ProducerSeqRegistry, SeqConfig, SeqDecision,
 };
@@ -48,9 +49,13 @@ use ironbus_storage::checkpoint::{
 };
 use ironbus_storage::dlq::{DeadLetterReason, DlqSink, DLQ_SUBDIR};
 use ironbus_storage::fs::Filesystem;
+use ironbus_storage::layout::PARTITIONED_STREAMS_SUBDIR;
 use ironbus_storage::log::{Append, Log, LogConfig, RetentionBounds, SyncTicket};
 use ironbus_storage::loss::LossReport;
-use ironbus_storage::naming::MAX_STREAM_NAME_LEN;
+use ironbus_storage::naming::{
+    parse_partition_subdir_name, parse_stream_subdir_name, stream_subdir_name, MAX_STREAM_NAME_LEN,
+};
+use ironbus_storage::partitioned::PartitionedStream;
 use ironbus_storage::segment::{OwnedRecord, RawByteRun, StorageError};
 use ironbus_storage::streamset::{CommitOutcome, StreamError, StreamId, StreamSet};
 use ironbus_storage::txn::{TxnStore, TxnStoreError};
@@ -2510,6 +2515,81 @@ fn recover_one_named_stream<F: Filesystem, C: Clock>(
     Ok(ns)
 }
 
+/// The recovered partitioned-stream state (#693): the reopened [`PartitionedStream`]s keyed by
+/// [`StreamId`], paired with each partition's resumed per-group consumer state keyed by
+/// `(stream, partition index)`. Named so the two-map tuple does not trip the `type_complexity` lint.
+type PartitionedRecovery<F, C> = (
+    BTreeMap<StreamId, PartitionedStream<F, C>>,
+    BTreeMap<(StreamId, u32), NamedStream>,
+);
+
+/// Reopens every PARTITIONED stream (#693) under `pstreams/<hex(name)>/`, and resumes each partition's
+/// per-group consumer cursor from its own sub-log subdir — the partitioned twin of
+/// [`recover_named_stream_groups`]. For each `pstreams/` child whose name is a canonical hex-encoded
+/// stream name, the partition count `P` is DERIVED from the number of materialized `p-<08x>/` subdirs
+/// (the source of truth #591 lays down), and the [`PartitionedStream`] is reopened with that `P` so its
+/// `P` sub-logs each recover independently over their own durable bytes. Each partition's cursor is
+/// resumed via [`recover_one_named_stream`] on that partition's [`Log`], so a partition-addressed
+/// consumer resumes at its committed offset after a restart instead of redelivering the partition.
+///
+/// A foreign/non-canonical child directory is skipped; a data dir with no `pstreams/` subtree returns
+/// two empty maps and never materializes it (the non-partitioned image is unchanged).
+///
+/// # Errors
+/// Propagates a storage error from enumerating `pstreams/`, opening/recovering a partition's log, or
+/// reading a partition's checkpoint files.
+fn recover_partitioned_streams<F, C>(
+    root_log: &Log<F, C>,
+    lease: LeaseConfig,
+    opened_at: u64,
+) -> Result<PartitionedRecovery<F, C>, EngineError>
+where
+    F: Filesystem + Clone,
+    C: Clock + Clone,
+{
+    let mut partitioned = BTreeMap::new();
+    let mut consumers = BTreeMap::new();
+    let root = root_log.filesystem();
+    if !root.subdir_exists(PARTITIONED_STREAMS_SUBDIR)? {
+        return Ok((partitioned, consumers));
+    }
+    let pfs = root.subdir(PARTITIONED_STREAMS_SUBDIR)?;
+    let config = root_log.config();
+    for dir in pfs.list_subdirs()? {
+        let Some(name) = parse_stream_subdir_name(&dir) else {
+            continue;
+        };
+        let Ok(id) = StreamId::named(&name) else {
+            continue;
+        };
+        let stream_root = pfs.subdir(&dir)?;
+        // P = the count of canonical `p-<08x>/` partition subdirs #591 materialized under this stream.
+        let count = stream_root
+            .list_subdirs()?
+            .iter()
+            .filter(|d| parse_partition_subdir_name(d).is_some())
+            .count();
+        let Some(pc) = u32::try_from(count).ok().and_then(PartitionCount::new) else {
+            continue;
+        };
+        let (ps, _recoveries) =
+            PartitionedStream::open(&stream_root, root_log.clock_clone(), config, pc)
+                .map_err(EngineError::Storage)?;
+        // Resume each partition's per-group consumer cursor from its own sub-log subdir.
+        for i in 0..pc.get() {
+            let idx = PartitionIndex::new(i);
+            if let Some(plog) = ps.partition(idx) {
+                let ns = recover_one_named_stream(plog, lease, opened_at)?;
+                if !ns.groups.is_empty() || !ns.group_last_checkpointed.is_empty() {
+                    consumers.insert((id.clone(), i), ns);
+                }
+            }
+        }
+        partitioned.insert(id, ps);
+    }
+    Ok((partitioned, consumers))
+}
+
 /// Reconstructs a group's carried attempt counts from a recovered `attempts.ckpt` payload, clamped
 /// to the durable log head `flushed` and the resumed committed watermark `committed`: a carried
 /// count is only meaningful for an offset that still exists (`< flushed`) and has NOT been committed
@@ -3037,6 +3117,24 @@ pub struct Engine<F: Filesystem, C: Clock> {
     /// before the first poison redelivers after a crash. Empty for a deployment that never
     /// dead-letters a named stream, so the default and no-poison paths cost nothing.
     named_dlq: BTreeMap<StreamId, DlqSink<F, C>>,
+    /// The per-PARTITIONED-stream storage (#693, V2-M2-I11b): each entry is a
+    /// [`PartitionedStream`] of `P > 1` independent, key-routed sub-logs rooted under
+    /// `pstreams/<hex(name)>/` (the `PartitionedStream` #591 primitive, threaded through the engine).
+    /// Keyed by [`StreamId`] so a partitioned stream is ISOLATED from the single-log named streams in
+    /// [`Engine::streams`] — the two are DISJOINT namespaces (a name is either a single stream or a
+    /// partitioned one, never both). A produce to one of these routes by the record's key to
+    /// `xxh3_64(key) % P` and commits with the stream's OWN [`PartitionedStream::commit_tick`]
+    /// group-commit barrier; a partition-addressed consume drains ONE partition's sub-log. EMPTY for a
+    /// deployment that never declares `P > 1`, so the default + named-stream paths are byte-for-byte
+    /// unchanged and `pstreams/` is never materialized.
+    partitioned: BTreeMap<StreamId, PartitionedStream<F, C>>,
+    /// The per-PARTITION consumer state (#693), keyed by `(stream, partition index)`: each entry is a
+    /// [`NamedStream`]'s work-group machinery (its competing `groups` + durable per-group cursor #681),
+    /// re-instantiated PER PARTITION so a consumer addressing partition `i` drains it on its OWN
+    /// independent, durably-checkpointed cursor — the per-partition twin of [`Engine::named_streams`].
+    /// A partition's cursor lives in ITS sub-log's `pstreams/<hex(name)>/p-<08x(i)>/cursor-<hex>.ckpt`,
+    /// so it recovers beside its own records. EMPTY until a partitioned stream is consumed.
+    partition_consumers: BTreeMap<(StreamId, u32), NamedStream>,
     /// The durable TRANSACTIONAL HALF-MESSAGE store (V2-M8, #640): the `txn/` sub-log that buffers
     /// prepared (half) messages INVISIBLE to consumers and their commit/rollback op-markers, plus the
     /// in-memory lifecycle table it rebuilds at open. Opened LAZILY on the first `TxnPrepare` (so a
@@ -3448,6 +3546,15 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
             }
         }
 
+        // Recover each PARTITIONED stream (#693) from its `pstreams/<hex(name)>/` subtree: reopen its
+        // `P` sub-logs (with `P` derived from the materialized `p-<08x>/` partition subdir count) as a
+        // `PartitionedStream`, and resume each partition's per-group consumer cursor from THAT
+        // partition's own subdir — the per-partition twin of `recover_named_stream_groups` above. A
+        // deployment that never declared `P > 1` has no `pstreams/` subtree, so this is a no-op and the
+        // on-disk image is byte-for-byte unchanged.
+        let (partitioned, partition_consumers) =
+            recover_partitioned_streams(&log, config.lease, opened_at)?;
+
         // The TRANSACTIONAL HALF-MESSAGE store's log (V2-M8, #640) shares the main log's segment
         // sizing but is NEVER byte-capped: a prepared half message is an undelivered durable payload
         // and a resolution op-marker is the durable record of the commit/rollback, so neither may be
@@ -3562,6 +3669,10 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
             // The per-named-stream dead-letter sinks (#681 follow-up), eagerly opened above for every
             // recovered stream whose `dlq/` subdir already exists; the rest open lazily on first poison.
             named_dlq,
+            // The per-partitioned-stream storage + per-partition consumer state (#693), recovered above
+            // from `pstreams/`. Empty for a deployment that never declared `P > 1`.
+            partitioned,
+            partition_consumers,
             // The transactional half-message store (V2-M8, #640): opened above iff the `txn/` subdir
             // already exists, else `None` until the first `TxnPrepare` lazily creates it. A
             // non-transactional broker keeps this `None`, so the produce/consume hot path is unchanged.
@@ -4409,6 +4520,21 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         for (id, group) in stream_groups {
             self.checkpoint_named_group(&id, &group)?;
         }
+        // Flush every PARTITION's per-group consumer cursor (#693), the per-partition twin of the
+        // named-stream loop above: a clean shutdown persists each partition-addressed consumer's
+        // committed position (to `pstreams/<hex(name)>/p-<08x(i)>/cursor-<hex(group)>.ckpt`) so a restart
+        // resumes it instead of redelivering the partition. Snapshot the `(stream, partition, group)`
+        // triples first so the `&mut self` checkpoint calls do not borrow `partition_consumers` across
+        // the loop. A no-op for a deployment that never consumed a partitioned stream.
+        let mut partition_groups: Vec<(StreamId, u32, String)> = Vec::new();
+        for ((id, partition), ns) in &self.partition_consumers {
+            for group in ns.groups.keys() {
+                partition_groups.push((id.clone(), *partition, group.clone()));
+            }
+        }
+        for (id, partition, group) in partition_groups {
+            self.checkpoint_partition_group(&id, PartitionIndex::new(partition), &group)?;
+        }
         // Flush the idempotent-producer SEQUENCE high-waters (V2-M8) on the clean-shutdown barrier too,
         // AFTER the cursors are flushed (so the durable head the high-waters clamp against is advanced)
         // and BEFORE the observability-only counters. CORRECTNESS state: a restart after a clean stop
@@ -4863,6 +4989,15 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
             });
         }
         let id = StreamId::named(stream)?;
+        // #693: a PARTITIONED stream (declared with `P > 1`) routes the produce BY KEY to its partition
+        // sub-log (`xxh3_64(key) % P`, #591), NOT to a single named-stream log. This runs BEFORE the
+        // single-stream path below so a partitioned name never materializes a plain `streams/<hex>/`
+        // log. A no-op for the common case (no partitioned streams declared): one map lookup.
+        if self.partitioned.contains_key(&id) {
+            return self
+                .produce_partitioned(&id, message)
+                .map(|(_, offset)| offset);
+        }
         // #863: cap the DISTINCT-stream count before materializing a NEW stream (inode/dir bound).
         self.check_stream_cap(&id)?;
         // Declare-on-first-produce THROUGH the hot-set LRU (#565): open (or lazily REOPEN + per-stream
@@ -4910,6 +5045,572 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         // unchanged.
         self.reap_named_for_retention(&id)?;
         Ok(offset)
+    }
+
+    // ===================================================================================
+    // PARTITIONED-STREAM WIRING (#693, V2-M2-I11b): thread the `PartitionedStream` (#591) storage
+    // primitive through the engine. A stream declared with `P > 1` is backed by a `PartitionedStream`
+    // of `P` independent, key-routed sub-logs under `pstreams/<hex(name)>/`. A produce ROUTES BY KEY to
+    // `xxh3_64(key) % P` (#591's stable hash), so every record sharing a key lands in — and keeps its
+    // order within — one partition; a keyless produce spreads by the stream's round-robin selector. A
+    // partition-addressed consume drains ONE partition's sub-log on its OWN competing work-group + its
+    // OWN durable per-partition cursor (#681, checkpointed under the partition subdir), so `P`
+    // partitions consume `P`-way in parallel with fully isolated cursors.
+    //
+    // SCOPE (this PR = the CORE wiring): declare-P, produce-route-by-key (+ the stream's own
+    // `PartitionedStream::commit_tick` group-commit barrier + froze->WriterFrozen), per-partition
+    // retention, and partition-addressed competing consume with a durable per-partition cursor. The
+    // ASSIGNMENT is SIMPLE/STATIC — a consumer names ONE explicit partition. DEFERRED follow-ups (never
+    // removed from a single-log named stream): cooperative rebalance / dynamic partition->consumer
+    // assignment, a per-partition DLQ (#1110-style; a poison is committed-past + `Poll::Parked` here),
+    // per-partition subject filters / key-shared routing / Tier-S streaming, and per-partition metric
+    // labels. `P == 1` is NEVER a `PartitionedStream`: it is today's single-log named stream, byte-for-
+    // byte on the wire AND on disk.
+    // ===================================================================================
+
+    /// Declares a stream with `partition_count` partitions (#693): the engine-side of the additive
+    /// `partition_count` field on the `StreamDeclare` wire verb. A `partition_count <= 1` is a plain
+    /// single-partition named stream and delegates to [`Engine::declare_stream`] BYTE-FOR-BYTE (no
+    /// `PartitionedStream`, no `pstreams/` subtree). A `partition_count > 1` opens (or idempotently
+    /// re-ensures) a [`PartitionedStream`] of `P` independent sub-logs under `pstreams/<hex(name)>/`.
+    ///
+    /// Idempotent: re-declaring an existing partitioned stream with the SAME `P` is `Ok(false)`; a
+    /// FIRST declare is `Ok(true)`. Repartitioning (a different `P`) is NOT supported (it would reshuffle
+    /// every key, #591's honest modulo-hash caveat) and a name that already exists as a SINGLE named
+    /// stream cannot be re-declared partitioned — both are rejected fail-closed.
+    ///
+    /// # Errors
+    /// [`EngineError::InvalidStreamName`] for the empty/default name (it is never partitioned), a
+    /// malformed named name, a name already resident as a single named stream, or a re-declare with a
+    /// DIFFERENT partition count; [`EngineError::TooManyStreams`] if opening one more would exceed the
+    /// distinct-stream cap; else a storage error from opening the partitioned stream's sub-logs.
+    pub fn declare_partitioned_stream(
+        &mut self,
+        stream: &str,
+        partition_count: u32,
+    ) -> Result<bool, EngineError>
+    where
+        F: Clone,
+    {
+        // P <= 1 is today's single-log named stream, byte-for-byte (no PartitionedStream at all).
+        if partition_count <= 1 {
+            return self.declare_stream(stream);
+        }
+        // The default stream is the root log and is never partitioned.
+        if stream.is_empty() {
+            return Err(EngineError::InvalidStreamName {
+                name: String::new(),
+            });
+        }
+        let id = StreamId::named(stream)?;
+        let pc =
+            PartitionCount::new(partition_count).ok_or_else(|| EngineError::InvalidStreamName {
+                name: stream.to_string(),
+            })?;
+        // Idempotent re-declare: SAME P -> Ok(false); DIFFERENT P -> fail-closed (no live repartition).
+        if let Some(existing) = self.partitioned.get(&id) {
+            if existing.count() == pc {
+                return Ok(false);
+            }
+            return Err(EngineError::InvalidStreamName {
+                name: stream.to_string(),
+            });
+        }
+        // A name already resident as a SINGLE named stream cannot also be a partitioned stream (the two
+        // are disjoint namespaces): reject rather than silently shadow.
+        if self.known_named_streams.contains(&id) {
+            return Err(EngineError::InvalidStreamName {
+                name: stream.to_string(),
+            });
+        }
+        // Distinct-stream cap (#863): count partitioned streams alongside named ones (inode/fd bound).
+        if self.max_streams != 0
+            && self.known_named_streams.len() + self.partitioned.len() >= self.max_streams
+        {
+            return Err(EngineError::TooManyStreams {
+                max: self.max_streams,
+            });
+        }
+        let root = self.partitioned_stream_root(&id)?;
+        let (ps, _recoveries) =
+            PartitionedStream::open(&root, self.log.clock_clone(), self.log.config(), pc)
+                .map_err(EngineError::Storage)?;
+        self.partitioned.insert(id, ps);
+        Ok(true)
+    }
+
+    /// The partition count `P` of the partitioned stream `stream` (#693), or `None` if `stream` is not
+    /// a partitioned stream (the default stream, a single named stream, an unknown/malformed name). The
+    /// query the wire/session layer uses to decide whether a produce/consume must route through the
+    /// partition path.
+    #[must_use]
+    pub fn partition_count_of(&self, stream: &str) -> Option<PartitionCount> {
+        let id = StreamId::named(stream).ok()?;
+        self.partitioned.get(&id).map(PartitionedStream::count)
+    }
+
+    /// Resolves the `pstreams/<hex(name)>/` root filesystem for a partitioned stream `id`, creating the
+    /// `pstreams/` subtree + the stream's subdir on first use. The [`PartitionedStream`] then roots its
+    /// `p-<08x(i)>/` sub-logs under this handle.
+    fn partitioned_stream_root(&self, id: &StreamId) -> Result<F, EngineError>
+    where
+        F: Clone,
+    {
+        let pfs = self.log.filesystem().subdir(PARTITIONED_STREAMS_SUBDIR)?;
+        let root = pfs.subdir(&stream_subdir_name(id.name()))?;
+        Ok(root)
+    }
+
+    /// Produces `message` to the partitioned stream `id` (#693), ROUTING it by key to `xxh3_64(key) % P`
+    /// (a keyless record spreads round-robin, #591), appending to that ONE partition's sub-log and
+    /// committing it with the stream's OWN [`PartitionedStream::commit_tick`] group-commit barrier.
+    /// Returns the partition it landed in and the [`Offset`] within that partition.
+    ///
+    /// The durability contract is per PARTITION: the record is acked only after its partition's covering
+    /// `fdatasync`; a partition whose barrier FROZE surfaces a fatal [`StorageError::WriterFrozen`]
+    /// instead of acking a non-durable record (I2, ack-implies-durable). Per-partition retention runs
+    /// after the durable commit, exactly as the named-stream produce reaps after its commit.
+    ///
+    /// # Errors
+    /// [`EngineError::UnknownStream`] if `id` is not a partitioned stream, a storage error from the
+    /// append, or [`StorageError::WriterFrozen`] if the chosen partition's commit barrier froze.
+    fn produce_partitioned(
+        &mut self,
+        id: &StreamId,
+        message: &Append<'_>,
+    ) -> Result<(PartitionIndex, Offset), EngineError> {
+        // Route + append to the key's partition (short mutable borrow of the storage map).
+        let (idx, offset) = {
+            let ps = self
+                .partitioned
+                .get_mut(id)
+                .ok_or_else(|| EngineError::UnknownStream {
+                    name: id.name().to_string(),
+                })?;
+            ps.append(message).map_err(EngineError::Storage)?
+        };
+        // Per-stream PRODUCE throughput (#571), keyed by the stream name (bounded/overflow-folded).
+        self.registry.record_stream_produced(id.name().as_bytes());
+        // ONE cross-partition group-commit tick (#591): K dirtied partitions => K fdatasync barriers,
+        // amortized over the batch; a clean partition costs nothing. A partition whose covering
+        // fdatasync FAILED is FROZEN (its durable head did not advance) -> surface WriterFrozen rather
+        // than ack a non-durable record (I2), exactly as the named-stream produce path does on a froze.
+        let froze = {
+            let ps = self
+                .partitioned
+                .get_mut(id)
+                .expect("partitioned stream present after append");
+            ps.commit_tick().froze.contains(&idx)
+        };
+        if froze {
+            return Err(EngineError::Storage(StorageError::WriterFrozen));
+        }
+        // Per-PARTITION retention + compaction (#566, per partition): reclaim disk on the chosen
+        // partition's own sub-log, floored at that partition's min-committed offset so a slow consumer's
+        // records are never reaped. A no-op unless retention/compaction is configured.
+        self.reap_partition_for_retention(id, idx)?;
+        Ok((idx, offset))
+    }
+
+    /// Per-partition retention + compaction (#693), the per-partition twin of
+    /// [`Engine::reap_named_for_retention`]: reaps fully-consumed old sealed segments of partition
+    /// `idx`'s sub-log past the retention bound (floored at that partition's own min-committed offset)
+    /// and runs one off-hot-path compaction pass, reusing the same [`Log::reap`] / [`Log::maybe_compact`]
+    /// machinery per partition. A no-op unless retention or compaction is configured.
+    ///
+    /// # Errors
+    /// Propagates a storage error from the partition's reap or compaction pass.
+    fn reap_partition_for_retention(
+        &mut self,
+        id: &StreamId,
+        idx: PartitionIndex,
+    ) -> Result<(), EngineError> {
+        if self.retention != RetentionBounds::default() {
+            let protect_below = self.min_committed_offset_partition(id, idx);
+            let bounds = self.retention;
+            if let Some(log) = self
+                .partitioned
+                .get_mut(id)
+                .and_then(|ps| ps.partition_mut(idx))
+            {
+                let outcome = log
+                    .reap(bounds, protect_below)
+                    .map_err(EngineError::Storage)?;
+                self.counters.segments_reaped = self
+                    .counters
+                    .segments_reaped
+                    .saturating_add(outcome.segments_reaped);
+            }
+        }
+        if self.compaction.enabled {
+            let compaction = self.compaction;
+            if let Some(log) = self
+                .partitioned
+                .get_mut(id)
+                .and_then(|ps| ps.partition_mut(idx))
+            {
+                let _ = log
+                    .maybe_compact(&compaction)
+                    .map_err(EngineError::Storage)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// The min committed offset across partition `(id, idx)`'s consumer groups (#693), the retention
+    /// PROTECT floor for that partition: no group's unconsumed records are reaped. Falls back to the
+    /// partition's durable head when it has no consumer groups yet (nothing consumes it, so retention is
+    /// free to reap up to the head). The per-partition twin of [`Engine::min_committed_offset_named`].
+    fn min_committed_offset_partition(&self, id: &StreamId, idx: PartitionIndex) -> u64 {
+        let head = self
+            .partitioned
+            .get(id)
+            .and_then(|ps| ps.partition(idx))
+            .map_or(0, |log| log.flushed_offset().get());
+        let Some(ns) = self.partition_consumers.get(&(id.clone(), idx.get())) else {
+            return head;
+        };
+        let live = ns
+            .groups
+            .values()
+            .filter(|g| g.touched)
+            .map(|g| g.cursor.committed().get());
+        let ghosts = ns
+            .group_last_checkpointed
+            .iter()
+            .filter(|(name, _)| !ns.groups.contains_key(name.as_str()))
+            .map(|(_, &committed)| committed);
+        live.chain(ghosts).min().unwrap_or(head)
+    }
+
+    /// Polls PARTITION `partition` of the partitioned stream `stream` in competing work-group `group`
+    /// (#693): delivers the next in-order record off THAT partition's OWN sub-log, on its OWN durable
+    /// cursor + lease table, isolated from every other partition (so `P` consumers drain `P` partitions
+    /// in parallel). The SIMPLE/STATIC assignment — one consumer names one explicit partition.
+    ///
+    /// The delivery loop is the plain-competing claim/lease/disposition core the default stream uses,
+    /// scoped to one partition; a poison over `max_deliver` is committed-past and surfaced as
+    /// [`Poll::Parked`] (a per-partition DLQ is a deferred follow-up). A below-earliest cursor (a
+    /// partition reaped past it) resets up and surfaces [`Poll::Truncated`] once, exactly as the default
+    /// path.
+    ///
+    /// # Errors
+    /// [`EngineError::InvalidStreamName`] for a malformed name, [`EngineError::UnknownStream`] for a
+    /// stream that is not partitioned or a `partition` out of range, [`EngineError::InvalidGroupName`] /
+    /// [`EngineError::TooManyGroups`] from the group gate, else a storage error from the read.
+    pub fn poll_partition(
+        &mut self,
+        stream: &str,
+        partition: u32,
+        group: &str,
+        now: u64,
+    ) -> Result<Poll, EngineError> {
+        let id = StreamId::named(stream)?;
+        let idx = PartitionIndex::new(partition);
+        // Resolve the partition's durable head, rejecting an unknown stream or out-of-range partition.
+        let flushed = match self.partitioned.get(&id) {
+            Some(ps) if partition < ps.count().get() => ps
+                .partition(idx)
+                .map_or(0, |log| log.flushed_offset().get()),
+            _ => {
+                return Err(EngineError::UnknownStream {
+                    name: stream.to_string(),
+                })
+            }
+        };
+        validate_group_name(group)?;
+        // Ensure the partition's work-group exists, under the per-partition group cap.
+        let lease_config = self.lease_config;
+        let max_groups = self.max_groups;
+        let ns = self
+            .partition_consumers
+            .entry((id.clone(), partition))
+            .or_insert_with(NamedStream::new);
+        if !ns.groups.contains_key(group) {
+            if max_groups != 0 && ns.groups.len() >= max_groups {
+                return Err(EngineError::TooManyGroups { max: max_groups });
+            }
+            ns.groups
+                .insert(group.to_string(), WorkGroup::new(lease_config, now));
+        }
+        self.deliver_from_partition(&id, idx, group, now, flushed)
+    }
+
+    /// The plain-competing claim/deliver loop for ONE partition (#693), factored out of
+    /// [`Engine::poll_partition`]. The work-group `group` of partition `(id, idx)` is already present
+    /// and `flushed` is the partition's durable head. Re-instantiates the SAME competing primitives the
+    /// default stream uses — the [`AckCursor`], the [`LeaseTable`] claim/ack, the 0/1/2-ack disposition
+    /// — scoped to this partition's sub-log, so per-partition order + a durable per-partition cursor
+    /// hold with no cross-partition contention.
+    // One cohesive competing scan (below-earliest trim, claim, compaction-hole, disposition) scoped to
+    // one partition — splitting it would scatter the single in-flight-window walk, exactly as the
+    // default stream's `poll_in_timed` keeps its scan whole.
+    #[allow(clippy::too_many_lines)]
+    fn deliver_from_partition(
+        &mut self,
+        id: &StreamId,
+        idx: PartitionIndex,
+        group: &str,
+        now: u64,
+        flushed: u64,
+    ) -> Result<Poll, EngineError> {
+        let key = (id.clone(), idx.get());
+        // The oldest record still retained in this partition (rises above 0 only after a retention reap).
+        let earliest = self
+            .partitioned
+            .get(id)
+            .and_then(|ps| ps.partition(idx))
+            .map_or(0, |log| log.earliest_offset().get());
+        let lease_config = self.lease_config;
+        // Stamp the group active and read its committed cursor in a short scoped borrow.
+        let committed = match self
+            .partition_consumers
+            .get_mut(&key)
+            .and_then(|ns| ns.groups.get_mut(group))
+        {
+            None => return Ok(Poll::Idle),
+            Some(g) => {
+                g.last_activity = now;
+                g.touched = true;
+                g.cursor.committed().get()
+            }
+        };
+        // BELOW-EARLIEST truncation (the per-partition twin of the default `poll_in` #84 path): if this
+        // group's cursor fell below the oldest retained record (a retention reap ran past it), reset UP
+        // to `earliest` and surface the truncation ONCE, so a consumer never silently skips records.
+        if committed < earliest {
+            if let Some(g) = self
+                .partition_consumers
+                .get_mut(&key)
+                .and_then(|ns| ns.groups.get_mut(group))
+            {
+                g.cursor = AckCursor::resume(Offset::new(earliest));
+                g.leases = LeaseTable::new(lease_config);
+            }
+            let skipped = earliest - committed;
+            self.counters.truncations = self.counters.truncations.saturating_add(1);
+            self.counters.truncated_records =
+                self.counters.truncated_records.saturating_add(skipped);
+            self.counters.last_skip_offset = self.counters.last_skip_offset.max(earliest);
+            return Ok(Poll::Truncated {
+                earliest_retained: Offset::new(earliest),
+                skipped,
+            });
+        }
+        // The delivery window: at most `max_in_flight` offsets above the committed cursor, never past
+        // the partition's durable end.
+        let window_end = committed
+            .saturating_add(u64::from(self.max_in_flight))
+            .min(flushed);
+        let mut offset = committed;
+        while offset < window_end {
+            let off = Offset::new(offset);
+            // Resolve the group and try to claim `off` (scoped borrow of `partition_consumers`).
+            let claim = match self
+                .partition_consumers
+                .get_mut(&key)
+                .and_then(|ns| ns.groups.get_mut(group))
+            {
+                None => return Ok(Poll::Idle),
+                Some(g) => {
+                    if g.cursor.is_acked(off) {
+                        offset += 1;
+                        continue;
+                    }
+                    g.leases.claim(off, now)
+                }
+            };
+            match claim {
+                Claim::InFlight => {
+                    offset += 1;
+                }
+                Claim::Exhausted => return Err(EngineError::GenerationExhausted),
+                Claim::Granted { token, deliveries } => {
+                    // Read the record off this partition's sub-log (immutable `partitioned` borrow,
+                    // DISJOINT from the `partition_consumers` field borrowed above).
+                    let record = match self.partitioned.get(id).and_then(|ps| ps.partition(idx)) {
+                        Some(log) => log.read_from(off, 1).map_err(EngineError::Storage)?,
+                        None => return Ok(Poll::Idle),
+                    };
+                    let Some(record) = record.into_iter().next() else {
+                        return Err(EngineError::MissingRecord { offset });
+                    };
+                    // A compacted hole (a later record superseded `off`): ack the group cursor past the
+                    // whole absent run and surface `Poll::Compacted`. A dense partition never takes this.
+                    if record.offset != off {
+                        if let Some(g) = self
+                            .partition_consumers
+                            .get_mut(&key)
+                            .and_then(|ns| ns.groups.get_mut(group))
+                        {
+                            g.leases.ack(&token);
+                            let mut hole = offset;
+                            while hole < record.offset.get() {
+                                g.cursor.ack(Offset::new(hole));
+                                hole += 1;
+                            }
+                        }
+                        return Ok(Poll::Compacted {
+                            from: off,
+                            to: record.offset,
+                        });
+                    }
+                    match self.delivery.disposition(deliveries) {
+                        Disposition::Deliver => {
+                            self.counters.delivered = self.counters.delivered.saturating_add(1);
+                            if deliveries > 1 {
+                                self.counters.redelivered =
+                                    self.counters.redelivered.saturating_add(1);
+                            }
+                            self.registry.record_stream_delivered(id.name().as_bytes());
+                            return Ok(Poll::Message(Delivery {
+                                offset: off,
+                                token,
+                                deliveries,
+                                record,
+                            }));
+                        }
+                        Disposition::DeadLetter => {
+                            // A per-partition DLQ is a deferred follow-up: commit the poison PAST (so it
+                            // never redelivers forever) and surface `Poll::Parked`, the same shape the
+                            // default stream's dead-letter returns. The lease is released here.
+                            if let Some(g) = self
+                                .partition_consumers
+                                .get_mut(&key)
+                                .and_then(|ns| ns.groups.get_mut(group))
+                            {
+                                g.leases.ack(&token);
+                                g.cursor.ack(off);
+                            }
+                            return Ok(Poll::Parked {
+                                offset: off,
+                                record,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+        Ok(Poll::Idle)
+    }
+
+    /// Acks a partition-addressed delivery (#693): commits partition `(stream, partition)`'s work-group
+    /// `group` cursor past `token.offset` and DURABLY checkpoints the partition's cursor, so the commit
+    /// survives a restart (the per-partition twin of [`Engine::ack_in_stream`]). A stale token (already
+    /// acked or redelivered) is a [`AckResult::Fenced`] no-op, exactly as the default ack.
+    ///
+    /// The checkpoint write is best-effort per ack (a failure loses only a lagging optimization — the
+    /// same at-least-once contract the default cursor's lagging checkpoint has); the clean-shutdown
+    /// flush ([`Engine::checkpoint_all_groups`]) is the guaranteed barrier.
+    #[must_use]
+    pub fn ack_partition(
+        &mut self,
+        stream: &str,
+        partition: u32,
+        group: &str,
+        token: &LeaseToken,
+    ) -> AckResult {
+        let Ok(id) = StreamId::named(stream) else {
+            return AckResult::Fenced;
+        };
+        let key = (id.clone(), partition);
+        let now = self.log.now_monotonic();
+        let acked = {
+            let Some(g) = self
+                .partition_consumers
+                .get_mut(&key)
+                .and_then(|ns| ns.groups.get_mut(group))
+            else {
+                return AckResult::Fenced;
+            };
+            g.last_activity = now;
+            g.touched = true;
+            match g.leases.ack(token) {
+                AckOutcome::Acked => {
+                    g.cursor.ack(token.offset);
+                    self.counters.acks = self.counters.acks.saturating_add(1);
+                    self.registry.record_group_consumed(group.as_bytes());
+                    true
+                }
+                AckOutcome::Fenced => false,
+            }
+        };
+        if acked {
+            // Durably checkpoint this partition's cursor so the commit survives a restart (#681-style,
+            // per partition). Best-effort: a write failure only loses a lagging optimization.
+            let _ = self.checkpoint_partition_group(&id, PartitionIndex::new(partition), group);
+            AckResult::Acked
+        } else {
+            AckResult::Fenced
+        }
+    }
+
+    /// The current committed offset of partition `(stream, partition)`'s work-group `group` (#693): the
+    /// exclusive next-to-deliver position on that partition's OWN cursor. `0` for an unknown
+    /// stream/partition/group. The per-partition twin of [`Engine::committed_offset_in_stream`], used by
+    /// tests and observability to read a partition's independent progress.
+    #[must_use]
+    pub fn committed_offset_in_partition(
+        &self,
+        stream: &str,
+        partition: u32,
+        group: &str,
+    ) -> Offset {
+        let Ok(id) = StreamId::named(stream) else {
+            return Offset::ZERO;
+        };
+        self.partition_consumers
+            .get(&(id, partition))
+            .and_then(|ns| ns.groups.get(group))
+            .map_or(Offset::ZERO, |g| g.cursor.committed())
+    }
+
+    /// Durably writes partition `(id, idx)`'s work-group cursor snapshot to
+    /// `pstreams/<hex(name)>/p-<08x(idx)>/cursor-<hex(group)>.ckpt` (#693), the per-partition twin of
+    /// [`Engine::write_named_group_checkpoint`]: the checkpoint lives in the PARTITION's own subdir
+    /// (resolved via that partition's sub-log filesystem), so a partition-addressed consumer's cursor is
+    /// co-located with — and recovers beside — its own records. Same `AckCursor` snapshot payload and
+    /// dual-slot [`Checkpoint`] as every other cursor; only the location differs. A no-op for an absent
+    /// stream/partition/group.
+    ///
+    /// # Errors
+    /// Propagates a storage error from opening or writing the checkpoint file.
+    fn checkpoint_partition_group(
+        &mut self,
+        id: &StreamId,
+        idx: PartitionIndex,
+        group: &str,
+    ) -> Result<(), EngineError> {
+        let key = (id.clone(), idx.get());
+        let (payload, committed) = match self
+            .partition_consumers
+            .get(&key)
+            .and_then(|s| s.groups.get(group))
+        {
+            Some(g) => (snapshot_payload(&g.cursor), g.cursor.committed().get()),
+            None => return Ok(()),
+        };
+        let name = group_checkpoint_name(group);
+        let file = {
+            let Some(log) = self.partitioned.get(id).and_then(|ps| ps.partition(idx)) else {
+                return Ok(());
+            };
+            let fs = log.filesystem();
+            if fs.exists(&name)? {
+                fs.open(&name)?
+            } else {
+                let f = fs.create_new(&name)?;
+                fs.sync_dir()?; // the new file's directory entry must be durable
+                f
+            }
+        };
+        let (mut cp, _) = Checkpoint::open(file)?;
+        cp.write(&payload)?;
+        if let Some(s) = self.partition_consumers.get_mut(&key) {
+            s.group_last_checkpointed
+                .insert(group.to_string(), committed);
+        }
+        Ok(())
     }
 
     // ===================================================================================
@@ -5699,7 +6400,10 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         let Ok(id) = StreamId::named(stream) else {
             return false;
         };
-        self.known_named_streams.contains(&id)
+        // A stream EXISTS if it is a known single named stream OR a declared PARTITIONED stream (#693):
+        // the two are disjoint namespaces, but both are client-reachable and both must report existence
+        // (e.g. a `SubTo` / `StreamInfo` on a partitioned stream).
+        self.known_named_streams.contains(&id) || self.partitioned.contains_key(&id)
     }
 
     /// Whether the named stream `stream`'s log is currently OPEN (fd-resident) rather than evicted by
@@ -23304,6 +24008,257 @@ mod tests {
         assert!(
             drain_visible_generic(&mut e).is_empty(),
             "the orphan was discarded, never delivered"
+        );
+    }
+
+    // ================================================================================
+    // PARTITIONED-STREAM WIRING (#693): declare-P, produce-route-by-key, partition-addressed consume
+    // with a durable per-partition cursor, P=1 identity, and per-partition contract independence.
+    // ================================================================================
+
+    /// An `Append` carrying a key, for the partition-routing tests.
+    fn part_keyed<'a>(key: &'a [u8], payload: &'a [u8]) -> Append<'a> {
+        Append {
+            timestamp_ms: 0,
+            flags: RecordFlags::EMPTY,
+            key,
+            headers: b"",
+            payload,
+        }
+    }
+
+    /// A key that routes to `target` over `pc` partitions (the same stable `xxh3_64 % P` the engine
+    /// uses), found by a bounded search — so a test can fill a SPECIFIC partition deterministically.
+    fn key_for_partition(target: u32, pc: PartitionCount) -> Vec<u8> {
+        for n in 0..1_000_000u32 {
+            let k = format!("key-{n}").into_bytes();
+            if ironbus_core::partition::partition_for_key(&k, pc).get() == target {
+                return k;
+            }
+        }
+        panic!("no key routes to partition {target}");
+    }
+
+    /// Drains partition `partition` of `stream` in group `group`, acking each delivery, returning the
+    /// payloads in delivery order.
+    fn drain_partition(
+        e: &mut Engine<InMemoryFs, ManualClock>,
+        stream: &str,
+        partition: u32,
+        group: &str,
+    ) -> Vec<Vec<u8>> {
+        let mut out = Vec::new();
+        loop {
+            let now = e.now_monotonic();
+            match e.poll_partition(stream, partition, group, now).unwrap() {
+                Poll::Message(d) => {
+                    out.push(d.record.payload.to_vec());
+                    assert_eq!(
+                        e.ack_partition(stream, partition, group, &d.token),
+                        AckResult::Acked
+                    );
+                }
+                Poll::Idle => break,
+                other => panic!("unexpected poll on partition {partition}: {other:?}"),
+            }
+        }
+        out
+    }
+
+    /// #693 (1): declaring `P > 1` backs the stream with a `PartitionedStream`, and a keyed produce
+    /// routes to `xxh3_64(key) % P`, STABLY — every record for a key lands in its one home partition,
+    /// in order, and no sibling partition holds it; a different key routes to its own stable home.
+    #[test]
+    fn keyed_produce_routes_to_a_stable_partition() {
+        let mut e = open(config(64, 5));
+        assert!(e.declare_partitioned_stream("orders", 4).unwrap());
+        assert_eq!(e.partition_count_of("orders").unwrap().get(), 4);
+        let pc = PartitionCount::new(4).unwrap();
+
+        let key = b"order-42";
+        let home = ironbus_core::partition::partition_for_key(key, pc).get();
+        for n in 0..5u8 {
+            e.produce_in_stream("orders", &part_keyed(key, &[n]))
+                .unwrap();
+        }
+        // Every sibling partition is empty of the key's records; the home partition holds all 5 in order.
+        for p in 0..4 {
+            if p != home {
+                assert!(
+                    drain_partition(&mut e, "orders", p, "w").is_empty(),
+                    "partition {p} holds none of the key's records"
+                );
+            }
+        }
+        assert_eq!(
+            drain_partition(&mut e, "orders", home, "w"),
+            vec![vec![0], vec![1], vec![2], vec![3], vec![4]],
+            "the key's records land in its home partition, in order"
+        );
+        // Stability: the SAME key still routes home on a later produce.
+        e.produce_in_stream("orders", &part_keyed(key, b"z"))
+            .unwrap();
+        assert_eq!(
+            drain_partition(&mut e, "orders", home, "w"),
+            vec![b"z".to_vec()],
+            "the same key is stable across produces"
+        );
+
+        // A DIFFERENT key routes to its OWN stable home partition.
+        let key2 = b"customer-7";
+        let home2 = ironbus_core::partition::partition_for_key(key2, pc).get();
+        e.produce_in_stream("orders", &part_keyed(key2, b"a"))
+            .unwrap();
+        e.produce_in_stream("orders", &part_keyed(key2, b"b"))
+            .unwrap();
+        assert_eq!(
+            drain_partition(&mut e, "orders", home2, "w"),
+            vec![b"a".to_vec(), b"b".to_vec()]
+        );
+    }
+
+    /// #693 (2): a partition-addressed consumer sees ONLY that partition's records, in order, on its
+    /// OWN durable cursor — which SURVIVES a restart (resumes past the committed offset, redelivering
+    /// nothing it acked).
+    #[test]
+    fn partition_addressed_consume_has_a_durable_cursor_across_restart() {
+        let fs = InMemoryFs::new();
+        let pc = PartitionCount::new(4).unwrap();
+        let k2 = key_for_partition(2, pc);
+        let k0 = key_for_partition(0, pc);
+
+        {
+            let mut e = Engine::open(fs.clone(), ManualClock::new(), config(64, 5)).unwrap();
+            e.declare_partitioned_stream("orders", 4).unwrap();
+            for n in 0..3u8 {
+                e.produce_in_stream("orders", &part_keyed(&k2, &[b'A', n]))
+                    .unwrap();
+            }
+            for n in 0..2u8 {
+                e.produce_in_stream("orders", &part_keyed(&k0, &[b'B', n]))
+                    .unwrap();
+            }
+            // The partition-2 consumer sees ONLY partition-2 records, in order.
+            let now = e.now_monotonic();
+            let d0 = message(e.poll_partition("orders", 2, "w", now).unwrap());
+            assert_eq!(&*d0.record.payload, b"A\x00");
+            assert_eq!(
+                e.ack_partition("orders", 2, "w", &d0.token),
+                AckResult::Acked
+            );
+            let now = e.now_monotonic();
+            let d1 = message(e.poll_partition("orders", 2, "w", now).unwrap());
+            assert_eq!(&*d1.record.payload, b"A\x01");
+            assert_eq!(
+                e.ack_partition("orders", 2, "w", &d1.token),
+                AckResult::Acked
+            );
+            assert_eq!(e.committed_offset_in_partition("orders", 2, "w").get(), 2);
+            // Durably flush the partition cursors for a clean shutdown.
+            e.checkpoint_all_groups().unwrap();
+        }
+
+        // Reopen over the SAME storage: the partitioned stream + the partition-2 cursor recover.
+        {
+            let mut e = Engine::open(fs.clone(), ManualClock::new(), config(64, 5)).unwrap();
+            assert_eq!(
+                e.partition_count_of("orders").unwrap().get(),
+                4,
+                "the partitioned stream recovered with its declared P"
+            );
+            assert_eq!(
+                e.committed_offset_in_partition("orders", 2, "w").get(),
+                2,
+                "the partition-2 cursor resumed at its durable committed offset"
+            );
+            let now = e.now_monotonic();
+            let d = message(e.poll_partition("orders", 2, "w", now).unwrap());
+            assert_eq!(
+                &*d.record.payload, b"A\x02",
+                "resumes past the durable cursor — no redelivery of acked records"
+            );
+            assert_eq!(
+                e.ack_partition("orders", 2, "w", &d.token),
+                AckResult::Acked
+            );
+            let now = e.now_monotonic();
+            assert!(matches!(
+                e.poll_partition("orders", 2, "w", now).unwrap(),
+                Poll::Idle
+            ));
+        }
+    }
+
+    /// #693 (3): declaring `P = 1` is NOT a partitioned stream — it is today's single-log named stream,
+    /// byte-for-byte: no `PartitionedStream`, no `pstreams/` subtree, and produce/consume route through
+    /// the unchanged named-stream path.
+    #[test]
+    fn single_partition_declare_is_the_unchanged_named_stream() {
+        let fs = InMemoryFs::new();
+        let mut e = Engine::open(fs.clone(), ManualClock::new(), config(64, 5)).unwrap();
+        assert!(e.declare_partitioned_stream("s", 1).unwrap());
+        assert!(
+            e.partition_count_of("s").is_none(),
+            "P=1 is not a partitioned stream"
+        );
+        assert!(e.stream_exists("s"));
+        // Produce + consume route through the NORMAL named-stream path (not the partition path).
+        e.produce_in_stream("s", &part_keyed(b"k", b"v")).unwrap();
+        let now = e.now_monotonic();
+        let d = message(e.poll_in_stream("s", "w", now).unwrap());
+        assert_eq!(&*d.record.payload, b"v");
+        assert_eq!(e.ack_in_stream("s", "w", &d.token), AckResult::Acked);
+        // No `pstreams/` subtree is ever materialized for a single-partition stream.
+        assert!(
+            !fs.subdir_exists(PARTITIONED_STREAMS_SUBDIR).unwrap(),
+            "P=1 never creates the pstreams/ subtree"
+        );
+        // A re-declare at P=1 is idempotent (already existed).
+        assert!(!e.declare_partitioned_stream("s", 1).unwrap());
+    }
+
+    /// #693 (4): each partition carries the durable contract INDEPENDENTLY — committing one partition's
+    /// cursor never touches a sibling's, each partition delivers its own records, and per-partition
+    /// retention reaps one partition's own old sealed segments.
+    #[test]
+    fn each_partition_carries_the_contract_independently() {
+        let mut e = open(config(64, 5));
+        e.declare_partitioned_stream("orders", 4).unwrap();
+        let pc = PartitionCount::new(4).unwrap();
+        let ka = key_for_partition(1, pc);
+        let kb = key_for_partition(3, pc);
+        for n in 0..3u8 {
+            e.produce_in_stream("orders", &part_keyed(&ka, &[n]))
+                .unwrap();
+        }
+        for n in 0..3u8 {
+            e.produce_in_stream("orders", &part_keyed(&kb, &[n]))
+                .unwrap();
+        }
+        // Consume + commit ONLY partition 1.
+        assert_eq!(drain_partition(&mut e, "orders", 1, "w").len(), 3);
+        assert_eq!(e.committed_offset_in_partition("orders", 1, "w").get(), 3);
+        // Partition 3's cursor is UNTOUCHED (independent) and still delivers all its records.
+        assert_eq!(
+            e.committed_offset_in_partition("orders", 3, "w").get(),
+            0,
+            "committing partition 1 never advanced partition 3's cursor"
+        );
+        assert_eq!(drain_partition(&mut e, "orders", 3, "w").len(), 3);
+
+        // Per-partition RETENTION: a produce-only partition (floor = head) reaps its OWN old sealed
+        // segments once it trips the shared byte bound, independently of its siblings.
+        let mut r = open(config_with_retention(320));
+        r.declare_partitioned_stream("orders", 2).unwrap();
+        let k0 = key_for_partition(0, PartitionCount::new(2).unwrap());
+        for n in 0..40u16 {
+            let payload = [u8::try_from(n & 0xff).unwrap(); 16];
+            r.produce_in_stream("orders", &part_keyed(&k0, &payload))
+                .unwrap();
+        }
+        assert!(
+            r.counters().segments_reaped >= 1,
+            "per-partition retention reaped at least one old sealed segment"
         );
     }
 }

--- a/crates/ironbus-server/src/session.rs
+++ b/crates/ironbus-server/src/session.rs
@@ -406,6 +406,15 @@ pub struct Session {
     /// engine job by value across the actor channel is a refcount bump, not an allocation, exactly like
     /// `subscription`.
     stream: GroupName,
+    /// The PARTITION this connection's consume path is addressed to (#693, M2-I11b), or `None` to
+    /// consume the bound stream as a whole (the ONLY behavior for a single-partition or default stream,
+    /// byte-for-byte the pre-#693 path). A `SubTo` carrying an additive partition selector sets this to
+    /// `Some(i)` (validated: the stream must be partitioned and `i < P`); a plain `Sub`/`Unsub`/subject
+    /// subscribe, or a whole-stream `SubTo`, resets it to `None`. When `Some`, the Flow poll loop and the
+    /// Ack path route through the engine's `poll_partition` / `ack_partition` (partition `i`'s OWN sub-log
+    /// on its OWN durable per-partition cursor); when `None` they use the unchanged
+    /// `poll_in_stream_member` / `ack_in_stream`, or the default-stream path when `stream` is empty.
+    partition: Option<u32>,
     /// Whether this connection has EVER published a Level-2 (server+client-ack) produce (#497): set
     /// when an L2 publish is registered for confirmation, and NEVER cleared. It is the gate that keeps
     /// the per-pass `ProduceConfirm` drain off the actor for a connection that never opted into Level 2
@@ -1290,6 +1299,8 @@ impl Session {
         // A repeated Connect re-negotiates idempotently: reset the active named stream to the default
         // so a re-handshake never leaves a stale named-stream binding from a prior negotiation.
         self.stream = GroupName::default();
+        // #693: resetting to the default stream clears any partition binding (whole-stream consume).
+        self.partition = None;
         // The server caps, read LOCALLY off the handle (NO actor round-trip), so the handshake never
         // touches the actor's checkpoint/fsync path and a stalled produce on one connection cannot
         // head-of-line-block this Connect (invariant 4, #177). The caps are static engine config.
@@ -1716,6 +1727,13 @@ impl Session {
         // phase, the #676 scope), so a named-stream consumer that sends one of those gets a fence rather
         // than a cross-stream effect. The default stream (`self.stream` empty) is byte-for-byte unchanged.
         let stream = self.stream.clone();
+        // #693: a PARTITION-addressed consumer routes its ACK to that partition's OWN durable cursor via
+        // `ack_partition` (plain ack-or-fence, mirroring the named-stream ack path). Checked before the
+        // whole-stream branch; `stream` is non-empty whenever a partition is bound.
+        if let Some(partition) = self.partition {
+            return self
+                .handle_ack_in_partition(engine, stream, partition, group, ack, &token, out);
+        }
         if !stream.is_empty() {
             return self.handle_ack_in_stream(engine, stream, group, ack, &token, out);
         }
@@ -1837,6 +1855,50 @@ impl Session {
             // Nack/Term/Progress are not on the per-stream consume path this phase (#676 scope): fence
             // them (status 0) rather than acting on the default stream's lease table. The lease expires
             // and redelivers on schedule, so at-least-once for the named stream is preserved.
+            AckOp::Nack | AckOp::Term | AckOp::Progress => {
+                self.leased.remove(&ack.offset);
+                reply(out, FrameType::AckStatus, &[0]);
+                Ok(())
+            }
+        }
+    }
+
+    /// Handles the ACK of a partition-addressed delivery (#693), the per-partition twin of
+    /// [`Session::handle_ack_in_stream`]: routes an `Ack` to partition `partition`'s OWN durable cursor
+    /// via [`Engine::ack_partition`] (which also durably checkpoints it), connection-scoped exactly like
+    /// every other ack (the lease-ownership check ran in [`Session::handle_ack`] before this is reached).
+    /// Nack/Term/Progress are not on the partition consume path this phase (mirroring the named-stream
+    /// scope): they reply FENCED (status 0), so the lease expires and redelivers on schedule.
+    // One more argument than `handle_ack_in_stream` (the partition index): the ack must name the exact
+    // (stream, partition, group) it commits, so the extra parameter is inherent, not incidental.
+    #[allow(clippy::too_many_arguments)]
+    fn handle_ack_in_partition<
+        F: Filesystem + Clone + 'static,
+        C: Clock + Clone + 'static,
+        E: EngineAccess<F, C>,
+    >(
+        &mut self,
+        engine: &E,
+        stream: GroupName,
+        partition: u32,
+        group: GroupName,
+        ack: ironbus_proto::message::AckBody,
+        token: &LeaseToken,
+        out: &mut Vec<u8>,
+    ) -> Result<(), SessionError> {
+        match ack.op {
+            AckOp::Ack => {
+                let token = *token;
+                let status = match engine
+                    .with(move |e| e.ack_partition(&stream, partition, &group, &token))?
+                {
+                    AckResult::Acked => 1u8,
+                    AckResult::Fenced => 0u8,
+                };
+                self.leased.remove(&ack.offset);
+                reply(out, FrameType::AckStatus, &[status]);
+                Ok(())
+            }
             AckOp::Nack | AckOp::Term | AckOp::Progress => {
                 self.leased.remove(&ack.offset);
                 reply(out, FrameType::AckStatus, &[0]);
@@ -2239,8 +2301,16 @@ impl Session {
                 let group = self.subscription.clone();
                 let member = self.member_id;
                 let stream = self.stream.clone();
+                // #693: a PARTITION-addressed consumer (`SubTo` carried a partition selector) drains ONE
+                // partition's sub-log via `poll_partition` (plain competing, its OWN durable per-partition
+                // cursor); `stream` is guaranteed non-empty here (SubTo validated it). A whole-stream or
+                // default-stream consumer takes the unchanged member-aware paths below.
+                let partition = self.partition;
                 let poll = engine.with(move |e| {
-                    if stream.is_empty() {
+                    if let Some(partition) = partition {
+                        let now = e.now_monotonic();
+                        e.poll_partition(&stream, partition, &group, now)
+                    } else if stream.is_empty() {
                         e.poll_now_in_member(&group, member)
                     } else {
                         let now = e.now_monotonic();
@@ -3339,6 +3409,8 @@ impl Session {
         // client never sends `SubTo`, so `self.stream` is already default for it; this only matters for
         // a streams-capable client switching from a named stream back to a plain default subscribe.)
         self.stream = GroupName::default();
+        // #693: resetting to the default stream clears any partition binding (whole-stream consume).
+        self.partition = None;
         self.leased.clear();
         // If the new group is configured key_shared (#64), put it into that mode and join as a
         // member so this connection's keys route to it. A failure to enable the mode (an invalid
@@ -3429,10 +3501,15 @@ impl Session {
             return Ok(());
         }
         let stream = stream.to_string();
-        match engine.with(move |e| e.declare_stream(&stream))? {
+        // #693: the additive `partition_count` decides the backing. `P <= 1` delegates to the plain
+        // single-log declare BYTE-FOR-BYTE; `P > 1` opts the stream into a `PartitionedStream` of `P`
+        // key-routed sub-logs. Both reply a body-less `Ok` (idempotent); a conflict (a different `P`, or
+        // a name already a single named stream) fails closed with the engine's typed reason.
+        let partition_count = decoded.partition_count;
+        match engine.with(move |e| e.declare_partitioned_stream(&stream, partition_count))? {
             // Idempotent: a first declare (`true`) and a re-declare (`false`) both reply a body-less Ok.
             Ok(_) => reply(out, FrameType::Ok, &[]),
-            // A malformed/over-long NAMED name fails closed with the engine's typed reason.
+            // A malformed/over-long NAMED name (or a partition conflict) fails closed with the reason.
             Err(e) => reply_err_coded(out, e.code().as_str(), &e.to_string()),
         }
         Ok(())
@@ -4020,6 +4097,38 @@ impl Session {
             );
             return Ok(());
         }
+        // #693: an additive partition selector addresses ONE partition of a PARTITIONED stream. Validate
+        // it (the stream must be partitioned AND the partition in range) and bind the connection's
+        // consume/ack to that partition — a plain competing subscribe on the partition's OWN sub-log +
+        // its OWN durable per-partition cursor. A selector on a non-partitioned stream, or an
+        // out-of-range partition, is a typed reject (never a silent whole-stream subscribe). Per-partition
+        // key_shared / Tier-S are deferred, so this is the plain competing bind; a whole-stream `SubTo`
+        // (`partition = None`) falls through to the historical named-stream path below unchanged.
+        if let Some(partition) = decoded.partition {
+            let stream_q = stream.to_string();
+            let in_range = engine.with(move |e| {
+                e.partition_count_of(&stream_q)
+                    .is_some_and(|pc| partition < pc.get())
+            })?;
+            if !in_range {
+                reply_err(
+                    out,
+                    &format!("partition {partition} is not addressable on stream {stream:?}"),
+                );
+                return Ok(());
+            }
+            // Abandon any prior key_shared membership + default-stream registration + leases, exactly as
+            // the whole-stream rebind below, then bind the partition.
+            self.leave_current_key_shared(engine)?;
+            self.stream = GroupName::from(stream);
+            self.subscription = GroupName::from(group);
+            self.partition = Some(partition);
+            self.registered_subscription = false;
+            self.joined_key_shared = false;
+            self.leased.clear();
+            reply(out, FrameType::Ok, &[]);
+            return Ok(());
+        }
         // Leave any prior key_shared membership (of the OLD stream+group) BEFORE rebinding, so its keys
         // re-route to the remaining members (#64 follow-up). This reads `self.stream`/`self.subscription`,
         // so it must run before they are reassigned below; a no-op for a connection that had not joined.
@@ -4029,6 +4138,8 @@ impl Session {
         // work-group is created lazily on the first named poll under the per-stream group cap (#676).
         self.stream = GroupName::from(stream);
         self.subscription = GroupName::from(group);
+        // A whole-stream SubTo consumes the stream as a whole (#693): clear any prior partition binding.
+        self.partition = None;
         // A named-stream consume does not register in the default-stream broadcast subscriber set (#676),
         // so leave any such default-stream registration behind (a no-op for a connection that never had
         // one) rather than stranding it. The key_shared membership below is per-(stream, group).
@@ -4367,6 +4478,8 @@ impl Session {
             // Bind this connection's consume path to the resolved stream (`""` = default) + the group.
             self.stream = GroupName::from(resolved_stream.as_str());
             self.subscription = GroupName::from(group);
+            // A subject subscribe binds the stream as a whole (#693): clear any partition binding.
+            self.partition = None;
             self.registered_subscription = false;
             self.joined_key_shared = false;
             self.leased.clear();
@@ -4405,6 +4518,8 @@ impl Session {
         // as a `SubTo` binds an explicit stream id (the resolved stream is already declared by its bind).
         self.stream = GroupName::from(stream.name());
         self.subscription = GroupName::from(group);
+        // A subject subscribe binds the stream as a whole (#693): clear any partition binding.
+        self.partition = None;
         self.registered_subscription = false;
         self.joined_key_shared = false;
         self.leased.clear();
@@ -4439,6 +4554,8 @@ impl Session {
         // eviction structures (#676 named consume is plain competing only), so the leave/evict calls
         // above are no-ops for it; only this local binding needs resetting.
         self.stream = GroupName::default();
+        // #693: resetting to the default stream clears any partition binding (whole-stream consume).
+        self.partition = None;
         self.leased.clear();
         if !leaving.is_empty() {
             engine.with(move |e| {
@@ -12765,6 +12882,142 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::too_many_lines)]
+    fn partition_wire_declare_produce_and_addressed_consume_end_to_end() {
+        // #693 THE wire end-to-end: a `StreamDeclare` carrying the additive `partition_count = 2` backs
+        // "orders" with a `PartitionedStream`; keyed produce routes each key to `xxh3_64(key) % 2`; a
+        // `SubTo` carrying the additive partition selector `Some(1)` binds partition 1, and a `Flow`
+        // delivers ONLY partition-1 records (never partition 0's), which ack to partition 1's own cursor.
+        let (e, mut s, mut out) = connect_streams();
+        let pc = ironbus_core::partition::PartitionCount::new(2).unwrap();
+
+        // Declare P=2 over the wire.
+        let mut declare = Vec::new();
+        ironbus_proto::message::encode_stream_declare(
+            &ironbus_proto::message::StreamDeclareBody {
+                stream_id: b"orders",
+                partition_count: 2,
+            },
+            &mut declare,
+        )
+        .unwrap();
+        s.process(&e, &frame(FrameType::StreamDeclare, &declare), &mut out)
+            .unwrap();
+        assert_eq!(
+            one_response(&out).0,
+            FrameType::Ok,
+            "partitioned declare is acked"
+        );
+        out.clear();
+        assert_eq!(e.engine_mut().partition_count_of("orders"), Some(pc));
+
+        // Two records keyed to partition 1, plus one keyed to partition 0 (to prove isolation).
+        let key1 = (0..10_000u32)
+            .map(|n| format!("k{n}").into_bytes())
+            .find(|k| ironbus_core::partition::partition_for_key(k, pc).get() == 1)
+            .expect("a key routing to partition 1");
+        let key0 = (0..10_000u32)
+            .map(|n| format!("z{n}").into_bytes())
+            .find(|k| ironbus_core::partition::partition_for_key(k, pc).get() == 0)
+            .expect("a key routing to partition 0");
+        for p in [&b"first"[..], b"second"] {
+            e.engine_mut()
+                .produce_in_stream(
+                    "orders",
+                    &Append {
+                        timestamp_ms: 0,
+                        flags: RecordFlags::EMPTY,
+                        key: &key1,
+                        headers: b"",
+                        payload: p,
+                    },
+                )
+                .unwrap();
+        }
+        e.engine_mut()
+            .produce_in_stream(
+                "orders",
+                &Append {
+                    timestamp_ms: 0,
+                    flags: RecordFlags::EMPTY,
+                    key: &key0,
+                    headers: b"",
+                    payload: b"other",
+                },
+            )
+            .unwrap();
+
+        // SubTo partition 1 over the wire (additive selector).
+        let mut sub = Vec::new();
+        ironbus_proto::message::encode_sub_to(
+            &ironbus_proto::message::SubToBody {
+                stream_id: b"orders",
+                group: b"w",
+                partition: Some(1),
+            },
+            &mut sub,
+        )
+        .unwrap();
+        s.process(&e, &frame(FrameType::SubTo, &sub), &mut out)
+            .unwrap();
+        assert_eq!(
+            one_response(&out).0,
+            FrameType::Ok,
+            "partition-addressed SubTo is acked"
+        );
+        out.clear();
+
+        // Flow: partition 1 delivers ONLY its own two records, never partition 0's "other".
+        s.process(&e, &frame(FrameType::Flow, &10u32.to_le_bytes()), &mut out)
+            .unwrap();
+        assert_eq!(
+            delivered_payloads(&out),
+            vec![b"first".to_vec(), b"second".to_vec()],
+            "the partition-1 consumer sees only partition-1 records over the wire"
+        );
+
+        // Ack every delivered record; each routes to partition 1's OWN durable cursor (status 1).
+        for (ty, body) in decode_all(&out) {
+            if ty != FrameType::Deliver {
+                continue;
+            }
+            let d = decode_deliver(&body).unwrap();
+            let mut ack = Vec::new();
+            encode_ack(
+                &AckBody {
+                    offset: d.offset,
+                    generation: d.generation,
+                    op: AckOp::Ack,
+                    delay_ms: 0,
+                },
+                &mut ack,
+            );
+            let mut aout = Vec::new();
+            s.process(&e, &frame(FrameType::Ack, &ack), &mut aout)
+                .unwrap();
+            let (aty, abody) = one_response(&aout);
+            assert_eq!(aty, FrameType::AckStatus);
+            assert_eq!(abody, vec![1u8], "the partition ack committed");
+        }
+        out.clear();
+
+        // Nothing more to deliver on partition 1 (all acked); its cursor advanced independently.
+        s.process(&e, &frame(FrameType::Flow, &10u32.to_le_bytes()), &mut out)
+            .unwrap();
+        assert!(
+            delivered_payloads(&out).is_empty(),
+            "no more partition-1 records after ack"
+        );
+        assert_eq!(
+            e.engine_mut()
+                .committed_offset_in_partition("orders", 1, "w")
+                .get(),
+            2,
+            "partition 1's cursor committed both its records"
+        );
+    }
+
+    #[test]
     fn bind_publish_and_subscribe_by_subject_end_to_end_over_the_wire() {
         // THE wire end-to-end: BindSubject "order.>" -> "orders"; PubSubject "order.us.created"
         // resolves single-home and lands in "orders" (a PubAck comes back); then a SubSubject on a
@@ -14438,6 +14691,7 @@ mod tests {
             &ironbus_proto::message::SubToBody {
                 stream_id: stream,
                 group,
+                partition: None,
             },
             &mut body,
         )

--- a/crates/ironbus-storage/src/layout.rs
+++ b/crates/ironbus-storage/src/layout.rs
@@ -69,6 +69,14 @@ pub const LAYOUT_VERSION: u32 = 1;
 /// M2-I2 materializes it.
 pub const STREAMS_SUBDIR: &str = "streams";
 
+/// The reserved data-dir subtree for PARTITIONED streams (M2-I11b, #693): each partitioned stream is
+/// a [`crate::partitioned::PartitionedStream`] rooted at `pstreams/<hex(name)>/`, whose `P` sub-logs
+/// live under `pstreams/<hex(name)>/p-<08x(i)>/`. It is a SEPARATE subtree from [`STREAMS_SUBDIR`] so
+/// the single-log [`crate::streamset::StreamSet`] (which scans only `streams/`) never mistakes a
+/// partitioned stream's root for a plain named-stream log. NOT created until a stream declares `P > 1`,
+/// so a deployment that never partitions never materializes `pstreams/` (its disk image is unchanged).
+pub const PARTITIONED_STREAMS_SUBDIR: &str = "pstreams";
+
 /// The on-disk file name of the layout marker. It deliberately does NOT match the `seg-<hex>.log`
 /// or `cursor*.ckpt` naming, so segment enumeration ([`crate::naming::segment_ids`]) and cursor
 /// discovery skip it as a foreign file.


### PR DESCRIPTION
Threads the #591 `PartitionedStream` storage primitive through the engine and adds the partition wire. Refs #693 (M2-I11b). **Draft — do not merge.**

## What this wires (the CORE, per the issue's item 1 + 2 + partial 3)
- **Declare P:** `StreamDeclare` gains an additive `partition_count` (u32). `P <= 1` is today's single-log named stream, byte-for-byte on the wire AND on disk. `P > 1` opens a `PartitionedStream` of `P` independent, key-routed sub-logs under a reserved `pstreams/<hex(name)>/` subtree (disjoint from `streams/`, so `StreamSet` never mistakes it for a plain log).
- **Produce routes by key:** a keyed produce to a partitioned stream routes to `xxh3_64(key) % P` (#591's stable hash) and commits with that stream's OWN `PartitionedStream::commit_tick` group-commit barrier; a frozen partition surfaces `WriterFrozen` (I2). A keyless produce spreads by the stream's round-robin selector. Reuses the existing `produce_in_stream` entry point (a one-map-lookup branch), so `PubTo`/produce-by-subject route transparently.
- **Address a partition on consume:** `SubTo` gains an additive partition selector (`Option<u32>`). A partition-addressed consumer drains ONE partition's sub-log on its OWN plain-competing work-group + its OWN durable per-partition cursor (#681-style, checkpointed to `pstreams/<hex(name)>/p-<08x(i)>/cursor-<hex(group)>.ckpt`, recovered at open + flushed on graceful shutdown).

## Assignment (item 3/4) — SIMPLE/STATIC only, as scoped
A consumer names ONE explicit partition (or the whole stream for `P=1`). **Deferred follow-ups** (never removed from a single-log named stream, surfaced here per design note D7): cooperative rebalance / dynamic partition→consumer assignment (likely its own frame), per-partition DLQ (#1110-style — a poison is committed-past + `Poll::Parked` here), per-partition subject filters / key-shared / Tier-S streaming, and per-partition metric labels.

## Wire / compat
- **Additive fields only, no new frame tag** (D7). Both fields are emitted ONLY when non-default, so a single-partition declare / whole-stream `SubTo` is byte-for-byte the pre-#693 body — the Go golden vectors are unchanged.
- **No on-disk format-const change:** `P` is derived at open from the materialized `p-<08x>/` subdir count (#591's own source of truth), so `scripts/check-format-registry.sh` passes with both digests unchanged.
- Old clients get P=1 behavior byte-for-byte; a partitioned stream is strictly opt-in.

## How a partition composes with the existing contract
Each partition is a full `Log`, so per partition: `commit_tick` durability + froze/I2, an independent `#681` durable cursor (below-earliest `Poll::Truncated` handled), and `#566` retention (`Log::reap` floored at that partition's own min-committed offset). DLQ per partition is the noted deferral.

## Tests
- proto: round-trip + byte-identical-default tests for both additive fields.
- engine: keyed-produce → stable partition; partition-addressed consume with a durable cursor across restart; `P=1` is the unchanged named stream (no `pstreams/`); each partition carries commit/cursor/retention independently.
- session: declare `P=2` → keyed produce → `SubTo` partition 1 → `Flow` delivers only partition-1 records → `Ack` to the partition's own cursor, end-to-end over the wire.

## CI (all green locally, Linux container)
`cargo test --workspace --locked` 0 failed · golden-path acceptance ok · `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` clean · `cargo fmt --all --check` ok · `scripts/check-format-registry.sh` ok.

## Key correctness points for review
- key→partition stability: routing is #591's deterministic `xxh3_64(key) % P` (no per-process seed); reproduced in tests.
- partition-addressed cursor isolation: per-`(stream, partition)` `NamedStream` state + a checkpoint on the partition sub-log's own filesystem handle; committing one partition never touches a sibling (tested).
- P=1 unchanged: `declare_partitioned_stream(_, 1)` delegates to `declare_stream`; produce/consume take the historical named path; no `pstreams/` is ever materialized (tested).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01McmNfYNWPmohVS8umY9Lkp