### PR TITLE
chore(release): rolling calendar version YYYY.MMDD.N -> YYMM.1DD.1{Build}

### DIFF
--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -13,8 +13,10 @@ name: Rolling release
 # the binary via `IRONBUS_BUILD_VERSION` (read by `option_env!` in the `version` verb, forwarded
 # into the cross container by Cross.toml).
 #
-# The version is `YYYY.MMDD.N` (UTC date + per-day build number); the first push of a day is `.1`,
-# the next `.2`, the next day resets. The release is a NORMAL release (not a prerelease, not a
+# The version is `YYMM.1DD.1{Build}` (e.g. 2026-07-08 build 3 -> `2607.108.13`): UTC 2-digit
+# year+month, then `1`+day, then `1`+per-day build number. The `1` prefixes keep every component
+# leading-zero-free, so the string is VALID SEMVER and monotonically increasing over time while still
+# reading as a calendar version. The first push of a day is `.11`, the next `.12`, the next day resets. The release is a NORMAL release (not a prerelease, not a
 # draft), so GitHub's `releases/latest` points at the newest rolling build and the installer's
 # default-latest works. Skip a build by putting `[skip release]` in the head commit message.
 on:
@@ -47,27 +49,31 @@ jobs:
       version: ${{ steps.compute.outputs.version }}
     steps:
       - id: compute
-        name: compute YYYY.MMDD.N
+        name: compute YYMM.1DD.1{Build}
         env:
           GH_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
-          # The UTC calendar date with leading-zero month/day, e.g. 2026.0609. This is a deliberate
-          # CalVer string used only as a tag + a printed version, never semver-parsed, so the
-          # leading zeros are fine.
-          DATE="$(date -u +%Y.%m%d)"
-          # N is the per-day build number: the MAX of the existing same-day build numbers plus
-          # one, NOT count + one. Counting is gap-fragile: a deleted tag, or an operator-created
-          # tag that jumped ahead, would make count+1 collide with an existing tag and
-          # `gh release create` would fail, shipping nothing. max+1 is robust against gaps. The
-          # next day, with no prior "$DATE." releases, max is 0 so the first build is 1, so each
-          # day resets. `startswith` + `split(".")` avoids escaping the date's own dots in a regex.
-          maxn="$(gh release list --repo "$GITHUB_REPOSITORY" --limit 1000 --json tagName \
-            --jq "[.[].tagName | select(startswith(\"${DATE}.\")) | split(\".\")[-1] | tonumber] | max // 0")"
-          build=$((maxn + 1))
-          VERSION="${DATE}.${build}"
-          echo "computed rolling version: $VERSION (highest existing $DATE.* build: $maxn)"
+          # CalVer `YYMM.1DD.1{Build}` (e.g. 2026-07-08 build 3 -> 2607.108.13). The `1` prefixes on the
+          # day and the build keep every component leading-zero-free, so this string is VALID SEMVER and
+          # monotonically increasing over time (major=year+month, minor=day, patch=build), while still
+          # reading as a calendar version. Used as the release tag + the stamped/printed version.
+          YYMM="$(date -u +%y%m)"      # 2-digit year + 2-digit month, e.g. 2607
+          DAY="$(date -u +%d)"         # zero-padded day-of-month, e.g. 08
+          PREFIX="${YYMM}.1${DAY}"     # `1`+DD -> the per-day namespace, e.g. 2607.108 (leading-zero-free)
+          # Build number: the MAX of the existing same-day builds plus one, NOT count + one. Counting is
+          # gap-fragile: a deleted tag, or an operator-created tag that jumped ahead, would make count+1
+          # collide with an existing tag and `gh release create` would fail, shipping nothing. max+1 is
+          # robust against gaps. Each same-day tag's patch is `1{Build}`, so `ltrimstr("1")` strips the
+          # leading `1` to recover the build number (11->1, 115->15). No prior "$PREFIX." tag => max 0 =>
+          # first build 1 => patch `11`, so each day resets. Old `YYYY.MMDD.N` and `v*` tags don't match
+          # the `$PREFIX.` startswith, so they're ignored.
+          maxbuild="$(gh release list --repo "$GITHUB_REPOSITORY" --limit 1000 --json tagName \
+            --jq "[.[].tagName | select(startswith(\"${PREFIX}.\")) | split(\".\")[-1] | ltrimstr(\"1\") | tonumber] | max // 0")"
+          build=$((maxbuild + 1))
+          VERSION="${PREFIX}.1${build}"  # `1`+build, e.g. 2607.108.115
+          echo "computed rolling version: $VERSION (highest existing $PREFIX.* build: $maxbuild)"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ negotiated wire envelope are the stability anchors called out per entry.
 
 ## [Unreleased]
 
+### Changed
+- Rolling-release calendar version format changed from `YYYY.MMDD.N` to `YYMM.1DD.1{Build}` (e.g. `2607.108.13` for 2026-07-08 build 3). The `1` prefixes on the day and build keep every component leading-zero-free, so the version is now valid SemVer and monotonically increasing, while still reading as a calendar version. Only the rolling (continuous) channel is affected; the formal `v*` semver channel and the internal crate version are unchanged.
+
 ## [v0.1.0]
 
 _Release date set at tag time by the maintainer (prepared 2026-07-07)._

--- a/Cross.toml
+++ b/Cross.toml
@@ -8,7 +8,7 @@
 # cross-build and the 32-bit parser job do not set `SOURCE_DATE_EPOCH`, so an unset var is simply
 # not forwarded), so this only affects the release path.
 #
-# `IRONBUS_BUILD_VERSION` is the rolling-release workflow's calendar version `YYYY.MMDD.N`; it is
+# `IRONBUS_BUILD_VERSION` is the rolling-release workflow's calendar version `YYMM.1DD.1{Build}`; it is
 # read at compile time by `option_env!` in the `version` verb so `ironbus version` reports the
 # published build (it is unset and ignored on every other `cross` caller, so the dev/CI build
 # falls back to `CARGO_PKG_VERSION` and the lockfile is untouched).

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Prefer to grab the binary yourself? Download the static `musl` binary for your C
 | armv7 / Raspberry Pi (32-bit) | `ironbus-linux-armv7` |
 | x86_64 / amd64 | `ironbus-linux-amd64` |
 
-Every push to main publishes a fresh `YYYY.MMDD.N` build (calendar-versioned, the three static binaries plus a consolidated `SHA256SUMS` and a Sigstore provenance attestation), so `releases/latest` and the installer always resolve to the newest build. See [docs/DISTRIBUTION.md](docs/DISTRIBUTION.md) for every channel.
+Every push to main publishes a fresh `YYMM.1DD.1{Build}` build (calendar-versioned, the three static binaries plus a consolidated `SHA256SUMS` and a Sigstore provenance attestation), so `releases/latest` and the installer always resolve to the newest build. See [docs/DISTRIBUTION.md](docs/DISTRIBUTION.md) for every channel.
 
 **Prefer a container?** Every build also publishes a multi-arch (amd64 / arm64 / armv7) distroless image to `ghcr.io/elares/ironbus`, so you can pull and run without installing anything (mind the loopback / security note above):
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,8 +4,8 @@ IronBus ships as a single static `musl` binary for three edge triples, through t
 channels:
 
 - **Rolling, calendar-versioned** releases, published AUTOMATICALLY on EVERY push to main by the
-  `Rolling release` workflow (`.github/workflows/rolling-release.yml`). The version is `YYYY.MMDD.N`
-  (the UTC date plus a per-day build number, e.g. `2026.0609.1` then `2026.0609.2`, resetting the
+  `Rolling release` workflow (`.github/workflows/rolling-release.yml`). The version is `YYMM.1DD.1{Build}`
+  (the UTC date plus a per-day build number, e.g. `2607.108.11` then `2607.108.12`, resetting the
   next day). Each rolling build publishes the three static musl binaries, their per-binary
   `.sha256`, a consolidated `SHA256SUMS`, and a Sigstore build-provenance attestation, as a NORMAL
   release, so `releases/latest` (and the `curl | sh` installer's default) always points at the

--- a/crates/ironbus-cli/src/main.rs
+++ b/crates/ironbus-cli/src/main.rs
@@ -1461,7 +1461,7 @@ fn run(args: &[String], out: &mut impl Write) -> Result<(), CliError> {
         // `ironbus <version>` and exit 0, so an operator (and the CI cross-build smoke, #100) can
         // identify the build with no broker, no data dir, and no socket. The version is the
         // compile-time `IRONBUS_BUILD_VERSION` if set (the rolling-release workflow stamps the
-        // calendar version `YYYY.MMDD.N` there) and otherwise the workspace package version from
+        // calendar version `YYMM.1DD.1{Build}` there) and otherwise the workspace package version from
         // Cargo's `CARGO_PKG_VERSION` (the normal dev/CI/test case). `option_env!` is read at
         // compile time and leaves `Cargo.lock` untouched, so it never breaks `cargo build
         // --locked` the way a `Cargo.toml` version bump would (the lockfile pins the workspace

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -14,7 +14,7 @@ only the packaging. There are four channels, each fail-closed verified before it
 There are two release CHANNELS the GitHub Releases come from:
 
 - A **rolling, calendar-versioned** release published AUTOMATICALLY on EVERY push to main
-  (`.github/workflows/rolling-release.yml`), versioned `YYYY.MMDD.N` (the UTC date plus a per-day
+  (`.github/workflows/rolling-release.yml`), versioned `YYMM.1DD.1{Build}` (the UTC date plus a per-day
   build number). Each rolling build ships the three static musl binaries, their per-binary
   `.sha256`, a consolidated `SHA256SUMS`, and a keyless Sigstore build-provenance attestation. It is
   a NORMAL release, so GitHub's `releases/latest` (and therefore the `curl | sh` installer's default
@@ -23,7 +23,7 @@ There are two release CHANNELS the GitHub Releases come from:
   release". It carries NO changelog gate (rolling builds are continuous, not curated) and does not
   attach the `.deb`. It DOES publish the distroless container image: every rolling build pushes a
   multi-arch (amd64/arm64/armv7) image to `ghcr.io/elares/ironbus`, tagged `:latest` and
-  `:YYYY.MMDD.N`, so the registry image is the live, continuously-published one (#334).
+  `:YYMM.1DD.1{Build}`, so the registry image is the live, continuously-published one (#334).
 - A **formal, tagged** release cut on a `v*` tag by the maintainer (`.github/workflows/release.yml`).
   This is the curated channel: it adds the `.deb` per triple, the syft CycloneDX SBOM, and a
   changelog gate (an empty `## [Unreleased]` FAILS the release before any binary is built), and it
@@ -258,7 +258,7 @@ release binaries (no recompile) and pushes a `linux/amd64` + `linux/arm64` + `li
 multi-arch manifest to `ghcr.io/elares/ironbus`, tagged with the calendar version AND `:latest`:
 
 - `ghcr.io/elares/ironbus:latest` always tracks the newest rolling build.
-- `ghcr.io/elares/ironbus:YYYY.MMDD.N` pins a specific rolling build.
+- `ghcr.io/elares/ironbus:YYMM.1DD.1{Build}` pins a specific rolling build.
 
 The formal `v*` channel (`.github/workflows/release.yml`) pushes the same multi-arch manifest on a
 tag, tagged `:vX.Y.Z` plus `:latest` (a 0.x prerelease pushes only the version tag, never moving
@@ -312,7 +312,7 @@ picks the matching asset. Verify integrity with `sha256sum -c SHA256SUMS` and pr
 `gh attestation verify <binary> --repo ELares/IronBus`.
 
 These releases come from the two channels above: the **rolling** channel (automatic on every main
-push, `YYYY.MMDD.N`, the three binaries + `SHA256SUMS` + provenance) and the **formal** `v*` channel
+push, `YYMM.1DD.1{Build}`, the three binaries + `SHA256SUMS` + provenance) and the **formal** `v*` channel
 (which additionally attaches the cargo-auditable and CycloneDX SBOMs, the `.deb` packages, and rides
 the changelog gate). The `curl | sh` installer and the `releases/latest` default both resolve to the
 newest rolling build. Details in [RELEASING.md](../RELEASING.md#what-the-release-produces).


### PR DESCRIPTION
Changes the rolling (continuous) channel version format from `YYYY.MMDD.N` to `YYMM.1DD.1{Build}` (e.g. `2607.108.13` for 2026-07-08 build 3). The `1` prefixes on the day and build keep every component leading-zero-free, so the version is now valid SemVer and monotonically increasing over time, while still reading as a calendar version.

Only `rolling-release.yml` is functionally changed (the version-compute step); build-number logic is unchanged (`max(same-day builds)+1`, now recovering the build via `ltrimstr("1")` from the `1{Build}` patch; daily reset). The formal `v*` semver channel, `prepare-release.sh`, and the internal crate version are untouched. Docs updated (README/RELEASING/DISTRIBUTION/Cross.toml/CHANGELOG). jq logic verified locally. Refs the versioning discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)