### PR TITLE
feat(dlq): durable per-message delivery-count across restart (#547)

### DIFF
--- a/crates/ironbus-cli/tests/effectively_once.rs
+++ b/crates/ironbus-cli/tests/effectively_once.rs
@@ -26,6 +26,11 @@
 //! the normal `cargo test` suite (`cargo test -p ironbus-cli --test effectively_once`), so the
 //! survival differentiator is demonstrated on every CI run, not asserted.
 //!
+//! Scenario 5 is the CONSUMER-side twin (#547): the durable per-message DELIVERY COUNT — a
+//! poison message nacked mid-retry across a kill -9 resumes its count and dead-letters after
+//! exactly `MaxDeliver` observed deliveries TOTAL, where NATS's volatile redelivery count (and
+//! `MaxDeliver=-1` default) redelivers it forever. See `docs/DURABILITY.md` for the contract.
+//!
 //! Methodology note (mirrors the NATS leg): the "long offline gap" is measured against a
 //! deliberately SHORTENED window — `--dedup-window-ms 3000` here, `duplicates: 5s` on the NATS
 //! stream — and the gap sleeps PAST it. Waiting out the real 2-minute defaults would measure
@@ -601,5 +606,135 @@ fn unclean_kill_before_any_checkpoint_degrades_unflushed_highwaters_to_at_least_
         publish_plain(&mut client, b"fresh-after-degrade"),
         6,
         "every un-checkpointed retry re-appended: the honest bound is checkpoint lag"
+    );
+}
+
+// =================================================================================================
+// SCENARIO 5 (the CONSUMER-side twin of scenario 4, #547): MaxDeliver -> DLQ fires ACROSS a
+// kill -9 mid-retry — the durable per-message DELIVERY COUNT survival that scenario 4's
+// producer-side measurement left unasserted.
+//
+// IronBus measured behavior: a poison message nacked K times before an UNCLEAN kill (SIGKILL, no
+// drain) resumes its delivery count at the durable floor after the restart, so it dead-letters
+// after EXACTLY MaxDeliver observed deliveries TOTAL across the crash — never 2 x MaxDeliver, and
+// never the NATS failure mode (redelivery count volatile, default MaxDeliver=-1: a poison
+// redelivers FOREVER across restarts). The count is made durable by the #547 redelivery-driven
+// attempts flush on the per-pass checkpoint seam (a poison retry loop never advances the cursor,
+// so the interval checkpoint alone would never persist it) plus the clean-disconnect flush; the
+// honest lag bound — an attempt-1-only kill loses at most that single first attempt, and a
+// disabled trigger degrades to interval/disconnect cadence — is measured at the engine level
+// (`engine::tests::an_unclean_kill_before_any_redelivery_costs_at_most_one_extra_delivery` and
+// `a_threshold_of_zero_disables_the_trigger_and_the_dlq_fires_late_but_fires`: LATE by exactly
+// the lag, but it FIRES).
+// =================================================================================================
+#[test]
+fn max_deliver_dead_letters_after_a_kill_minus_nine_mid_retry_never_redelivers_forever() {
+    const MAX_DELIVER: u32 = 5;
+    let scratch = Scratch::new("poison");
+    let dir = scratch.join("data");
+    let dir = dir.to_str().expect("utf8 data dir");
+
+    let (broker, addr, _h) = start_broker(dir, &["--max-deliver", "5"]);
+    let mut client = Client::connect(&addr).expect("connect the producer");
+    assert_eq!(publish_plain(&mut client, b"poison-rec"), 0);
+    drop(client);
+
+    // Deliver + NACK the poison twice (attempts 1 and 2). Each `sub --nack` run takes one
+    // window-bounded batch and disconnects; the explicit 1 ms delay overrides the escalating
+    // backoff schedule so the next run redelivers immediately.
+    let mut observed_deliveries = 0u32;
+    for attempt in 1..=2u32 {
+        let (out, _e, code) = run(&[
+            "sub",
+            "--addr",
+            &addr,
+            "--max",
+            "1",
+            "--nack",
+            "--delay-ms",
+            "1",
+        ]);
+        assert_eq!(code, 0, "nack run {attempt}: {out}");
+        let got = payloads(&out);
+        assert_eq!(got, vec!["poison-rec".to_string()], "attempt {attempt}");
+        observed_deliveries += 1;
+    }
+    // Let the broker's actor drain the per-pass attempts flush + the close-path checkpoint the
+    // second run scheduled (both are broker-side and complete in microseconds; this sleep only
+    // de-flakes a pathologically loaded CI runner) — then KILL -9 MID-RETRY: the poison is
+    // nacked, its retry pending, its delivery count 2. No drain, no shutdown flush.
+    std::thread::sleep(Duration::from_millis(500));
+    drop(broker);
+
+    // RESTART over the same dir: the delivery count must RESUME (NATS restarts it at zero).
+    let (broker2, addr2, health2) = start_broker(dir, &["--max-deliver", "5"]);
+    for run_idx in 3..=MAX_DELIVER {
+        let (out, _e, code) = run(&[
+            "sub",
+            "--addr",
+            &addr2,
+            "--max",
+            "1",
+            "--nack",
+            "--delay-ms",
+            "1",
+        ]);
+        assert_eq!(code, 0, "post-restart nack run {run_idx}: {out}");
+        let got = payloads(&out);
+        assert_eq!(
+            got,
+            vec!["poison-rec".to_string()],
+            "post-restart delivery {run_idx} still under the resumed MaxDeliver budget"
+        );
+        observed_deliveries += 1;
+    }
+    assert_eq!(
+        observed_deliveries, MAX_DELIVER,
+        "exactly MaxDeliver observed deliveries TOTAL across the kill -9"
+    );
+
+    // The NEXT fetch dead-letters the poison instead of delivering it: the count resumed at the
+    // durable floor, so this is attempt MaxDeliver + 1 ACROSS the crash — the assertion NATS
+    // cannot make (its redelivery count is volatile and its default MaxDeliver is unlimited).
+    let (out, _e, code) = run(&[
+        "sub",
+        "--addr",
+        &addr2,
+        "--max",
+        "1",
+        "--nack",
+        "--delay-ms",
+        "1",
+    ]);
+    assert_eq!(code, 0, "the dead-lettering fetch: {out}");
+    assert!(
+        payloads(&out).is_empty(),
+        "the poison is PARKED, not redelivered a 6th time: {out}"
+    );
+    let metrics = http_get(&health2, "/metrics");
+    assert_eq!(
+        metric_value(&metrics, "ironbus_dead_lettered_total"),
+        Some(1),
+        "MaxDeliver -> DLQ fired exactly once, across the kill -9"
+    );
+    assert_eq!(
+        metric_value(&metrics, "ironbus_delivered_total"),
+        Some(u64::from(MAX_DELIVER - 2)),
+        "this broker run delivered only the RESUMED budget (3), not a fresh MaxDeliver"
+    );
+
+    // The durable ground truth, offline: stop the broker and stream the DLQ sink itself. The one
+    // entry records attempt 6 (MaxDeliver + 1) — the count was TOTAL across the restart.
+    drop(broker2);
+    let (out, _e, code) = run(&["dump", "--data-dir", dir, "--dlq"]);
+    assert_eq!(code, 0, "offline dlq dump: {out}");
+    let dlq_lines: Vec<&str> = out
+        .lines()
+        .filter(|l| l.contains("source_offset="))
+        .collect();
+    assert_eq!(dlq_lines.len(), 1, "exactly one dead-letter record: {out}");
+    assert!(
+        dlq_lines[0].contains("source_offset=0") && dlq_lines[0].contains("attempt=6"),
+        "the poison dead-lettered as attempt MaxDeliver + 1, counted across the kill -9: {out}"
     );
 }

--- a/crates/ironbus-core/src/delivery.rs
+++ b/crates/ironbus-core/src/delivery.rs
@@ -63,11 +63,22 @@ pub struct DeliveryConfig {
     max_deliver: u32,
     allow_unlimited: bool,
     backoff_nanos: Vec<u64>,
+    attempts_flush_redeliveries: u32,
 }
 
 impl DeliveryConfig {
     /// The default cap on delivery attempts before a message is dead-lettered.
     pub const DEFAULT_MAX_DELIVER: u32 = 5;
+
+    /// The default redelivery-driven attempt-count flush threshold (#547): once at least this
+    /// many REDELIVERY grants (attempts >= 2, the poison-relevant events) have accumulated in a
+    /// group since its attempt counts were last durable, the server's per-pass checkpoint seam
+    /// writes the attempt snapshot even though the cursor has not advanced. `1` (the default)
+    /// makes every pass that granted a redelivery end with one amortized snapshot write, so the
+    /// durable count lags the true count by AT MOST the redeliveries of a single in-progress
+    /// pass — bounded in deliveries, never in wall-clock or cursor distance. First deliveries
+    /// (attempt 1, the hot path) never trip it, so a healthy workload pays nothing.
+    pub const DEFAULT_ATTEMPTS_FLUSH_REDELIVERIES: u32 = 1;
 
     /// Builds a delivery config.
     ///
@@ -95,7 +106,30 @@ impl DeliveryConfig {
             max_deliver,
             allow_unlimited,
             backoff_nanos,
+            attempts_flush_redeliveries: Self::DEFAULT_ATTEMPTS_FLUSH_REDELIVERIES,
         })
+    }
+
+    /// Overrides the redelivery-driven attempt-count flush threshold (#547), returning the
+    /// config for chaining. `0` DISABLES the delivery-driven trigger entirely (the attempt
+    /// counts then persist only on the legacy cadence: cursor-interval, clean disconnect,
+    /// graceful shutdown, and eviction — the pre-#547 behavior, whose un-persisted lag is
+    /// unbounded in redeliveries). A larger value amortizes further: the durable count may lag
+    /// the true count by up to `n - 1` FULLY-ACCUMULATED redeliveries plus the current pass's
+    /// grants, and `MaxDeliver -> DLQ` fires correspondingly later (never never) after a crash.
+    /// The default ([`Self::DEFAULT_ATTEMPTS_FLUSH_REDELIVERIES`], 1) is the tight, safe bound.
+    #[must_use]
+    pub fn with_attempts_flush_redeliveries(mut self, n: u32) -> DeliveryConfig {
+        self.attempts_flush_redeliveries = n;
+        self
+    }
+
+    /// The redelivery-driven attempt-count flush threshold (#547): flush the durable attempt
+    /// snapshot once this many redelivery grants have accumulated since the last flush; `0`
+    /// means the delivery-driven trigger is disabled.
+    #[must_use]
+    pub fn attempts_flush_redeliveries(&self) -> u32 {
+        self.attempts_flush_redeliveries
     }
 
     /// The configured delivery cap (`0` means unlimited).
@@ -238,6 +272,30 @@ mod tests {
         // An explicit delay wins, even zero (retry immediately).
         assert_eq!(c.effective_nack_delay(2, Some(7)), 7);
         assert_eq!(c.effective_nack_delay(2, Some(0)), 0);
+    }
+
+    #[test]
+    fn the_attempts_flush_threshold_defaults_to_one_and_is_overridable() {
+        // The safe default (#547): every accumulated redelivery makes the attempt snapshot due.
+        let c = config(5, vec![]);
+        assert_eq!(
+            c.attempts_flush_redeliveries(),
+            DeliveryConfig::DEFAULT_ATTEMPTS_FLUSH_REDELIVERIES
+        );
+        assert_eq!(c.attempts_flush_redeliveries(), 1);
+        // Amortize (a nack-storm-heavy deployment) or disable (0, the legacy cadence) explicitly.
+        assert_eq!(
+            config(5, vec![])
+                .with_attempts_flush_redeliveries(8)
+                .attempts_flush_redeliveries(),
+            8
+        );
+        assert_eq!(
+            config(5, vec![])
+                .with_attempts_flush_redeliveries(0)
+                .attempts_flush_redeliveries(),
+            0
+        );
     }
 
     #[test]

--- a/crates/ironbus-core/src/lease.rs
+++ b/crates/ironbus-core/src/lease.rs
@@ -159,9 +159,21 @@ pub struct LeaseTable {
     /// so the live lease owns the count from then on. Empty in steady state (every entry is consumed
     /// by the first redelivery), and bounded by the same `max_in_flight` window that bounds
     /// `leases`, so it never grows unbounded. Acked / committed-past offsets never redeliver (the
-    /// cursor gates them), so a stale carried entry is simply never consumed; the snapshot is
-    /// rebuilt from the live leases each checkpoint, so such an entry never persists.
+    /// cursor gates them), so a stale carried entry is simply never consumed; an acked or
+    /// committed-past offset leaves both `leases` and `carried` (see [`LeaseTable::ack`] /
+    /// [`LeaseTable::release_below`]), so it ages out of the durable snapshot too.
     carried: BTreeMap<u64, u32>,
+    /// REDELIVERY grants (a [`LeaseTable::claim`] granted at attempt >= 2, including a carried
+    /// resume) since the last durable attempt-count flush (#547). This is the delivery-driven
+    /// dirtiness signal behind the durable `MaxDeliver` contract: the interval checkpoint is gated
+    /// on CURSOR advance, which a head-of-line poison never produces, so without this counter a
+    /// poison's rising attempt count could stay un-persisted for arbitrarily many redeliveries and
+    /// an unclean restart would replay them all. The server checks it on its per-pass checkpoint
+    /// seam and flushes the attempt snapshot once the configured threshold is reached, then calls
+    /// [`LeaseTable::note_attempts_flushed`] — so the durable lag is bounded in REDELIVERIES, not
+    /// wall-clock or cursor distance, and first deliveries (attempt 1, the hot path) never pay a
+    /// flush. Saturating; never decremented except by the flush note.
+    redeliveries_since_flush: u32,
 }
 
 impl LeaseTable {
@@ -173,7 +185,25 @@ impl LeaseTable {
             leases: BTreeMap::new(),
             next_generation: 0,
             carried: BTreeMap::new(),
+            redeliveries_since_flush: 0,
         }
+    }
+
+    /// The number of REDELIVERY grants (claims granted at attempt >= 2, including a carried
+    /// resume across a restart) since the last [`note_attempts_flushed`](Self::note_attempts_flushed)
+    /// (#547). The server's checkpoint seam compares this against its configured threshold to
+    /// decide whether the durable attempt snapshot is due, independent of cursor advance.
+    #[must_use]
+    pub fn redeliveries_since_flush(&self) -> u32 {
+        self.redeliveries_since_flush
+    }
+
+    /// Marks the durable attempt snapshot as freshly written (#547), resetting the
+    /// redelivery-dirtiness counter. Called by every attempt-snapshot writer (interval,
+    /// disconnect, shutdown, eviction, and the redelivery-driven trigger), so the counter always
+    /// measures redeliveries SINCE the counts were last durable.
+    pub fn note_attempts_flushed(&mut self) {
+        self.redeliveries_since_flush = 0;
     }
 
     /// Seeds the durable per-message attempt counts CARRIED from a prior run (#358), so the next
@@ -280,6 +310,11 @@ impl LeaseTable {
             lease.attempt_start = now;
             lease.deadline = deadline;
             lease.deliveries = lease.deliveries.saturating_add(1);
+            // A redelivery grant escalated a durable-relevant count (#547): mark the attempt
+            // snapshot dirty so the server's delivery-driven flush trigger can bound the
+            // un-persisted lag in redeliveries (a poison retry loop never advances the cursor,
+            // so the interval checkpoint alone would never fire).
+            self.redeliveries_since_flush = self.redeliveries_since_flush.saturating_add(1);
             lease.deliveries
         } else {
             // First claim of this offset in THIS table. If a durable attempt count was carried
@@ -292,6 +327,13 @@ impl LeaseTable {
                 .carried
                 .remove(&off)
                 .map_or(1, |prior| prior.saturating_add(1));
+            if resumed >= 2 {
+                // A carried resume IS a redelivery (the message had been delivered before the
+                // restart), so it marks the snapshot dirty exactly like the in-table redelivery
+                // branch above: the resumed count must become durable again promptly, or a second
+                // crash could regress it to the pre-restart floor (#547).
+                self.redeliveries_since_flush = self.redeliveries_since_flush.saturating_add(1);
+            }
             self.leases.insert(
                 off,
                 Lease {
@@ -528,6 +570,53 @@ mod tests {
         // Redeliver by re-claiming after expiry, so tok0 is now stale.
         let _ = t.claim(off(0), 1000);
         assert_eq!(t.nack(&tok0, 1000, 0), NackOutcome::Fenced);
+    }
+
+    #[test]
+    fn redeliveries_since_flush_counts_regrants_and_carried_resumes_not_first_deliveries() {
+        // First deliveries (attempt 1) are the hot path and must NEVER mark the attempt
+        // snapshot dirty (#547): no per-delivery flush pressure.
+        let mut t = LeaseTable::new(cfg());
+        assert_eq!(t.redeliveries_since_flush(), 0);
+        t.claim(off(0), 0);
+        t.claim(off(1), 0);
+        assert_eq!(
+            t.redeliveries_since_flush(),
+            0,
+            "attempt-1 grants are not redeliveries"
+        );
+        // An expired lease's re-claim IS a redelivery (attempt 2): counts once per grant.
+        t.claim(off(0), 40);
+        assert_eq!(t.redeliveries_since_flush(), 1);
+        t.claim(off(0), 80);
+        assert_eq!(t.redeliveries_since_flush(), 2);
+        // The flush note resets the dirtiness; subsequent redeliveries count from zero again.
+        t.note_attempts_flushed();
+        assert_eq!(t.redeliveries_since_flush(), 0);
+        t.claim(off(1), 40);
+        assert_eq!(t.redeliveries_since_flush(), 1);
+    }
+
+    #[test]
+    fn a_carried_resume_is_a_redelivery_for_the_flush_trigger() {
+        // A post-restart first claim that RESUMES a carried count is a redelivery (the message
+        // was delivered before the crash), so it must mark the snapshot dirty: without this, a
+        // resumed poison's count would only re-persist on a cursor advance it never causes, and
+        // a second crash would regress it to the pre-restart floor (#547).
+        let mut t = LeaseTable::new(cfg());
+        t.resume_attempts(vec![(0, 3)]);
+        match t.claim(off(0), 0) {
+            Claim::Granted { deliveries, .. } => assert_eq!(deliveries, 4, "resumed 3 + 1"),
+            other => panic!("expected a grant, got {other:?}"),
+        }
+        assert_eq!(
+            t.redeliveries_since_flush(),
+            1,
+            "the carried resume marks the snapshot dirty"
+        );
+        // A genuinely fresh first claim alongside it still does not count.
+        t.claim(off(1), 0);
+        assert_eq!(t.redeliveries_since_flush(), 1);
     }
 
     #[test]

--- a/crates/ironbus-server/src/engine.rs
+++ b/crates/ironbus-server/src/engine.rs
@@ -4510,8 +4510,10 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         }
         // Persist the durable per-message attempt counts (#358) when the cursor advanced OR there
         // are in-flight leases: a redelivery escalates an attempt count WITHOUT moving the cursor,
-        // so a poison record being retried must still record its rising count. Writing an empty
-        // snapshot when nothing is in flight clears any stale carried counts from the last crash.
+        // so a poison record being retried must still record its rising count. The snapshot is the
+        // live ∪ carried union (#565/#547), so a flush in a partially re-claimed recovery state
+        // never regresses a still-carried count; acked or committed-past offsets leave both
+        // inputs, so a clean ack still clears its durable count on the next write.
         if committed > self.last_attempts_checkpointed || has_in_flight {
             self.checkpoint_default_attempts()?;
             self.last_attempts_checkpointed = committed;
@@ -4531,11 +4533,19 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
             .map_or_else(Vec::new, |g| snapshot_payload(&g.cursor))
     }
 
-    /// Durably writes the default group's in-flight attempt-count snapshot to `attempts.ckpt`
-    /// (#358), via the same CRC'd dual-slot checkpoint the cursor uses. The payload is the live
-    /// lease table's `(offset, attempt)` pairs, capped to a slot; an empty payload (nothing in
-    /// flight) is a valid snapshot that clears any stale carried counts. The handle is long-lived,
-    /// so this continues the crash-safe two-slot sequence without reopening.
+    /// Durably writes the default group's attempt-count snapshot to `attempts.ckpt` (#358), via
+    /// the same CRC'd dual-slot checkpoint the cursor uses. The payload is the FULL attempt state
+    /// — live leases UNION the CARRIED (recovered-but-not-yet-re-claimed) counts, via
+    /// [`LeaseTable::all_attempt_counts`] (#565/#547) — capped to a slot. The union is what keeps
+    /// a PARTIALLY re-claimed recovery honest: after a restart with several poisons carried, the
+    /// first poll re-claims only the lowest one, so a live-leases-only snapshot written then (the
+    /// disconnect flush fires on `has_in_flight`) would silently CLOBBER the still-carried
+    /// siblings' durable counts back to zero — the same regression class the #565 eviction fix
+    /// closed. An offset acked or committed-past leaves BOTH inputs, so a clean ack still clears
+    /// its durable count; an empty union (nothing in flight, nothing carried) is a valid snapshot
+    /// that clears stale counts. The handle is long-lived, so this continues the crash-safe
+    /// two-slot sequence without reopening. Notes the flush on the lease table, resetting the
+    /// redelivery-dirtiness counter behind the #547 delivery-driven trigger.
     ///
     /// # Errors
     /// Propagates a storage error from writing the checkpoint.
@@ -4543,21 +4553,28 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         let pairs = self
             .groups
             .get(DEFAULT_GROUP)
-            .map_or_else(Vec::new, |g| g.leases.attempt_counts());
+            .map_or_else(Vec::new, |g| g.leases.all_attempt_counts());
         let payload = attempts_snapshot_payload(&pairs);
         self.attempts_checkpoint.write(&payload)?;
+        if let Some(g) = self.groups.get_mut(DEFAULT_GROUP) {
+            g.leases.note_attempts_flushed();
+        }
         Ok(())
     }
 
-    /// Durably writes a NAMED group's in-flight attempt-count snapshot to its `attempts-<hex>.ckpt`
-    /// (#358), the companion to [`Engine::write_group_checkpoint`]. The file is reopened per write so
-    /// the crash-safe two-slot sequence continues correctly, exactly as the named cursor checkpoint.
+    /// Durably writes a NAMED group's attempt-count snapshot to its `attempts-<hex>.ckpt` (#358),
+    /// the companion to [`Engine::write_group_checkpoint`]. Like
+    /// [`Engine::checkpoint_default_attempts`] it persists the FULL attempt state (live leases
+    /// UNION carried, [`LeaseTable::all_attempt_counts`], #565/#547) so a snapshot written while
+    /// some recovered counts are still carried never regresses them. The file is reopened per
+    /// write so the crash-safe two-slot sequence continues correctly, exactly as the named cursor
+    /// checkpoint. Notes the flush on the lease table (#547).
     ///
     /// # Errors
     /// Propagates a storage error from opening or writing the checkpoint file.
     fn write_group_attempts(&mut self, group: &str) -> Result<(), EngineError> {
         let pairs = match self.groups.get(group) {
-            Some(g) => g.leases.attempt_counts(),
+            Some(g) => g.leases.all_attempt_counts(),
             None => return Ok(()),
         };
         let payload = attempts_snapshot_payload(&pairs);
@@ -4574,6 +4591,9 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         };
         let (mut cp, _) = AttemptsCheckpoint::open(file)?;
         cp.write(&payload)?;
+        if let Some(g) = self.groups.get_mut(group) {
+            g.leases.note_attempts_flushed();
+        }
         Ok(())
     }
 
@@ -4659,10 +4679,33 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         Ok(())
     }
 
+    /// Whether a group's durable attempt snapshot is DUE under the redelivery-driven trigger
+    /// (#547): the configured threshold ([`DeliveryConfig::attempts_flush_redeliveries`],
+    /// default 1) is enabled AND at least that many REDELIVERY grants have accumulated since
+    /// the group's counts were last durable. The cursor-interval checkpoint is gated on cursor
+    /// ADVANCE, which
+    /// a head-of-line poison under retry never produces — so without this trigger a poison's
+    /// rising attempt count could stay un-persisted for arbitrarily many redeliveries and every
+    /// unclean restart would replay them (the NATS volatile-redelivery-count failure mode this
+    /// engine exists to beat). Checked on the same per-pass seam as the interval checkpoint, so
+    /// the flush amortizes over a pass (one snapshot write per pass that granted redeliveries,
+    /// never one per delivery); first deliveries (attempt 1) never trip it.
+    fn attempts_flush_due(&self, leases: &LeaseTable) -> bool {
+        let threshold = self.delivery.attempts_flush_redeliveries();
+        threshold != 0 && leases.redeliveries_since_flush() >= threshold
+    }
+
     /// Checkpoints the committed cursor if it has advanced at least `checkpoint_interval`
     /// offsets since the last checkpoint, returning whether a checkpoint was written. This
     /// bounds how many messages a crash redelivers to roughly `checkpoint_interval` while
     /// keeping the checkpoint write rate far below one per ack (edge flash endurance).
+    ///
+    /// Independently of cursor advance, it also flushes JUST the durable attempt snapshot when
+    /// the redelivery-driven trigger is due ([`Engine::attempts_flush_due`], #547), so a poison
+    /// message's rising delivery count becomes durable on a cadence bounded in REDELIVERIES —
+    /// `MaxDeliver -> DLQ` then holds across an unclean restart even though a retry loop never
+    /// advances the cursor. That flush is one targeted `attempts.ckpt` write (no cursor, no
+    /// counters, no producer-seq piggyback), and returns `true` like any other written checkpoint.
     ///
     /// # Errors
     /// Propagates a storage error from writing the checkpoint.
@@ -4693,6 +4736,19 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
             // a later crash, never correctness, so it must NOT fail the cursor checkpoint that just
             // succeeded. The counters are an observability aid, not durable correctness state.
             let _ = self.checkpoint_counters();
+            Ok(true)
+        } else if self
+            .groups
+            .get(DEFAULT_GROUP)
+            .is_some_and(|g| self.attempts_flush_due(&g.leases))
+        {
+            // The redelivery-driven attempts flush (#547): the cursor did not advance (a poison
+            // retry loop never advances it), but enough redelivery grants accumulated that the
+            // durable attempt counts must catch up, or an unclean restart would replay them and
+            // `MaxDeliver` would fire late — unboundedly late across repeated crashes. One
+            // targeted `attempts.ckpt` write; the flush note inside resets the trigger.
+            self.checkpoint_default_attempts()?;
+            self.last_attempts_checkpointed = committed;
             Ok(true)
         } else {
             Ok(false)
@@ -4759,8 +4815,9 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
 
     /// Like [`Engine::maybe_checkpoint`] but for a named work-group (#60): checkpoints it if its
     /// committed cursor advanced at least `checkpoint_interval` since its last checkpoint, so a
-    /// crash redelivers a bounded tail per group. The default group delegates to
-    /// [`Engine::maybe_checkpoint`].
+    /// crash redelivers a bounded tail per group. Also flushes just the group's attempt snapshot
+    /// when the redelivery-driven trigger is due (#547), exactly as the default group does. The
+    /// default group delegates to [`Engine::maybe_checkpoint`].
     ///
     /// # Errors
     /// Propagates a storage error from writing the checkpoint.
@@ -4772,6 +4829,7 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
             return Ok(false);
         };
         let committed = g.cursor.committed().get();
+        let attempts_due = self.attempts_flush_due(&g.leases);
         let last = self
             .group_last_checkpointed
             .get(group)
@@ -4780,6 +4838,10 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         if committed.saturating_sub(last) >= self.checkpoint_interval.max(1) {
             self.write_group_checkpoint(group, committed)?;
             // Persist the named group's attempt counts on the same interval cadence (#358).
+            self.write_group_attempts(group)?;
+            Ok(true)
+        } else if attempts_due {
+            // The redelivery-driven attempts flush (#547): see `maybe_checkpoint`.
             self.write_group_attempts(group)?;
             Ok(true)
         } else {
@@ -4941,8 +5003,13 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
     /// The file lives in the STREAM's OWN subdirectory (resolved via that stream's log filesystem), so
     /// a named-stream consumer's poison-cap state is co-located with — and recovers beside — its own
     /// log and cursor, the `dlq/` subdir pattern generalized. Same [`AttemptsCheckpoint`] snapshot as
-    /// the default stream: no parallel format, only a different location. Reopened per write so the
-    /// crash-safe two-slot sequence continues correctly. A no-op for an absent stream/group.
+    /// the default stream: no parallel format, only a different location. Like every attempt-snapshot
+    /// writer it persists the FULL attempt state (live leases UNION carried,
+    /// [`LeaseTable::all_attempt_counts`], #565/#547), so a write in ANY recovery state — including
+    /// the eviction of a recovered-but-never-re-polled stream, the original #565 clobber, and the
+    /// partially re-claimed state the periodic/disconnect writers can hit — never lowers a durable
+    /// count. Reopened per write so the crash-safe two-slot sequence continues correctly. Notes the
+    /// flush on the lease table (#547). A no-op for an absent stream/group.
     ///
     /// # Errors
     /// Propagates a storage error from opening or writing the checkpoint file.
@@ -4952,42 +5019,26 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         group: &str,
     ) -> Result<(), EngineError> {
         let pairs = match self.named_streams.get(id).and_then(|s| s.groups.get(group)) {
-            Some(g) => g.leases.attempt_counts(),
-            None => return Ok(()),
-        };
-        self.write_named_group_attempt_pairs(id, group, &pairs)
-    }
-
-    /// The EVICTION-safe attempt-count writer (#565): persists the FULL attempt state — live leases
-    /// UNION carried (recovered-but-not-yet-re-claimed) counts, via [`LeaseTable::all_attempt_counts`]
-    /// — rather than the live leases ONLY. This is what [`evict_named_stream`](Self::evict_named_stream)
-    /// uses so evicting a stream whose poison counts are still CARRIED (recovered from disk but not yet
-    /// re-polled, so `leases` is empty) does NOT overwrite `attempts-<hex>.ckpt` with an empty snapshot
-    /// — which would reset the poison's delivery count to zero and let it escape its `MaxDeliver` cap.
-    /// The periodic checkpoint keeps [`write_named_group_attempts`](Self::write_named_group_attempts)
-    /// (live leases only), gated on cursor-advance / in-flight so it never fires in the
-    /// recovered-not-repolled state. A no-op for an absent stream/group.
-    ///
-    /// # Errors
-    /// Propagates a storage error from opening or writing the checkpoint file.
-    fn write_named_group_attempts_full(
-        &mut self,
-        id: &StreamId,
-        group: &str,
-    ) -> Result<(), EngineError> {
-        let pairs = match self.named_streams.get(id).and_then(|s| s.groups.get(group)) {
             Some(g) => g.leases.all_attempt_counts(),
             None => return Ok(()),
         };
-        self.write_named_group_attempt_pairs(id, group, &pairs)
+        self.write_named_group_attempt_pairs(id, group, &pairs)?;
+        if let Some(g) = self
+            .named_streams
+            .get_mut(id)
+            .and_then(|s| s.groups.get_mut(group))
+        {
+            g.leases.note_attempts_flushed();
+        }
+        Ok(())
     }
 
     /// Durably writes `pairs` as NAMED stream `id`'s work-group `group` attempt snapshot to
     /// `streams/<hex(name)>/attempts-<hex(group)>.ckpt` — the shared file-write behind
-    /// [`write_named_group_attempts`](Self::write_named_group_attempts) (live leases, periodic) and
-    /// [`write_named_group_attempts_full`](Self::write_named_group_attempts_full) (leases ∪ carried,
-    /// eviction). Reopened per write so the crash-safe two-slot sequence continues. A no-op if the
-    /// stream's log is not open.
+    /// [`write_named_group_attempts`](Self::write_named_group_attempts) (leases ∪ carried, every
+    /// cadence: periodic, disconnect, eviction, and the #547 redelivery-driven trigger). Reopened
+    /// per write so the crash-safe two-slot sequence continues. A no-op if the stream's log is not
+    /// open.
     ///
     /// # Errors
     /// Propagates a storage error from opening or writing the checkpoint file.
@@ -5057,7 +5108,8 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
     /// Like [`Engine::maybe_checkpoint_group`] but for a NAMED stream's work-group (#681): checkpoints
     /// it only if its committed cursor advanced at least `checkpoint_interval` since its last
     /// checkpoint, so a hot named-stream consumer writes its cursor on a bounded cadence rather than
-    /// per ack. A no-op for an absent stream/group.
+    /// per ack. Also flushes just the group's attempt snapshot when the redelivery-driven trigger is
+    /// due (#547), exactly as the default stream does. A no-op for an absent stream/group.
     ///
     /// # Errors
     /// Propagates a storage error from writing the checkpoint.
@@ -5070,6 +5122,7 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
             return Ok(false);
         };
         let committed = g.cursor.committed().get();
+        let attempts_due = self.attempts_flush_due(&g.leases);
         let last = self
             .named_streams
             .get(id)
@@ -5080,6 +5133,10 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
             self.write_named_group_checkpoint(id, group, committed)?;
             // Persist the named-stream group's attempt counts on the same interval cadence (#681 DLQ
             // follow-up), exactly as `maybe_checkpoint_group` does for the default stream (#358).
+            self.write_named_group_attempts(id, group)?;
+            Ok(true)
+        } else if attempts_due {
+            // The redelivery-driven attempts flush (#547): see `maybe_checkpoint`.
             self.write_named_group_attempts(id, group)?;
             Ok(true)
         } else {
@@ -7984,15 +8041,15 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
     ///      watermark, unconditionally, BEFORE dropping the in-memory consumer state — else the
     ///      committed position / poison-cap would be lost and reopen would redeliver / re-poison. The
     ///      cursor write is unconditional so the LATEST committed position is durable even if no interval
-    ///      checkpoint fired since the last ack. The attempts write uses
-    ///      [`write_named_group_attempts_full`](Self::write_named_group_attempts_full) (live leases UNION
-    ///      CARRIED counts), NOT the live-leases-only periodic writer: a stream RECOVERED from disk but
-    ///      not yet re-polled holds its poison counts in `carried` with `leases` EMPTY, so the
-    ///      live-leases-only snapshot would be empty and OVERWRITE the durable `attempts.ckpt` to zero —
-    ///      resetting the poison's delivery count and letting it escape its `MaxDeliver` cap. The union
-    ///      guarantees the persisted count NEVER drops below what is already on disk. (This is unlike the
-    ///      idle-group eviction #277, which writes only the cursor and only for caught-up, lease-free
-    ///      groups.)
+    ///      checkpoint fired since the last ack. The attempts write is
+    ///      [`write_named_group_attempts`](Self::write_named_group_attempts), which persists live
+    ///      leases UNION CARRIED counts (post-#547 EVERY attempt writer does): a stream RECOVERED from
+    ///      disk but not yet re-polled holds its poison counts in `carried` with `leases` EMPTY, so a
+    ///      live-leases-only snapshot would be empty and would OVERWRITE the durable `attempts.ckpt`
+    ///      to zero — resetting the poison's delivery count and letting it escape its `MaxDeliver`
+    ///      cap. The union guarantees the persisted count NEVER drops below what is already on disk.
+    ///      (This is unlike the idle-group eviction #277, which writes only the cursor and only for
+    ///      caught-up, lease-free groups.)
     ///   3. DROP the in-memory consumer state and the DLQ sink handle (the DLQ's records are already
     ///      durable — `append_poison` fsyncs in-band — and its per-group idempotency set rebuilds
     ///      lazily from those records on the next reopen, so a poison is never double-dead-lettered);
@@ -8025,9 +8082,9 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         // 2) Persist each group's committed cursor + FULL attempt counts at the current watermark, before
         //    the in-memory state is dropped. The cursor write is unconditional so the LATEST committed
         //    position is durable even if no interval checkpoint fired since the last ack; the attempts
-        //    write persists leases UNION carried (`write_named_group_attempts_full`) so a
+        //    write persists leases UNION carried (`write_named_group_attempts`, the union writer) so a
         //    recovered-not-yet-repolled poison's durable count is never clobbered to zero (its count sits
-        //    in `carried` with `leases` empty — the live-leases-only writer would erase it).
+        //    in `carried` with `leases` empty — a live-leases-only snapshot would erase it).
         let groups: Vec<String> = self
             .named_streams
             .get(id)
@@ -8040,7 +8097,7 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
                 .and_then(|s| s.groups.get(group))
                 .map_or(0, |g| g.cursor.committed().get());
             self.write_named_group_checkpoint(id, group, committed)?;
-            self.write_named_group_attempts_full(id, group)?;
+            self.write_named_group_attempts(id, group)?;
         }
         // 3) Drop the in-memory consumer state + DLQ handle (both are reconstructable from disk).
         self.named_streams.remove(id);
@@ -18301,6 +18358,450 @@ mod tests {
         assert_eq!(
             d.deliveries, 5,
             "the attempt count resumed; a reset-to-1 regression would fail here"
+        );
+    }
+
+    #[test]
+    fn a_redelivery_schedules_a_durable_attempts_flush_with_no_cursor_advance_or_clean_flush() {
+        // THE #547 TEETH, default stream: a poison retry loop never advances the cursor and never
+        // disconnects cleanly, so pre-#547 NOTHING persisted its rising attempt count — an unclean
+        // kill replayed every retry and repeated crashes redelivered the poison forever (the NATS
+        // volatile-redelivery-count failure mode). The redelivery-driven trigger makes the count
+        // durable on the ordinary per-pass `maybe_checkpoint` seam, with NO explicit
+        // `checkpoint_cursor` (no clean disconnect, no shutdown) anywhere in this test.
+        let clock = std::sync::Arc::new(ManualClock::new());
+        let fs = InMemoryFs::new();
+        let probe = fs.clone();
+        let mut e = Engine::open(fs, std::sync::Arc::clone(&clock), config(10, 5)).unwrap();
+        e.produce(&Append {
+            timestamp_ms: 0,
+            flags: RecordFlags::EMPTY,
+            key: b"",
+            headers: b"",
+            payload: b"poison",
+        })
+        .unwrap();
+        // FIRST delivery (attempt 1, the hot path): the per-pass checkpoint stays a no-op — no
+        // cursor advance, no redelivery, so no attempts write is scheduled (no per-delivery fsync).
+        let d = message(e.poll_now().unwrap());
+        assert_eq!(d.deliveries, 1);
+        assert!(
+            !e.maybe_checkpoint().unwrap(),
+            "a first delivery alone schedules nothing"
+        );
+        // REDELIVERY (attempt 2): the per-pass checkpoint now writes JUST the attempt snapshot,
+        // even though the cursor has not moved a single offset (pre-#547 this returned false and
+        // the count stayed volatile).
+        clock.advance_monotonic_nanos(40);
+        let d = message(e.poll_now().unwrap());
+        assert_eq!(d.deliveries, 2);
+        assert!(
+            e.maybe_checkpoint().unwrap(),
+            "the redelivery scheduled the attempts flush on the ordinary per-pass seam"
+        );
+        assert_eq!(e.committed_offset(), Offset::ZERO, "the cursor never moved");
+        // UNCLEAN KILL: no checkpoint_cursor, no checkpoint_all_groups — drop the engine dead.
+        drop(e);
+
+        // RESTART: the count resumes at the durable floor (2), so the next delivery is attempt 3,
+        // and the poison dead-letters after EXACTLY MaxDeliver observed deliveries TOTAL across
+        // the crash — 2 before + 3 after = 5, never 2 + 5.
+        let clock2 = std::sync::Arc::new(ManualClock::new());
+        let mut e =
+            Engine::open(probe.clone(), std::sync::Arc::clone(&clock2), config(10, 5)).unwrap();
+        let mut post_restart = 0u32;
+        loop {
+            match e.poll_now().unwrap() {
+                Poll::Message(d) => {
+                    post_restart += 1;
+                    if post_restart == 1 {
+                        assert_eq!(d.deliveries, 3, "resumed at the durable floor + 1");
+                    }
+                    clock2.advance_monotonic_nanos(40);
+                }
+                Poll::Parked { offset, .. } => {
+                    assert_eq!(offset, Offset::ZERO);
+                    break;
+                }
+                other => panic!("unexpected poll {other:?}"),
+            }
+        }
+        assert_eq!(
+            post_restart, 3,
+            "exactly MaxDeliver - 2 = 3 more deliveries: 5 TOTAL observed across the kill -9"
+        );
+        assert_eq!(
+            e.dlq_records(),
+            1,
+            "MaxDeliver -> DLQ fired across the crash"
+        );
+        let entries = read_dlq_entries(&probe).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(
+            entries[0].attempt, 6,
+            "the poisoning claim is attempt MaxDeliver + 1, counted ACROSS the unclean restart"
+        );
+    }
+
+    #[test]
+    fn first_deliveries_alone_never_schedule_an_attempts_flush() {
+        // The no-per-delivery-fsync evidence (#547): a healthy pass — every message on its FIRST
+        // attempt, nothing acked — leaves the per-pass checkpoint a complete no-op. Only a
+        // REDELIVERY (attempt >= 2, the poison-relevant event) can schedule the attempts write.
+        let clock = std::sync::Arc::new(ManualClock::new());
+        let fs = InMemoryFs::new();
+        let mut e = Engine::open(fs, std::sync::Arc::clone(&clock), config(10, 5)).unwrap();
+        for p in [&b"a"[..], b"b", b"c"] {
+            e.produce(&Append {
+                timestamp_ms: 0,
+                flags: RecordFlags::EMPTY,
+                key: b"",
+                headers: b"",
+                payload: p,
+            })
+            .unwrap();
+        }
+        for _ in 0..3 {
+            let d = message(e.poll_now().unwrap());
+            assert_eq!(d.deliveries, 1, "all first deliveries");
+        }
+        assert!(
+            !e.maybe_checkpoint().unwrap(),
+            "three first deliveries schedule no checkpoint write at all"
+        );
+    }
+
+    #[test]
+    fn the_attempts_flush_threshold_amortizes_over_n_redeliveries() {
+        // The tunable amortization (#547): threshold 3 means the per-pass seam writes the attempt
+        // snapshot only once every 3 ACCUMULATED redelivery grants — the documented trade of a
+        // longer (but still delivery-bounded) durable lag for fewer flash writes.
+        let clock = std::sync::Arc::new(ManualClock::new());
+        let fs = InMemoryFs::new();
+        let mut c = config(10, 100);
+        c.delivery = DeliveryConfig::new(100, false, vec![])
+            .unwrap()
+            .with_attempts_flush_redeliveries(3);
+        let mut e = Engine::open(fs, std::sync::Arc::clone(&clock), c).unwrap();
+        e.produce(&Append {
+            timestamp_ms: 0,
+            flags: RecordFlags::EMPTY,
+            key: b"",
+            headers: b"",
+            payload: b"p",
+        })
+        .unwrap();
+        let d = message(e.poll_now().unwrap());
+        assert_eq!(d.deliveries, 1);
+        for expected_attempt in 2..=4u32 {
+            clock.advance_monotonic_nanos(40);
+            let d = message(e.poll_now().unwrap());
+            assert_eq!(d.deliveries, expected_attempt);
+            let flushed = e.maybe_checkpoint().unwrap();
+            if expected_attempt < 4 {
+                assert!(!flushed, "below the threshold: no write yet");
+            } else {
+                assert!(flushed, "the 3rd accumulated redelivery flushes");
+            }
+        }
+        // The flush reset the accumulation: the next redelivery is 1-of-3 again.
+        clock.advance_monotonic_nanos(40);
+        let d = message(e.poll_now().unwrap());
+        assert_eq!(d.deliveries, 5);
+        assert!(
+            !e.maybe_checkpoint().unwrap(),
+            "the counter reset on flush; one redelivery is below the threshold again"
+        );
+    }
+
+    #[test]
+    fn a_threshold_of_zero_disables_the_trigger_and_the_dlq_fires_late_but_fires() {
+        // The opt-out (#547) doubles as the honest-bound proof: with the delivery-driven trigger
+        // OFF, an unclean kill loses every un-checkpointed attempt (the legacy lag), the count
+        // resumes LOWER, and MaxDeliver -> DLQ fires LATE by exactly the lost deliveries — but it
+        // FIRES. The lag is bounded by the deliveries since the last durability point, never
+        // infinite within a run.
+        let clock = std::sync::Arc::new(ManualClock::new());
+        let fs = InMemoryFs::new();
+        let probe = fs.clone();
+        let mut c = config(10, 5);
+        c.delivery = DeliveryConfig::new(5, false, vec![])
+            .unwrap()
+            .with_attempts_flush_redeliveries(0);
+        let mut e = Engine::open(fs, std::sync::Arc::clone(&clock), c).unwrap();
+        e.produce(&Append {
+            timestamp_ms: 0,
+            flags: RecordFlags::EMPTY,
+            key: b"",
+            headers: b"",
+            payload: b"poison",
+        })
+        .unwrap();
+        deliver_n_times(&mut e, &clock, 2);
+        assert!(
+            !e.maybe_checkpoint().unwrap(),
+            "trigger disabled: the redelivery schedules nothing (the pre-#547 behavior)"
+        );
+        drop(e); // unclean kill; the 2 observed deliveries were never persisted
+
+        let clock2 = std::sync::Arc::new(ManualClock::new());
+        let mut c2 = config(10, 5);
+        c2.delivery = DeliveryConfig::new(5, false, vec![])
+            .unwrap()
+            .with_attempts_flush_redeliveries(0);
+        let mut e = Engine::open(probe, std::sync::Arc::clone(&clock2), c2).unwrap();
+        let mut post_restart = 0u32;
+        loop {
+            match e.poll_now().unwrap() {
+                Poll::Message(d) => {
+                    post_restart += 1;
+                    if post_restart == 1 {
+                        assert_eq!(
+                            d.deliveries, 1,
+                            "the un-persisted count was lost: resumes low"
+                        );
+                    }
+                    clock2.advance_monotonic_nanos(40);
+                }
+                Poll::Parked { .. } => break,
+                other => panic!("unexpected poll {other:?}"),
+            }
+        }
+        assert_eq!(
+            post_restart, 5,
+            "LATE by exactly the 2 lost deliveries (7 observed total, not 5) — but it FIRED"
+        );
+        assert_eq!(e.dlq_records(), 1, "the DLQ still fires: late, never never");
+    }
+
+    #[test]
+    fn an_unclean_kill_before_any_redelivery_costs_at_most_one_extra_delivery() {
+        // The honest first-attempt lag under the DEFAULT trigger (#547): a FIRST delivery
+        // (attempt 1) deliberately never schedules a flush (that would be a per-delivery fsync on
+        // the hot path), so a kill -9 landing before ANY redelivery loses exactly that one
+        // attempt. The poison then dead-letters after MaxDeliver + 1 observed deliveries — the
+        // documented worst case for a single crash, and every redelivery AFTER the restart is
+        // durable-before-hand-out again.
+        let clock = std::sync::Arc::new(ManualClock::new());
+        let fs = InMemoryFs::new();
+        let probe = fs.clone();
+        let mut e = Engine::open(fs, std::sync::Arc::clone(&clock), config(10, 5)).unwrap();
+        e.produce(&Append {
+            timestamp_ms: 0,
+            flags: RecordFlags::EMPTY,
+            key: b"",
+            headers: b"",
+            payload: b"poison",
+        })
+        .unwrap();
+        let d = message(e.poll_now().unwrap());
+        assert_eq!(d.deliveries, 1, "one observed delivery, never persisted");
+        drop(e); // kill -9 before any redelivery, tick, or clean flush
+
+        let clock2 = std::sync::Arc::new(ManualClock::new());
+        let mut e = Engine::open(probe, std::sync::Arc::clone(&clock2), config(10, 5)).unwrap();
+        let mut post_restart = 0u32;
+        loop {
+            match e.poll_now().unwrap() {
+                Poll::Message(d) => {
+                    post_restart += 1;
+                    if post_restart == 1 {
+                        assert_eq!(d.deliveries, 1, "the first attempt was the only loss");
+                    }
+                    clock2.advance_monotonic_nanos(40);
+                }
+                Poll::Parked { .. } => break,
+                other => panic!("unexpected poll {other:?}"),
+            }
+        }
+        assert_eq!(
+            post_restart, 5,
+            "MaxDeliver + 1 = 6 observed deliveries total: late by exactly the one lost attempt"
+        );
+        assert_eq!(e.dlq_records(), 1);
+    }
+
+    #[test]
+    fn a_partial_reclaim_flush_never_regresses_a_still_carried_sibling_count() {
+        // The #565 clobber class on the PERIODIC/DISCONNECT path (#547): after a restart with TWO
+        // poisons carried, the first poll re-claims only the LOWER one (consuming its carried
+        // entry into a live lease) while the higher one is STILL carried. A live-leases-only
+        // snapshot written in that state — the disconnect flush fires on `has_in_flight` — would
+        // silently erase the higher poison's durable count; a second crash would then regress it
+        // to zero and let it outlive its MaxDeliver cap. The union writer keeps both.
+        let clock = std::sync::Arc::new(ManualClock::new());
+        let fs = InMemoryFs::new();
+        let probe = fs.clone();
+        let mut e = Engine::open(fs, std::sync::Arc::clone(&clock), config(10, 5)).unwrap();
+        for p in [&b"p0"[..], b"p1"] {
+            e.produce(&Append {
+                timestamp_ms: 0,
+                flags: RecordFlags::EMPTY,
+                key: b"",
+                headers: b"",
+                payload: p,
+            })
+            .unwrap();
+        }
+        // Deliver BOTH twice (attempts 1 and 2 each), persist {0: 2, 1: 2}, and crash.
+        for expected_attempt in 1..=2u32 {
+            for expected_offset in 0..=1u64 {
+                let d = message(e.poll_now().unwrap());
+                assert_eq!(d.offset, Offset::new(expected_offset));
+                assert_eq!(d.deliveries, expected_attempt);
+            }
+            clock.advance_monotonic_nanos(40);
+        }
+        e.checkpoint_cursor().unwrap();
+        drop(e);
+
+        // RESTART 1: re-claim ONLY offset 0 (offset 1 stays carried), then hit the disconnect
+        // flush in exactly that partially re-claimed state, then crash again.
+        let clock2 = std::sync::Arc::new(ManualClock::new());
+        let mut e =
+            Engine::open(probe.clone(), std::sync::Arc::clone(&clock2), config(10, 5)).unwrap();
+        let d = message(e.poll_now().unwrap());
+        assert_eq!(d.offset, Offset::ZERO);
+        assert_eq!(d.deliveries, 3, "offset 0 resumed at 2 + 1");
+        e.checkpoint_cursor().unwrap(); // the disconnect flush: live {0: 3} UNION carried {1: 2}
+        drop(e);
+
+        // RESTART 2: offset 1's count MUST have survived the intermediate flush. A live-only
+        // snapshot would have erased it and this delivery would report attempt 1.
+        let clock3 = std::sync::Arc::new(ManualClock::new());
+        let mut e = Engine::open(probe, std::sync::Arc::clone(&clock3), config(10, 5)).unwrap();
+        let d = message(e.poll_now().unwrap());
+        assert_eq!(d.offset, Offset::ZERO);
+        assert_eq!(d.deliveries, 4, "offset 0 resumed at 3 + 1");
+        // Offset 0 is now in flight, so the next poll grants offset 1 without any clock advance.
+        let d = message(e.poll_now().unwrap());
+        assert_eq!(d.offset, Offset::new(1));
+        assert_eq!(
+            d.deliveries, 3,
+            "offset 1 resumed at 2 + 1: the partial-reclaim flush did NOT regress its count"
+        );
+    }
+
+    #[test]
+    fn a_named_group_redelivery_schedules_its_attempts_flush() {
+        // The named-GROUP leg of #547 (default stream, `cursor-<hex>`/`attempts-<hex>` files): the
+        // per-pass `maybe_checkpoint_group` flushes the group's attempt snapshot on the redelivery
+        // trigger with no cursor advance and no clean flush, and the count survives an unclean kill.
+        let clock = std::sync::Arc::new(ManualClock::new());
+        let fs = InMemoryFs::new();
+        let probe = fs.clone();
+        let mut e = Engine::open(fs, std::sync::Arc::clone(&clock), config(10, 5)).unwrap();
+        e.produce(&Append {
+            timestamp_ms: 0,
+            flags: RecordFlags::EMPTY,
+            key: b"",
+            headers: b"",
+            payload: b"poison",
+        })
+        .unwrap();
+        let d = message(e.poll_now_in("workers").unwrap());
+        assert_eq!(d.deliveries, 1);
+        assert!(
+            !e.maybe_checkpoint_group("workers").unwrap(),
+            "a first delivery schedules nothing for a named group either"
+        );
+        clock.advance_monotonic_nanos(40);
+        let d = message(e.poll_now_in("workers").unwrap());
+        assert_eq!(d.deliveries, 2);
+        assert!(
+            e.maybe_checkpoint_group("workers").unwrap(),
+            "the redelivery scheduled the named group's attempts flush"
+        );
+        drop(e); // unclean kill
+
+        let clock2 = std::sync::Arc::new(ManualClock::new());
+        let mut e = Engine::open(probe, std::sync::Arc::clone(&clock2), config(10, 5)).unwrap();
+        let d = message(e.poll_now_in("workers").unwrap());
+        assert_eq!(
+            d.deliveries, 3,
+            "the named group's count resumed across the unclean kill"
+        );
+    }
+
+    #[test]
+    fn a_named_stream_redelivery_schedules_its_attempts_flush_and_the_dlq_fires_across_a_kill() {
+        use ironbus_storage::dlq::{read_dead_letter_entries, DLQ_SUBDIR};
+        use ironbus_storage::layout::STREAMS_SUBDIR;
+        use ironbus_storage::naming::stream_subdir_name;
+
+        // The named-STREAM leg of #547 (`streams/<hex>/attempts-<hex>.ckpt`): same contract as the
+        // default stream — the redelivery trigger persists the count on the per-pass seam, the
+        // count survives an unclean kill, and the poison dead-letters after EXACTLY MaxDeliver
+        // observed deliveries total, into the stream's OWN dlq/.
+        let clock = std::sync::Arc::new(ManualClock::new());
+        let fs = InMemoryFs::new();
+        let probe = fs.clone();
+        let mut e = Engine::open(fs, std::sync::Arc::clone(&clock), config(10, 5)).unwrap();
+        e.produce_in_stream(
+            "orders",
+            &Append {
+                timestamp_ms: 0,
+                flags: RecordFlags::EMPTY,
+                key: b"",
+                headers: b"",
+                payload: b"poison",
+            },
+        )
+        .unwrap();
+        let d = message(e.poll_in_stream("orders", "g", e.now_monotonic()).unwrap());
+        assert_eq!(d.deliveries, 1);
+        assert!(
+            !e.maybe_checkpoint_in_stream("orders", "g").unwrap(),
+            "a first delivery schedules nothing for a named stream either"
+        );
+        clock.advance_monotonic_nanos(40);
+        let d = message(e.poll_in_stream("orders", "g", e.now_monotonic()).unwrap());
+        assert_eq!(d.deliveries, 2);
+        assert!(
+            e.maybe_checkpoint_in_stream("orders", "g").unwrap(),
+            "the redelivery scheduled the named stream's attempts flush"
+        );
+        drop(e); // unclean kill: no checkpoint_in_stream, no shutdown flush
+
+        let clock2 = std::sync::Arc::new(ManualClock::new());
+        let mut e =
+            Engine::open(probe.clone(), std::sync::Arc::clone(&clock2), config(10, 5)).unwrap();
+        let mut post_restart = 0u32;
+        loop {
+            match e.poll_in_stream("orders", "g", e.now_monotonic()).unwrap() {
+                Poll::Message(d) => {
+                    post_restart += 1;
+                    if post_restart == 1 {
+                        assert_eq!(d.deliveries, 3, "resumed at the durable floor + 1");
+                    }
+                    clock2.advance_monotonic_nanos(40);
+                }
+                Poll::Parked { offset, .. } => {
+                    assert_eq!(offset, Offset::ZERO);
+                    break;
+                }
+                other => panic!("unexpected poll {other:?}"),
+            }
+        }
+        assert_eq!(
+            post_restart, 3,
+            "exactly MaxDeliver - 2 = 3 more deliveries: 5 TOTAL observed across the kill -9"
+        );
+        drop(e);
+        let stream_fs = probe
+            .subdir(STREAMS_SUBDIR)
+            .unwrap()
+            .subdir(&stream_subdir_name("orders"))
+            .unwrap();
+        let entries = read_dead_letter_entries(&stream_fs, DLQ_SUBDIR).unwrap();
+        assert_eq!(
+            entries.len(),
+            1,
+            "the stream's own DLQ fired across the crash"
+        );
+        assert_eq!(
+            entries[0].attempt, 6,
+            "attempt MaxDeliver + 1, counted across the unclean restart"
         );
     }
 

--- a/docs/DURABILITY.md
+++ b/docs/DURABILITY.md
@@ -330,6 +330,55 @@ explicitly NOT a number this document or any host-side test invents.
 
 ---
 
+## 6. The durable per-message delivery count (#547): MaxDeliver -> DLQ across crashes
+
+Poison-message containment is durable state, not a best-effort in-memory
+counter. NATS's redelivery count is volatile (lost on every server restart) and
+its default `MaxDeliver=-1` is unlimited, so a poison message there can
+redeliver forever across restarts. IronBus persists each in-flight message's
+delivery count (`attempts.ckpt` / `attempts-<hex>.ckpt` /
+`streams/<hex>/attempts-<hex>.ckpt`, #358/#60/#681) and RESUMES it on open, so
+`MaxDeliver -> DLQ` (default 5, unlimited only by explicit opt-in) fires even
+across crashes. The honest contract, exactly:
+
+- **What survives a clean restart (SIGTERM drain or clean disconnect):** every
+  group's attempt counts as of the final flush — the drain checkpoints every
+  group, and a clean disconnect flushes a group with anything in flight. No lag.
+- **What survives kill -9:** every count as of the last completed
+  attempt-snapshot write. Writers fire on the cursor-interval tick, the
+  clean-disconnect flush, the graceful-shutdown drain, hot-set eviction, AND —
+  because a poison retry loop never advances the cursor, so none of those are
+  guaranteed to fire — the #547 REDELIVERY-DRIVEN trigger: any engine pass that
+  granted at least `attempts_flush_redeliveries` redeliveries (attempt >= 2;
+  default threshold 1, `0` disables, a larger value amortizes further) ends with
+  one snapshot write, amortized over the pass. The durable lag is therefore
+  bounded in DELIVERIES, not wall-clock or cursor distance: at most the current
+  pass's redelivery grants, plus a message's very first attempt (attempt 1
+  deliberately never schedules a flush — that would be a per-delivery fsync on
+  the hot path).
+- **The guarantee:** a poison message NEVER redelivers unboundedly across
+  restarts. The recovered count never regresses below the durable floor (every
+  snapshot writer persists live leases UNION carried counts, the #565 rule, so a
+  flush in any partially-recovered state can only raise a count), and the count
+  resumes and reaches `MaxDeliver`; the worst case is lag-extra observed
+  deliveries — `MaxDeliver + 1` total for a kill -9 that lands before the first
+  redelivery ever becomes durable, more only under a raised amortization
+  threshold or a disabled trigger (then bounded by the legacy interval /
+  disconnect cadence within each run). Late by the lag, but it always fires.
+
+Proven by: `engine::tests::a_redelivery_schedules_a_durable_attempts_flush_*`
+(the trigger, no cursor advance, exactly `MaxDeliver` total across the kill),
+`an_unclean_kill_before_any_redelivery_costs_at_most_one_extra_delivery` and
+`a_threshold_of_zero_disables_the_trigger_and_the_dlq_fires_late_but_fires`
+(the lag bounds), `a_partial_reclaim_flush_never_regresses_a_still_carried_sibling_count`
+(the never-regress rule), the named-group / named-stream legs, and the
+end-to-end `effectively_once.rs` scenario 5
+(`max_deliver_dead_letters_after_a_kill_minus_nine_mid_retry_never_redelivers_forever`),
+which drives the real binary through nack, kill -9, restart, and the offline
+DLQ dump.
+
+---
+
 ## Summary: what is true today
 
 - IronBus DEFAULTS to ONE durability level, `sync`: ack-implies-durable (I2). The
@@ -351,6 +400,11 @@ explicitly NOT a number this document or any host-side test invents.
 - The across-levels throughput / latency / bytes-at-risk curve on ARM SD/eMMC is
   a DEVICE residual: it now has the relaxed levels but still needs the reference
   hardware, it is not faked host-side, and it feeds #19.
+- Per-message DELIVERY COUNTS are durable (#547, section 6): the count resumes
+  across kill -9 (lag bounded in deliveries, never wall-clock; it never
+  regresses below the durable floor), so `MaxDeliver -> DLQ` always fires — at
+  worst lag-late — where NATS's volatile count plus `MaxDeliver=-1` default
+  redelivers a poison forever.
 
 ## Cross-references
 


### PR DESCRIPTION
Implements V2-M3 issue #547: the per-message delivery count is now durable across ANY restart — clean or kill -9 — so `MaxDeliver -> DLQ` always fires and a poison message can never redeliver unboundedly. This is the consumer-side survival beat over NATS, whose redelivery count is volatile (lost on every restart) and whose default `MaxDeliver=-1` lets a poison redeliver forever.

## The audit (what already existed, and the gap)

The attempts machinery predates this PR: durable `attempts.ckpt` / `attempts-<hex>.ckpt` / `streams/<hex>/attempts-<hex>.ckpt` (#358/#60/#681), carried-count resume on open with the `>= committed && < flushed` clamp, the #565 eviction fix (union writer), and identical default-vs-named cadence. The GAP: **every persist trigger was gated on cursor advance, disconnect, shutdown, or eviction** — and a poison retry loop produces none of those. A head-of-line poison redelivered K times on a live connection had its count in memory ONLY; kill -9 replayed all K, and repeated crashes redelivered up to MaxDeliver per run, forever. A second latent seam (the #565 clobber class on the periodic/disconnect path): those writers persisted live leases only, so a flush taken while some recovered counts were still carried erased them.

## The tightening

1. **Redelivery-driven flush trigger** — `LeaseTable` counts redelivery grants (attempt >= 2, including carried resumes); the existing per-pass checkpoint seam (`maybe_checkpoint{,_group,_named_group}`) flushes just the attempt snapshot once `DeliveryConfig::attempts_flush_redeliveries` (default 1; `0` disables; larger amortizes further) redeliveries have accumulated. One targeted write per pass that granted redeliveries — amortized over the pass, **no per-delivery fsync** (attempt-1 grants never trip it; proven by test).
2. **Never-regress on every writer** — all attempt-snapshot writers now persist live ∪ carried (`all_attempt_counts`), generalizing the #565 rule; `write_named_group_attempts_full` is consolidated away.
3. **The honest contract** (docs/DURABILITY.md, new section 6):
   - Clean restart / clean disconnect: every count survives, no lag.
   - kill -9: counts as of the last completed snapshot write; lag is bounded in DELIVERIES (the current pass's redelivery grants, plus a message's never-persisted very first attempt), never wall-clock.
   - Guarantee: the count never regresses below the durable floor, resumes, and reaches MaxDeliver — exactly MaxDeliver total observed deliveries once any snapshot fired; worst case MaxDeliver + 1 for a kill before the first redelivery; late-but-fires under a raised threshold or a disabled trigger.

## Tests

- Engine: trigger fires with zero cursor advance and no clean flush, count resumes, DLQ at exactly MaxDeliver total across the kill (default stream, named group, named stream + its own `dlq/`); first-attempt lag bound (MaxDeliver + 1, exact); threshold 0 → late-but-fires (MaxDeliver + 2, exact); partial-reclaim never-regress (two carried poisons, flush between re-claims, second crash); no flush on first deliveries; threshold-3 amortization.
- End-to-end (#647 harness, scenario 5): real binary — pub, `sub --nack` x2, kill -9 mid-retry, restart, nack to the cap, the parked (empty) fetch, `ironbus_dead_lettered_total == 1`, post-restart `ironbus_delivered_total == 3` (the RESUMED budget, not a fresh 5), offline `dump --dlq` shows exactly one record with `attempt=6`.

## Gates (all run locally, full output in the session)

- `cargo test --workspace --all-features --locked`: **3318 passed, 0 failed** (58 suites)
- acceptance golden path: **PASS**
- `cargo clippy 1.97 --workspace --all-targets --all-features -- -D warnings`: clean
- `cargo fmt --all --check`: clean
- `scripts/check-format-registry.sh`: both digests ok (no on-disk format change — same `AttemptsCheckpoint` payload, only the cadence and the union source changed)

## Residual (pre-existing, unchanged)

Partitioned-stream consumers checkpoint only their cursors (no attempts file at all), so their delivery counts remain volatile — that surface needs its own slice; flagged in the commit body.

Closes #547

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01McmNfYNWPmohVS8umY9Lkp
