### PR TITLE
bench(dedup): effectively-once survival benchmark vs NATS (#647)

### DIFF
--- a/crates/ironbus-cli/tests/effectively_once.rs
+++ b/crates/ironbus-cli/tests/effectively_once.rs
@@ -1,0 +1,605 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! The IronBus side of the #647 effectively-once SURVIVAL head-to-head vs NATS (V2-M12).
+//!
+//! The scenario family injects the two things that lapse a time-bounded dedup window — a broker
+//! RESTART and a LONG PRODUCER-OFFLINE GAP — and MEASURES whether a producer's retry of an
+//! already-acknowledged publish is deduplicated or double-appended. IronBus carries TWO distinct
+//! dedup primitives (see `ironbus_core::dedup` and `ironbus_core::producer_seq`), and this
+//! harness measures BOTH honestly:
+//!
+//!   - the `msg_id` WINDOW (#3, #33): per-producer, bounded by a count AND a monotonic TIME
+//!     window (default 2 minutes), held IN MEMORY ONLY. It is the same primitive class as the
+//!     NATS `Nats-Msg-Id` duplicate window: a republish outside the window (or after the state
+//!     is lost) reads FRESH and is appended again — measured below, not hidden;
+//!   - the idempotent-producer SEQUENCE (V2-M8, #638/#639): a per-producer
+//!     `(producer_id, epoch, last_seq, last_offset)` high-water, persisted to
+//!     `producer-seq.ckpt` on the cursor-checkpoint cadence, the graceful-shutdown flush, and
+//!     inline at txn commit. The bound is SEQUENCE STATE, not wall-clock, so a retry is deduped
+//!     across a restart AND an arbitrarily long gap — the effectively-once survival this
+//!     head-to-head exists to demonstrate. Its honest durability bound is also measured: an
+//!     UNCLEAN kill before any checkpoint tick loses the un-flushed high-water and degrades
+//!     exactly those retries to at-least-once (`unclean_kill_before_any_checkpoint_...` below).
+//!
+//! The NATS side of the head-to-head is scripted in
+//! `docs/benchmarks/effectively_once_nats.sh`, and the measured results table lives in
+//! `docs/benchmarks/effectively-once.md`. This file is the REPEATABLE IronBus leg: it runs in
+//! the normal `cargo test` suite (`cargo test -p ironbus-cli --test effectively_once`), so the
+//! survival differentiator is demonstrated on every CI run, not asserted.
+//!
+//! Methodology note (mirrors the NATS leg): the "long offline gap" is measured against a
+//! deliberately SHORTENED window — `--dedup-window-ms 3000` here, `duplicates: 5s` on the NATS
+//! stream — and the gap sleeps PAST it. Waiting out the real 2-minute defaults would measure
+//! the same lapse, only slower; shortening the window on BOTH sides is the standard, symmetric
+//! methodology. The sequence path's assertions are wall-clock-INDEPENDENT, which is the point.
+//!
+//! The harness helpers mirror `corruption_recovery.rs` (the #644 head-to-head) and
+//! `acceptance.rs`. `serve` is Unix-only in v1, so this whole file is gated to Unix (Windows
+//! still compiles it to an empty module, keeping `-D warnings` clean on all targets).
+#![cfg(unix)]
+// The same shape-not-correctness style allowances the sibling #644 harness carries:
+// deliberately-sequential scenario bodies, and prose that names products ("NATS JetStream").
+#![allow(
+    clippy::too_many_lines,
+    clippy::items_after_statements,
+    clippy::doc_markdown
+)]
+
+use ironbus_client::proto::{PubBody, PubDedup};
+use ironbus_client::{Client, ProduceAck};
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::TcpStream;
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+/// The freshly-built `ironbus` binary under test (Cargo sets this for integration tests).
+const BIN: &str = env!("CARGO_BIN_EXE_ironbus");
+
+/// The stable idempotent-producer identity every sequenced leg publishes under.
+const PRODUCER: &[u8] = b"survival-producer";
+
+/// The producer epoch (the fencing token) for the whole harness: one live session, never fenced.
+const EPOCH: u64 = 1;
+
+/// The SHORTENED `msg_id` dedup window for the gap legs, in milliseconds (see the module doc:
+/// the symmetric stand-in for the 2-minute default, mirroring the NATS leg's `duplicates: 5s`).
+const SHORT_WINDOW_MS: u64 = 3_000;
+
+/// How long the "producer-offline gap" sleeps: comfortably PAST [`SHORT_WINDOW_MS`].
+const GAP: Duration = Duration::from_millis(4_500);
+
+/// Kills and reaps the broker on drop, so a panicking assertion never leaks a serve process.
+/// Dropping the guard is the harness's UNCLEAN stop (SIGKILL: no drain, no shutdown flush).
+struct ChildGuard(Child);
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+/// A self-cleaning scratch directory under the system temp root, unique per test.
+struct Scratch(PathBuf);
+impl Scratch {
+    fn new(tag: &str) -> Self {
+        let p = std::env::temp_dir().join(format!(
+            "ironbus-effectively-once-{tag}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let _ = std::fs::remove_dir_all(&p);
+        std::fs::create_dir_all(&p).expect("create the scratch dir");
+        Scratch(p)
+    }
+    fn join(&self, name: &str) -> PathBuf {
+        self.0.join(name)
+    }
+}
+impl Drop for Scratch {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+/// Boots `ironbus serve` on ephemeral loopback wire + health ports over `data_dir`, returning a
+/// kill-guard and the parsed `(wire, health)` addresses. `--checkpoint-interval 1` persists the
+/// cursor (and, on the same tick, the producer-seq high-water) synchronously per ack, so a
+/// restart resume is deterministic. Same pattern as `corruption_recovery.rs`.
+fn start_broker(data_dir: &str, extra: &[&str]) -> (ChildGuard, String, String) {
+    let mut args: Vec<String> = vec![
+        "serve".into(),
+        "--data-dir".into(),
+        data_dir.into(),
+        "--addr".into(),
+        "127.0.0.1:0".into(),
+        "--health-addr".into(),
+        "127.0.0.1:0".into(),
+        "--checkpoint-interval".into(),
+        "1".into(),
+    ];
+    args.extend(extra.iter().map(|s| (*s).to_string()));
+    let child = Command::new(BIN)
+        .args(&args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn ironbus serve");
+    let mut guard = ChildGuard(child);
+    let stdout = guard.0.stdout.take().expect("piped stdout");
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let mut reader = BufReader::new(stdout);
+        for _ in 0..8 {
+            let mut line = String::new();
+            if reader.read_line(&mut line).unwrap_or(0) == 0 {
+                break;
+            }
+            if tx.send(line).is_err() {
+                break;
+            }
+        }
+    });
+    let mut wire = None;
+    let mut health = None;
+    while wire.is_none() || health.is_none() {
+        let Ok(line) = rx.recv_timeout(Duration::from_secs(10)) else {
+            break;
+        };
+        if let Some(a) = line
+            .split("listening on ")
+            .nth(1)
+            .and_then(|rest| rest.split(',').next())
+            .map(str::trim)
+        {
+            wire = Some(a.to_string());
+        } else if let Some(a) = line
+            .split("health endpoints on ")
+            .nth(1)
+            .and_then(|rest| rest.split(' ').next())
+            .map(str::trim)
+        {
+            health = Some(a.to_string());
+        }
+    }
+    let (Some(wire), Some(health)) = (wire, health) else {
+        let mut err = String::new();
+        if let Some(mut se) = guard.0.stderr.take() {
+            let _ = se.read_to_string(&mut err);
+        }
+        panic!("could not parse wire+health addresses; stderr: {err}");
+    };
+    (guard, wire, health)
+}
+
+/// Stops the broker GRACEFULLY (SIGTERM: the #637 drain flushes the pending batch and
+/// checkpoints every group, INCLUDING the producer-seq high-water) and waits for the exit.
+/// The clean operational restart, as opposed to the guard-drop SIGKILL.
+fn stop_gracefully(mut guard: ChildGuard) {
+    let pid = guard.0.id().to_string();
+    let status = Command::new("kill")
+        .args(["-TERM", &pid])
+        .status()
+        .expect("send SIGTERM to serve");
+    assert!(status.success(), "SIGTERM delivered to the broker");
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while guard.0.try_wait().expect("poll serve").is_none() {
+        assert!(
+            Instant::now() < deadline,
+            "serve must drain and exit promptly on SIGTERM"
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    // The guard's drop now signals an already-reaped process, which is harmless.
+}
+
+/// Runs one `ironbus` subcommand to completion, returning stdout, stderr, and the exit code.
+fn run(args: &[&str]) -> (String, String, i32) {
+    let out = Command::new(BIN)
+        .args(args)
+        .output()
+        .expect("run an ironbus subcommand");
+    (
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+        out.status.code().unwrap_or(-1),
+    )
+}
+
+/// Publishes `payload` on the idempotent-producer SEQUENCE path: the dedup block carries
+/// [`PRODUCER`]/[`EPOCH`] plus the per-producer monotonic `seq`, which routes the produce
+/// through the DURABLE sequence high-water instead of the time-bounded `msg_id` window.
+fn publish_seq(client: &mut Client, seq: u64, payload: &[u8]) -> ProduceAck {
+    let msg_id = format!("seq-{seq}");
+    client
+        .produce_dedup(&PubBody {
+            flags: 0,
+            timestamp_ms: 0,
+            key: b"",
+            headers: b"",
+            dedup: Some(PubDedup {
+                producer_id: PRODUCER,
+                epoch: EPOCH,
+                msg_id: msg_id.as_bytes(),
+                seq: Some(seq),
+            }),
+            fire_and_forget: false,
+            payload,
+        })
+        .expect("sequenced produce")
+}
+
+/// Publishes `payload` on the `msg_id` WINDOW path (`seq: None`): the NATS-`Nats-Msg-Id`-class
+/// time-bounded dedup, measured here for the honest comparison.
+fn publish_window(client: &mut Client, msg_id: &str, payload: &[u8]) -> ProduceAck {
+    client
+        .produce_dedup(&PubBody {
+            flags: 0,
+            timestamp_ms: 0,
+            key: b"",
+            headers: b"",
+            dedup: Some(PubDedup {
+                producer_id: b"window-producer",
+                epoch: 0,
+                msg_id: msg_id.as_bytes(),
+                seq: None,
+            }),
+            fire_and_forget: false,
+            payload,
+        })
+        .expect("windowed produce")
+}
+
+/// Publishes a plain no-dedup record and returns its offset: the "next fresh offset" probe that
+/// proves exactly how many records the retries appended (or did not).
+fn publish_plain(client: &mut Client, payload: &[u8]) -> u64 {
+    client
+        .produce(&PubBody {
+            flags: 0,
+            timestamp_ms: 0,
+            key: b"",
+            headers: b"",
+            dedup: None,
+            fire_and_forget: false,
+            payload,
+        })
+        .expect("plain produce")
+}
+
+/// A minimal blocking HTTP/1.0 GET against a loopback `host:port`, retrying a just-spawned
+/// health thread.
+fn http_get(addr: &str, path: &str) -> String {
+    for _ in 0..40 {
+        if let Ok(body) = http_get_once(addr, path) {
+            if !body.is_empty() {
+                return body;
+            }
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    panic!("health endpoint {addr} did not answer GET {path} in time");
+}
+
+fn http_get_once(addr: &str, path: &str) -> std::io::Result<String> {
+    let mut stream = TcpStream::connect(addr)?;
+    stream.set_read_timeout(Some(Duration::from_secs(5)))?;
+    write!(
+        stream,
+        "GET {path} HTTP/1.0\r\nHost: {addr}\r\nConnection: close\r\n\r\n"
+    )?;
+    let mut body = String::new();
+    stream.read_to_string(&mut body)?;
+    Ok(body)
+}
+
+/// Reads a single Prometheus sample value by EXACT line key (labels included).
+fn metric_value(body: &str, key: &str) -> Option<u64> {
+    let prefix = format!("{key} ");
+    body.lines().find_map(|line| {
+        let line = line.trim();
+        if line.starts_with('#') {
+            return None;
+        }
+        line.strip_prefix(&prefix)
+            .and_then(|rest| rest.split_whitespace().next())
+            .and_then(|v| v.parse().ok())
+    })
+}
+
+/// The delivered payloads from a `sub` run's stdout (`payload=<value>`).
+fn payloads(out: &str) -> Vec<String> {
+    out.lines()
+        .filter_map(|l| l.split("payload=").nth(1))
+        .filter_map(|rest| rest.split_whitespace().next())
+        .map(str::to_string)
+        .collect()
+}
+
+// =================================================================================================
+// SCENARIO 1: RETRY AFTER A CLEAN RESTART — a producer whose acks were lost in transit retries
+// every publish after the broker comes back.
+//
+// IronBus measured behavior, sequence path: the graceful-shutdown flush persisted the
+// `(producer_id, epoch, last_seq, last_offset)` high-water to `producer-seq.ckpt`, so every
+// retry is a BENIGN duplicate (`duplicate = true`, nothing appended) — 0 duplicate records
+// out of 10 retries. Per the high-water contract, a retry of an OLDER seq returns the
+// LAST-accepted offset ("already durable, do not re-append"), not the per-seq original.
+//
+// IronBus measured behavior, `msg_id` window path (the honest half): the window is in-memory
+// and does NOT survive the restart — the same retry re-appends (1 duplicate record out of 1).
+// That is exactly the volatile-window class NATS's `Nats-Msg-Id` lives in; the durable seq path
+// is the differentiator, not the window.
+// =================================================================================================
+#[test]
+fn retry_after_clean_restart_is_deduped_by_the_durable_seq_highwater() {
+    let scratch = Scratch::new("restart");
+    let dir = scratch.join("data");
+    let dir = dir.to_str().expect("utf8 data dir");
+
+    // Publish a 10-record sequenced corpus (seq 1..=10) plus one msg_id-window record, all acked.
+    let (broker, addr, _h) = start_broker(dir, &[]);
+    let mut client = Client::connect(&addr).expect("connect the producer");
+    for seq in 1..=10_u64 {
+        let ack = publish_seq(&mut client, seq, format!("rec-{seq}").as_bytes());
+        assert!(!ack.duplicate, "seq {seq} is a fresh publish");
+        assert_eq!(ack.offset, seq - 1, "contiguous durable offsets");
+    }
+    let ack = publish_window(&mut client, "w-1", b"window-rec");
+    assert!(!ack.duplicate, "the windowed publish is fresh");
+    assert_eq!(ack.offset, 10);
+    drop(client);
+
+    // RESTART: the clean operational restart (SIGTERM drain, then a fresh serve over the dir).
+    stop_gracefully(broker);
+    let (_broker2, addr2, health2) = start_broker(dir, &[]);
+    let mut client = Client::connect(&addr2).expect("reconnect after the restart");
+
+    // The producer retries EVERY sequenced publish (its acks were "lost"): all deduped, nothing
+    // appended, each retry answered with the durable high-water offset (9, the last accepted).
+    for seq in 1..=10_u64 {
+        let ack = publish_seq(&mut client, seq, format!("rec-{seq}").as_bytes());
+        assert!(
+            ack.duplicate,
+            "seq {seq} retried across the restart is a benign duplicate, not a re-append"
+        );
+        assert_eq!(
+            ack.offset, 9,
+            "a retry of an older seq returns the high-water offset (the last-accepted append)"
+        );
+    }
+    let metrics = http_get(&health2, "/metrics");
+    assert_eq!(
+        metric_value(&metrics, "ironbus_dedup_hits_total"),
+        Some(10),
+        "every one of the 10 cross-restart retries is a counted dedup hit"
+    );
+
+    // The honest window half: the SAME retry shape on the msg_id window re-appends, because the
+    // window is in-memory and the restart cleared it (measured, recorded in the results table).
+    let ack = publish_window(&mut client, "w-1", b"window-rec");
+    assert!(
+        !ack.duplicate,
+        "the msg_id window does NOT survive a restart: the retry reads fresh (the volatile class)"
+    );
+    assert_eq!(ack.offset, 11, "the windowed retry was re-appended");
+
+    // The duplicate-count ground truth: exactly ONE record was appended since the restart (the
+    // windowed retry), ZERO from the ten sequenced retries.
+    assert_eq!(
+        publish_plain(&mut client, b"fresh-after-retries"),
+        12,
+        "10 sequenced retries appended nothing; only the windowed retry re-appended"
+    );
+    let (out, _e, code) = run(&["sub", "--addr", &addr2, "--max", "100", "--ack"]);
+    assert_eq!(code, 0, "consume the whole log");
+    let got = payloads(&out);
+    assert_eq!(
+        got.len(),
+        13,
+        "10 + window original + window dup + probe: {out}"
+    );
+    for seq in 1..=10_u64 {
+        let rec = format!("rec-{seq}");
+        assert_eq!(
+            got.iter().filter(|p| **p == rec).count(),
+            1,
+            "sequenced record {rec} appears EXACTLY once (effectively-once held): {out}"
+        );
+    }
+    assert_eq!(
+        got.iter().filter(|p| *p == "window-rec").count(),
+        2,
+        "the windowed record appears twice (the measured, honest window lapse): {out}"
+    );
+}
+
+// =================================================================================================
+// SCENARIO 2: a LONG PRODUCER-OFFLINE GAP, no restart — the producer comes back after the dedup
+// window has aged out and retries.
+//
+// IronBus measured behavior: the `msg_id` window lapses BY DESIGN (time-bounded, like NATS's
+// `duplicate_window`) — the retry re-appends and the `ironbus_dedup_out_of_window_total`
+// operator signal fires. The SEQUENCE path is wall-clock-independent: the same gap dedups every
+// retry (0 duplicates out of 5).
+// =================================================================================================
+#[test]
+fn offline_gap_lapses_the_msg_id_window_but_never_the_seq_highwater() {
+    let scratch = Scratch::new("gap");
+    let dir = scratch.join("data");
+    let dir = dir.to_str().expect("utf8 data dir");
+
+    // The SHORTENED window (see the module doc): 3 s here vs `duplicates: 5s` on the NATS leg.
+    let window_ms = SHORT_WINDOW_MS.to_string();
+    let (_broker, addr, health) = start_broker(dir, &["--dedup-window-ms", &window_ms]);
+    let mut client = Client::connect(&addr).expect("connect the producer");
+
+    for seq in 1..=5_u64 {
+        let ack = publish_seq(&mut client, seq, format!("rec-{seq}").as_bytes());
+        assert!(!ack.duplicate);
+        assert_eq!(ack.offset, seq - 1);
+    }
+    let ack = publish_window(&mut client, "gap-1", b"gap-rec");
+    assert!(!ack.duplicate);
+    assert_eq!(ack.offset, 5);
+
+    // The producer goes OFFLINE past the whole window, then comes back and retries everything.
+    std::thread::sleep(GAP);
+
+    let ack = publish_window(&mut client, "gap-1", b"gap-rec");
+    assert!(
+        !ack.duplicate,
+        "the msg_id window lapsed over the gap: the retry reads fresh (time-bounded by design)"
+    );
+    assert_eq!(ack.offset, 6, "the windowed retry was re-appended");
+    let metrics = http_get(&health, "/metrics");
+    assert_eq!(
+        metric_value(&metrics, "ironbus_dedup_out_of_window_total"),
+        Some(1),
+        "the window lapse is an operator-visible signal, never silent"
+    );
+
+    for seq in 1..=5_u64 {
+        let ack = publish_seq(&mut client, seq, format!("rec-{seq}").as_bytes());
+        assert!(
+            ack.duplicate,
+            "seq {seq} retried after the gap is still a duplicate: the high-water is sequence \
+             state, not wall-clock"
+        );
+        assert_eq!(ack.offset, 4, "the high-water offset answers the retry");
+    }
+
+    // Ground truth: the gap retries appended exactly ONE record (the lapsed-window one).
+    assert_eq!(
+        publish_plain(&mut client, b"fresh-after-gap"),
+        7,
+        "5 sequenced retries appended nothing across the gap; only the windowed retry re-appended"
+    );
+}
+
+// =================================================================================================
+// SCENARIO 3: the COMBINED injection — an UNCLEAN kill (SIGKILL, no shutdown flush) PLUS an
+// offline gap past the window, the worst case of the head-to-head.
+//
+// IronBus measured behavior: the sequenced corpus was consumed and acked before the kill, so the
+// cursor-checkpoint tick (`--checkpoint-interval 1`) had already persisted the producer-seq
+// high-water; every sequenced retry after kill + gap is STILL deduped (0 duplicates out of 5).
+// The `msg_id` window loses on BOTH axes at once (state gone AND time lapsed): its retry
+// re-appends, measured.
+// =================================================================================================
+#[test]
+fn unclean_kill_plus_offline_gap_still_dedupes_the_checkpointed_seq_highwater() {
+    let scratch = Scratch::new("combined");
+    let dir = scratch.join("data");
+    let dir = dir.to_str().expect("utf8 data dir");
+
+    let window_ms = SHORT_WINDOW_MS.to_string();
+    let (broker, addr, _h) = start_broker(dir, &["--dedup-window-ms", &window_ms]);
+    let mut client = Client::connect(&addr).expect("connect the producer");
+    for seq in 1..=5_u64 {
+        let ack = publish_seq(&mut client, seq, format!("rec-{seq}").as_bytes());
+        assert!(!ack.duplicate);
+        assert_eq!(ack.offset, seq - 1);
+    }
+    let ack = publish_window(&mut client, "c-1", b"combined-rec");
+    assert!(!ack.duplicate);
+    assert_eq!(ack.offset, 5);
+    drop(client);
+
+    // A downstream consumer drains and acks the corpus: each ack's checkpoint tick persists the
+    // cursor AND the producer-seq high-water (the cadence a real pipeline runs on).
+    let (out, _e, code) = run(&["sub", "--addr", &addr, "--max", "6", "--ack"]);
+    assert_eq!(code, 0, "the consumer drains the corpus: {out}");
+    assert_eq!(
+        payloads(&out).len(),
+        6,
+        "all six records consumed and acked"
+    );
+
+    // KILL -9 (no drain, no shutdown flush), then the offline gap, then the restart.
+    drop(broker);
+    std::thread::sleep(GAP);
+    let (_broker2, addr2, _h2) = start_broker(dir, &["--dedup-window-ms", &window_ms]);
+    let mut client = Client::connect(&addr2).expect("reconnect after kill + gap");
+
+    for seq in 1..=5_u64 {
+        let ack = publish_seq(&mut client, seq, format!("rec-{seq}").as_bytes());
+        assert!(
+            ack.duplicate,
+            "seq {seq} retried across kill -9 PLUS the gap is still deduped: the checkpointed \
+             high-water survives both"
+        );
+        assert_eq!(
+            ack.offset, 4,
+            "the recovered high-water offset answers the retry"
+        );
+    }
+    let ack = publish_window(&mut client, "c-1", b"combined-rec");
+    assert!(
+        !ack.duplicate,
+        "the msg_id window lost both ways (restart AND gap): the retry re-appends, measured"
+    );
+    assert_eq!(ack.offset, 6);
+
+    assert_eq!(
+        publish_plain(&mut client, b"fresh-after-combined"),
+        7,
+        "5 sequenced retries appended nothing across kill + gap; only the windowed retry re-appended"
+    );
+}
+
+// =================================================================================================
+// SCENARIO 4 (the HONEST BOUND of the sequence path): an unclean kill BEFORE any checkpoint
+// tick, graceful flush, or txn commit has persisted the high-water.
+//
+// IronBus measured behavior: the high-water recorded since the last durability point is LOST —
+// the retries read FRESH and re-append (3 duplicates out of 3), the documented at-least-once
+// degrade. The bound on the durable seq path is CHECKPOINT LAG (an unclean kill may lose
+// high-waters newer than the last ack-driven checkpoint tick / graceful shutdown / txn-commit
+// flush), plus the [`ironbus_core::producer_seq::DEFAULT_MAX_SEQ_PRODUCERS`] LRU cap on tracked
+// producers — never wall-clock. This leg exists so the results table states the real contract
+// instead of claiming infinity.
+// =================================================================================================
+#[test]
+fn unclean_kill_before_any_checkpoint_degrades_unflushed_highwaters_to_at_least_once() {
+    let scratch = Scratch::new("unflushed");
+    let dir = scratch.join("data");
+    let dir = dir.to_str().expect("utf8 data dir");
+
+    let (broker, addr, _h) = start_broker(dir, &[]);
+    let mut client = Client::connect(&addr).expect("connect the producer");
+    for seq in 1..=3_u64 {
+        let ack = publish_seq(&mut client, seq, format!("rec-{seq}").as_bytes());
+        assert!(!ack.duplicate);
+        assert_eq!(ack.offset, seq - 1);
+    }
+    drop(client);
+
+    // KILL -9 with ZERO durability points for the high-water: no consumer ever acked (no
+    // checkpoint tick), no SIGTERM (no shutdown flush), no txn. The RECORDS are durable (each
+    // PubAck is fsync-backed); only the dedup high-water since the last tick is not.
+    drop(broker);
+    let (_broker2, addr2, _h2) = start_broker(dir, &[]);
+    let mut client = Client::connect(&addr2).expect("reconnect after the unclean kill");
+
+    for (i, seq) in (1..=3_u64).enumerate() {
+        let ack = publish_seq(&mut client, seq, format!("rec-{seq}").as_bytes());
+        assert!(
+            !ack.duplicate,
+            "seq {seq}: the un-checkpointed high-water was lost with the unclean kill, so the \
+             retry reads fresh — the measured at-least-once degrade, recorded honestly"
+        );
+        assert_eq!(
+            ack.offset,
+            3 + i as u64,
+            "the degraded retry re-appends at the head"
+        );
+    }
+    // Ground truth: all three retries re-appended (3 originals + 3 duplicates + this probe).
+    assert_eq!(
+        publish_plain(&mut client, b"fresh-after-degrade"),
+        6,
+        "every un-checkpointed retry re-appended: the honest bound is checkpoint lag"
+    );
+}

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -16,10 +16,14 @@ on-device history is [PERF_LEDGER.md](PERF_LEDGER.md), and the Redpanda studies 
 the [README benchmarks section](../README.md#benchmarks). The corruption-recovery head-to-head
 ([#644](https://github.com/ELares/IronBus/issues/644): the same four on-disk corruption classes
 injected into both brokers' file stores, behavior measured on both sides) is
-[benchmarks/corruption-recovery.md](benchmarks/corruption-recovery.md), and the
+[benchmarks/corruption-recovery.md](benchmarks/corruption-recovery.md), the
 write-amplification + RSS-per-message head-to-head
 ([#645](https://github.com/ELares/IronBus/issues/645)) is
 [benchmarks/write-amp-rss.md](benchmarks/write-amp-rss.md).
+The effectively-once
+survival head-to-head ([#647](https://github.com/ELares/IronBus/issues/647): broker restart +
+producer-offline gap injected on both sides, duplicate counts measured) is
+[benchmarks/effectively-once.md](benchmarks/effectively-once.md).
 
 ## Headlines
 

--- a/docs/benchmarks/effectively-once.md
+++ b/docs/benchmarks/effectively-once.md
@@ -1,0 +1,117 @@
+<!-- SPDX-License-Identifier: MIT OR Apache-2.0 -->
+# Effectively-once survival head-to-head: IronBus vs NATS JetStream
+
+The [#647](https://github.com/ELares/IronBus/issues/647) (V2-M12) benchmark: **demonstrate,
+not assert**, the effectively-once survival differentiator built in
+[#639](https://github.com/ELares/IronBus/issues/639) (M8-I2) by injecting the two things a
+time-bounded dedup window is vulnerable to — a **broker restart** and a **producer-offline gap
+longer than the window** — and measuring, on both brokers, whether a producer's retry of an
+already-acknowledged publish is deduplicated or double-appended.
+
+Every result below is **measured**, both sides, on the same host, with duplicate counts as the
+ground truth. Wins, losses, and behaviors that differ from folklore are all recorded; the
+honest-notes section is part of the result.
+
+## Harnesses (how to re-run)
+
+- **IronBus legs** — a repeatable integration test over the real `ironbus` binary (durable
+  disk mode, fsync-per-ack, the zero-config default):
+  `cargo test -p ironbus-cli --test effectively_once`
+  ([`crates/ironbus-cli/tests/effectively_once.rs`](../../crates/ironbus-cli/tests/effectively_once.rs)).
+  It runs in the normal CI suite, so the behaviors in this table are asserted on every run.
+- **NATS legs** — a scripted, observation-only harness (downloads the pinned nats-server +
+  natscli for the host arch, runs each scenario against a fresh JetStream file store, prints
+  `OBSERV:` lines): `bash docs/benchmarks/effectively_once_nats.sh`
+  ([`effectively_once_nats.sh`](effectively_once_nats.sh)).
+
+## Methodology and versions
+
+- **Environment:** Linux container (aarch64), single node, loopback. This is a
+  correctness/behavior benchmark: no throughput numbers are read from it.
+- **Versions:** IronBus at this commit (debug build, defaults: `durability_level=sync`,
+  `power_loss_safe=true`, `--checkpoint-interval 1`) vs **nats-server v2.14.3** driven by
+  **natscli 0.4.0** (JetStream file storage, `replicas=1`, `sync_interval: always`, fresh
+  store per scenario). 2026-07-10.
+- **The retry shape is identical on both sides:** publish an acknowledged corpus of messages
+  each carrying a stable idempotency identity (IronBus: the `PubDedup` block — `producer_id` +
+  `epoch` + `msg_id`, with the sequenced legs also carrying the per-producer monotonic `seq`;
+  NATS: the `Nats-Msg-Id` header on an acknowledged JetStream publish), inject the scenario's
+  restart and/or gap, then **re-publish the exact same identities** — a producer retrying
+  after its acks were lost in transit. The measured result is how many retries were appended
+  a second time.
+- **Shortened windows (the standard methodology):** the gap scenarios run against
+  deliberately shortened windows — `duplicates: 5s` on the NATS stream (config
+  `duplicate_window`, default 2 minutes) and `--dedup-window-ms 3000` on IronBus's `msg_id`
+  window (same 2-minute default) — and the producer sleeps past them (8 s / 4.5 s). Waiting
+  out the real defaults would measure the same lapse, only slower. The restart scenarios keep
+  the default windows so the restart is isolated from the time bound. IronBus's **sequence**
+  path has no time parameter to shorten — its wall-clock independence is the thing measured.
+- **Both IronBus dedup paths are measured**, including the one that loses: the time-bounded
+  `msg_id` window (the same primitive class as `Nats-Msg-Id`) and the durable
+  idempotent-producer sequence (the differentiator under test).
+
+## Results
+
+Duplicate counts are `duplicates appended / retries sent`. **0 = effectively-once held.**
+
+| # | Scenario | IronBus (measured) | NATS 2.14.3 (measured) |
+| --- | --- | --- | --- |
+| 1 | Retry after a broker **restart** (window still open) | **Sequence path: 0/10 duplicates.** The graceful-shutdown flush persisted the `(producer_id, epoch, last_seq, last_offset)` high-water to `producer-seq.ckpt`; every cross-restart retry answered `duplicate = true` (10 counted `ironbus_dedup_hits_total`), nothing appended, and the log carries each record exactly once. `msg_id` window path: **1/1 duplicated** — the window is in-memory and does not survive a restart (measured, recorded honestly; see the notes). | **0/10 duplicates** — measured on both a clean (SIGTERM) restart and a `kill -9` restart. On 2.14.3 the file store **rebuilds the duplicate-tracking state from the stored message headers** still inside the window, so a restart alone does NOT lapse it. Recorded as measured, against the folklore. |
+| 2 | Retry after a **producer-offline gap** longer than the window (no restart) | **Sequence path: 0/5 duplicates** — the high-water is sequence state, not wall-clock, so the gap is irrelevant by construction. `msg_id` window path: **1/1 duplicated** after the gap, and the lapse is **operator-visible** (`ironbus_dedup_out_of_window_total` fired), never silent. | **10/10 duplicated** — every retry past the `duplicate_window` was accepted as an ordinary new message (stream count 10 -> 20). The window is the whole defense: once wall-clock passes it, the same `Nats-Msg-Id` reads fresh. |
+| 3 | **Combined**: restart PLUS a gap past the window | **Sequence path: 0/5 duplicates** across a `kill -9` (no shutdown flush) plus the gap: the ack-driven checkpoint tick had already persisted the high-water, and it is time-independent. `msg_id` window path: **1/1 duplicated** (state gone and time lapsed). | **10/10 duplicated** (stream count 10 -> 20) — the rebuilt-on-restart tracking state only covers messages still inside the window, so the gap lapses it exactly as with no restart. |
+| 4 | The **honest bound** of the IronBus sequence path: `kill -9` before ANY durability point | **3/3 duplicated** — an unclean kill before any ack-driven checkpoint tick, graceful shutdown, or txn-commit flush loses the un-persisted high-water, and the retries re-append (the documented at-least-once degrade). The bound is **checkpoint lag**, never wall-clock. | — (no durable dedup path to bound; the window scenarios above are the whole contract) |
+
+## The dedup contracts, as measured
+
+- **NATS `Nats-Msg-Id`:** one primitive — a per-stream duplicate-tracking window bounded by
+  wall-clock (`duplicate_window`, default 2 minutes). On 2.14.3 with file storage it **does
+  survive restarts** (clean and `kill -9`): the tracking state is rebuilt from stored message
+  headers still inside the window. What it cannot survive is **time**: any retry arriving
+  after the window — a producer offline past 2 minutes, a long partition, a queued redelivery
+  — is appended again, indistinguishable from a fresh publish. Widening the window widens the
+  per-message tracking state it implies; the bound stays wall-clock.
+- **IronBus `msg_id` window (#33):** the same primitive class, deliberately: per-producer,
+  bounded by a count (default 100k ids) AND a monotonic time window (default 2 minutes,
+  `--dedup-window-ms`), epoch-fenced. Held **in memory only** — it does not survive a restart
+  (on that one axis it is weaker than NATS's file-store window, measured in scenario 1 and
+  stated here rather than hidden). A lapse is counted (`ironbus_dedup_out_of_window_total`),
+  never silent. This is the content-keyed convenience path, not the survival contract.
+- **IronBus idempotent-producer sequence (V2-M8, #638/#639):** the survival contract. The
+  broker keeps one `(epoch, last_seq, last_offset)` high-water per `producer_id` — O(1) per
+  producer, not O(messages) — persisted to `producer-seq.ckpt` (dual-slot, CRC-protected) on
+  the ack-driven cursor-checkpoint cadence, the graceful-shutdown flush, and inline at txn
+  commit. A retry (`seq <= last_seq`) is deduplicated to exactly-once-append **across
+  restarts and arbitrarily long gaps** — the bound is sequence state, never wall-clock. Its
+  real limits, measured or stated: (a) an unclean kill loses high-waters newer than the last
+  durability point (scenario 4: at-least-once for exactly those retries, never a wrong
+  offset); (b) the registry tracks at most 4096 producers (attacker-chosen ids are
+  LRU-evicted; an evicted producer degrades to at-least-once); (c) a retry of an *older* seq
+  is answered with the *high-water* offset, honoring "already durable, do not re-append"
+  rather than per-seq offset recall; (d) a sequence *gap* (`seq > last + 1`) is rejected
+  (`OutOfOrder`, the Kafka semantics), never silently accepted.
+
+## Honest notes
+
+- **The headline claim needed qualifying, and the measurement did it.** The M8-I2 framing
+  ("NATS's dedup is volatile and lapses on restart") is **not what 2.14.3 does on file
+  storage**: scenarios 1/1b measured 0/10 duplicates across both clean and `kill -9`
+  restarts. What lapses NATS's dedup is the **wall-clock window itself** (scenarios 2 and 3:
+  10/10 duplicated). The IronBus differentiator is therefore precisely: *dedup bounded by
+  sequence state instead of wall-clock*, plus the measured restart survival — not a claim
+  that NATS forgets on restart.
+- **IronBus's own `msg_id` window is the volatile one across restarts** (scenario 1: 1/1
+  duplicated where NATS's file-store window held). The doc says so because the measurement
+  did. A producer that needs survival uses the sequence path; the window path is for
+  content-keyed dedup inside a session.
+- **Scenario 4 is a deliberate leg, not a failure:** it measures the sequence path's real
+  durability bound (checkpoint lag under an unclean kill with zero durability points) so this
+  page states the actual contract instead of claiming infinity. In a running pipeline the
+  high-water persists on every ack-driven checkpoint tick (`--checkpoint-interval 1` in the
+  harness), on every graceful shutdown, and inline at txn commit.
+- **The shortened windows are methodology, not a thumb on the scale:** both sides' gap legs
+  shorten their window (5 s NATS, 3 s IronBus) and wait past it; the 2-minute defaults lapse
+  identically, only slower. The IronBus sequence path's 0-duplicate results are
+  wall-clock-independent and hold for any gap length by construction.
+- IronBus ran a **debug build** (this is a behavior benchmark, not a throughput one); NATS
+  ran its release binary. Corpus sizes are stated in the harnesses; both sides of each
+  scenario retry the same identities they published.

--- a/docs/benchmarks/effectively_once_nats.sh
+++ b/docs/benchmarks/effectively_once_nats.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT OR Apache-2.0
+#
+# The NATS side of the #647 effectively-once SURVIVAL head-to-head (V2-M12).
+#
+# Measures what JetStream's `Nats-Msg-Id` duplicate window actually does when the two things a
+# time-bounded window is vulnerable to are injected — a broker RESTART and a producer-offline
+# GAP longer than the window — and RECORDS the observed duplicate counts (it asserts nothing;
+# the point is measurement):
+#
+#   S1  retry after a broker restart, window still open (default duplicate_window, clean stop)
+#   S1b the same retry after a kill -9 restart (the unclean variant)
+#   S2  retry after a producer-offline gap LONGER than the window (no restart)
+#   S3  the combined injection: restart PLUS a gap longer than the window
+#
+# Methodology (mirrors the IronBus leg): the "long gap" scenarios run against a stream with a
+# deliberately SHORTENED `duplicates: 5s` window and sleep past it — waiting out the real
+# 2-minute default would measure the same lapse, only slower. The restart scenarios keep the
+# default window so the restart is isolated from the time bound. The IronBus side of the same
+# scenarios is the repeatable `crates/ironbus-cli/tests/effectively_once.rs` integration test;
+# the measured results of BOTH sides live in `docs/benchmarks/effectively-once.md`.
+#
+# Usage (no root needed; downloads the pinned nats-server + natscli for this arch):
+#   bash docs/benchmarks/effectively_once_nats.sh
+# Environment overrides: NATS_SERVER_VERSION, NATSCLI_VERSION, WORK (scratch dir).
+#
+# Every observation line is prefixed `OBSERV:` so a transcript can be grepped into the
+# results table.
+
+set -u
+
+NATS_SERVER_VERSION=${NATS_SERVER_VERSION:-2.14.3}
+NATSCLI_VERSION=${NATSCLI_VERSION:-0.4.0}
+WORK=${WORK:-$(mktemp -d /tmp/effectively-once-nats.XXXXXX)}
+URL=nats://127.0.0.1:4222
+NATS="$WORK/nats -s $URL"
+# A private config home: natscli's context machinery errors out ("context not found") when the
+# shared config home is unusable; the harness never wants a saved context anyway.
+export XDG_CONFIG_HOME="$WORK/xdg"
+
+# The shortened duplicate window for the gap scenarios, and a sleep comfortably past it.
+DUPE_WINDOW=5s
+GAP_SECONDS=8
+
+case "$(uname -m)" in
+  aarch64|arm64) ARCH=arm64 ;;
+  x86_64) ARCH=amd64 ;;
+  *) echo "unsupported arch $(uname -m)"; exit 1 ;;
+esac
+
+mkdir -p "$WORK"
+cd "$WORK"
+
+echo "== downloading nats-server v${NATS_SERVER_VERSION} + natscli v${NATSCLI_VERSION} (linux-${ARCH})"
+curl -fsSL -o ns.tar.gz "https://github.com/nats-io/nats-server/releases/download/v${NATS_SERVER_VERSION}/nats-server-v${NATS_SERVER_VERSION}-linux-${ARCH}.tar.gz"
+tar xzf ns.tar.gz
+cp "nats-server-v${NATS_SERVER_VERSION}-linux-${ARCH}/nats-server" .
+curl -fsSL -o natscli.zip "https://github.com/nats-io/natscli/releases/download/v${NATSCLI_VERSION}/nats-${NATSCLI_VERSION}-linux-${ARCH}.zip"
+unzip -oq natscli.zip
+cp "nats-${NATSCLI_VERSION}-linux-${ARCH}/nats" .
+./nats-server --version
+./nats --version
+
+SRV_PID=""
+
+# Starts nats-server over $1 (store dir), logging to $1.log. JetStream file storage with
+# `sync_interval: always` (the durable comparison point, same as the #644 harness).
+start_server() {
+  local store=$1
+  cat > "$store.conf" <<EOF
+port: 4222
+jetstream {
+  store_dir: "$store"
+  sync_interval: always
+}
+EOF
+  ./nats-server -c "$store.conf" > "$store.log" 2>&1 &
+  SRV_PID=$!
+  for _ in $(seq 1 100); do
+    $NATS rtt >/dev/null 2>&1 && return 0
+    sleep 0.1
+  done
+  echo "OBSERV: server failed to become ready; log tail:"; tail -5 "$store.log"
+  return 1
+}
+
+stop_server() { # clean stop (SIGTERM), the normal operational restart
+  kill -TERM "$SRV_PID" 2>/dev/null
+  wait "$SRV_PID" 2>/dev/null
+}
+
+kill_server() { # unclean stop (SIGKILL), the crash variant
+  kill -KILL "$SRV_PID" 2>/dev/null
+  wait "$SRV_PID" 2>/dev/null
+}
+
+messages_in() { # $1 stream: the stream's stored message count (the duplicate ground truth)
+  $NATS stream info "$1" --json | grep -o '"messages": *[0-9]*' | head -1 | grep -o '[0-9]*'
+}
+
+# Publishes $3 messages onto subject $2 for stream $1, each an ACKNOWLEDGED JetStream publish
+# carrying a STABLE `Nats-Msg-Id` (id-1..id-N) — the retryable idempotent-producer shape. A
+# second identical call is exactly "the producer retries every publish".
+publish_ids() {
+  local stream=$1 subject=$2 count=$3
+  local i
+  for i in $(seq 1 "$count"); do
+    $NATS pub "$subject" "payload-$i" -H "Nats-Msg-Id:id-$i" --jetstream >/dev/null 2>&1
+  done
+}
+
+echo
+echo "================ S1: retry after a CLEAN restart (default duplicate_window, still open) ================"
+S1=$WORK/store-s1
+start_server "$S1"
+$NATS stream add S1 --subjects=s1 --storage=file --replicas=1 --defaults >/dev/null
+echo "OBSERV: stream S1 duplicate_window: $($NATS stream info S1 --json | grep -o '"duplicate_window": *[0-9]*' | head -1) ns (the 2-minute default)"
+publish_ids S1 s1 10
+echo "OBSERV: pre-restart: messages=$(messages_in S1) (10 published with Nats-Msg-Id id-1..id-10)"
+stop_server
+start_server "$S1"
+publish_ids S1 s1 10
+AFTER=$(messages_in S1)
+echo "OBSERV: post-restart retry of the same 10 ids: messages=$AFTER (duplicates appended: $((AFTER - 10)))"
+stop_server
+
+echo
+echo "================ S1b: the same retry after a KILL -9 restart ================"
+S1B=$WORK/store-s1b
+start_server "$S1B"
+$NATS stream add S1B --subjects=s1b --storage=file --replicas=1 --defaults >/dev/null
+publish_ids S1B s1b 10
+echo "OBSERV: pre-kill: messages=$(messages_in S1B)"
+kill_server
+start_server "$S1B"
+publish_ids S1B s1b 10
+AFTER=$(messages_in S1B)
+echo "OBSERV: post-kill-9 retry of the same 10 ids: messages=$AFTER (duplicates appended: $((AFTER - 10)))"
+stop_server
+
+echo
+echo "================ S2: producer-offline GAP past the window (duplicates: ${DUPE_WINDOW}, no restart) ================"
+S2=$WORK/store-s2
+start_server "$S2"
+$NATS stream add S2 --subjects=s2 --storage=file --replicas=1 --dupe-window="$DUPE_WINDOW" --defaults >/dev/null
+publish_ids S2 s2 10
+echo "OBSERV: pre-gap: messages=$(messages_in S2) (window shortened to ${DUPE_WINDOW}; the 2-minute default lapses identically, only slower)"
+echo "OBSERV: producer offline for ${GAP_SECONDS}s (> ${DUPE_WINDOW} window)..."
+sleep "$GAP_SECONDS"
+publish_ids S2 s2 10
+AFTER=$(messages_in S2)
+echo "OBSERV: post-gap retry of the same 10 ids: messages=$AFTER (duplicates appended: $((AFTER - 10)))"
+stop_server
+
+echo
+echo "================ S3: COMBINED — restart PLUS a gap past the window (duplicates: ${DUPE_WINDOW}) ================"
+S3=$WORK/store-s3
+start_server "$S3"
+$NATS stream add S3 --subjects=s3 --storage=file --replicas=1 --dupe-window="$DUPE_WINDOW" --defaults >/dev/null
+publish_ids S3 s3 10
+echo "OBSERV: pre-injection: messages=$(messages_in S3)"
+stop_server
+echo "OBSERV: broker down + producer offline for ${GAP_SECONDS}s (> ${DUPE_WINDOW} window)..."
+sleep "$GAP_SECONDS"
+start_server "$S3"
+publish_ids S3 s3 10
+AFTER=$(messages_in S3)
+echo "OBSERV: post-restart-plus-gap retry of the same 10 ids: messages=$AFTER (duplicates appended: $((AFTER - 10)))"
+stop_server
+
+echo
+echo "== done; transcripts in $WORK (grep OBSERV: for the results table inputs)"


### PR DESCRIPTION
The V2-M12 effectively-once survival benchmark ([#647](https://github.com/ELares/IronBus/issues/647), ties to M8-I2 [#639](https://github.com/ELares/IronBus/issues/639)): inject a broker **restart** and a **long producer-offline gap** and measure, on both brokers, whether a producer's retry of an already-acknowledged publish is deduplicated or double-appended. Mirrors the #644 head-to-head structure (#1132): a repeatable cargo-test IronBus leg, a scripted observation-only NATS leg, a measured results page, one link line in `docs/BENCHMARKS.md`.

Closes #647.

## Measured results (duplicates appended / retries sent; 0 = effectively-once held)

| # | Scenario | IronBus (measured) | NATS 2.14.3 (measured) |
| --- | --- | --- | --- |
| 1 | Retry after broker restart (window open) | seq path **0/10**; msg_id window 1/1 (in-memory, lost on restart — recorded honestly) | **0/10** on both clean and kill -9 restarts: the file store rebuilds the duplicate map from stored headers inside the window |
| 2 | Producer-offline gap past the window | seq path **0/5** (wall-clock-independent); msg_id window 1/1 + `ironbus_dedup_out_of_window_total` fired | **10/10 duplicated** (stream 10 -> 20) |
| 3 | Combined: restart + gap | seq path **0/5** across kill -9 + gap (ack-driven checkpoint tick); msg_id window 1/1 | **10/10 duplicated** |
| 4 | Honest bound (IronBus-only): kill -9 before any durability point | **3/3 re-appended** — un-flushed high-waters degrade to at-least-once; the bound is checkpoint lag, never wall-clock | — |

## The honest findings

- **The M8-I2 headline needed qualifying, and the measurement did it**: on 2.14.3 **file storage the `Nats-Msg-Id` window survives restarts** (clean AND kill -9). What lapses it is **wall-clock** — any retry past `duplicate_window` duplicates, restart or not. The differentiator, as measured, is dedup bounded by **sequence state instead of wall-clock**.
- **IronBus's own msg_id window is measured as the volatile class it is** (it does not survive a restart — on that one axis weaker than NATS's file-store window; stated in the doc, not hidden). The survival contract is the idempotent-producer **sequence** path (#638/#639).
- The sequence path's real limits are measured/stated: checkpoint lag under an unclean kill (scenario 4), the 4096-producer LRU cap, retries of older seqs answered with the high-water offset, sequence gaps rejected (`OutOfOrder`).
- Methodology: the gap legs shorten the window on **both** sides (`duplicates: 5s` NATS, `--dedup-window-ms 3000` IronBus) and sleep past it — the 2-minute defaults lapse identically, only slower. Restart legs keep the default window so the restart is isolated from the time bound.

## Files

- `crates/ironbus-cli/tests/effectively_once.rs` — the repeatable IronBus leg (4 tests, normal CI suite, helpers mirror `corruption_recovery.rs`)
- `docs/benchmarks/effectively_once_nats.sh` — the pinned NATS leg (nats-server 2.14.3 + natscli 0.4.0, JetStream file storage, `sync_interval: always`, `OBSERV:` lines)
- `docs/benchmarks/effectively-once.md` — the measured results table + the dedup contracts as measured + honest notes
- `docs/BENCHMARKS.md` — one link line

## Gates (all run in a Linux container, aarch64)

- `cargo test --workspace --locked`: **3252 passed, 0 failed** (58 suites ok, exit 0)
- `cargo test -p ironbus-cli --test acceptance`: ok, 1 passed; `--test golden_path`: ok, 13 passed; `--test effectively_once`: ok, 4 passed
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` on rustc 1.97.0: clean
- `cargo fmt --all --check`: clean
- `scripts/check-format-registry.sh`: both digests ok
- `scripts/ci/relative-link-check.sh`: ~950 links, 0 problems

No engine/storage production code touched; no PERF_LEDGER.md changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01McmNfYNWPmohVS8umY9Lkp
