### PR TITLE
feat(bench): multi-subject publish + subject-filtered consume modes (#1126, unblocks #606)

### DIFF
--- a/crates/ironbus-cli/src/bench.rs
+++ b/crates/ironbus-cli/src/bench.rs
@@ -331,6 +331,28 @@ pub struct BenchConfig {
     /// durable single-consumer streaming-consume path benched head-to-head with a NATS `JetStream`
     /// pull consumer). SUBSCRIBE-only, exactly like [`Self::consume_ack`].
     pub consume_tier: ConsumeTier,
+    /// MULTI-SUBJECT addressing (#1126, unblocks #606): `Some(n)` binds the `n` synthetic subjects
+    /// `bench.s0`..`bench.s{n-1}` to the DEFAULT stream over the live wire (`BindSubject`) and
+    /// drives the load SUBJECT-ADDRESSED — publish distributes records across the subjects
+    /// round-robin via `PubSubject` (the awaited per-publish path, so every sample is an honest
+    /// produce-to-ack RTT that includes the routing-trie resolve, the #606 flat-per-record-cost
+    /// claim under measurement), and the subscribe preload interleaves the same way so a
+    /// [`Self::filter`] has a multi-subject stream to filter. `None` (the default) is the
+    /// historical subject-less path, byte-for-byte unchanged. Publish/subscribe only, and
+    /// mutually exclusive with the pipelined publish shapes (`--pubwindow > 1`, `--stream`,
+    /// `--autopipe`, `--faf`) and `--producers > 1`: no pipelined `PubSubject` client path exists,
+    /// so accepting those flags would silently change what they mean.
+    pub subjects: Option<u32>,
+    /// SUBJECT-FILTERED consume (#594 over the wire, #1126): `Some(pattern)` establishes the
+    /// SUBSCRIBE drain's subscription FILTERED (`SubSubject` with `filter_mode = 1` plus the
+    /// subject-filter capability bit), so the broker delivers ONLY the records whose subject
+    /// matches the #567 pattern and reports each skipped run as one coalesced
+    /// `GapMarker(reason = FILTERED)` — the direct head-to-head against `JetStream`'s measured
+    /// filtered-consumer re-scan penalty. Requires `--mode subscribe`, [`Self::subjects`] (the
+    /// preload must interleave subjects for the filter to act on), and the Tier-W work queue
+    /// (the filtered path is the work-queue consume path). `None` (the default) drains
+    /// unfiltered, byte-for-byte the historical subscribe.
+    pub filter: Option<String>,
     /// Emit the versioned JSON object instead of (well, in addition to a suppressed) human view.
     pub json: bool,
 }
@@ -414,6 +436,19 @@ pub struct BenchReport {
     /// Whether the fsync cost was measured through the real per-ack durable path. `false` in the
     /// `--no-fsync` dry run, so a consumer never mistakes a dry-run number for an honest one.
     pub fsync_measured: bool,
+    /// Per-subject produced tallies for a `--subjects` publish (#1126): one `(subject, produced)`
+    /// entry per bound subject, in slot order, so a recorded run self-describes how the round-robin
+    /// distributed. Empty for every subject-less run (and for the subscribe modes, whose
+    /// distribution is the preload's, not a measured result).
+    pub per_subject: Vec<(String, u64)>,
+    /// The number of coalesced `GapMarker(reason = FILTERED)` frames the `--filter` drain received
+    /// (#594): each marks ONE skipped run of non-matching offsets, so this counts the filter's
+    /// wire-visible overhead events. `None` for every unfiltered run.
+    pub gap_markers: Option<u64>,
+    /// The total offsets those FILTERED gap markers skipped (the sum of each marker's `to - from`
+    /// span): with the recorded (delivered) count this gives the exact filtered/total split the
+    /// #606 filtered-vs-unfiltered ratio needs. `None` for every unfiltered run.
+    pub gap_offsets_skipped: Option<u64>,
 }
 
 /// Parses the raw `bench` argument list into a validated [`BenchConfig`], or a usage error. This is
@@ -450,6 +485,8 @@ pub fn parse_bench(args: &[String], random_suffix: &str) -> Result<BenchConfig, 
     let mut io_mode = ironbus_storage::substrate::IoMode::Buffered;
     let mut per_message_ack = false;
     let mut consume_tier = ConsumeTier::Work;
+    let mut subjects: Option<u32> = None;
+    let mut filter: Option<String> = None;
     let mut json = false;
     let mut i = 0;
     while i < args.len() {
@@ -620,6 +657,39 @@ pub fn parse_bench(args: &[String], random_suffix: &str) -> Result<BenchConfig, 
                         "`--consume-tier` must be `work` or `streaming`, got `{raw}`"
                     ))
                 })?;
+            }
+            // MULTI-SUBJECT addressing (#1126): bind N synthetic subjects to the default stream
+            // over the live wire and drive the load subject-addressed. 0 is meaningless (nothing
+            // would ever be addressable), so it is a usage error naming the bound.
+            "--subjects" => {
+                let raw = take(args, &mut i, "--subjects")?;
+                let parsed: u32 = raw.parse().map_err(|_| {
+                    CliError::Usage(format!(
+                        "`--subjects` must be a positive integer, got `{raw}`"
+                    ))
+                })?;
+                if parsed == 0 {
+                    return Err(CliError::Usage(
+                        "`--subjects` must be at least 1 (omit the flag for the subject-less \
+                         default path)"
+                            .into(),
+                    ));
+                }
+                subjects = Some(parsed);
+            }
+            // SUBJECT-FILTERED consume (#594, #1126): the SUBSCRIBE drain subscribes with the
+            // pattern as the work-group's filter (filter_mode = 1). Validated against the REAL
+            // #567 grammar here so a malformed pattern fails fast as a usage error instead of a
+            // mid-run server reject.
+            "--filter" => {
+                let raw = take(args, &mut i, "--filter")?;
+                if let Err(e) = ironbus_core::subject::SubjectPattern::parse(&raw) {
+                    return Err(CliError::Usage(format!(
+                        "`--filter` must be a valid subject pattern (dot-separated tokens; `*` \
+                         matches one token, `>` matches trailing tokens): {e}"
+                    )));
+                }
+                filter = Some(raw);
             }
             "--json" => {
                 json = true;
@@ -840,6 +910,66 @@ pub fn parse_bench(args: &[String], random_suffix: &str) -> Result<BenchConfig, 
         ));
     }
 
+    // MULTI-SUBJECT guards (#1126). Subject addressing shapes the publish loop and the subscribe
+    // preload; round-trip's fixed producer/consumer pair is a separate path the flag says nothing
+    // about, so it is refused there (a no-op flag is a footgun, the `--per-message-ack` precedent).
+    if subjects.is_some() && mode == Mode::RoundTrip {
+        return Err(CliError::Usage(
+            "`--subjects` drives the subject-addressed publish/preload paths and requires \
+             `--mode publish` or `--mode subscribe`: round-trip is the fixed \
+             one-producer/one-consumer default-stream pair, so the flag would mean nothing there."
+                .into(),
+        ));
+    }
+    // The subject-addressed publish is the PLAIN AWAITED `PubSubject` loop (no pipelined
+    // subject-publish client path exists), so the pipelined publish shapes cannot combine with it:
+    // accepting them would silently change what those flags mean. Each names the clash.
+    if subjects.is_some() && (pub_window > 1 || stream || auto_pipeline || fire_and_forget) {
+        return Err(CliError::Usage(
+            "`--subjects` drives the plain awaited subject-addressed publish (`PubSubject`, one \
+             awaited ack per record — the honest per-record routing-cost measurement); the \
+             pipelined shapes (`--pubwindow > 1`, `--stream`, `--autopipe`, `--fire-and-forget`) \
+             have no subject-addressed client path, so they cannot combine with it. Drop one side."
+                .into(),
+        ));
+    }
+    if subjects.is_some() && producers > 1 {
+        return Err(CliError::Usage(
+            "`--subjects` cannot combine with `--producers > 1` yet: the multi-producer driver \
+             runs the subject-less publish legs. Drop one of the two flags."
+                .into(),
+        ));
+    }
+
+    // SUBJECT-FILTER guards (#1126). The filter shapes ONLY the subscribe drain's subscription
+    // (the #594 filtered work-queue consume path), so every other placement is refused explicitly.
+    if filter.is_some() && mode != Mode::Subscribe {
+        return Err(CliError::Usage(
+            "`--filter` establishes the `--mode subscribe` drain's subscription FILTERED (the \
+             #594 per-subject consume path): publish never consumes and round-trip uses a \
+             separate concurrent consumer, so the flag would mean nothing there. Pass \
+             `--mode subscribe`, or drop `--filter`."
+                .into(),
+        ));
+    }
+    if filter.is_some() && subjects.is_none() {
+        return Err(CliError::Usage(
+            "`--filter` needs `--subjects <n>`: the filtered drain measures delivery against an \
+             INTERLEAVED multi-subject stream, and only a subject-addressed preload gives the \
+             records subjects for the filter to act on (a plain preload's records carry no \
+             subject and would ALL be skipped)."
+                .into(),
+        ));
+    }
+    if filter.is_some() && consume_tier == ConsumeTier::Streaming {
+        return Err(CliError::Usage(
+            "`--filter` drives the Tier-W work-queue filtered consume path (#594) and has no \
+             meaning for `--consume-tier streaming` (the streaming cursor consumes the stream \
+             unfiltered). Drop one of the two flags."
+                .into(),
+        ));
+    }
+
     Ok(BenchConfig {
         mode,
         bound,
@@ -859,8 +989,19 @@ pub fn parse_bench(args: &[String], random_suffix: &str) -> Result<BenchConfig, 
         io_mode,
         consume_ack,
         consume_tier,
+        subjects,
+        filter,
         json,
     })
+}
+
+/// The synthetic subject the multi-subject modes bind and address for slot `i` (#1126):
+/// `bench.s{i}` under the bench-owned `bench.` prefix, so a live run's bindings are recognizable
+/// as bench-created, exactly as the `ironbus-bench-` group/dir prefix marks the bench namespace.
+/// Shared by the publish loop, the subscribe preload, and the tests, so the name can never drift.
+#[must_use]
+pub fn bench_subject_name(i: u32) -> String {
+    format!("bench.s{i}")
 }
 
 /// Runs a parsed `bench` invocation: executes the load (the platform seam) and renders the report
@@ -911,6 +1052,7 @@ fn execute(cfg: &BenchConfig) -> Result<BenchReport, CliError> {
     fill_payload(&mut probe, cfg.payload_shape, 0, ROUND_TRIP_TOKEN_LEN);
     let _ = nanos_to_us(0);
     let _ = cleanup_failed_error("", "");
+    let _ = bench_subject_name(0);
     Err(CliError::Internal(
         "ironbus bench requires a Unix host in v1: the isolated broker uses the Unix-only on-disk \
          storage path"
@@ -948,6 +1090,7 @@ pub fn write_human<W: Write + ?Sized>(
         }
     )?;
     writeln!(out, "group:          {}", cfg.group)?;
+    write_subject_config_lines(cfg, out)?;
     // The multi-producer fleet (#1040): named only above the single-connection default, so the
     // historical `--producers 1` view is byte-identical.
     if cfg.mode == Mode::Publish && cfg.producers > 1 {
@@ -991,9 +1134,15 @@ pub fn write_human<W: Write + ?Sized>(
         )?;
     }
     writeln!(out, "produced:       {} messages", report.produced)?;
+    // The per-subject round-robin tallies (#1126): one line per bound subject, publish mode only
+    // (the subscribe preload's distribution is setup, not a measured result).
+    for (subject, produced) in &report.per_subject {
+        writeln!(out, "  {subject}:     {produced} messages")?;
+    }
     if cfg.mode.measures_latency() {
         writeln!(out, "recorded:       {} messages", report.recorded)?;
     }
+    write_gap_marker_line(report, out)?;
     writeln!(
         out,
         "throughput:     {:.0} msg/s, {:.2} MB/s",
@@ -1016,6 +1165,49 @@ pub fn write_human<W: Write + ?Sized>(
         write_latency_line(out, "ack max", report.ack_max_us)?;
     }
     write_fsync_cost_line(cfg, report, out)?;
+    Ok(())
+}
+
+/// Writes the `subjects:` and `filter:` config lines (#1126), each named only when its flag is on,
+/// so the historical subject-less human view stays byte-identical. Split from [`write_human`] to
+/// keep that function under the line-count lint the way [`write_fsync_cost_line`] is.
+fn write_subject_config_lines<W: Write + ?Sized>(
+    cfg: &BenchConfig,
+    out: &mut W,
+) -> Result<(), CliError> {
+    // MULTI-SUBJECT addressing (#1126).
+    if let Some(n) = cfg.subjects {
+        writeln!(
+            out,
+            "subjects:       {n} (live-bound {}..{}, distributed round-robin via PubSubject)",
+            bench_subject_name(0),
+            bench_subject_name(n.saturating_sub(1))
+        )?;
+    }
+    // SUBJECT-FILTERED consume (#594, #1126).
+    if let Some(pattern) = &cfg.filter {
+        writeln!(
+            out,
+            "filter:         {pattern} (filtered subscription: only matching records are \
+             delivered; skips arrive as coalesced FILTERED gap markers)"
+        )?;
+    }
+    Ok(())
+}
+
+/// Writes the filtered drain's wire-visible skip accounting (#594, #1126), printed only when the
+/// run was filtered (both tallies present), so the unfiltered view is byte-identical.
+fn write_gap_marker_line<W: Write + ?Sized>(
+    report: &BenchReport,
+    out: &mut W,
+) -> Result<(), CliError> {
+    if let (Some(markers), Some(skipped)) = (report.gap_markers, report.gap_offsets_skipped) {
+        writeln!(
+            out,
+            "gap markers:    {markers} coalesced FILTERED markers ({skipped} offsets skipped \
+             past by the filter)"
+        )?;
+    }
     Ok(())
 }
 
@@ -1129,12 +1321,13 @@ pub fn bench_json(cfg: &BenchConfig, report: &BenchReport) -> String {
         s,
         "{{\"schema_version\":{},\"mode\":\"{}\",\"isolated\":{},\"group\":\"{}\",\
          \"bound\":{{{}}},\"target_rate_hz\":{},\"payload_bytes\":{},\"payload_shape\":\"{}\",\
-         \"fetch_batch\":{},\"no_fsync\":{},\"pubwindow\":{},\"producers\":{},\"stream\":{},\"fire_and_forget\":{},\"auto_pipeline\":{},\"storage\":\"{}\",\"consume_ack\":\"{}\",\"consume_tier\":\"{}\",\"results\":{{\
+         \"fetch_batch\":{},\"no_fsync\":{},\"pubwindow\":{},\"producers\":{},\"stream\":{},\"fire_and_forget\":{},\"auto_pipeline\":{},\"storage\":\"{}\",\"consume_ack\":\"{}\",\"consume_tier\":\"{}\",\"subjects\":{},\"filter\":{},\"results\":{{\
          \"produced\":{},\"recorded\":{},\"elapsed_secs\":{},\"msgs_per_sec\":{},\
          \"mb_per_sec\":{},\"bytes_per_op\":{},\
          \"latency_p50_us\":{},\"latency_p99_us\":{},\"latency_p999_us\":{},\"latency_max_us\":{},\
          \"ack_p50_us\":{},\"ack_p99_us\":{},\"ack_p999_us\":{},\"ack_max_us\":{},\
-         \"fsync_cost_us\":{},\"fsync_measured\":{}}}}}",
+         \"fsync_cost_us\":{},\"fsync_measured\":{},\
+         \"per_subject\":{},\"gap_markers\":{},\"gap_offsets_skipped\":{}}}}}",
         BENCH_JSON_SCHEMA_VERSION,
         cfg.mode.as_str(),
         cfg.is_isolated(),
@@ -1153,6 +1346,8 @@ pub fn bench_json(cfg: &BenchConfig, report: &BenchReport) -> String {
         cfg.storage.as_str(),
         cfg.consume_ack.as_str(),
         cfg.consume_tier.as_str(),
+        opt_u32_json(cfg.subjects),
+        opt_string_json(cfg.filter.as_deref()),
         report.produced,
         report.recorded,
         f64_json(report.elapsed_secs),
@@ -1169,8 +1364,50 @@ pub fn bench_json(cfg: &BenchConfig, report: &BenchReport) -> String {
         opt_f64_json(report.ack_max_us),
         opt_f64_json(report.fsync_cost_us),
         report.fsync_measured,
+        per_subject_json(&report.per_subject),
+        opt_u64_json(report.gap_markers),
+        opt_u64_json(report.gap_offsets_skipped),
     );
     s
+}
+
+/// Serializes the per-subject produced tallies (#1126) as a JSON array of
+/// `{"subject":...,"produced":...}` objects in slot order, or `null` for a subject-less run (the
+/// additive null-not-omitted shape every optional bench field uses).
+fn per_subject_json(per_subject: &[(String, u64)]) -> String {
+    use std::fmt::Write as _;
+    if per_subject.is_empty() {
+        return "null".to_string();
+    }
+    let mut s = String::from("[");
+    for (i, (subject, produced)) in per_subject.iter().enumerate() {
+        if i > 0 {
+            s.push(',');
+        }
+        // A write into a String is infallible, so the result is intentionally discarded.
+        let _ = write!(
+            s,
+            "{{\"subject\":\"{}\",\"produced\":{produced}}}",
+            escape_json(subject)
+        );
+    }
+    s.push(']');
+    s
+}
+
+/// Serializes an optional `u32` as a JSON number or `null`.
+fn opt_u32_json(v: Option<u32>) -> String {
+    v.map_or_else(|| "null".to_string(), |n| n.to_string())
+}
+
+/// Serializes an optional `u64` as a JSON number or `null`.
+fn opt_u64_json(v: Option<u64>) -> String {
+    v.map_or_else(|| "null".to_string(), |n| n.to_string())
+}
+
+/// Serializes an optional string as a JSON string literal or `null`.
+fn opt_string_json(v: Option<&str>) -> String {
+    v.map_or_else(|| "null".to_string(), |s| format!("\"{}\"", escape_json(s)))
 }
 
 /// The `bound` sub-object fields (exactly one of duration/count is present, the other null).
@@ -1495,6 +1732,7 @@ mod tests {
             ack_max_us: Some(2100.0),
             fsync_cost_us: Some(900.0),
             fsync_measured: true,
+            ..BenchReport::default()
         };
         let json = bench_json(&cfg, &report);
         // Versioned.
@@ -2307,6 +2545,248 @@ mod tests {
             p[16..],
             GOLDEN_LCG_SEQ7_48,
             "random fill drifted from the twin"
+        );
+    }
+
+    #[test]
+    fn subjects_and_filter_parse_and_default_off() {
+        // #1126: both flags default OFF, so an unflagged run is byte-for-byte the historical
+        // subject-less path.
+        let cfg = parse(&["--count", "10"]).unwrap();
+        assert_eq!(cfg.subjects, None);
+        assert_eq!(cfg.filter, None);
+        // Publish accepts --subjects; subscribe accepts --subjects + --filter.
+        let cfg = parse(&["--count", "10", "--mode", "publish", "--subjects", "4"]).unwrap();
+        assert_eq!(cfg.subjects, Some(4));
+        let cfg = parse(&[
+            "--count",
+            "10",
+            "--mode",
+            "subscribe",
+            "--subjects",
+            "3",
+            "--filter",
+            "bench.s1",
+        ])
+        .unwrap();
+        assert_eq!(cfg.subjects, Some(3));
+        assert_eq!(cfg.filter.as_deref(), Some("bench.s1"));
+        // Wildcard patterns pass the real #567 grammar.
+        let cfg = parse(&[
+            "--count",
+            "10",
+            "--mode",
+            "subscribe",
+            "--subjects",
+            "3",
+            "--filter",
+            "bench.*",
+        ])
+        .unwrap();
+        assert_eq!(cfg.filter.as_deref(), Some("bench.*"));
+    }
+
+    #[test]
+    fn the_bench_subject_names_are_pinned() {
+        // The synthetic subject names are a wire-visible contract (a live run's bindings must be
+        // recognizable as bench-owned, and an operator re-running the #606 scenarios pastes these
+        // into --filter), so the shape is pinned.
+        assert_eq!(bench_subject_name(0), "bench.s0");
+        assert_eq!(bench_subject_name(7), "bench.s7");
+    }
+
+    #[test]
+    fn subjects_guards_refuse_round_trip_pipelined_shapes_and_multi_producer() {
+        // #1126 guards: --subjects is the plain awaited PubSubject path, so every placement it
+        // cannot honestly shape is a usage error naming the clash (a no-op or silently-changed
+        // flag is a footgun, the --per-message-ack precedent). This FAILS if any guard is dropped.
+        let err = parse(&["--count", "10", "--subjects", "3"]).unwrap_err();
+        assert!(matches!(err, CliError::Usage(_)), "round-trip is refused");
+        for extra in [
+            &["--pubwindow", "2"][..],
+            &["--stream", "--pubwindow", "8"][..],
+            &["--autopipe"][..],
+            &["--faf"][..],
+            &["--producers", "2"][..],
+        ] {
+            let mut args = vec!["--count", "10", "--mode", "publish", "--subjects", "3"];
+            args.extend_from_slice(extra);
+            let err = parse(&args).unwrap_err();
+            assert!(
+                matches!(err, CliError::Usage(_)),
+                "--subjects with {extra:?} must be refused"
+            );
+        }
+        // Zero subjects is meaningless.
+        assert!(parse(&["--count", "10", "--mode", "publish", "--subjects", "0"]).is_err());
+    }
+
+    #[test]
+    fn filter_guards_refuse_wrong_mode_missing_subjects_streaming_tier_and_bad_patterns() {
+        // --filter shapes only the Tier-W subscribe drain against a multi-subject stream; every
+        // other placement is refused explicitly (#1126). This FAILS if any guard is dropped.
+        let err = parse(&[
+            "--count",
+            "10",
+            "--mode",
+            "publish",
+            "--subjects",
+            "3",
+            "--filter",
+            "bench.s1",
+        ])
+        .unwrap_err();
+        assert!(matches!(err, CliError::Usage(_)), "publish is refused");
+        let err = parse(&[
+            "--count",
+            "10",
+            "--mode",
+            "subscribe",
+            "--filter",
+            "bench.s1",
+        ])
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("--subjects"),
+            "a filter without a multi-subject preload is refused: {err}"
+        );
+        let err = parse(&[
+            "--count",
+            "10",
+            "--mode",
+            "subscribe",
+            "--subjects",
+            "3",
+            "--filter",
+            "bench.s1",
+            "--consume-tier",
+            "streaming",
+        ])
+        .unwrap_err();
+        assert!(matches!(err, CliError::Usage(_)), "Tier-S is refused");
+        // A malformed pattern fails fast at parse time through the REAL #567 grammar (a partial
+        // wildcard is an illegal-char rejection), never as a mid-run server reject.
+        let err = parse(&[
+            "--count",
+            "10",
+            "--mode",
+            "subscribe",
+            "--subjects",
+            "3",
+            "--filter",
+            "bench.s*x",
+        ])
+        .unwrap_err();
+        assert!(
+            matches!(err, CliError::Usage(_)),
+            "a malformed pattern is a parse-time usage error"
+        );
+    }
+
+    #[test]
+    fn subject_and_filter_fields_land_in_the_json_and_null_when_off() {
+        // The ADDITIVE #1126 JSON fields: always present, null when the feature is off (the ack-
+        // percentile precedent), so a downstream consumer can gate on them without schema sniffing.
+        let cfg = parse(&["--count", "10", "--mode", "publish"]).unwrap();
+        let json = bench_json(&cfg, &BenchReport::default());
+        for field in [
+            "\"subjects\":null",
+            "\"filter\":null",
+            "\"per_subject\":null",
+            "\"gap_markers\":null",
+            "\"gap_offsets_skipped\":null",
+        ] {
+            assert!(json.contains(field), "missing {field} in json: {json}");
+        }
+        // ON: the config echoes both flags and the results carry the tallies.
+        let cfg = parse(&[
+            "--count",
+            "10",
+            "--mode",
+            "subscribe",
+            "--subjects",
+            "3",
+            "--filter",
+            "bench.s1",
+        ])
+        .unwrap();
+        let report = BenchReport {
+            produced: 9,
+            recorded: 3,
+            elapsed_secs: 1.0,
+            gap_markers: Some(3),
+            gap_offsets_skipped: Some(6),
+            ..BenchReport::default()
+        };
+        let json = bench_json(&cfg, &report);
+        assert!(json.contains("\"subjects\":3"), "json: {json}");
+        assert!(json.contains("\"filter\":\"bench.s1\""), "json: {json}");
+        assert!(json.contains("\"gap_markers\":3"), "json: {json}");
+        assert!(json.contains("\"gap_offsets_skipped\":6"), "json: {json}");
+        // A publish run's per-subject tallies serialize in slot order.
+        let cfg = parse(&["--count", "9", "--mode", "publish", "--subjects", "3"]).unwrap();
+        let report = BenchReport {
+            produced: 9,
+            elapsed_secs: 1.0,
+            per_subject: vec![
+                ("bench.s0".to_string(), 3),
+                ("bench.s1".to_string(), 3),
+                ("bench.s2".to_string(), 3),
+            ],
+            ..BenchReport::default()
+        };
+        let json = bench_json(&cfg, &report);
+        assert!(
+            json.contains(
+                "\"per_subject\":[{\"subject\":\"bench.s0\",\"produced\":3},\
+                 {\"subject\":\"bench.s1\",\"produced\":3},\
+                 {\"subject\":\"bench.s2\",\"produced\":3}]"
+            ),
+            "json: {json}"
+        );
+    }
+
+    #[test]
+    fn human_view_prints_subject_and_filter_lines_only_when_on() {
+        // OFF: the historical human view is byte-identical (no subjects/filter/gap lines at all).
+        let cfg = parse(&["--count", "10", "--mode", "subscribe"]).unwrap();
+        let mut human = Vec::new();
+        write_human(&cfg, &BenchReport::default(), &mut human).unwrap();
+        let human = String::from_utf8(human).unwrap();
+        assert!(!human.contains("subjects:"), "human: {human}");
+        assert!(!human.contains("filter:"), "human: {human}");
+        assert!(!human.contains("gap markers:"), "human: {human}");
+        // ON: each line names its feature.
+        let cfg = parse(&[
+            "--count",
+            "10",
+            "--mode",
+            "subscribe",
+            "--subjects",
+            "3",
+            "--filter",
+            "bench.s1",
+        ])
+        .unwrap();
+        let report = BenchReport {
+            produced: 9,
+            recorded: 3,
+            elapsed_secs: 1.0,
+            gap_markers: Some(3),
+            gap_offsets_skipped: Some(6),
+            ..BenchReport::default()
+        };
+        let mut human = Vec::new();
+        write_human(&cfg, &report, &mut human).unwrap();
+        let human = String::from_utf8(human).unwrap();
+        assert!(
+            human.contains("subjects:       3 (live-bound bench.s0..bench.s2"),
+            "human: {human}"
+        );
+        assert!(human.contains("filter:         bench.s1"), "human: {human}");
+        assert!(
+            human.contains("gap markers:    3 coalesced FILTERED markers (6 offsets skipped"),
+            "human: {human}"
         );
     }
 }

--- a/crates/ironbus-cli/src/bench_run.rs
+++ b/crates/ironbus-cli/src/bench_run.rs
@@ -10,8 +10,8 @@
 //! [`crate::bench`] and are unit-tested on every target.
 
 use crate::bench::{
-    fill_payload, percentiles_us, AckMode, BenchConfig, BenchReport, Bound, ConsumeTier, Mode,
-    BENCH_NAMESPACE_PREFIX, ROUND_TRIP_TOKEN_LEN,
+    bench_subject_name, fill_payload, percentiles_us, AckMode, BenchConfig, BenchReport, Bound,
+    ConsumeTier, Mode, BENCH_NAMESPACE_PREFIX, ROUND_TRIP_TOKEN_LEN,
 };
 use crate::{
     materialized_config_line, open_disk_engine, open_memory_engine, CliError, DurabilityLevelArg,
@@ -19,7 +19,8 @@ use crate::{
 };
 use ironbus_client::{Client, ClientConfig, ClientError, StreamConsumerConfig};
 use ironbus_core::clock::Clock; // the monotonic seam the serve loop's liveness beacon (#95) reads
-use ironbus_proto::message::{ConsumeTier as ProtoConsumeTier, PubBody};
+use ironbus_core::subject::{Subject, SubjectPattern};
+use ironbus_proto::message::{gap_reason, ConsumeTier as ProtoConsumeTier, PubBody};
 use ironbus_server::actor::{spawn_actor_with_gather, DEFAULT_CHANNEL_BOUND};
 use ironbus_server::server::serve;
 use ironbus_storage::fs::{EphemeralFs, Filesystem, StdFs};
@@ -391,6 +392,56 @@ fn connect_streaming(addr: &str) -> Result<Client, CliError> {
             "bench: connecting streaming client to broker at {addr}: {e}"
         ))
     })
+}
+
+/// Connects a STREAM-ADDRESSING client to `addr` (#1126): advertises `understands_streams` in the
+/// `Connect` handshake so this connection may `BindSubject` / `PubSubject` over the wire — the
+/// producer side of the multi-subject modes. If the server does not confirm the capability the
+/// subject verbs return a typed server error the caller surfaces, so the bench cannot silently
+/// fall back to the subject-less path.
+fn connect_subjects(addr: &str) -> Result<Client, CliError> {
+    let client_cfg = ClientConfig {
+        understands_streams: true,
+        ..ClientConfig::default()
+    };
+    Client::connect_with(addr, &client_cfg).map_err(|e| {
+        CliError::Unreachable(format!(
+            "bench: connecting subject-addressing client to broker at {addr}: {e}"
+        ))
+    })
+}
+
+/// Connects the FILTERED consumer (#594, #1126): advertises stream addressing (the `SubSubject`
+/// verb rides it), the subject-filter capability (`filter_mode = 1` is fail-closed rejected
+/// without it), and gap-marker support (so each skipped run arrives as a typed [`ironbus_client::Gap`]
+/// with reason FILTERED, which the drain counts — the filter's wire-visible overhead).
+fn connect_filtered(addr: &str) -> Result<Client, CliError> {
+    let client_cfg = ClientConfig {
+        understands_streams: true,
+        request_subject_filter: true,
+        request_gap_marker: true,
+        ..ClientConfig::default()
+    };
+    Client::connect_with(addr, &client_cfg).map_err(|e| {
+        CliError::Unreachable(format!(
+            "bench: connecting filtered consumer to broker at {addr}: {e}"
+        ))
+    })
+}
+
+/// Live-binds the `n` synthetic bench subjects (`bench.s0`..`bench.s{n-1}`) to the DEFAULT stream
+/// over the wire (`BindSubject`, #1126) and returns their names in slot order. Binding every
+/// subject to ONE stream is deliberate: the records interleave in a single log, which is exactly
+/// the stream a filtered consumer must be measured against (filtered vs unfiltered on the SAME
+/// data). Idempotent server-side, so a re-run against a live broker is a benign success.
+fn bind_bench_subjects(client: &mut Client, addr: &str, n: u32) -> Result<Vec<String>, CliError> {
+    let subjects: Vec<String> = (0..n).map(bench_subject_name).collect();
+    for subject in &subjects {
+        client
+            .bind_subject("", subject)
+            .map_err(|e| classify(addr, "binding a bench subject on", &e))?;
+    }
+    Ok(subjects)
 }
 
 /// Whether the run should stop given how many ops are done and when it started.
@@ -822,6 +873,9 @@ fn multi_publish_attribution(cfg: &BenchConfig) -> SampleAttribution {
 /// independent connections concurrently — the multi-connection load the pipelined sync tier needs
 /// to fill its overlap window, which the design spec proved a single connection cannot.
 fn run_publish(cfg: &BenchConfig, addr: &str) -> Result<BenchReport, CliError> {
+    if let Some(n) = cfg.subjects {
+        return run_publish_subjects(cfg, addr, n);
+    }
     if cfg.producers > 1 {
         return run_publish_multi(cfg, addr);
     }
@@ -838,6 +892,94 @@ fn run_publish(cfg: &BenchConfig, addr: &str) -> Result<BenchReport, CliError> {
         elapsed,
         publish_attribution(cfg),
     ))
+}
+
+/// The MULTI-SUBJECT publish mode (#1126, unblocks #606): live-bind the `n` synthetic subjects to
+/// the default stream (`BindSubject` over the wire), then distribute the bound/rate-paced records
+/// across them ROUND-ROBIN via the awaited `PubSubject` — every record resolves its literal subject
+/// through the broker's routing trie, so the per-produce samples are honest produce-to-ack RTTs
+/// that INCLUDE the routing hot-path cost (#606's flat-per-record-cost claim under measurement).
+/// The parse guards refuse the pipelined shapes with `--subjects`, so this is always the plain
+/// awaited path and [`publish_attribution`] returns the plain-path honesty flags. Reports the
+/// per-subject tallies alongside the aggregate.
+fn run_publish_subjects(cfg: &BenchConfig, addr: &str, n: u32) -> Result<BenchReport, CliError> {
+    let mut client = connect_subjects(addr)?;
+    let subjects = bind_bench_subjects(&mut client, addr, n)?;
+    let slots = subjects.len() as u64;
+    let mut payload = vec![0u8; cfg.payload_bytes];
+    let mut produced: u64 = 0;
+    let mut samples: Vec<u64> = Vec::new();
+    let mut per_subject: Vec<u64> = vec![0; subjects.len()];
+    // The measurement window matches the plain publish leg: from after the connect + binds (the
+    // binds are setup, not the measured load) to after the last send.
+    let started = Instant::now();
+    while !should_stop(&cfg.bound, produced, started) {
+        let slot = usize::try_from(produced % slots).unwrap_or(0);
+        fill_payload(
+            &mut payload,
+            cfg.payload_shape,
+            produced,
+            ROUND_TRIP_TOKEN_LEN,
+        );
+        stamp_seq(&mut payload, produced);
+        samples.push(produce_one_subject(
+            &mut client,
+            addr,
+            &subjects[slot],
+            &mut payload,
+            started,
+        )?);
+        per_subject[slot] += 1;
+        produced += 1;
+        pace(cfg.target_rate_hz, produced, started);
+    }
+    let elapsed = started.elapsed();
+    let mut report = finish_report(
+        cfg,
+        produced,
+        produced,
+        &[],
+        &samples,
+        elapsed,
+        publish_attribution(cfg),
+    );
+    report.per_subject = subjects.into_iter().zip(per_subject).collect();
+    Ok(report)
+}
+
+/// Produces one message BY SUBJECT (#1126): the `PubSubject` twin of [`produce_one`], stamping the
+/// send-time token at the real send instant and returning the produce-CALL latency in nanoseconds.
+/// A `PubSubject` ack is the same fsynced-durable `PubAck` a plain produce returns (I2), so the
+/// sample is an honest awaited RTT — including the routing-trie resolve — and, on the per-ack
+/// durable disk path, an honest per-op fsync cost. A capacity shed is tolerated exactly like
+/// [`produce_one`] (the overload workload).
+fn produce_one_subject(
+    client: &mut Client,
+    addr: &str,
+    subject: &str,
+    payload: &mut [u8],
+    started: Instant,
+) -> Result<u64, CliError> {
+    stamp_send_time(payload, started);
+    let call_start = Instant::now();
+    let result = client.publish_subject(
+        subject,
+        &PubBody {
+            flags: 0,
+            timestamp_ms: 0,
+            key: b"",
+            headers: b"",
+            dedup: None,
+            fire_and_forget: false,
+            payload,
+        },
+    );
+    let latency_ns = u64::try_from(call_start.elapsed().as_nanos()).unwrap_or(u64::MAX);
+    match result {
+        Ok(_) => Ok(latency_ns),
+        Err(e) if is_shed(&e) => Ok(latency_ns),
+        Err(e) => Err(classify(addr, "subject-publishing to", &e)),
+    }
 }
 
 /// The per-producer payload-entropy stride (#1040): leg `i` seeds its payload fills from sequence
@@ -970,12 +1112,59 @@ fn run_subscribe(cfg: &BenchConfig, addr: &str) -> Result<BenchReport, CliError>
         Bound::Duration(_) => SUBSCRIBE_DURATION_PRELOAD,
     };
     let started = Instant::now();
+    // Preload the queue: SUBJECT-ADDRESSED interleaved round-robin when `--subjects` is set
+    // (#1126, the multi-subject stream a `--filter` acts on), else the historical plain pipelined
+    // window. `expected` is what the DRAIN should deliver: the filter-matched subset under
+    // `--filter`, else the whole preload.
+    let expected = if let Some(n) = cfg.subjects {
+        preload_subjects(cfg, addr, preload, n)?
+    } else {
+        preload_plain(cfg, addr, preload)?;
+        preload
+    };
+
+    // The measured drain phase: time it from here so the throughput reflects fetch/ack, not the
+    // preload. The preload fsync cost is not the SUBSCRIBE metric (drain throughput is), so the
+    // fsync histogram is empty for this mode.
+    let drain_start = Instant::now();
+    // TIER selector (#554): Tier-W is the per-message-lease work queue; Tier-S is the streaming
+    // consumer-managed-offset path (the durable single-consumer streaming-consume head-to-head).
+    let (recorded, latencies, gaps) = match cfg.consume_tier {
+        ConsumeTier::Work => drain(cfg, addr, expected, started)?,
+        ConsumeTier::Streaming => {
+            let (recorded, latencies) = drain_streaming(cfg, addr, expected, started)?;
+            (recorded, latencies, GapTally::default())
+        }
+    };
+    let mut report = finish_report(
+        cfg,
+        preload,
+        recorded,
+        &latencies,
+        &[],
+        drain_start.elapsed(),
+        SampleAttribution {
+            fsync_measured: false,
+            acks_awaited: false,
+        },
+    );
+    // The filtered drain's skip accounting (#594, #1126): reported only when the run was filtered,
+    // so an unfiltered report keeps its historical null fields.
+    if cfg.filter.is_some() {
+        report.gap_markers = Some(gaps.markers);
+        report.gap_offsets_skipped = Some(gaps.offsets);
+    }
+    Ok(report)
+}
+
+/// The historical PLAIN subscribe preload: a pipelined produce window (group-committed), not a
+/// serial per-message produce — SUBSCRIBE measures the DRAIN rate, so the preload's write speed is
+/// irrelevant to the metric, and a serial fdatasync-per-message preload is otherwise fsync-bound
+/// (~SD speed), making a large preload take minutes for no measurement value. Each message still
+/// carries its `seq` stamp. Chunked so the in-flight window stays bounded. Extracted verbatim from
+/// `run_subscribe` for the #1126 preload dispatch; the bytes on the wire are unchanged.
+fn preload_plain(cfg: &BenchConfig, addr: &str, preload: u64) -> Result<(), CliError> {
     let mut producer = connect(addr)?;
-    // Pre-load via a PIPELINED produce window (group-committed), not a serial per-message produce:
-    // SUBSCRIBE measures the DRAIN rate, so the preload's write speed is irrelevant to the metric,
-    // and a serial fdatasync-per-message preload is otherwise fsync-bound (~SD speed), making a
-    // large preload take minutes for no measurement value. Each message still carries its `seq`
-    // stamp. Chunked so the in-flight window stays bounded.
     let mut seq: u64 = 0;
     while seq < preload {
         let n = (preload - seq).min(PRELOAD_CHUNK);
@@ -1003,30 +1192,77 @@ fn run_subscribe(cfg: &BenchConfig, addr: &str) -> Result<BenchReport, CliError>
             .map_err(|e| classify(addr, "preloading the subscribe queue on", &e))?;
         seq += n;
     }
-    drop(producer);
+    Ok(())
+}
 
-    // The measured drain phase: time it from here so the throughput reflects fetch/ack, not the
-    // preload. The preload fsync cost is not the SUBSCRIBE metric (drain throughput is), so the
-    // fsync histogram is empty for this mode.
-    let drain_start = Instant::now();
-    // TIER selector (#554): Tier-W is the per-message-lease work queue; Tier-S is the streaming
-    // consumer-managed-offset path (the durable single-consumer streaming-consume head-to-head).
-    let (recorded, latencies) = match cfg.consume_tier {
-        ConsumeTier::Work => drain(cfg, addr, preload, started)?,
-        ConsumeTier::Streaming => drain_streaming(cfg, addr, preload, started)?,
+/// The SUBJECT-ADDRESSED subscribe preload (#1126): live-binds the `n` bench subjects to the
+/// default stream and publishes the `preload` records ROUND-ROBIN across them via the awaited
+/// `PubSubject`, so the drain consumes an INTERLEAVED multi-subject stream — the shape a
+/// `--filter` measurement needs. Per-record awaited (no pipelined subject-publish client path
+/// exists); the preload is setup, not the drain metric, so its write speed shapes no reported
+/// number. Returns the drain's EXPECTED delivery count: the records whose subject the configured
+/// `--filter` matches (computed through the REAL #567 pattern matcher, the same primitive the
+/// broker's filter applies, so the expectation can never drift from the broker's semantics), or
+/// every non-shed record when unfiltered.
+fn preload_subjects(cfg: &BenchConfig, addr: &str, preload: u64, n: u32) -> Result<u64, CliError> {
+    let mut producer = connect_subjects(addr)?;
+    let subjects = bind_bench_subjects(&mut producer, addr, n)?;
+    // Whether each subject slot matches the drain's filter, precomputed once per slot.
+    let slot_matches: Vec<bool> = match &cfg.filter {
+        Some(pattern) => {
+            // The pattern was already validated at parse time; a failure here means the two
+            // validators drifted, which is an internal fault worth naming, not a usage error.
+            let parsed = SubjectPattern::parse(pattern).map_err(|e| {
+                CliError::Internal(format!(
+                    "bench: the parse-time-validated `--filter` pattern was rejected by the \
+                     matcher: {e}"
+                ))
+            })?;
+            subjects
+                .iter()
+                .map(|s| Subject::parse_literal(s).is_ok_and(|subject| parsed.matches(&subject)))
+                .collect()
+        }
+        None => vec![true; subjects.len()],
     };
-    Ok(finish_report(
-        cfg,
-        preload,
-        recorded,
-        &latencies,
-        &[],
-        drain_start.elapsed(),
-        SampleAttribution {
-            fsync_measured: false,
-            acks_awaited: false,
-        },
-    ))
+    let slots = subjects.len() as u64;
+    let mut expected: u64 = 0;
+    let mut payload = vec![0u8; cfg.payload_bytes];
+    for seq in 0..preload {
+        let slot = usize::try_from(seq % slots).unwrap_or(0);
+        fill_payload(&mut payload, cfg.payload_shape, seq, ROUND_TRIP_TOKEN_LEN);
+        stamp_seq(&mut payload, seq);
+        let result = producer.publish_subject(
+            &subjects[slot],
+            &PubBody {
+                flags: 0,
+                timestamp_ms: 0,
+                key: b"",
+                headers: b"",
+                dedup: None,
+                fire_and_forget: false,
+                payload: &payload,
+            },
+        );
+        match result {
+            // Only a record that actually landed can be expected off the drain; a shed one never
+            // arrives (the overload workload the plain preload tolerates the same way).
+            Ok(_) => {
+                if slot_matches[slot] {
+                    expected += 1;
+                }
+            }
+            Err(e) if is_shed(&e) => {}
+            Err(e) => {
+                return Err(classify(
+                    addr,
+                    "subject-preloading the subscribe queue on",
+                    &e,
+                ))
+            }
+        }
+    }
+    Ok(expected)
 }
 
 /// ROUND-TRIP mode: a producer thread appends on the bound/rate while this thread fetches + acks and
@@ -1163,11 +1399,25 @@ fn drain(
     addr: &str,
     expected: u64,
     produce_started: Instant,
-) -> Result<(u64, Vec<u64>), CliError> {
-    let mut consumer = connect(addr)?;
-    subscribe_group(&mut consumer, addr, &cfg.group)?;
+) -> Result<(u64, Vec<u64>, GapTally), CliError> {
+    // FILTERED consume (#594, #1126): under `--filter` the subscription is established with the
+    // pattern as the work-group's filter (`SubSubject` filter_mode = 1 on a connection that
+    // advertised the subject-filter + gap-marker capabilities), so the broker delivers ONLY
+    // matching records and reports each skipped run as one coalesced FILTERED gap marker, which
+    // this drain counts. Unfiltered keeps the historical group subscribe, byte-for-byte.
+    let mut consumer = if let Some(pattern) = &cfg.filter {
+        let mut c = connect_filtered(addr)?;
+        c.subscribe_subject_filtered(pattern, &cfg.group)
+            .map_err(|e| classify(addr, "filter-subscribing to", &e))?;
+        c
+    } else {
+        let mut c = connect(addr)?;
+        subscribe_group(&mut c, addr, &cfg.group)?;
+        c
+    };
     let mut latencies: Vec<u64> = Vec::new();
     let mut recorded: u64 = 0;
+    let mut gaps = GapTally::default();
     let mut empty_streak: u32 = 0;
     // Reused across iterations so the batched-ack path does not reallocate the ack vector per batch.
     let mut acks: Vec<(u64, u64)> = Vec::with_capacity(cfg.fetch_batch as usize);
@@ -1179,6 +1429,15 @@ fn drain(
         // with whatever is ready (a single drain pass), exactly the closed-loop drain shape.
         let fetched = fetch_batch_pull(&mut consumer, addr, cfg.fetch_batch)?;
         let now = Instant::now();
+        // Tally the filter's wire-visible skips (#594): one coalesced FILTERED marker per skipped
+        // run, spanning `[from, to)` offsets. Other gap reasons (trim/compaction) are not the
+        // filter's doing and are left out of the filter accounting.
+        for g in &fetched.gaps {
+            if g.reason == gap_reason::FILTERED {
+                gaps.markers += 1;
+                gaps.offsets += g.to.saturating_sub(g.from);
+            }
+        }
         acks.clear();
         for m in &fetched.messages {
             if let Some(sent) = read_round_trip_time(&m.payload, produce_started) {
@@ -1225,12 +1484,24 @@ fn drain(
         // `expected` records means the broker shed the rest under its byte cap (memory mode, or a
         // disk drop policy) -- report it rather than hang waiting for records that will never come.
         eprintln!(
-            "note: drained {recorded} of {expected} preloaded records; the broker shed \
+            "note: drained {recorded} of {expected} expected records; the broker shed \
              {} under its cap (the consume rate is over the {recorded} that survived)",
             expected - recorded
         );
     }
-    Ok((recorded, latencies))
+    Ok((recorded, latencies, gaps))
+}
+
+/// The FILTERED-consume skip tally (#594, #1126): how many coalesced `GapMarker(reason = FILTERED)`
+/// frames the drain received and how many offsets they skipped in total, so the report carries the
+/// filter's exact wire-visible overhead next to the delivered count. Zero/zero for an unfiltered
+/// drain (no FILTERED marker is ever sent without a filter).
+#[derive(Clone, Copy, Debug, Default)]
+struct GapTally {
+    /// Coalesced FILTERED gap markers received (one per skipped run).
+    markers: u64,
+    /// Total offsets those markers skipped (the sum of each marker's `to - from` span).
+    offsets: u64,
 }
 
 /// Drains the preloaded prefix via the TIER-S STREAMING consumer (#554): the batched-fetch +

--- a/crates/ironbus-cli/src/main.rs
+++ b/crates/ironbus-cli/src/main.rs
@@ -962,6 +962,7 @@ USAGE:
                   [--rate <msg/s>] [--payload-bytes <n>] [--payload-shape <realistic|random>]
                   [--fetch-batch <n>] [--group <name>] [--no-fsync] [--pubwindow <n>] [--stream] [--json]
                   [--producers <n>] [--storage <disk|memory>] [--per-message-ack]
+                  [--subjects <n>] [--filter <pattern>]
                   [--addr <host:port> --i-understand-this-is-live]
     ironbus upgrade --new-binary <path> --dest <path> [--max-failed-starts <n>]
     ironbus rollback --dest <path>
@@ -1243,6 +1244,20 @@ Notes:
     sample is one self-contained awaited produce RTT); the per-op fsync cost is not attributed
     above 1 (concurrent connections share covering group-commit fsyncs). The JSON gains an
     additive producers field.
+    --subjects <n> (#1126, publish/subscribe) drives the load SUBJECT-ADDRESSED: it live-binds
+    the n synthetic subjects bench.s0..bench.s{n-1} to the default stream over the wire
+    (BindSubject) and distributes records across them round-robin via the awaited PubSubject,
+    so every sample is an honest produce-to-ack RTT that includes the routing-trie resolve.
+    Publish reports per-subject tallies plus the aggregate (additive subjects/per_subject JSON
+    fields); subscribe interleaves its preload the same way. Mutually exclusive with the
+    pipelined publish shapes (--pubwindow > 1, --stream, --autopipe, --faf) and --producers > 1
+    (no pipelined subject-publish client path exists).
+    --filter <pattern> (#594, subscribe + --subjects, Tier-W only) establishes the drain's
+    subscription FILTERED (SubSubject filter_mode=1 + the subject-filter capability): the broker
+    delivers ONLY the records whose subject matches the pattern and reports each skipped run as
+    ONE coalesced FILTERED gap marker, which the drain counts (additive filter/gap_markers/
+    gap_offsets_skipped JSON fields) — the filtered-vs-unfiltered delivery ratio measured over
+    the real wire, the head-to-head against JetStream's filtered-consumer re-scan penalty.
     <secs> or --count <n> is REQUIRED (no unbounded default), and --no-fsync is a dry run that
     runs the spawned isolated broker at INTERVAL durability (bounded-loss page-cache acks, the
     honest relaxed tier a real serve --durability-level interval runs, #1027) and batches its

--- a/crates/ironbus-cli/tests/bench.rs
+++ b/crates/ironbus-cli/tests/bench.rs
@@ -484,6 +484,176 @@ fn a_zero_duration_is_rejected() {
 }
 
 #[test]
+fn multi_subject_publish_distributes_across_live_bound_subjects() {
+    // #1126 HARNESS SELF-TEST (publish side): a `--subjects 3` publish against the isolated (but
+    // REAL, wire-served) broker live-binds bench.s0..bench.s2 (`BindSubject`), distributes the 60
+    // records round-robin via `PubSubject`, and reports the per-subject tallies plus the
+    // aggregate. The path is the plain awaited subject publish, so the ack RTT percentiles (which
+    // now INCLUDE the routing-trie resolve, the #606 measurement) and the disk fsync cost are
+    // honestly claimed.
+    let tmp = PrivateTmp::new();
+    let out = run_bench_in(
+        &tmp,
+        &[
+            "--count",
+            "60",
+            "--mode",
+            "publish",
+            "--subjects",
+            "3",
+            "--json",
+        ],
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "bench --subjects should exit 0; stderr: {stderr}\nstdout: {stdout}"
+    );
+    assert!(stdout.contains("\"subjects\":3"), "json: {stdout}");
+    assert!(stdout.contains("\"produced\":60"), "json: {stdout}");
+    // The round-robin split is exact: 60 records across 3 subjects, in slot order.
+    assert!(
+        stdout.contains(
+            "\"per_subject\":[{\"subject\":\"bench.s0\",\"produced\":20},\
+             {\"subject\":\"bench.s1\",\"produced\":20},\
+             {\"subject\":\"bench.s2\",\"produced\":20}]"
+        ),
+        "json: {stdout}"
+    );
+    // Awaited per-record path: the ack percentiles are measured, and on disk so is the fsync cost.
+    assert!(
+        json_number(&stdout, "ack_p50_us").is_some(),
+        "subject publish awaits every record, so ack RTTs are honest: {stdout}"
+    );
+    assert!(stdout.contains("\"fsync_measured\":true"), "json: {stdout}");
+    assert_eq!(tmp.count_bench_dirs(), 0, "synthetic dir cleaned up");
+}
+
+#[test]
+fn filtered_consume_delivers_only_the_matching_subset_with_gap_markers() {
+    // #1126 HARNESS SELF-TEST (the #594 filtered-consume side): preload an INTERLEAVED 3-subject
+    // stream (round-robin bench.s0/s1/s2, offsets 0..60), then drain it through a FILTERED
+    // subscription (`--filter bench.s1`: SubSubject filter_mode=1 + the capability bit). The drain
+    // must deliver ONLY the 20 matching records, and the 40 non-matching offsets must arrive as
+    // coalesced FILTERED gap markers — the wire-visible skip accounting the #606
+    // filtered-vs-unfiltered ratio is computed from. This FAILS if the filter silently delivers
+    // everything (recorded would be 60) or the markers are not surfaced/counted.
+    let tmp = PrivateTmp::new();
+    let out = run_bench_in(
+        &tmp,
+        &[
+            "--count",
+            "60",
+            "--mode",
+            "subscribe",
+            "--subjects",
+            "3",
+            "--filter",
+            "bench.s1",
+            "--json",
+        ],
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "filtered bench should exit 0; stderr: {stderr}\nstdout: {stdout}"
+    );
+    assert!(stdout.contains("\"filter\":\"bench.s1\""), "json: {stdout}");
+    // Exactly the matching third is delivered.
+    let recorded = json_number(&stdout, "recorded").expect("recorded present");
+    assert!(
+        (recorded - 20.0).abs() < f64::EPSILON,
+        "the filtered drain must record EXACTLY the 20 bench.s1 records, got {recorded}: {stdout}"
+    );
+    // The 40 skipped offsets arrive as coalesced FILTERED markers: one per skipped run (the
+    // leading run before the first match, one between each pair of matches, and possibly a
+    // trailing run after the last match, depending on when the head is reached).
+    let markers = json_number(&stdout, "gap_markers").expect("gap_markers present");
+    assert!(
+        (19.0..=21.0).contains(&markers),
+        "expected one coalesced marker per skipped run (~20), got {markers}: {stdout}"
+    );
+    let skipped = json_number(&stdout, "gap_offsets_skipped").expect("gap_offsets_skipped");
+    assert!(
+        (39.0..=40.0).contains(&skipped),
+        "the markers must account the ~40 non-matching offsets, got {skipped}: {stdout}"
+    );
+    assert_eq!(tmp.count_bench_dirs(), 0, "synthetic dir cleaned up");
+}
+
+#[test]
+fn unfiltered_consume_on_the_same_multi_subject_stream_gets_everything() {
+    // The #1126 control leg: the SAME interleaved 3-subject preload drained UNFILTERED delivers
+    // every record (recorded == 60) and reports NO filter accounting (null fields) — the
+    // denominator of the #606 filtered-vs-unfiltered ratio, over the same wire and data shape.
+    let tmp = PrivateTmp::new();
+    let out = run_bench_in(
+        &tmp,
+        &[
+            "--count",
+            "60",
+            "--mode",
+            "subscribe",
+            "--subjects",
+            "3",
+            "--json",
+        ],
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "unfiltered multi-subject bench should exit 0; stderr: {stderr}\nstdout: {stdout}"
+    );
+    let recorded = json_number(&stdout, "recorded").expect("recorded present");
+    assert!(
+        (recorded - 60.0).abs() < f64::EPSILON,
+        "the unfiltered drain must record ALL 60 records, got {recorded}: {stdout}"
+    );
+    assert!(stdout.contains("\"filter\":null"), "json: {stdout}");
+    assert!(stdout.contains("\"gap_markers\":null"), "json: {stdout}");
+    assert_eq!(tmp.count_bench_dirs(), 0, "synthetic dir cleaned up");
+}
+
+#[test]
+fn subject_and_filter_guards_hold_at_the_binary() {
+    // The #1126 parse guards, proven at the real binary (exit 1, never a spawned broker): a
+    // filter without the multi-subject preload, and --subjects with a pipelined publish shape.
+    let out = run_bench(&[
+        "--count",
+        "10",
+        "--mode",
+        "subscribe",
+        "--filter",
+        "bench.s1",
+    ]);
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "--filter without --subjects must be exit 1 (usage)"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("--subjects"), "stderr: {stderr}");
+    let out = run_bench(&[
+        "--count",
+        "10",
+        "--mode",
+        "publish",
+        "--subjects",
+        "3",
+        "--pubwindow",
+        "2",
+    ]);
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "--subjects with a pipelined shape must be exit 1 (usage)"
+    );
+}
+
+#[test]
 fn human_output_describes_the_isolated_target() {
     // Without --json the human view names the isolated synthetic broker and the synthetic group.
     let out = run_bench(&["--count", "50"]);

--- a/crates/ironbus-client/src/lib.rs
+++ b/crates/ironbus-client/src/lib.rs
@@ -443,6 +443,18 @@ pub struct ClientConfig {
     /// delivery. The decoded `Message` payload is IDENTICAL either way; this only governs whether the
     /// bytes travel compressed on the wire.
     pub understands_compressed_delivery: bool,
+    /// Whether this client ADVERTISES that it understands the per-subject FILTERED consume mode
+    /// (#594): when `true`, the `Connect` sets the subject-filter capability bit
+    /// (`ironbus_proto::message::CONNECT_FLAG2_WANTS_SUBJECT_FILTER`, the second bit of the appended
+    /// `flags2` byte), so the server may honor a [`Client::subscribe_subject_filtered`] (a
+    /// `SubSubject` with `filter_mode = 1`) that binds a wildcard subject PATTERN as the
+    /// work-group's filter, delivering ONLY matching records with one coalesced
+    /// `GapMarker(reason = FILTERED)` per skipped run (advertise
+    /// [`ClientConfig::request_gap_marker`] too to receive those markers as typed [`Gap`]s instead
+    /// of nothing). When `false` (the default, backward-compatible) the client does not advertise it
+    /// and a filtered subscribe is FAIL-CLOSED rejected by the server with a typed error — an old
+    /// client (or one that opted out) can never be silently placed in filtered mode.
+    pub request_subject_filter: bool,
     /// The connection-scoped authentication credential this client presents in its `Connect`
     /// handshake (#631, #884), or `None` (the default) for an unauthenticated connection. When
     /// `Some(cred)`, `connect_with` appends the auth section the broker verifies (via
@@ -514,6 +526,12 @@ impl Default for ClientConfig {
             // passthrough. A caller wrapping a legacy consumer that cannot decode the descriptor sets it
             // `false` to force the broker to decompress before delivery (the silent-corruption guard).
             understands_compressed_delivery: true,
+            // Off by default: an unconfigured client does not advertise the subject-filter mode, so
+            // its `Connect` flags2 byte is byte-for-byte the pre-#594 layout and a filtered
+            // subscribe is fail-closed rejected by the server. A caller that wants the filtered
+            // consume path opts in by setting this (typically alongside `understands_streams` and
+            // `request_gap_marker`).
+            request_subject_filter: false,
             // None by default: an unconfigured client presents NO credential, so `connect_with`
             // appends no auth section and the `Connect` body is byte-for-byte the pre-#631 layout — an
             // unauthenticated connect to a no-auth broker is unchanged (#884). A caller opts into auth
@@ -1350,7 +1368,11 @@ impl Client {
                 // client verbatim; a caller wrapping a legacy consumer sets it `false` to force the
                 // broker to decompress before delivery.
                 understands_compressed_delivery: config.understands_compressed_delivery,
-                wants_subject_filter: false,
+                // The subject-filter capability bit (#594, the second `flags2` bit). Off by default,
+                // so the body is byte-for-byte the pre-#594 `Connect` and a filtered subscribe is
+                // fail-closed rejected; a caller opts in via the config to use
+                // `subscribe_subject_filtered`.
+                wants_subject_filter: config.request_subject_filter,
             },
             &mut connect_body,
         );
@@ -3434,14 +3456,52 @@ impl Client {
     /// negotiated, an unbound/ambiguous/malformed/wildcard subject), [`ClientError::Body`] on an
     /// over-large field, or a frame/connection error.
     pub fn subscribe_subject(&mut self, subject: &str, group: &str) -> Result<(), ClientError> {
+        self.subscribe_subject_with_mode(subject, group, 0)
+    }
+
+    /// Subscribes this connection's consume path with a per-subject FILTER (#594): a `SubSubject`
+    /// with `filter_mode = 1`, binding the wildcard-capable subject `pattern` (the #567 grammar:
+    /// dot-separated tokens; `*` matches exactly one token, `>` matches one-or-more trailing tokens)
+    /// as the work-`group`'s filter on the covering stream. Subsequent [`Client::fetch`] /
+    /// [`Client::ack`] then deliver ONLY the records whose stored subject matches the pattern; each
+    /// skipped run of non-matching offsets is committed past by the broker and reported as ONE
+    /// coalesced `GapMarker` with reason FILTERED (`ironbus_proto::message::gap_reason::FILTERED`),
+    /// surfaced in [`Fetch::gaps`] when this connection also negotiated gap-marker support
+    /// ([`ClientConfig::request_gap_marker`]). The filter is a per-GROUP property (shared by every
+    /// consumer in the group, so the durable cursor stays coherent).
+    ///
+    /// Requires the stream-addressing capability ([`ClientConfig::understands_streams`]) AND the
+    /// subject-filter capability ([`ClientConfig::request_subject_filter`]): a filtered subscribe
+    /// without either is FAIL-CLOSED rejected by the server with a typed error, so an old client is
+    /// never silently placed in filtered mode.
+    ///
+    /// # Errors
+    /// Returns [`ClientError::Server`] if the server rejects the subscription (a capability not
+    /// negotiated, or a malformed pattern), [`ClientError::Body`] on an over-large field, or a
+    /// frame/connection error.
+    pub fn subscribe_subject_filtered(
+        &mut self,
+        pattern: &str,
+        group: &str,
+    ) -> Result<(), ClientError> {
+        self.subscribe_subject_with_mode(pattern, group, 1)
+    }
+
+    /// The shared `SubSubject` sender behind [`Client::subscribe_subject`] (`filter_mode = 0`, the
+    /// single-home literal subscribe) and [`Client::subscribe_subject_filtered`] (`filter_mode = 1`,
+    /// the #594 per-subject filtered bind), so the two paths can never drift on the wire shape.
+    fn subscribe_subject_with_mode(
+        &mut self,
+        subject: &str,
+        group: &str,
+        filter_mode: u8,
+    ) -> Result<(), ClientError> {
         let mut body = Vec::new();
         encode_sub_subject(
             &SubSubjectBody {
                 subject: subject.as_bytes(),
                 group: group.as_bytes(),
-                // The sync client subscribes single-home for now (#594); filtered consume is a
-                // client follow-up, so it never advertises the capability or sends filter_mode = 1.
-                filter_mode: 0,
+                filter_mode,
             },
             &mut body,
         )
@@ -7863,6 +7923,102 @@ toYtkjmdU2eQ2pK/3gM=
             other => panic!("expected a typed server reject, got {other:?}"),
         }
 
+        drop(c);
+        shutdown.store(true, Ordering::Release);
+        handle.join().unwrap();
+    }
+
+    /// A `ClientConfig` advertising the streams, subject-filter, AND gap-marker capabilities (#594):
+    /// what a filtered consumer connects with, so it may use `subscribe_subject_filtered` and
+    /// receive the `GapMarker(reason = FILTERED)` skips as typed [`Gap`]s.
+    fn config_for_filtered_consume() -> ClientConfig {
+        ClientConfig {
+            understands_streams: true,
+            request_subject_filter: true,
+            request_gap_marker: true,
+            ..ClientConfig::default()
+        }
+    }
+
+    #[test]
+    fn a_filtered_subject_subscribe_delivers_only_matches_with_filtered_gaps_end_to_end() {
+        // TEETH (#594 client half, #1126): over the REAL wire server, a filter-capable client binds
+        // a broad pattern to the DEFAULT stream, publishes an INTERLEAVED multi-subject stream, then
+        // `subscribe_subject_filtered` delivers ONLY the matching records, with the skipped runs
+        // surfaced as typed Gaps carrying reason FILTERED. This FAILS if the config flag stops
+        // setting the capability bit or the method stops sending filter_mode = 1 (the server then
+        // fail-closed rejects, or delivers everything).
+        let (addr, shutdown, handle) = start_server();
+        let mut c = Client::connect_with(addr, &config_for_filtered_consume()).unwrap();
+        assert!(c.streams_enabled());
+        assert!(c.gap_marker_enabled());
+
+        // Bind a broad pattern to the DEFAULT stream ("") so several subjects interleave in one log.
+        c.bind_subject("", "msg.>").unwrap();
+        let body = |p: &'static [u8]| PubBody {
+            flags: 0,
+            timestamp_ms: 0,
+            key: b"",
+            headers: b"",
+            dedup: None,
+            fire_and_forget: false,
+            payload: p,
+        };
+        // Offsets 0..5: MATCH, non, MATCH, non, MATCH under the filter `msg.orders.*`.
+        for (subject, payload) in [
+            ("msg.orders.a", b"A" as &'static [u8]), // 0 MATCH
+            ("msg.audit.x", b"X"),                   // 1 skip
+            ("msg.orders.b", b"B"),                  // 2 MATCH
+            ("msg.audit.y", b"Y"),                   // 3 skip
+            ("msg.orders.c", b"C"),                  // 4 MATCH
+        ] {
+            c.publish_subject(subject, &body(payload)).unwrap();
+        }
+
+        // FILTERED subscribe: the pattern becomes the work-group's filter (filter_mode = 1).
+        c.subscribe_subject_filtered("msg.orders.*", "workers")
+            .unwrap();
+        let fetched = c.fetch(10).unwrap();
+        let got: Vec<Vec<u8>> = fetched.messages.iter().map(|m| m.payload.clone()).collect();
+        assert_eq!(
+            got,
+            vec![b"A".to_vec(), b"B".to_vec(), b"C".to_vec()],
+            "only records whose subject matches the filter are delivered"
+        );
+        // The two skipped offsets (1 and 3) each arrive as ONE coalesced typed Gap with reason
+        // FILTERED — a reported, bounded skip, never silent loss.
+        assert_eq!(fetched.gaps.len(), 2, "gaps: {:?}", fetched.gaps);
+        for g in &fetched.gaps {
+            assert_eq!(
+                g.reason,
+                ironbus_proto::message::gap_reason::FILTERED,
+                "each skip marker carries reason FILTERED: {g:?}"
+            );
+        }
+        for m in &fetched.messages {
+            assert!(c.ack(m.offset, m.generation).unwrap());
+        }
+
+        drop(c);
+        shutdown.store(true, Ordering::Release);
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn a_filtered_subscribe_without_the_capability_is_fail_closed_rejected() {
+        // A streams-capable client that did NOT opt into `request_subject_filter` is REFUSED a
+        // filtered subscribe with a typed server error (never silently placed in filtered mode, and
+        // never silently served unfiltered).
+        let (addr, shutdown, handle) = start_server();
+        let mut c = Client::connect_with(addr, &config_understanding_streams()).unwrap();
+        c.bind_subject("", "msg.>").unwrap();
+        let err = c
+            .subscribe_subject_filtered("msg.orders.*", "workers")
+            .unwrap_err();
+        assert!(
+            matches!(&err, ClientError::Server(e) if e.to_string().contains("wants_subject_filter")),
+            "expected the fail-closed capability reject, got {err:?}"
+        );
         drop(c);
         shutdown.store(true, Ordering::Release);
         handle.join().unwrap();


### PR DESCRIPTION
Closes #1126. Unblocks #606 (the NATS baselines are already measured; this harness gap was the only thing preventing the IronBus side).

## What

`ironbus bench` gains the two modes the #606 vs-NATS scenarios need, both over the REAL wire against a live broker (`--addr ... --i-understand-this-is-live`) or the default isolated broker. Every existing bench mode is byte-for-byte unchanged (new flags only; the JSON gains additive always-present-null-when-off fields, the #1024/#1040 precedent).

### `--subjects <n>` (publish / subscribe)
Live-binds `bench.s0..bench.s{n-1}` to the DEFAULT stream over the wire (`BindSubject`) and distributes records round-robin via the awaited `PubSubject`, so every sample is an honest produce-to-ack RTT that INCLUDES the routing-trie resolve — the #606 flat-per-record-cost claim under measurement. Publish reports per-subject tallies + aggregate (additive `subjects` / `per_subject` JSON fields); subscribe interleaves its preload the same way. Refused with the pipelined publish shapes (`--pubwindow > 1`, `--stream`, `--autopipe`, `--faf`) and `--producers > 1` (no pipelined subject-publish client path exists).

### `--filter <pattern>` (subscribe + `--subjects`, Tier-W)
Establishes the drain's subscription FILTERED: `SubSubject` `filter_mode = 1` + the `CONNECT_FLAG2_WANTS_SUBJECT_FILTER` capability bit (the #594 path). The broker delivers ONLY matching records and reports each skipped run as ONE coalesced `GapMarker(reason = FILTERED)`, which the drain counts (additive `filter` / `gap_markers` / `gap_offsets_skipped` JSON fields) — the direct wire-level head-to-head against JetStream's measured ~7x filtered re-scan penalty (IronBus was ~1.04x in-process in #1107). Patterns are validated at parse time against the real #567 grammar, and the expected delivery count is computed through the real `ironbus-core` `SubjectPattern` matcher, so the harness cannot drift from the broker's semantics.

### Client half (the #594 filtered-consume client follow-up)
`ClientConfig::request_subject_filter` (default off; the `Connect` flags2 byte stays byte-for-byte pre-#594 when unset) + `Client::subscribe_subject_filtered(pattern, group)`, sharing one `SubSubject` sender with the single-home `subscribe_subject` so the two wire shapes can never drift. A filtered subscribe without the capability stays FAIL-CLOSED rejected.

`--partition` (#693, the optional item) is deliberately left out to keep this reviewable.

## #606 example invocations

```sh
# multi-subject publish, 8 subjects, live broker
ironbus bench --mode publish --subjects 8 --count 100000 --json \
  --addr HOST:4222 --i-understand-this-is-live

# filtered consume (1-of-3 subjects) vs unfiltered on the SAME interleaved shape
ironbus bench --mode subscribe --subjects 3 --filter bench.s1 --count 60000 --json \
  --addr HOST:4222 --i-understand-this-is-live
ironbus bench --mode subscribe --subjects 3 --count 60000 --json \
  --addr HOST:4222 --i-understand-this-is-live
```

## Tests

- Client end-to-end against a real wire server: filtered subscribe delivers ONLY matches with typed `Gap(reason = FILTERED)`; capability-less filtered subscribe is fail-closed rejected.
- Bench unit tests: parse guards (mode/pipeline/tier/pattern), additive JSON shape, human view byte-identical when the flags are off.
- Binary-level harness self-tests: multi-subject publish distributes 60 records exactly 20/20/20 with per-subject tallies; filtered consume records EXACTLY the matching 20 of 60 with ~20 coalesced FILTERED markers accounting the 40 skips; the unfiltered control drains all 60.

## Verification (Linux container, CI-equivalent)

- `cargo test --workspace --locked`: **3232 passed, 0 failed**
- `#133` golden-path acceptance gate: **PASS** (`golden_path_acceptance_install_to_recovery_to_upgrade`, summary `"result":"PASS"`)
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` on rustc **1.97.0**: clean
- `cargo fmt --all --check`: clean
- `scripts/check-format-registry.sh`: ok (no wire-tag or on-disk-layout change; the connect bit and SubSubject filter byte already existed server-side)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01McmNfYNWPmohVS8umY9Lkp