### PR TITLE
feat(storage): detect externally-damaged checkpoints (warn+metric, not silent-empty) (#1142)

### DIFF
--- a/crates/ironbus-cli/src/main.rs
+++ b/crates/ironbus-cli/src/main.rs
@@ -14710,7 +14710,7 @@ mod tests {
             return None;
         }
         let (_, recovered) = Checkpoint::open(fs.open(&name).unwrap()).unwrap();
-        let payload = recovered?;
+        let payload = recovered.into_option()?;
         Some(
             AckCursor::decode_snapshot(&payload)
                 .unwrap()

--- a/crates/ironbus-server/src/cluster/geo.rs
+++ b/crates/ironbus-server/src/cluster/geo.rs
@@ -629,10 +629,18 @@ impl<F: Filesystem> OriginCursorStore<F> {
         .map_err(|e| GeoError::Cursor {
             what: e.to_string(),
         })?;
-        let (checkpoint, payload) = SlotCheckpoint::<F::File, GEO_CURSOR_PAYLOAD>::open(file)
+        let (checkpoint, state) = SlotCheckpoint::<F::File, GEO_CURSOR_PAYLOAD>::open(file)
             .map_err(|e| GeoError::Cursor {
                 what: e.to_string(),
             })?;
+        // Surface external damage (both slots nonzero-seq, both CRC-bad — impossible from a crash)
+        // loudly (#1142), then recover as empty: an origin cursor is at-least-once (a lost cursor
+        // re-applies from the origin's durable log), so warn+empty is the right degrade, never a
+        // broker-down. A torn single slot still recovers its valid sibling upstream.
+        let payload = crate::engine::observe_checkpoint_damage(
+            state,
+            ironbus_storage::checkpoint::CheckpointArtifact::GeoCursor,
+        );
         let cursors = match payload {
             Some(bytes) => decode_cursor_payload(&bytes)?,
             None => BTreeMap::new(),

--- a/crates/ironbus-server/src/cluster/metadata_storage.rs
+++ b/crates/ironbus-server/src/cluster/metadata_storage.rs
@@ -365,7 +365,15 @@ impl<F: Filesystem, C: Clock> MetadataLogStorage<F, C> {
                 fs.sync_dir().map_err(StorageError::Io)?; // the new file's dir entry must be durable
                 file
             };
-            let (checkpoint, recovered) = MetadataSnapshotCheckpoint::open(file)?;
+            let (checkpoint, state) = MetadataSnapshotCheckpoint::open(file)?;
+            // Surface external damage loudly (#1142), then recover as empty — the snapshot is never
+            // load-bearing on its own (a missing/damaged one falls back to a full-log replay), so
+            // warn+empty is the right degrade, never a broker-down. A torn single slot recovers its
+            // valid sibling upstream in the dual-slot open.
+            let recovered = crate::engine::observe_checkpoint_damage(
+                state,
+                ironbus_storage::checkpoint::CheckpointArtifact::MetadataSnapshot,
+            );
             if let Some(bytes) = recovered {
                 let snapshot = Snapshot::parse_from_bytes(&bytes)?;
                 install_snapshot_into_core(&mut core, &snapshot);

--- a/crates/ironbus-server/src/engine.rs
+++ b/crates/ironbus-server/src/engine.rs
@@ -44,7 +44,8 @@ use ironbus_core::sublist::{Sublist, SublistBuilder, SublistError, SublistSnapsh
 use ironbus_core::ttl::{decode_ttl_headers, is_expired, Ttl};
 use ironbus_core::types::{Offset, RecordFlags};
 use ironbus_storage::checkpoint::{
-    AttemptsCheckpoint, BindingsCheckpoint, Checkpoint, CountersCheckpoint, ProducerSeqCheckpoint,
+    record_checkpoint_damage, AttemptsCheckpoint, BindingsCheckpoint, Checkpoint,
+    CheckpointArtifact, CountersCheckpoint, ProducerSeqCheckpoint, RecoveredCheckpoint,
     ATTEMPTS_PAYLOAD, BINDINGS_PAYLOAD, MAX_PAYLOAD, PRODUCER_SEQ_PAYLOAD,
 };
 use ironbus_storage::dlq::{DeadLetterExchange, DeadLetterReason, DlqSink, DLQ_SUBDIR};
@@ -1458,6 +1459,36 @@ impl RecoveryArtifact {
     }
 }
 
+/// Surfaces a checkpoint-open classification (#1142) and returns its recovered payload as an
+/// `Option`, preserving the pre-#1142 control flow at every call site. On
+/// [`RecoveredCheckpoint::Damaged`] — both slots carrying a nonzero sequence yet both failing CRC,
+/// which is impossible from any crash (a write touches one slot), so provable EXTERNAL damage — it
+/// emits a LOUD `warn!` and bumps `ironbus_checkpoint_damaged_total{artifact}`, then recovers as
+/// empty. This is the OBSERVABLE-NON-FATAL policy the tracking issue lands on for ALL checkpoint
+/// types: making the damage detectable + loud without turning a data-availability event into a
+/// broker-won't-start regression. The load-bearing checkpoints (bindings, reap) keep their existing
+/// independent fail-closed guards downstream — a loud `NoStream` for bindings, the physical-earliest
+/// cross-check for reap — so empty-recovery here is never a silent correctness loss.
+///
+/// `Valid`/`Empty` pass through silently (an `Empty` is a fresh/absent file or a torn first write,
+/// never damage). Used at the RECOVERY-READ call sites; write-handle re-opens that discard the
+/// recovered value do not re-observe (the recovery read already did, so damage counts once per open).
+pub(crate) fn observe_checkpoint_damage(
+    state: RecoveredCheckpoint,
+    artifact: CheckpointArtifact,
+) -> Option<Vec<u8>> {
+    if state.is_damaged() {
+        record_checkpoint_damage(artifact);
+        tracing::warn!(
+            artifact = artifact.metric_label(),
+            "checkpoint externally damaged: both dual-slots carry a nonzero sequence yet both fail \
+             their CRC, which is impossible from a crash (a write touches one slot) — bit rot or a \
+             lost extent. Recovering as empty (observable via ironbus_checkpoint_damaged_total)."
+        );
+    }
+    state.into_option()
+}
+
 /// The durable counters-snapshot format version (#98). A future field addition bumps this only if
 /// the decode rule must change; today the format is forward-compatible by construction (a shorter
 /// payload zero-fills missing trailing fields, a longer one ignores extra trailing bytes), so a
@@ -2417,8 +2448,11 @@ fn read_group_attempts<F: Filesystem>(fs: &F, group: &str) -> Result<Option<Vec<
     if !fs.exists(&name)? {
         return Ok(None);
     }
-    let (_, recovered) = AttemptsCheckpoint::open(fs.open(&name)?)?;
-    Ok(recovered)
+    let (_, state) = AttemptsCheckpoint::open(fs.open(&name)?)?;
+    Ok(observe_checkpoint_damage(
+        state,
+        CheckpointArtifact::Attempts,
+    ))
 }
 
 /// Builds a [`WorkGroup`] around a recovered `cursor` and seeds its lease table with the durable
@@ -2478,7 +2512,8 @@ fn recover_named_groups<F: Filesystem>(
         // clamped exactly like the default group, so MaxDeliver survives a restart in every group.
         let cursor_name = group_checkpoint_name(&gname);
         let gcursor = if fs.exists(&cursor_name)? {
-            let (_, recovered) = Checkpoint::open(fs.open(&cursor_name)?)?;
+            let (_, state) = Checkpoint::open(fs.open(&cursor_name)?)?;
+            let recovered = observe_checkpoint_damage(state, CheckpointArtifact::Cursor);
             resume_cursor_from_snapshot(recovered.as_deref(), flushed)
         } else {
             AckCursor::new()
@@ -2599,7 +2634,8 @@ fn recover_stream_groups_at<F: Filesystem>(
         // stream (#358), so `MaxDeliver` and the poison-cap survive a restart in every named stream.
         let cursor_name = group_checkpoint_name(&group);
         let cursor = if fs.exists(&cursor_name)? {
-            let (_, recovered) = Checkpoint::open(fs.open(&cursor_name)?)?;
+            let (_, state) = Checkpoint::open(fs.open(&cursor_name)?)?;
+            let recovered = observe_checkpoint_damage(state, CheckpointArtifact::Cursor);
             resume_cursor_from_snapshot(recovered.as_deref(), flushed)
         } else {
             AckCursor::new()
@@ -3206,9 +3242,11 @@ impl BindingTable {
                     .sum::<usize>(),
         );
         out.push(BINDINGS_SNAPSHOT_VERSION);
-        // The cap check bounds a WRITTEN snapshot to ~12k entries; `u32::MAX` is unreachable for any
-        // table that can exist in memory, so the saturation below is a formality, never a truncation
-        // that could be persisted (an over-cap payload is rejected before the write).
+        // Each entry frames as `u32` plen + pattern + `u32` slen + name = 8 bytes of overhead over a
+        // 9-byte minimum entry, so after the 5-byte header the `BINDINGS_PAYLOAD` cap check bounds a
+        // WRITTEN snapshot to ~6.8k worst-case minimal entries (~1400-1600 typical); `u32::MAX` is
+        // unreachable for any table that can exist in memory, so the saturation below is a formality,
+        // never a truncation that could be persisted (an over-cap payload is rejected before the write).
         let count = u32::try_from(self.entries.len()).unwrap_or(u32::MAX);
         out.extend_from_slice(&count.to_le_bytes());
         for (pattern, stream) in &self.entries {
@@ -3975,7 +4013,8 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
                 file
             }
         };
-        let (checkpoint, recovered) = Checkpoint::open(checkpoint_file)?;
+        let (checkpoint, cursor_state) = Checkpoint::open(checkpoint_file)?;
+        let recovered = observe_checkpoint_damage(cursor_state, CheckpointArtifact::Cursor);
 
         // Open (creating if absent) the default group's attempt-count checkpoint (#358) and recover
         // its snapshot, so the durable per-message attempt counts seed the default lease table below
@@ -4791,7 +4830,11 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
                 file
             }
         };
-        Ok(AttemptsCheckpoint::open(attempts_file)?)
+        let (cp, state) = AttemptsCheckpoint::open(attempts_file)?;
+        Ok((
+            cp,
+            observe_checkpoint_damage(state, CheckpointArtifact::Attempts),
+        ))
     }
 
     /// Opens the durable idempotent-producer SEQUENCE checkpoint (V2-M8) IF it already exists, and
@@ -4812,8 +4855,11 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
             return Ok((None, None));
         }
         let file = fs.open(PRODUCER_SEQ_CHECKPOINT)?;
-        let (checkpoint, recovered) = ProducerSeqCheckpoint::open(file)?;
-        Ok((Some(checkpoint), recovered))
+        let (checkpoint, state) = ProducerSeqCheckpoint::open(file)?;
+        Ok((
+            Some(checkpoint),
+            observe_checkpoint_damage(state, CheckpointArtifact::ProducerSeq),
+        ))
     }
 
     /// RESTORES the recovered idempotent-producer SEQUENCE high-waters (V2-M8) into the registry at
@@ -4867,8 +4913,11 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
             return Ok((None, None));
         }
         let file = fs.open(BINDINGS_CHECKPOINT)?;
-        let (checkpoint, recovered) = BindingsCheckpoint::open(file)?;
-        Ok((Some(checkpoint), recovered))
+        let (checkpoint, state) = BindingsCheckpoint::open(file)?;
+        Ok((
+            Some(checkpoint),
+            observe_checkpoint_damage(state, CheckpointArtifact::Bindings),
+        ))
     }
 
     /// Opens (creating + directory-fsyncing if absent) the durable binding-table checkpoint (#1106)
@@ -4932,7 +4981,8 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
                 file
             }
         };
-        let (counters_checkpoint, recovered) = CountersCheckpoint::open(counters_file)?;
+        let (counters_checkpoint, counters_state) = CountersCheckpoint::open(counters_file)?;
+        let recovered = observe_checkpoint_damage(counters_state, CheckpointArtifact::Counters);
         let mut counters = recovered
             .as_deref()
             .map_or_else(Counters::default, Counters::decode_snapshot);
@@ -5816,7 +5866,8 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         let (cursor, recovered_a) = {
             let fs = self.log.filesystem();
             let cursor = if fs.exists(&name)? {
-                let (_, recovered) = Checkpoint::open(fs.open(&name)?)?;
+                let (_, state) = Checkpoint::open(fs.open(&name)?)?;
+                let recovered = observe_checkpoint_damage(state, CheckpointArtifact::Cursor);
                 resume_cursor_from_snapshot(recovered.as_deref(), flushed)
             } else {
                 AckCursor::new()

--- a/crates/ironbus-server/src/health.rs
+++ b/crates/ironbus-server/src/health.rs
@@ -1166,6 +1166,7 @@ fn metrics_body(snapshot: MetricsSnapshot) -> String {
     body.push_str(&recovery_data_loss_lines(recovery_data_loss));
     body.push_str(&recovery_loss_records_lines(&recovery_loss_records));
     body.push_str(&recovery_event_lines(&counters.recovery));
+    body.push_str(&checkpoint_damage_lines());
     body.push_str(&fsync_histogram_lines(&fsync));
     body.push_str(&edge_metric_lines(&edge, rss, disk_free));
     body.push_str(&connz_metric_lines(connz));
@@ -2132,6 +2133,32 @@ fn recovery_event_lines(recovery: &RecoveryCounters) -> String {
             s,
             "ironbus_corruption_repairs_total{{artifact=\"{}\"}} {repairs}",
             artifact.metric_label()
+        );
+    }
+    s
+}
+
+/// Renders the `ironbus_checkpoint_damaged_total{artifact}` counter (#1142): one labeled sample per
+/// [`CheckpointArtifact`], read from the process-wide monotonic damage store. A non-zero value means a
+/// dual-slot checkpoint opened with BOTH slots carrying a nonzero sequence yet BOTH failing their CRC
+/// — impossible from any crash (a write touches one slot), so provable EXTERNAL damage (bit rot / a
+/// lost extent) rather than the never-written `None` the pre-#1142 open collapsed it into. The broker
+/// recovers as empty (the load-bearing checkpoints keep their own downstream fail-closed guards), so
+/// this is the OBSERVABILITY signal an operator alerts on, not a startup failure. All series are
+/// always emitted (zero where undamaged) so the frozen taxonomy holds. Like
+/// `ironbus_corruption_repairs_total{artifact}`, it carries a label, so it is excluded from the
+/// unlabeled-`_total` resilience-taxonomy set by construction and pinned only in `FROZEN_METRIC_TYPES`.
+fn checkpoint_damage_lines() -> String {
+    let mut s = String::from(
+        "# HELP ironbus_checkpoint_damaged_total Dual-slot checkpoints opened with both slots carrying a nonzero sequence yet both failing CRC (provable EXTERNAL damage — impossible from a crash), by on-disk artifact. Recovered as empty (observable, non-fatal); NATS has no analogue.\n\
+         # TYPE ironbus_checkpoint_damaged_total counter\n",
+    );
+    for artifact in ironbus_storage::checkpoint::CheckpointArtifact::ALL {
+        let _ = writeln!(
+            s,
+            "ironbus_checkpoint_damaged_total{{artifact=\"{}\"}} {}",
+            artifact.metric_label(),
+            ironbus_storage::checkpoint::checkpoint_damaged_total(artifact),
         );
     }
     s
@@ -5450,6 +5477,41 @@ mod tests {
         handle.join().unwrap();
     }
 
+    #[test]
+    fn metrics_render_the_checkpoint_damage_counter_for_every_artifact() {
+        // The externally-damaged-checkpoint surface (#1142) renders on /metrics: the labeled
+        // `ironbus_checkpoint_damaged_total{artifact}` counter with TYPE/HELP (so a strict parser and
+        // the frozen-taxonomy golden accept it), one series per CheckpointArtifact so the taxonomy is
+        // complete. The value is NOT pinned to 0 (the store is a process-global; other tests in this
+        // binary may have opened a damaged checkpoint), only structural presence.
+        let (addr, shutdown, handle, _engine) = start();
+        let m = request(addr, "GET /metrics HTTP/1.1\r\n\r\n");
+        assert!(m.starts_with("HTTP/1.1 200 OK"), "{m}");
+        assert!(
+            m.contains("# TYPE ironbus_checkpoint_damaged_total counter"),
+            "{m}"
+        );
+        assert!(
+            m.contains("# HELP ironbus_checkpoint_damaged_total "),
+            "{m}"
+        );
+        for artifact in ironbus_storage::checkpoint::CheckpointArtifact::ALL {
+            let prefix = format!(
+                "ironbus_checkpoint_damaged_total{{artifact=\"{}\"}} ",
+                artifact.metric_label()
+            );
+            assert!(
+                m.lines().any(|l| l.starts_with(&prefix)
+                    && l[prefix.len()..].bytes().all(|b| b.is_ascii_digit())),
+                "missing/!numeric checkpoint-damage series for {}: {m}",
+                artifact.metric_label()
+            );
+        }
+
+        shutdown.store(true, Ordering::Release);
+        handle.join().unwrap();
+    }
+
     /// The COMPLETE, FROZEN set of resilience-counter metric names `/metrics` renders (#96). Every
     /// name here is an `ironbus_*_total` counter whose increment marks one resilience event the
     /// taxonomy guarantees is never silent (a shed, drop, skip, dead-letter, or reclamation). This
@@ -5753,6 +5815,11 @@ mod tests {
         ("ironbus_recovery_runs_total", "counter"),
         ("ironbus_torn_tail_repairs_total", "counter"),
         ("ironbus_corruption_repairs_total", "counter"),
+        // The externally-damaged-checkpoint counter (#1142): both dual-slots nonzero-seq yet both
+        // CRC-bad (provable external damage), by artifact. A LABELED `_total`, so — like
+        // `ironbus_corruption_repairs_total{artifact}` — it is pinned ONLY here and excluded from the
+        // unlabeled-`_total` resilience-taxonomy set by construction.
+        ("ironbus_checkpoint_damaged_total", "counter"),
         // Reconciled skip/loss gauges (the resilience watermarks; NOT `_total`).
         ("ironbus_records_skipped", "gauge"),
         ("ironbus_bytes_skipped", "gauge"),

--- a/crates/ironbus-storage/src/admin.rs
+++ b/crates/ironbus-storage/src/admin.rs
@@ -218,8 +218,11 @@ fn read_committed<F: Filesystem>(fs: &F, group: &str) -> Result<Option<u64>, Sto
     if !fs.exists(&name)? {
         return Ok(None);
     }
+    // An offline admin read (not the broker's live open), so it stays behavior-preserving: a
+    // `Damaged` classification (#1142) recovers as empty here, exactly like a torn slot, and the
+    // broker-open path is where damage is surfaced (warn + metric).
     let (_, recovered) = Checkpoint::open(fs.open(&name)?)?;
-    let Some(payload) = recovered else {
+    let Some(payload) = recovered.into_option() else {
         return Ok(None);
     };
     // The current format is the full snapshot; a payload too short to be a snapshot is the legacy
@@ -479,7 +482,10 @@ fn read_redrive_watermark<F: Filesystem>(fs: &F) -> Result<u64, StorageError> {
         return Ok(0);
     }
     let (_, recovered) = Checkpoint::open(fs.open(REDRIVE_CHECKPOINT)?)?;
-    let value = recovered
+    // Offline admin read: a `Damaged` classification (#1142) recovers as the zero watermark, exactly
+    // like a torn slot, so redrive resumes from the start (at-least-once-safe re-injection).
+    let payload = recovered.into_option();
+    let value = payload
         .as_deref()
         .and_then(|p| p.get(..8))
         .and_then(|s| <[u8; 8]>::try_from(s).ok())
@@ -1539,7 +1545,7 @@ mod tests {
         // an AckCursor snapshot whose committed watermark is 4.
         let name = cursor_checkpoint_name("orders");
         let (_, recovered) = Checkpoint::open(fs.open(&name).unwrap()).unwrap();
-        let payload = recovered.expect("a cursor was written");
+        let payload = recovered.into_option().expect("a cursor was written");
         let cursor = AckCursor::decode_snapshot(&payload).expect("the broker codec decodes it");
         assert_eq!(cursor.committed(), Offset::new(4));
         assert!(
@@ -1665,7 +1671,7 @@ mod tests {
 
         let name = cursor_checkpoint_name("orders");
         let (_, recovered) = Checkpoint::open(fs.open(&name).unwrap()).unwrap();
-        let cursor = AckCursor::decode_snapshot(&recovered.unwrap()).unwrap();
+        let cursor = AckCursor::decode_snapshot(&recovered.into_option().unwrap()).unwrap();
         assert_eq!(cursor.committed(), Offset::new(3), "the latest write wins");
     }
 

--- a/crates/ironbus-storage/src/checkpoint.rs
+++ b/crates/ironbus-storage/src/checkpoint.rs
@@ -88,9 +88,12 @@ pub const SHARED_WAL_REAP_PAYLOAD: usize = 60 * 1024;
 /// `BindSubject` ack, so an acked bind always survives a restart. Bindings mutate rarely (a bind is
 /// an admin-scoped routing declaration, and no unbind verb exists yet, so the table only grows), so
 /// the full-table rewrite costs nothing at bind frequency and buys the simplest possible recovery:
-/// decode one snapshot, rebuild the trie once. Each entry is `2 + pattern + 2 + stream name (<= 64)`
-/// bytes; this 60 KiB cap (under the slot's `u16` length field, like the other large checkpoints)
-/// holds ~800 worst-case short-pattern entries and thousands of typical ones. Unlike the tolerant
+/// decode one snapshot, rebuild the trie once. Each entry is `4 + pattern + 4 + stream name (<= 64)`
+/// bytes — the codec length-prefixes BOTH the pattern and the stream name with a `u32`, so 8 bytes of
+/// per-entry framing over a 9-byte-minimum entry (a 1-byte pattern bound to the default `""` stream).
+/// After the 5-byte header (a version byte + a `u32` entry count), this 60 KiB cap (under the slot's
+/// `u16` length field, like the other large checkpoints) holds ~6.8k worst-case minimal entries and
+/// ~1400-1600 typical ones (a ~20-byte pattern + a ~12-byte stream name). Unlike the tolerant
 /// cursor checkpoints, this payload is LOAD-BEARING for routing correctness (an acked bind silently
 /// dropped would re-open the exact NoStream-after-restart gap #1106 closes), so a
 /// CRC-valid-but-undecodable snapshot fails the open closed (see `ironbus-server`'s engine open);
@@ -106,31 +109,56 @@ const CRC_LEN: usize = 4;
 /// `SLOT_OVERHEAD + PAYLOAD_CAP` bytes.
 const SLOT_OVERHEAD: usize = SEQ_LEN + LEN_LEN + CRC_LEN;
 
-/// Reads `[seq, len, payload]` from a `CAP`-payload slot and returns the payload if the slot is
-/// valid: a nonzero sequence, an in-range length, and a matching CRC over the meaningful bytes.
-fn decode_slot<const CAP: usize>(slot: &[u8]) -> Option<(u64, Vec<u8>)> {
+/// The classification of a single slot (#1142). The key distinction the old `Option` lacked is
+/// [`SlotDecode::Corrupt`] vs [`SlotDecode::Empty`]: a slot carrying a NONZERO sequence but failing
+/// its length bound or CRC was WRITTEN (so its corruption is meaningful), whereas a zero-sequence or
+/// short slot was never written. That separation is what lets [`SlotCheckpoint::open`] distinguish
+/// provable external damage (both slots `Corrupt`) from a fresh/torn-first file.
+enum SlotDecode {
+    /// Never written: a zero sequence, or a slot from a short/truncated file.
+    Empty,
+    /// Written (nonzero sequence) but invalid: an out-of-range length or a CRC mismatch. A torn or
+    /// bit-rotted slot.
+    Corrupt,
+    /// A fully valid slot: `(sequence, payload)`.
+    Valid(u64, Vec<u8>),
+}
+
+/// Reads `[seq, len, payload]` from a `CAP`-payload slot and classifies it. A nonzero sequence, an
+/// in-range length, and a matching CRC over the meaningful bytes is [`SlotDecode::Valid`]; a zero
+/// sequence or short slot is [`SlotDecode::Empty`] (never written); a nonzero sequence that then
+/// fails its length bound or CRC is [`SlotDecode::Corrupt`] (written but torn/damaged).
+fn decode_slot<const CAP: usize>(slot: &[u8]) -> SlotDecode {
     if slot.len() != SLOT_OVERHEAD + CAP {
-        return None;
+        return SlotDecode::Empty; // a short/truncated file: treat as never-written
     }
-    let seq = u64::from_le_bytes(slot[0..SEQ_LEN].try_into().ok()?);
+    let seq = u64::from_le_bytes(slot[0..SEQ_LEN].try_into().expect("SEQ_LEN bytes present"));
     if seq == 0 {
-        return None; // sequence 0 means "never written"
+        return SlotDecode::Empty; // sequence 0 means "never written"
     }
+    // The slot carries a nonzero sequence, so it WAS written: any failure below is a written-but-
+    // invalid (Corrupt) slot, distinct from a never-written one.
     let len = usize::from(u16::from_le_bytes(
-        slot[SEQ_LEN..SEQ_LEN + LEN_LEN].try_into().ok()?,
+        slot[SEQ_LEN..SEQ_LEN + LEN_LEN]
+            .try_into()
+            .expect("LEN_LEN bytes present"),
     ));
     if len > CAP {
-        return None;
+        return SlotDecode::Corrupt;
     }
     let payload_start = SEQ_LEN + LEN_LEN;
     let crc_start = payload_start + CAP;
-    let stored_crc = u32::from_le_bytes(slot[crc_start..crc_start + CRC_LEN].try_into().ok()?);
+    let stored_crc = u32::from_le_bytes(
+        slot[crc_start..crc_start + CRC_LEN]
+            .try_into()
+            .expect("CRC_LEN bytes present"),
+    );
     // The CRC covers the sequence, the length field, and the meaningful payload bytes
     // (the padding and the CRC field itself are excluded).
     if crc32c::crc32c(&slot[0..payload_start + len]) != stored_crc {
-        return None;
+        return SlotDecode::Corrupt;
     }
-    Some((seq, slot[payload_start..payload_start + len].to_vec()))
+    SlotDecode::Valid(seq, slot[payload_start..payload_start + len].to_vec())
 }
 
 fn encode_slot<const CAP: usize>(seq: u64, payload: &[u8]) -> Vec<u8> {
@@ -213,15 +241,180 @@ pub type SharedWalReapCheckpoint<F> = SlotCheckpoint<F, SHARED_WAL_REAP_PAYLOAD>
 /// the routing table.
 pub type BindingsCheckpoint<F> = SlotCheckpoint<F, BINDINGS_PAYLOAD>;
 
+/// The classification a checkpoint file receives on [`SlotCheckpoint::open`] (#1142): the tri-state
+/// that separates a value that recovered, a checkpoint that was never durably written, and one that
+/// is EXTERNALLY DAMAGED (bit rot / a lost extent), which the old two-state `Option` collapsed into
+/// the same `None` as a fresh file.
+///
+/// The distinction is provable from the dual-slot crash model. Each [`SlotCheckpoint::write`] touches
+/// exactly one slot (`slot = seq % 2`), so a crash mid-write tears AT MOST one slot; its sibling stays
+/// either durable-valid or zero-sequence ("never written"). Therefore:
+/// - a torn slot with a valid sibling recovers the sibling → [`RecoveredCheckpoint::Valid`];
+/// - a torn FIRST write (one corrupt slot, the other still zero-sequence) → [`RecoveredCheckpoint::Empty`]
+///   (a legitimate crash outcome, NOT damage);
+/// - BOTH slots carrying a nonzero sequence yet BOTH failing their CRC is impossible from any crash,
+///   so it is provably external damage → [`RecoveredCheckpoint::Damaged`].
+///
+/// `Damaged` is DETECTABLE (distinguishable from a fresh/absent file) but, per #1142, non-fatal by
+/// default: the caller surfaces it (a `warn!` + the `ironbus_checkpoint_damaged_total{artifact}`
+/// counter via [`record_checkpoint_damage`]) and then recovers as empty, turning a formerly SILENT
+/// empty-recovery into a LOUD, observable data-availability event without turning it into a
+/// broker-won't-start regression.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RecoveredCheckpoint {
+    /// A fully-valid slot recovered this payload (the highest durable sequence).
+    Valid(Vec<u8>),
+    /// No slot was ever durably written: a fresh, absent, or short file, OR exactly one slot torn by
+    /// a crash with no valid sibling (a torn first write). Recover as empty; NOT an error, no warning.
+    Empty,
+    /// Both slots carry a nonzero sequence yet both fail their CRC — impossible from any crash, so
+    /// EXTERNAL damage. Surfaced (warn + metric) and then recovered as empty by the caller.
+    Damaged,
+}
+
+impl RecoveredCheckpoint {
+    /// The recovered payload if a valid slot was found, else `None`. Both `Empty` and `Damaged` map
+    /// to `None` (the pre-#1142 behavior), so a call site that only needs the value — and observes
+    /// damage separately, or is a write-handle re-open where a prior read already observed it — reads
+    /// exactly as before.
+    #[must_use]
+    pub fn into_option(self) -> Option<Vec<u8>> {
+        match self {
+            RecoveredCheckpoint::Valid(payload) => Some(payload),
+            RecoveredCheckpoint::Empty | RecoveredCheckpoint::Damaged => None,
+        }
+    }
+
+    /// Whether the file was classified as externally damaged (both slots nonzero-seq, both CRC-bad).
+    #[must_use]
+    pub fn is_damaged(&self) -> bool {
+        matches!(self, RecoveredCheckpoint::Damaged)
+    }
+}
+
+/// The bounded, append-only vocabulary of on-disk checkpoint artifacts, for the
+/// `ironbus_checkpoint_damaged_total{artifact}` counter (#1142). One label per [`SlotCheckpoint`]
+/// consumer, mirroring the frozen [`crate::loss::ReasonCode`]-style discipline: a new variant goes at
+/// the END so the counter-array index order never shifts. The label strings are frozen alongside the
+/// metric name (a rename is a gated taxonomy change).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CheckpointArtifact {
+    /// A consumer-cursor checkpoint (`cursor.ckpt` / `cursor-<hex>.ckpt`).
+    Cursor,
+    /// A durable per-message attempt-count checkpoint (`attempts*.ckpt`, #358).
+    Attempts,
+    /// The resilience-counters observability checkpoint (`counters.ckpt`, #98).
+    Counters,
+    /// The idempotent-producer sequence high-water checkpoint (`producer-seq.ckpt`, V2-M8).
+    ProducerSeq,
+    /// The metadata-raft snapshot checkpoint (`metadata snapshot`, V2-C1).
+    MetadataSnapshot,
+    /// The shared-WAL reap (demux-floor) checkpoint (`reap.ckpt`, #597).
+    SharedWalReap,
+    /// The subject->stream binding-table checkpoint (`bindings.ckpt`, #1106).
+    Bindings,
+    /// The geo/leaf origin-replication cursor checkpoint (`OriginCursorStore`, cluster).
+    GeoCursor,
+}
+
+impl CheckpointArtifact {
+    /// Every artifact in a fixed order; the index into the damage-counter array. Append-only.
+    pub const ALL: [CheckpointArtifact; 8] = [
+        CheckpointArtifact::Cursor,
+        CheckpointArtifact::Attempts,
+        CheckpointArtifact::Counters,
+        CheckpointArtifact::ProducerSeq,
+        CheckpointArtifact::MetadataSnapshot,
+        CheckpointArtifact::SharedWalReap,
+        CheckpointArtifact::Bindings,
+        CheckpointArtifact::GeoCursor,
+    ];
+
+    /// This artifact's index into [`CheckpointArtifact::ALL`]. A total match in `ALL` order, so it is
+    /// infallible and stays in sync with the array.
+    #[must_use]
+    pub fn index(self) -> usize {
+        match self {
+            CheckpointArtifact::Cursor => 0,
+            CheckpointArtifact::Attempts => 1,
+            CheckpointArtifact::Counters => 2,
+            CheckpointArtifact::ProducerSeq => 3,
+            CheckpointArtifact::MetadataSnapshot => 4,
+            CheckpointArtifact::SharedWalReap => 5,
+            CheckpointArtifact::Bindings => 6,
+            CheckpointArtifact::GeoCursor => 7,
+        }
+    }
+
+    /// The frozen Prometheus `artifact` label value.
+    #[must_use]
+    pub fn metric_label(self) -> &'static str {
+        match self {
+            CheckpointArtifact::Cursor => "cursor",
+            CheckpointArtifact::Attempts => "attempts",
+            CheckpointArtifact::Counters => "counters",
+            CheckpointArtifact::ProducerSeq => "producer_seq",
+            CheckpointArtifact::MetadataSnapshot => "metadata_snapshot",
+            CheckpointArtifact::SharedWalReap => "shared_wal_reap",
+            CheckpointArtifact::Bindings => "bindings",
+            CheckpointArtifact::GeoCursor => "geo_cursor",
+        }
+    }
+}
+
+/// The process-wide, monotonic `ironbus_checkpoint_damaged_total{artifact}` counter store (#1142),
+/// one cell per [`CheckpointArtifact`]. Damage is detected at OPEN time, spread across several crates
+/// (the engine, the shared WAL, the cluster origin cursors, the metadata store), so a process-global
+/// is the low-coupling place to accumulate it without threading a return through every open signature;
+/// it is exactly Prometheus counter semantics (a monotonic, process-lifetime total for the one broker
+/// this process is). It is NOT part of any durable snapshot, so the on-disk formats are unchanged.
+// Eight explicit cells (MSRV 1.78 predates inline-const array repeat).
+static CHECKPOINT_DAMAGED: [core::sync::atomic::AtomicU64; CheckpointArtifact::ALL.len()] = [
+    core::sync::atomic::AtomicU64::new(0),
+    core::sync::atomic::AtomicU64::new(0),
+    core::sync::atomic::AtomicU64::new(0),
+    core::sync::atomic::AtomicU64::new(0),
+    core::sync::atomic::AtomicU64::new(0),
+    core::sync::atomic::AtomicU64::new(0),
+    core::sync::atomic::AtomicU64::new(0),
+    core::sync::atomic::AtomicU64::new(0),
+];
+
+/// Records one externally-damaged-checkpoint detection for `artifact`, bumping the monotonic
+/// `ironbus_checkpoint_damaged_total{artifact}` counter (#1142). Saturating; safe to call from any
+/// crate/thread on the recovery-read path.
+pub fn record_checkpoint_damage(artifact: CheckpointArtifact) {
+    CHECKPOINT_DAMAGED[artifact.index()].fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+}
+
+/// The current `ironbus_checkpoint_damaged_total{artifact}` value for `artifact` (#1142), for the
+/// `/metrics` render and tests.
+#[must_use]
+pub fn checkpoint_damaged_total(artifact: CheckpointArtifact) -> u64 {
+    CHECKPOINT_DAMAGED[artifact.index()].load(core::sync::atomic::Ordering::Relaxed)
+}
+
+/// Resets the damage counters to zero. Test-only: the store is a process-global, so a test that
+/// asserts an ABSOLUTE damage count resets first (parallel tests otherwise accumulate). Prefer a
+/// read-delta assertion where possible.
+#[cfg(test)]
+pub fn reset_checkpoint_damage() {
+    for cell in &CHECKPOINT_DAMAGED {
+        cell.store(0, core::sync::atomic::Ordering::Relaxed);
+    }
+}
+
 impl<F: RandomAccessFile, const PAYLOAD_CAP: usize> SlotCheckpoint<F, PAYLOAD_CAP> {
     /// Bytes per slot for this cap: sequence, payload length, payload, CRC.
     const SLOT_LEN: usize = SLOT_OVERHEAD + PAYLOAD_CAP;
     /// The whole checkpoint file is two slots.
     const FILE_LEN: u64 = (Self::SLOT_LEN * 2) as u64;
 
-    /// Opens a checkpoint file, reading both slots to recover the latest durable value.
-    /// A fresh (zeroed or short) file recovers nothing. Returns the checkpoint plus the
-    /// recovered payload, if any.
+    /// Opens a checkpoint file, reading both slots to CLASSIFY it (#1142): the higher-sequence valid
+    /// slot recovers as [`RecoveredCheckpoint::Valid`]; a fresh/absent/short file — or a torn first
+    /// write with no valid sibling — recovers as [`RecoveredCheckpoint::Empty`]; and a file whose BOTH
+    /// slots carry a nonzero sequence yet BOTH fail their CRC recovers as [`RecoveredCheckpoint::Damaged`]
+    /// (provable external damage — impossible from any crash, since a write touches one slot).
     ///
     /// The caller owns the file's existence: it must create the file (e.g. via
     /// [`crate::fs::Filesystem::create_new`]) and fsync the parent directory (so the file
@@ -231,7 +424,7 @@ impl<F: RandomAccessFile, const PAYLOAD_CAP: usize> SlotCheckpoint<F, PAYLOAD_CA
     /// Propagates an IO error.
     pub fn open(
         file: F,
-    ) -> Result<(SlotCheckpoint<F, PAYLOAD_CAP>, Option<Vec<u8>>), StorageError> {
+    ) -> Result<(SlotCheckpoint<F, PAYLOAD_CAP>, RecoveredCheckpoint), StorageError> {
         let slot_len = Self::SLOT_LEN;
         let len = file.len()?;
         let mut buf = vec![0u8; slot_len * 2];
@@ -240,26 +433,42 @@ impl<F: RandomAccessFile, const PAYLOAD_CAP: usize> SlotCheckpoint<F, PAYLOAD_CA
         }
         let a = decode_slot::<PAYLOAD_CAP>(&buf[0..slot_len]);
         let b = decode_slot::<PAYLOAD_CAP>(&buf[slot_len..slot_len * 2]);
-        // The higher valid sequence wins.
+        // Whether each slot was WRITTEN-but-invalid, captured before the by-value match consumes them.
+        // Both slots corrupt is the external-damage signature (see below).
+        let both_corrupt = matches!(a, SlotDecode::Corrupt) && matches!(b, SlotDecode::Corrupt);
+        // The higher valid sequence wins; a torn slot with a valid sibling recovers the sibling.
         let best = match (a, b) {
-            (Some((sa, pa)), Some((sb, pb))) => {
+            (SlotDecode::Valid(sa, pa), SlotDecode::Valid(sb, pb)) => {
                 if sa >= sb {
                     Some((sa, pa))
                 } else {
                     Some((sb, pb))
                 }
             }
-            (Some(x), None) | (None, Some(x)) => Some(x),
-            (None, None) => None,
+            (SlotDecode::Valid(s, p), _) | (_, SlotDecode::Valid(s, p)) => Some((s, p)),
+            _ => None,
         };
-        let (next_seq, payload) = match best {
-            Some((seq, payload)) => (
+        let (next_seq, recovered) = if let Some((seq, payload)) = best {
+            (
                 seq.checked_add(1).ok_or(StorageError::SegmentFull)?,
-                Some(payload),
-            ),
-            None => (1, None),
+                RecoveredCheckpoint::Valid(payload),
+            )
+        } else {
+            // No valid slot. Each `write` touches exactly one slot (`slot = seq % 2`), so a crash
+            // tears AT MOST one slot while its sibling stays durable-valid or zero-sequence. Both
+            // slots carrying a nonzero sequence yet both failing CRC is therefore IMPOSSIBLE from any
+            // crash — it is provable external damage (bit rot / a lost extent), and is distinguishable
+            // from a fresh/absent file or a torn first write (one corrupt slot, one still zero-seq),
+            // which stay `Empty`. Damage recovers as empty here too (the caller surfaces it loudly);
+            // `next_seq` starts at 1 so the next two writes heal both slots.
+            let recovered = if both_corrupt {
+                RecoveredCheckpoint::Damaged
+            } else {
+                RecoveredCheckpoint::Empty
+            };
+            (1, recovered)
         };
-        Ok((SlotCheckpoint { file, next_seq }, payload))
+        Ok((SlotCheckpoint { file, next_seq }, recovered))
     }
 
     /// Durably writes a new checkpoint payload (fsync). The previous value remains intact
@@ -296,7 +505,10 @@ mod tests {
     const CHECKPOINT_LEN: u64 = (SLOT_LEN * 2) as u64;
 
     fn decode_slot(slot: &[u8]) -> Option<(u64, Vec<u8>)> {
-        super::decode_slot::<MAX_PAYLOAD>(slot)
+        match super::decode_slot::<MAX_PAYLOAD>(slot) {
+            SlotDecode::Valid(seq, payload) => Some((seq, payload)),
+            SlotDecode::Empty | SlotDecode::Corrupt => None,
+        }
     }
 
     fn encode_slot(seq: u64, payload: &[u8]) -> Vec<u8> {
@@ -308,6 +520,12 @@ mod tests {
     }
 
     fn reopen(file: &Arc<InMemoryFile>) -> Option<Vec<u8>> {
+        let cp: (Checkpoint<Arc<InMemoryFile>>, _) = Checkpoint::open(Arc::clone(file)).unwrap();
+        cp.1.into_option()
+    }
+
+    /// The tri-state classification a reopen produces, for the #1142 damage tests.
+    fn reopen_state(file: &Arc<InMemoryFile>) -> RecoveredCheckpoint {
         let cp: (Checkpoint<Arc<InMemoryFile>>, _) = Checkpoint::open(Arc::clone(file)).unwrap();
         cp.1
     }
@@ -321,7 +539,7 @@ mod tests {
     fn write_then_reopen_round_trips() {
         let file = fresh();
         let (mut cp, recovered) = Checkpoint::open(Arc::clone(&file)).unwrap();
-        assert_eq!(recovered, None);
+        assert_eq!(recovered, RecoveredCheckpoint::Empty);
         cp.write(b"hello").unwrap();
         assert_eq!(reopen(&file), Some(b"hello".to_vec()));
     }
@@ -372,19 +590,116 @@ mod tests {
     }
 
     #[test]
-    fn both_slots_torn_recovers_nothing() {
+    fn both_slots_corrupt_is_detected_as_external_damage() {
+        // Both slots carry a nonzero sequence (seq 1 and seq 2) yet both fail CRC. A crash tears at
+        // most one slot, so this is IMPOSSIBLE from any crash — it is provable external damage (#1142).
+        // It is DETECTED as `Damaged` (distinct from a fresh file's `Empty`) yet still recovers as
+        // empty via `into_option`, preserving the pre-#1142 control flow.
         let file = fresh();
         let (mut cp, _) = Checkpoint::open(Arc::clone(&file)).unwrap();
-        cp.write(b"a").unwrap();
-        cp.write(b"b").unwrap();
+        cp.write(b"a").unwrap(); // seq 1 -> slot 1
+        cp.write(b"b").unwrap(); // seq 2 -> slot 0
         let mut bytes = file.snapshot();
-        // Corrupt a payload byte in both slots.
+        // Corrupt a CRC-covered payload byte in BOTH slots.
         bytes[SEQ_LEN + LEN_LEN] ^= 0xff;
         bytes[SLOT_LEN + SEQ_LEN + LEN_LEN] ^= 0xff;
         file.set_len(0).unwrap();
         file.write_all_at(&bytes, 0).unwrap();
         file.sync_data().unwrap();
-        assert_eq!(reopen(&file), None);
+        assert_eq!(reopen_state(&file), RecoveredCheckpoint::Damaged);
+        assert_eq!(reopen(&file), None, "damage still recovers as empty");
+    }
+
+    #[test]
+    fn a_torn_first_write_is_empty_not_damaged() {
+        // The crash-model corner the loose "any corrupt slot" rule would false-alarm on: the FIRST
+        // write (seq 1 -> slot 1) is torn by a crash, leaving slot 1 corrupt and slot 0 still
+        // zero-sequence (never written). This is a LEGITIMATE crash outcome, so it MUST classify as
+        // `Empty`, NOT `Damaged` — else a real power loss during the first checkpoint would raise a
+        // false external-damage alarm (#1142).
+        let file = fresh();
+        let (mut cp, _) = Checkpoint::open(Arc::clone(&file)).unwrap();
+        cp.write(b"only").unwrap(); // seq 1 -> slot 1; slot 0 stays all-zero
+        let mut bytes = file.snapshot();
+        // Corrupt slot 1 (the only written slot); slot 0 remains zero-sequence.
+        bytes[SLOT_LEN + SEQ_LEN + LEN_LEN] ^= 0xff;
+        file.set_len(0).unwrap();
+        file.write_all_at(&bytes, 0).unwrap();
+        file.sync_data().unwrap();
+        assert_eq!(
+            reopen_state(&file),
+            RecoveredCheckpoint::Empty,
+            "a torn first write with a zero-seq sibling is Empty, never Damaged"
+        );
+    }
+
+    #[test]
+    fn a_torn_single_slot_with_a_valid_sibling_is_valid_not_damaged() {
+        // Two durable writes, then ONE slot torn (the crash model's at-most-one-torn invariant). The
+        // valid sibling must recover as `Valid` — never `Damaged` — so a real crash never trips the
+        // external-damage signal.
+        let file = fresh();
+        let (mut cp, _) = Checkpoint::open(Arc::clone(&file)).unwrap();
+        cp.write(b"first").unwrap(); // seq 1 -> slot 1
+        cp.write(b"second").unwrap(); // seq 2 -> slot 0
+        let mut bytes = file.snapshot();
+        bytes[SEQ_LEN + LEN_LEN] ^= 0xff; // corrupt only slot 0 (the newest)
+        file.set_len(0).unwrap();
+        file.write_all_at(&bytes, 0).unwrap();
+        file.sync_data().unwrap();
+        assert_eq!(
+            reopen_state(&file),
+            RecoveredCheckpoint::Valid(b"first".to_vec()),
+            "a torn single slot recovers its valid sibling, never Damaged"
+        );
+    }
+
+    #[test]
+    fn an_absent_or_fresh_file_is_empty_not_damaged() {
+        // A brand-new (absent/zero-length) file, and a freshly-created zero-seq file, both classify
+        // as `Empty` with no warning — the never-false-alarm floor.
+        assert_eq!(reopen_state(&fresh()), RecoveredCheckpoint::Empty);
+        let file = fresh();
+        // Materialize a full-size all-zero file (both slots zero-sequence), as create+truncate would.
+        file.write_all_at(&[0u8; SLOT_LEN * 2], 0).unwrap();
+        file.sync_data().unwrap();
+        assert_eq!(reopen_state(&file), RecoveredCheckpoint::Empty);
+    }
+
+    #[test]
+    fn the_damage_counter_is_bumped_per_artifact() {
+        // The `ironbus_checkpoint_damaged_total{artifact}` counter increments once per recorded
+        // damage, per artifact. A read-delta assertion, robust against the process-global being
+        // touched by other tests running in parallel.
+        let before = checkpoint_damaged_total(CheckpointArtifact::Bindings);
+        record_checkpoint_damage(CheckpointArtifact::Bindings);
+        record_checkpoint_damage(CheckpointArtifact::Bindings);
+        assert_eq!(
+            checkpoint_damaged_total(CheckpointArtifact::Bindings),
+            before + 2
+        );
+        // Distinct artifacts count independently.
+        let cursor_before = checkpoint_damaged_total(CheckpointArtifact::Cursor);
+        record_checkpoint_damage(CheckpointArtifact::Cursor);
+        assert_eq!(
+            checkpoint_damaged_total(CheckpointArtifact::Cursor),
+            cursor_before + 1
+        );
+    }
+
+    #[test]
+    fn every_artifact_label_is_distinct_and_indexed() {
+        // The frozen taxonomy invariant: `ALL` order matches `index()`, and every label is unique.
+        for (i, artifact) in CheckpointArtifact::ALL.iter().enumerate() {
+            assert_eq!(artifact.index(), i);
+        }
+        let mut labels: Vec<&str> = CheckpointArtifact::ALL
+            .iter()
+            .map(|a| a.metric_label())
+            .collect();
+        labels.sort_unstable();
+        labels.dedup();
+        assert_eq!(labels.len(), CheckpointArtifact::ALL.len());
     }
 
     #[test]
@@ -488,9 +803,16 @@ mod tests {
             file.write_all_at(&bytes, 0).unwrap();
             file.sync_data().unwrap();
 
-            // open must not panic; whatever it returns must be a value we actually wrote.
+            // open must not panic; whatever it returns must be a value we actually wrote, and a
+            // SINGLE-byte flip must NEVER classify as external Damage — a lone flip corrupts at most
+            // one slot, so the crash-model invariant (both-slots-corrupt is impossible from a crash)
+            // holds and no false damage alarm can fire (#1142).
             let recovered = Checkpoint::open(Arc::clone(&file)).unwrap().1;
-            if let Some(payload) = recovered {
+            prop_assert!(
+                !recovered.is_damaged(),
+                "a single-byte flip must not be classified as external damage",
+            );
+            if let Some(payload) = recovered.into_option() {
                 prop_assert!(
                     payloads.iter().any(|p| p == &payload),
                     "fabricated a payload never written: {payload:?}",
@@ -506,11 +828,11 @@ mod tests {
     fn a_counters_checkpoint_round_trips_a_full_size_payload() {
         let file = fresh();
         let (mut cp, recovered) = CountersCheckpoint::open(Arc::clone(&file)).unwrap();
-        assert_eq!(recovered, None);
+        assert_eq!(recovered, RecoveredCheckpoint::Empty);
         let payload = vec![0x42; COUNTERS_PAYLOAD];
         cp.write(&payload).unwrap();
         let reopened = CountersCheckpoint::open(Arc::clone(&file)).unwrap().1;
-        assert_eq!(reopened, Some(payload));
+        assert_eq!(reopened.into_option(), Some(payload));
     }
 
     #[test]
@@ -540,7 +862,10 @@ mod tests {
         assert_eq!(bytes.len(), counters_slot_len * 2);
         // Recovery regresses to the previous durable value, never a torn one.
         assert_eq!(
-            CountersCheckpoint::open(Arc::clone(&file)).unwrap().1,
+            CountersCheckpoint::open(Arc::clone(&file))
+                .unwrap()
+                .1
+                .into_option(),
             Some(vec![1u8; COUNTERS_PAYLOAD])
         );
     }
@@ -548,7 +873,13 @@ mod tests {
     #[test]
     fn a_fresh_counters_checkpoint_recovers_nothing() {
         let file = fresh();
-        assert_eq!(CountersCheckpoint::open(Arc::clone(&file)).unwrap().1, None);
+        assert_eq!(
+            CountersCheckpoint::open(Arc::clone(&file))
+                .unwrap()
+                .1
+                .into_option(),
+            None
+        );
     }
 
     // The attempt-count checkpoint (#358) reuses the identical dual-slot crash-safe machinery with
@@ -559,11 +890,11 @@ mod tests {
     fn an_attempts_checkpoint_round_trips_a_full_size_payload() {
         let file = fresh();
         let (mut cp, recovered) = AttemptsCheckpoint::open(Arc::clone(&file)).unwrap();
-        assert_eq!(recovered, None);
+        assert_eq!(recovered, RecoveredCheckpoint::Empty);
         let payload = vec![0x42; ATTEMPTS_PAYLOAD];
         cp.write(&payload).unwrap();
         let reopened = AttemptsCheckpoint::open(Arc::clone(&file)).unwrap().1;
-        assert_eq!(reopened, Some(payload));
+        assert_eq!(reopened.into_option(), Some(payload));
     }
 
     #[test]
@@ -591,7 +922,10 @@ mod tests {
         file.sync_data().unwrap();
         // Recovery regresses to the previous durable value, never a torn one.
         assert_eq!(
-            AttemptsCheckpoint::open(Arc::clone(&file)).unwrap().1,
+            AttemptsCheckpoint::open(Arc::clone(&file))
+                .unwrap()
+                .1
+                .into_option(),
             Some(vec![1u8; 64])
         );
     }
@@ -611,7 +945,8 @@ mod tests {
             let f = DirectFile::create_new(&path).unwrap();
             let (mut cp, recovered) = Checkpoint::open(f).unwrap();
             assert_eq!(
-                recovered, None,
+                recovered,
+                RecoveredCheckpoint::Empty,
                 "a fresh direct-mode checkpoint recovers nothing"
             );
             // Several alternating-slot writes: each slot write RMWs the shared boundary block.
@@ -624,7 +959,7 @@ mod tests {
         let (_cp, recovered) = Checkpoint::open(g).unwrap();
         assert_eq!(
             recovered,
-            Some(b"five".to_vec()),
+            RecoveredCheckpoint::Valid(b"five".to_vec()),
             "direct-mode checkpoint recovers the latest value"
         );
     }

--- a/crates/ironbus-storage/src/layout.rs
+++ b/crates/ironbus-storage/src/layout.rs
@@ -225,7 +225,12 @@ fn read_marker_version<F: Filesystem>(fs: &F) -> Option<u32> {
     }
     let file = fs.open(LAYOUT_MARKER_FILE).ok()?;
     let (_checkpoint, recovered) = Checkpoint::open(file).ok()?;
-    decode_marker(recovered.as_deref()?)
+    // A version-detection heuristic, NOT durable state: a `Damaged` marker (#1142) is treated as "no
+    // valid marker" (layout v1), exactly as a corrupt one always was — this must NEVER brick a valid
+    // data dir, so it stays behavior-preserving (empty), and the broker's durable checkpoints carry
+    // the damage surfacing instead.
+    let payload = recovered.into_option()?;
+    decode_marker(&payload)
 }
 
 /// Best-effort durable write of the v1 marker, creating `layout.meta` if absent. Returns an IO error
@@ -437,7 +442,7 @@ mod tests {
         // Now a real v1 marker is in place.
         let file = fs.open(LAYOUT_MARKER_FILE).unwrap();
         let (_, recovered) = Checkpoint::open(file).unwrap();
-        assert_eq!(decode_marker(recovered.as_deref().unwrap()), Some(1));
+        assert_eq!(decode_marker(&recovered.into_option().unwrap()), Some(1));
     }
 
     /// The marker round-trips its version and the encode/decode are inverses for v1.

--- a/crates/ironbus-storage/src/shared_wal.rs
+++ b/crates/ironbus-storage/src/shared_wal.rs
@@ -269,8 +269,19 @@ impl<F: Filesystem, C: Clock> SharedWal<F, C> {
         // means no reap ever completed its checkpoint — and therefore, by the write-then-unlink
         // discipline, no reap ever unlinked a segment — which the physical-earliest check pins.
         let (reap_checkpoint, recovered) = if shared_fs.exists(REAP_CHECKPOINT)? {
-            let (cp, payload) = SharedWalReapCheckpoint::open(shared_fs.open(REAP_CHECKPOINT)?)?;
-            (Some(cp), payload)
+            let (cp, state) = SharedWalReapCheckpoint::open(shared_fs.open(REAP_CHECKPOINT)?)?;
+            if state.is_damaged() {
+                // Both slots carry a nonzero sequence yet both fail CRC — impossible from any crash,
+                // so provable external damage (#1142). Surface it via the metric (this is the storage
+                // crate; the loud `warn!` rides the server-side observer). Correctness is unaffected:
+                // the DAMAGED checkpoint recovers as "no reap floor" and the physical-earliest
+                // cross-check below still fail-closes if any segment was already unlinked, so the
+                // "leave reap's fail-close intact" policy holds.
+                crate::checkpoint::record_checkpoint_damage(
+                    crate::checkpoint::CheckpointArtifact::SharedWalReap,
+                );
+            }
+            (Some(cp), state.into_option())
         } else {
             (None, None)
         };

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -138,8 +138,10 @@ observed across all the paths.
 | `ironbus_corruption_repairs_total{artifact="segment"}` | A **corruption span in a log** — the root log, a named per-stream log, the shared WAL, or a partition sub-log (#1130) — was quarantined-and-dropped at recovery (or by the offline `ironbus repair`). | **Segment corruption repaired**: the headline corruption signal. NATS has **no** corruption-repair metric. |
 | `ironbus_corruption_repairs_total{artifact="cursor"}` | A **consumer cursor** corruption was repaired (reserved: a torn cursor reverts via its dual-slot checkpoint, so recovery does not emit one today; driven by the offline `ironbus repair` cursor path). | Reserved + offline-`repair`-driven, frozen up front. |
 | `ironbus_corruption_repairs_total{artifact="dlq"}` | A **DLQ** corruption was repaired (reserved, same shape as `cursor`). | Reserved + offline-`repair`-driven, frozen up front. |
+| `ironbus_checkpoint_damaged_total{artifact}` | A dual-slot checkpoint opened with **both** slots carrying a nonzero sequence yet **both** failing their CRC — impossible from any crash (each write touches one slot, so a crash tears at most one), so provable **external** damage (bit rot / a lost extent), NOT the never-written `None` the pre-#1142 open collapsed it into (#1142). One increment per damaged open, by on-disk `artifact` (`cursor`, `attempts`, `counters`, `producer_seq`, `metadata_snapshot`, `shared_wal_reap`, `bindings`, `geo_cursor`). The broker warns and recovers as **empty** — the load-bearing checkpoints (`bindings`, `shared_wal_reap`) keep their own downstream fail-closed guards (a loud NoStream; the physical-earliest cross-check), so empty-recovery is never a silent correctness loss. | **External-damage detection, observable + non-fatal**: turns a formerly SILENT empty-recovery into a LOUD, alertable data-availability event without making it a broker-won't-start regression. NATS has no analogue. |
 
-`ironbus_recovery_runs_total` and `ironbus_corruption_repairs_total` are **labeled**
+`ironbus_recovery_runs_total`, `ironbus_corruption_repairs_total`, and
+`ironbus_checkpoint_damaged_total` are **labeled**
 `_total` counters, so (exactly like `ironbus_cluster_ack_total{level}` and
 `ironbus_retry_shed_total{side}`) their sample lines are excluded from the
 unlabeled-`_total` frozen **resilience-counter** set by construction and are pinned


### PR DESCRIPTION
## What & why

`SlotCheckpoint::open` collapsed **three** states into a single `None`: (i) `seq==0` never-written, (ii) a torn slot with a valid sibling, and (iii) **both** slots carrying a nonzero sequence yet **both** failing CRC. Case (iii) is **impossible from any crash** — each `write` touches exactly one slot (`slot = seq % 2`), so a crash tears at most one slot while its sibling stays durable-valid or zero-seq. It is therefore provable **external** damage (bit rot / a lost extent), is **distinguishable** from a fresh/absent file, yet was recovered **silently** as an empty checkpoint. This surfaced in the #1140 review.

This makes damage **detectable + LOUD** without turning a data-availability event into a broker-won't-start regression.

## Design: tri-state open

`open` now returns `RecoveredCheckpoint` = **`Valid(payload)` / `Empty` / `Damaged`**:

- **Valid** — the higher-sequence valid slot (a torn slot with a valid sibling still recovers the sibling).
- **Empty** — a fresh/absent/short file, **or** a torn FIRST write (one corrupt slot, the other still zero-seq). A legitimate crash outcome, never flagged.
- **Damaged** — **both** slots nonzero-seq **and** both CRC-bad. The crash-model-correct signature (strictly case iii), so a real crash is never mis-classified.

Internally `decode_slot` gained a `Corrupt` (written-but-invalid) vs `Empty` (never-written) distinction, which is what lets `open` tell provable damage from a fresh/torn-first file.

## Per-consumer policy (audited — OBSERVABLE-NON-FATAL for all)

On `Damaged`: `warn!` + bump `ironbus_checkpoint_damaged_total{artifact}`, then recover as empty (today's control flow, now observable). **Refused for none** — justified below.

| Artifact | Policy | Justification |
|---|---|---|
| `cursor` | warn+empty | at-least-once; empty = redelivery/re-count. Refusing = one group's broker down = worse. |
| `attempts` | warn+empty | empty = MaxDeliver resets to attempt 1, at-least-once-safe. |
| `counters` | warn+empty | pure observability aid; must never block startup. |
| `producer_seq` | warn+empty | empty = producers degrade to at-least-once (a later publish reads fresh). |
| `metadata_snapshot` | warn+empty | never load-bearing alone — a missing/damaged snapshot falls back to a full-log replay. |
| `shared_wal_reap` | warn+empty (**metric only**, storage crate) | the reap keeps its **independent physical-earliest cross-check** that fail-closes if a segment was already unlinked — left intact per the issue. |
| `bindings` | warn+empty | downstream is a **loud typed NoStream**, so empty is acceptable; refusing would down the broker. |
| `geo_cursor` | warn+empty | origin-replication cursor is at-least-once (re-applies from the origin's durable log). |

**Likely outcome confirmed: warn+metric for all, refuse for none.** The two load-bearing checkpoints (bindings, reap) keep their existing downstream fail-closed guards, so empty-recovery here is never a silent correctness loss.

## Metric

New labeled counter `ironbus_checkpoint_damaged_total{artifact}` (a process-global monotonic store in `ironbus-storage`, read by `health.rs`). Like `ironbus_corruption_repairs_total{artifact}` it is a **labeled** `_total`, so it is excluded from the unlabeled resilience-taxonomy set by construction and pinned in `FROZEN_METRIC_TYPES`; documented in `docs/METRICS.md`.

## Cap-doc math fix

The bindings codec uses **`u32` (4-byte)** length prefixes = **8B/entry** framing over a **9B-minimum** entry, so a 60 KiB slot holds **~6.8k worst-case / ~1400-1600 typical** entries. Corrected in `checkpoint.rs` (was "2-byte prefixes / ~800") and `engine.rs` (was "~12k").

## Format unchanged

Detection is **read-side only** — `check-format-registry.sh` passes with unchanged digests, and the counters-snapshot format is untouched (the metric is not a durable field).

## Tests

- both-slots-CRC-bad → `Damaged` (warn+metric fire, recovers empty)
- torn FIRST write → `Empty`; torn single slot w/ valid sibling → `Valid` (crash-model invariant)
- absent / fresh zero-seq file → `Empty` (never-false-alarm floor)
- proptest extended: a single-byte flip is **never** `Damaged`
- per-artifact counter increments; `/metrics` render test for every artifact; frozen-taxonomy golden

Gates (container, CI-equivalent): workspace test **0 failed**, acceptance golden-path PASS, clippy 1.97 `-D warnings`, fmt, format-registry — all green.

Closes #1142.
