### PR TITLE
fix: low-severity bug pass (#804 produce-gate false-reject, #805 reply-channel ActorGone dead-code, #806 geo pull-loop stall)

### DIFF
--- a/crates/ironbus-server/src/actor.rs
+++ b/crates/ironbus-server/src/actor.rs
@@ -400,8 +400,11 @@ fn recv_sliced(
     loop {
         match rx.recv_timeout(WAIT_ACTOR_ALIVE_POLL) {
             Ok(outcome) => return Ok(outcome),
-            // A real disconnect (a non-recycled reply channel, e.g. the direct/test path) is still
-            // `ActorGone`, exactly as before.
+            // UNREACHABLE for a POOLED produce reply channel: its co-located `tx` (#475) keeps the
+            // channel open, so a `recv_timeout` here never observes a disconnect — actor departure is
+            // detected on the Timeout arm via the `actor_alive` flag (#949), NOT via channel closure.
+            // The arm is retained to exhaustively handle the `Result` (and to still surface `ActorGone`
+            // for any hypothetical non-co-located reply channel), never as the liveness mechanism.
             Err(RecvTimeoutError::Disconnected) => return Err(ActorGone),
             Err(RecvTimeoutError::Timeout) => {
                 // The actor is still running: the outcome is merely not ready yet (a slow covering
@@ -479,9 +482,15 @@ impl ProduceSubmission {
     /// up empty parks nothing and returns immediately, where `wait` would block).
     ///
     /// # Errors
-    /// Returns [`ActorGone`] only if the actor dropped its cloned `tx` UN-sent (it exited before
-    /// replying), which disconnects the channel — exactly the condition `wait` maps to `ActorGone`. An
-    /// empty (not-yet-ready) channel is NOT an error; it is [`TryTake::NotReady`].
+    /// Returns [`ActorGone`] only if the reply channel is genuinely disconnected — which, for a POOLED
+    /// produce reply channel, CANNOT happen: its co-located `tx` (#475) keeps the channel open, so a
+    /// gone actor shows here as [`TryTake::NotReady`] (an empty channel), NOT `ActorGone`. This
+    /// non-blocking poll therefore does NOT itself detect actor departure; the caller's BLOCKING backstop
+    /// does — a not-ready front is re-parked and later block-awaited via [`wait`](ProduceSubmission::wait),
+    /// which consults the `actor_alive` flag (#949) and returns `ActorGone` instead of wedging. (The
+    /// `Disconnected` arm is retained for exhaustiveness and to surface `ActorGone` for any hypothetical
+    /// non-co-located channel.) An empty (not-yet-ready) channel is NOT an error; it is
+    /// [`TryTake::NotReady`].
     ///
     /// [`wait`]: ProduceSubmission::wait
     pub fn try_take(self) -> Result<TryTake, ActorGone> {
@@ -499,16 +508,20 @@ impl ProduceSubmission {
                     Ok(TryTake::Ready(outcome))
                 }
                 // Not yet released: return the submission INTACT (channel un-drained) to re-park. The
-                // co-located `tx` guarantees the channel cannot be disconnected here (the #802
-                // invariant), so `Empty` truly means "the actor has not committed this batch yet".
+                // co-located `tx` (#475) keeps the channel open, so `Empty` means EITHER the actor has
+                // not committed this batch yet OR it exited un-replied (#949) — a non-blocking poll cannot
+                // tell them apart. Either way the front is re-parked; a gone actor is surfaced by the
+                // caller's later BLOCKING `wait` (which consults `actor_alive`), never wedged here.
                 Err(TryRecvError::Empty) => Ok(TryTake::NotReady(ProduceSubmission::Pending {
                     channel,
                     pool,
                     spin,
                     actor_alive,
                 })),
-                // The actor exited before replying (it dropped its cloned `tx` un-sent): map it exactly
-                // like `wait`'s recv error so the session ends the connection cleanly.
+                // UNREACHABLE for a pooled channel (its co-located `tx`, #475, keeps the channel open, so
+                // a gone actor shows as `Empty`/`NotReady` above, not `Disconnected`). Retained to
+                // exhaustively handle the `Result` and to map any hypothetical genuine disconnect to
+                // `ActorGone`, exactly like `wait`'s recv error, so the session ends cleanly.
                 Err(TryRecvError::Disconnected) => Err(ActorGone),
             },
         }
@@ -4291,6 +4304,31 @@ mod tests {
         assert!(
             matches!(submission.wait(), Err(ActorGone)),
             "a spin-tier pending produce whose actor exited must return ActorGone, not wedge"
+        );
+    }
+
+    #[test]
+    fn try_take_polls_notready_not_actorgone_on_a_pooled_channel_whose_actor_is_gone() {
+        // #805: `try_take` is a NON-BLOCKING poll. For a POOLED reply channel the co-located `tx` (#475)
+        // keeps the channel OPEN even after the actor exited un-replied, so `try_recv` sees `Empty`, not
+        // `Disconnected` — `try_take` returns `NotReady`, NEVER a spurious `ActorGone`. Actor departure
+        // on the produce path is not detected by this poll; it is surfaced by the caller's BLOCKING
+        // `wait` backstop (which consults `actor_alive`, #949). This pins the corrected contract so the
+        // recv-side `Disconnected`-arm comment can never silently drift back to claiming that this poll
+        // detects a gone actor via channel closure (it cannot — the closure never happens here).
+        let pool: ReplyPool = Arc::new(Mutex::new(Vec::new()));
+        let channel = pool_take(&pool);
+        let actor_alive = Arc::new(AtomicBool::new(false)); // the actor is already gone
+        let submission = ProduceSubmission::Pending {
+            channel,
+            pool: Arc::clone(&pool),
+            spin: false,
+            actor_alive,
+        };
+        assert!(
+            matches!(submission.try_take(), Ok(TryTake::NotReady(_))),
+            "a pooled produce whose actor exited un-replied polls NotReady (the co-located tx keeps the \
+             channel open), never a spurious ActorGone — the blocking wait backstop detects departure"
         );
     }
 

--- a/crates/ironbus-server/src/actor.rs
+++ b/crates/ironbus-server/src/actor.rs
@@ -1757,9 +1757,15 @@ where
     // Seed the gate to the engine's CURRENT durable bytes and policy, so a broker recovered ALREADY
     // over its cap (a restart on a full log) fast-rejects from the very first produce rather than
     // waiting for the first commit to publish a reading. Publish-only (no reconcile): nothing has run
-    // yet, so there are no fast-rejects to fold, and `&engine` is still borrowed before the move.
+    // yet, so there are no fast-rejects to fold, and `&engine` is still borrowed before the move. The
+    // drop-new seed is REAP-AWARE (#804), exactly like the running refresh: a broker configured with
+    // retention / compaction starts DISENGAGED (the byte total is non-monotone across a commit), so it
+    // never false-rejects against a stale-high seed before the first reap.
     match engine.disk_full_policy() {
-        DiskFullPolicy::DropNew => cap_gate.publish_drop_new(engine.durable_record_bytes()),
+        DiskFullPolicy::DropNew => {
+            cap_gate
+                .publish_drop_new_reap_aware(engine.durable_record_bytes(), reap_possible(&engine));
+        }
         _ => cap_gate.disengage(),
     }
     let actor_gate = Arc::clone(&cap_gate);
@@ -1868,14 +1874,42 @@ where
     //    a Level-1 rejection. Two separate exact deltas, each reconciled to its own counter.
     engine.record_fast_reject_sheds(gate.take_unreconciled_fast_rejects());
     engine.record_fire_and_forget_sheds(gate.take_unreconciled_l0_sheds());
-    // 2. Publish the gate's next snapshot from the now-current byte total and overflow policy.
+    // 2. Publish the gate's next snapshot from the now-current byte total and overflow policy. Under
+    //    drop-new the publish is REAP-AWARE (#804): if a consumer-safe retention / compaction reap can
+    //    lower the byte total inside a `commit_batch`, the total is non-monotone across a commit, so the
+    //    last-published snapshot could be transiently STALE-HIGH after an in-commit reap — the gate
+    //    disengages rather than let a connection thread false-reject a produce the post-reap actor would
+    //    accept. With no reap possible (the common case) the total only grows between refreshes, so the
+    //    snapshot is exact and the full #476 fast-reject stays engaged.
     match engine.disk_full_policy() {
-        DiskFullPolicy::DropNew => gate.publish_drop_new(engine.durable_record_bytes()),
+        DiskFullPolicy::DropNew => {
+            gate.publish_drop_new_reap_aware(engine.durable_record_bytes(), reap_possible(engine));
+        }
         // Drop-oldest accepts over-cap produces (force-reap then append), so the gate must not fire.
         // `#[non_exhaustive]` enum: any future non-drop-new policy also disengages, which is the
         // conservative default (fall through to the authoritative actor path).
         _ => gate.disengage(),
     }
+}
+
+/// Whether a consumer-safe retention OR compaction reap can lower `durable_record_bytes` inside a
+/// `commit_batch` under the engine's CURRENT (live-reloadable) config (#804). Any retention bound set
+/// (size / age / count) or compaction enabled makes the byte total NON-MONOTONE across a commit, so the
+/// connection-thread fast-reject's last-published snapshot can be transiently stale-high after an
+/// in-commit reap — and the gate must DISENGAGE rather than risk a false reject. `false` (the common
+/// case: no retention / compaction) means the total only grows between refreshes, so the snapshot is an
+/// exact lower bound and the full #476 fast-reject stays engaged. Read from the engine's cheap
+/// (`Copy`-field) config snapshot, once per batch, amortized with the covering fsync — never per message.
+fn reap_possible<F, C>(engine: &Engine<F, C>) -> bool
+where
+    F: Filesystem,
+    C: Clock + Clone,
+{
+    let cfg = engine.config_snapshot();
+    cfg.max_retained_bytes != 0
+        || cfg.max_age_ms != 0
+        || cfg.max_messages != 0
+        || engine.compaction_config().enabled
 }
 
 /// The pipelined sync tier's spawn-time rig (#1040): the dedicated flusher thread plus its two

--- a/crates/ironbus-server/src/cluster/geo.rs
+++ b/crates/ironbus-server/src/cluster/geo.rs
@@ -1448,10 +1448,20 @@ pub fn pull_loop<S, A>(
         }
         match link.recv() {
             Ok(Some(GeoFrame::Response(resp))) => {
-                let empty = resp.record_count == 0;
+                // Classify "caught up" with the SAME predicate the applier uses (#806): a response is a
+                // clean no-op ONLY when it carries zero records AND zero bytes (`apply_pull_response`'s
+                // guard). A MALFORMED response — `record_count == 0` but NON-EMPTY `frame_bytes` —
+                // is NOT caught-up: classifying on the count ALONE would short-circuit `apply`, pin the
+                // cursor, and re-poll the same offset FOREVER (a silent, permanent no-progress stall).
+                // Flowing it into `apply` instead walks the bytes and surfaces a typed error
+                // (`RecordCountMismatch` / `NonContiguous` / `CorruptFrame`), so the link is dropped
+                // fail-closed and the caller reconnects — consistent with the surrounding fail-closed
+                // discipline (a malformed origin frame is surfaced, never silently swallowed).
+                let empty = resp.record_count == 0 && resp.frame_bytes.is_empty();
                 if !empty {
-                    // Apply the CRC-revalidated bytes. A corrupt / non-contiguous frame fails closed; the
-                    // cursor did not move past it, so drop this link and re-pull from the cursor.
+                    // Apply the CRC-revalidated bytes. A corrupt / non-contiguous / count-mismatched
+                    // frame fails closed; the cursor did not move past it, so drop this link and re-pull
+                    // from the cursor.
                     if let Err(e) = apply(&resp) {
                         tracing::debug!(origin = origin_key, error = %e, "geo: apply failed; will resume from cursor");
                         return;
@@ -2950,5 +2960,90 @@ mod live_geo_tests {
 
         shutdown.store(true, Ordering::Release);
         let _ = handle.join();
+    }
+
+    #[test]
+    fn a_count_zero_non_empty_response_is_not_treated_as_caught_up_and_does_not_stall() {
+        // #806: a MALFORMED response — `record_count == 0` but NON-EMPTY `frame_bytes` — must NOT be
+        // classified as "caught up" (which would short-circuit `apply`, pin the cursor, and re-poll the
+        // same offset forever, a silent no-progress stall). The loop must flow it into `apply`; the
+        // applier surfaces a typed error (`RecordCountMismatch`), and the loop drops the link
+        // fail-closed so the caller reconnects.
+        //
+        // MUTATION CHECK: revert the classifier to `resp.record_count == 0` and `apply` is NEVER called
+        // (the loop sleeps `GEO_POLL` and re-polls the pinned cursor), so `apply_calls` stays 0 and the
+        // assert below fails.
+
+        // A one-shot replay stream: hands back the framed response, then EOF; writes (the pull requests)
+        // are sunk. `Read + Write` so it drives `GeoLink` like a real transport, with no origin process.
+        struct ReplayStream {
+            to_read: std::io::Cursor<Vec<u8>>,
+        }
+        impl std::io::Read for ReplayStream {
+            fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+                self.to_read.read(buf)
+            }
+        }
+        impl std::io::Write for ReplayStream {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                Ok(buf.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        // A malformed response: one VALID CRC frame, but a claimed `record_count` of 0.
+        let mut frame = Vec::new();
+        ironbus_core::codec::encode(
+            &ironbus_core::codec::RecordView {
+                seq: ironbus_core::types::Seq::new(0),
+                timestamp_ms: 1,
+                flags: RecordFlags::EMPTY,
+                key: b"",
+                headers: b"",
+                payload: b"x",
+            },
+            &mut frame,
+        )
+        .unwrap();
+        let resp = MirrorPullResponse {
+            origin_high_watermark: 1,
+            first_offset: 0,
+            record_count: 0, // MALFORMED: zero count, non-empty bytes
+            frame_bytes: Bytes::from(frame),
+        };
+        // Wire-frame the response once, then EOF, so the loop reads it and drops the link on the error.
+        let wire = encode_geo_frame(&resp.encode()).unwrap();
+
+        let mut link = GeoLink::new(ReplayStream {
+            to_read: std::io::Cursor::new(wire),
+        });
+        let shutdown = AtomicBool::new(false);
+        let apply_calls = std::cell::Cell::new(0u32);
+        pull_loop(
+            &mut link,
+            "origin-key",
+            "",
+            &shutdown,
+            || 0u64, // cursor pinned at 0
+            |r: &MirrorPullResponse| -> Result<ApplyOutcome, GeoError> {
+                apply_calls.set(apply_calls.get() + 1);
+                // The applier's real verdict on (count == 0, non-empty bytes) is a RecordCountMismatch;
+                // returning it drops the link exactly as the real applier would.
+                assert_eq!(r.record_count, 0);
+                assert!(!r.frame_bytes.is_empty());
+                Err(GeoError::RecordCountMismatch {
+                    claimed: 0,
+                    actual: 1,
+                })
+            },
+        );
+        assert_eq!(
+            apply_calls.get(),
+            1,
+            "the malformed count==0/non-empty response must flow into apply (dropping the link), not be \
+             silently classified as caught-up and re-polled forever"
+        );
     }
 }

--- a/crates/ironbus-server/src/produce_gate.rs
+++ b/crates/ironbus-server/src/produce_gate.rs
@@ -40,14 +40,24 @@
 //!    it GROWS on an append (inside `commit_batch`) and SHRINKS only on a reap (also inside
 //!    `commit_batch`, or on a config-reload reap — both on the actor).
 //!
-//! 2. **A stale snapshot under drop-new can only be too LOW, never falsely too high.** The actor
-//!    refreshes this gate's bytes value right AFTER every `commit_batch` (the one place bytes change).
-//!    Between that refresh and the actor next processing a produce, NOTHING lowers the real bytes (a
-//!    reap only runs during a `commit_batch`, which is when/after the pre-checked produce is itself
-//!    processed). So if the snapshot reads "at/over cap," the real value is still at/over cap when the
-//!    actor checks it — the fast-reject matches the authoritative outcome. A snapshot that lags LOW
-//!    (e.g. a not-yet-published recent append) merely makes the gate fall through to the actor, which
-//!    is always safe.
+//! 2. **A stale snapshot under drop-new is a valid LOWER bound ONLY when no reap can lower the byte
+//!    total across a commit.** The actor refreshes this gate right AFTER every `commit_batch`. While
+//!    only appends move the total it GROWS between refreshes, so the last-published value is a lower
+//!    bound on the real bytes and "snapshot at/over cap" implies the actor is still at/over cap — an
+//!    EXACT fast-reject. BUT a consumer-safe retention / compaction reap (drop-new's size/age/count
+//!    trim, #337) ALSO runs INSIDE `commit_batch`, and it LOWERS `durable_record_bytes`. Across a
+//!    commit that reaps, the total is NON-MONOTONE, so the last-published value can be transiently
+//!    STALE-HIGH (over cap) after the in-commit reap has already brought the real bytes UNDER cap, for
+//!    the window between that reap and the post-commit refresh (#804). A racing connection thread
+//!    reading the stale-high value would FALSE-reject a produce the post-reap actor would accept —
+//!    exactly the forbidden false reject. The gate closes this window by DISENGAGING whenever a reap is
+//!    possible: the actor passes `reap_possible` (any retention bound set, or compaction enabled) to
+//!    [`ProduceCapGate::publish_drop_new_reap_aware`], which publishes the under-cap sentinel instead of
+//!    the byte total, so no snapshot is ever compared while it could be stale-high. When no reap is
+//!    possible (the common case: no retention / compaction configured) the total only grows between
+//!    refreshes, the snapshot is an exact lower bound, and the full #476 fast-reject stays engaged. A
+//!    snapshot that merely lags LOW (a not-yet-published recent append, or the reap-aware disengage)
+//!    only makes the gate fall through to the authoritative actor, which is always safe.
 //!
 //! 3. **Drop-oldest never fast-rejects.** Under [`DiskFullPolicy::DropOldest`](crate::engine) an
 //!    over-cap produce is ACCEPTED after a force-reap, so an over-cap snapshot does NOT imply a shed.
@@ -155,6 +165,33 @@ impl ProduceCapGate {
     /// [`ProduceCapGate::publish`].
     pub fn disengage(&self) {
         self.publish(0);
+    }
+
+    /// Publishes the gate's next drop-new snapshot, DISENGAGING instead when a retention / compaction
+    /// reap can lower the durable byte total across the upcoming commit (#804). `reap_possible` is the
+    /// actor's answer to "can a consumer-safe reap run in a `commit_batch` under the current config"
+    /// (any retention bound set — size/age/count — or compaction enabled).
+    ///
+    /// The connection-thread fast-reject compares the LAST-published byte total, which is a valid lower
+    /// bound on the real bytes ONLY while the total is MONOTONE between refreshes. That holds when only
+    /// appends move it (bytes grow), but a reap running INSIDE `commit_batch` LOWERS the total, so for
+    /// the window between the in-commit reap and the post-commit refresh the last-published value can be
+    /// transiently STALE-HIGH — over cap while the real bytes are already under it. Fast-rejecting
+    /// against that stale-high value is a FALSE reject (the post-reap actor would accept the produce),
+    /// which the module forbids. So whenever a reap is possible this publishes the `0` sentinel
+    /// ([`ProduceCapGate::disengage`]) rather than the byte total: the gate falls through to the
+    /// authoritative actor (an over-cap produce is still shed there — never lost, just not fast-pathed),
+    /// which is always safe. When NO reap is possible the total only grows between refreshes, so the
+    /// snapshot is an exact lower bound and this publishes the real byte total, keeping the full #476
+    /// fast-reject engaged (no regression to the #465 fix in the common, no-retention configuration).
+    pub fn publish_drop_new_reap_aware(&self, durable_record_bytes: u64, reap_possible: bool) {
+        if reap_possible {
+            // A reap can lower the byte total mid-commit, so the published snapshot could be stale-high
+            // during the reap window: disengage rather than risk a false reject (#804).
+            self.disengage();
+        } else {
+            self.publish_drop_new(durable_record_bytes);
+        }
     }
 
     /// The connection-thread fast-reject decision: returns `true` ONLY when the gate is SURE the
@@ -320,6 +357,59 @@ mod tests {
         assert!(
             !gate.would_shed(),
             "drop-oldest accepts over-cap; the gate must disengage (no false reject)"
+        );
+    }
+
+    #[test]
+    fn a_reap_possible_drop_new_publish_disengages_to_avoid_a_stale_high_false_reject() {
+        // #804: under drop-new WITH a retention / compaction reap possible, the durable byte total is
+        // NON-MONOTONE across a commit — an in-commit reap lowers it below the cap AFTER the gate's
+        // last snapshot was taken, so the snapshot is transiently STALE-HIGH (over cap) while the real
+        // bytes are already under it. Fast-rejecting against that stale-high value is the FALSE reject
+        // the module forbids (the post-reap actor would accept the produce).
+        let cap = 1_000;
+        let gate = ProduceCapGate::new(cap);
+
+        // THE BUG, reproduced: the plain drop-new publish stores the over-cap total, so a connection
+        // thread racing the in-commit reap fast-rejects — a false reject once the reap lands under cap.
+        gate.publish_drop_new(cap + 500);
+        assert!(
+            gate.would_shed(),
+            "the plain publish leaves the gate engaged on the stale-high total (the #804 window)"
+        );
+
+        // THE FIX: with a reap possible, the reap-aware publish disengages instead of storing the
+        // over-cap total, so no connection thread fast-rejects during the reap window.
+        gate.publish_drop_new_reap_aware(cap + 500, true);
+        assert!(
+            !gate.would_shed(),
+            "reap-aware publish disengages under a possible reap (no stale-high false reject, #804)"
+        );
+
+        // And once the reap has landed and the actor republishes the now-under-cap total, the gate is
+        // (still) open — the produce the racing thread would have been falsely rejected is admissible.
+        gate.publish_drop_new_reap_aware(cap - 100, true);
+        assert!(
+            !gate.would_shed(),
+            "the post-reap under-cap total is admissible"
+        );
+    }
+
+    #[test]
+    fn a_reap_impossible_drop_new_publish_keeps_the_fast_reject_engaged() {
+        // The common case (no retention / compaction configured): the byte total only GROWS between
+        // refreshes, so the snapshot is an exact lower bound and the #476 fast-reject stays fully
+        // engaged — `reap_possible = false` publishes the real total, engaging at/over cap exactly like
+        // `publish_drop_new`. This pins that the #804 fix does NOT regress the #465 fast-reject when no
+        // reap can move the byte total.
+        let cap = 1_000;
+        let gate = ProduceCapGate::new(cap);
+        gate.publish_drop_new_reap_aware(cap - 1, false);
+        assert!(!gate.would_shed(), "under cap: fall through");
+        gate.publish_drop_new_reap_aware(cap + 500, false);
+        assert!(
+            gate.would_shed(),
+            "over cap with no reap possible: the fast-reject stays engaged (no #476 regression)"
         );
     }
 


### PR DESCRIPTION
Closes #804
Closes #805
Closes #806

Consolidation pass fixing three low-severity, pre-adoption-hardening bugs in `ironbus-server`, one per distinct file, each a separate clean commit.

## #804 — ProduceCapGate transient false-reject under drop-new (`produce_gate.rs`)
The connection-thread fast-reject documents a "never fast-reject a produce the actor would have ACCEPTED" invariant, but under `DiskFullPolicy::DropNew` a consumer-safe retention/compaction reap runs INSIDE `commit_batch` and lowers `durable_record_bytes` before the post-commit gate refresh — so a connection thread racing that window reads a STALE-HIGH snapshot and false-rejects a produce the post-reap actor would accept.

**Fix:** the fast-reject snapshot is a valid lower bound only while the byte total is monotone between refreshes; an in-commit reap breaks that. New `ProduceCapGate::publish_drop_new_reap_aware` disengages the gate whenever a retention/compaction reap is possible (read from the engine's cheap config snapshot, once per batch). Falling through to the authoritative actor is always safe. When no reap is possible (the common case) the fast-reject stays fully engaged — no regression to #465/#476. Corrects the module's no-false-reject argument. Regression tests reproduce the window.

**Behavior change to review:** with retention/compaction configured under drop-new, over-cap produces are shed by the authoritative actor rather than the connection-thread fast path (same outcome, slightly higher latency). No change for the common no-retention config.

## #805 — pooled reply channel's false ActorGone safety comments (`actor.rs`)
The pooled `ReplyChannel` co-locates a live `SyncSender` with its `Receiver` (needed for #475 pooling), so recv-side `ActorGone` (disconnect) detection can never fire for a pooled channel. #949 already made the hang detectable via the shared `actor_alive` flag (and tests pin `wait()` returning `ActorGone`), but several comments still falsely claimed detection worked via channel closure.

**Fix:** corrects `recv_sliced`'s and `try_take`'s comments/docstring to state how liveness is ACTUALLY detected (the `actor_alive` flag / the blocking `wait` backstop), so the module carries no false safety claim; the retained `Disconnected` arms are exhaustive/defensive only. No behavior change; #475 pooling and #949 liveness detection preserved. Regression test pins `try_take` returning `NotReady` (never a spurious `ActorGone`) on a pooled channel whose actor is gone.

## #806 — geo pull_loop silent stall on a malformed response (`cluster/geo.rs`)
`pull_loop` classified "caught up" using `record_count` alone, but the applier's no-op guard is `record_count == 0 && frame_bytes.is_empty()`. A malformed `(record_count == 0, non-empty frame_bytes)` response was treated as empty → `apply` never called, cursor pinned, re-polled forever (a silent permanent stall).

**Fix:** classify with the same predicate the applier uses, so the malformed response flows into `apply`, hits a typed error (`RecordCountMismatch`/`NonContiguous`/`CorruptFrame`), and the link is dropped fail-closed for the caller to reconnect. Conforming origins are unaffected. Regression test drives `pull_loop` with a stub link and asserts `apply` is called (link dropped) rather than a pinned-cursor re-poll.

## Gates (container, CI-equivalent)
- `cargo test --workspace --locked` — 0 failed
- `cargo test -p ironbus-cli --locked --test acceptance -- --exact golden_path_acceptance_install_to_recovery_to_upgrade` — 1 passed; 0 failed
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- `scripts/check-format-registry.sh` — ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01McmNfYNWPmohVS8umY9Lkp