### PR TITLE
feat(obs): W3C trace-context propagation + producer→consumer span links (#770, distributed tracing)

### DIFF
--- a/crates/ironbus-cli/src/main.rs
+++ b/crates/ironbus-cli/src/main.rs
@@ -7252,11 +7252,40 @@ fn cmd_serve(
              feature; OTLP span export is disabled (rebuild with --features otlp to enable it)"
         )?;
     }
-    let _span_queue = ironbus_server::obs::init_tracing(&ironbus_server::obs::TracingConfig {
+    // The OTLP head-sampling ratio (#770, #99): when export is ON, produce/deliver spans are admitted
+    // at this fraction (the exporter samples at drain, and the produce/deliver EMISSION sites sample at
+    // push through the same gate). Env-TUNABLE (`IRONBUS_OTLP_SAMPLE_RATIO`, clamped to [0,1]) so an
+    // operator can dial trace volume without a rebuild; DEFAULTS to full sampling when export is on (the
+    // bounded-lossy queue sheds any excess, never blocking a produce) and to 0.0 (no distributed spans;
+    // ERROR/WARN events still record) when export is off, so a non-tracing broker pays nothing. A
+    // malformed env value falls back to the default.
+    let otlp_sample_ratio = if config.enable_otlp_export {
+        std::env::var("IRONBUS_OTLP_SAMPLE_RATIO")
+            .ok()
+            .and_then(|s| s.parse::<f64>().ok())
+            .map_or(1.0, |r| r.clamp(0.0, 1.0))
+    } else {
+        ironbus_server::obs::DEFAULT_SAMPLE_RATIO
+    };
+    // Held for the broker's lifetime (the drain thread also holds its own `Arc` clone): the bounded
+    // span-export queue the OTLP exporter drains AND the produce/deliver emission sites push onto.
+    let span_queue = ironbus_server::obs::init_tracing(&ironbus_server::obs::TracingConfig {
         otlp_export_enabled: config.enable_otlp_export,
         otlp_endpoint: config.otlp_endpoint.clone(),
+        sample_ratio: otlp_sample_ratio,
         ..ironbus_server::obs::TracingConfig::default()
     });
+    // The span-emission sink threaded to the engine so the produce/deliver/ack sites emit into the SAME
+    // queue (#770). `None` when export is off (a zero-cost no-op at every emission site); `Some` when on
+    // (built once here, installed on the engine handle in `run_broker` before any connection clone).
+    let span_sink: Option<ironbus_server::obs::SpanSink> = if config.enable_otlp_export {
+        Some(ironbus_server::obs::SpanSink::new(
+            std::sync::Arc::clone(&span_queue),
+            otlp_sample_ratio,
+        ))
+    } else {
+        None
+    };
 
     // SECURE-BIND guard (#95, the #107 bind invariant), FAIL-CLOSED and FIRST: resolve and classify
     // `--health-addr` before ANY broker side effect (no data dir touched, no lock taken, no listener
@@ -7472,6 +7501,7 @@ fn cmd_serve(
                 preauth_cfg,
                 audit,
                 tls_termination,
+                span_sink.clone(),
                 reload,
                 out,
             );
@@ -7525,6 +7555,7 @@ fn cmd_serve(
                 preauth_cfg,
                 audit,
                 tls_termination,
+                span_sink,
                 reload,
                 out,
             )
@@ -8908,6 +8939,10 @@ fn run_broker<F: Filesystem + Clone + 'static>(
     // (where the resolved transport flags are in scope). A live rustls TLS 1.3 config behind
     // `--features tls`, or a zero-cost plaintext terminator otherwise.
     tls_termination: ironbus_server::server::TlsTermination,
+    // The distributed-tracing span-emission sink (#770): `Some` when `--enable-otlp-export` is on,
+    // installed on the engine handle below so every connection's produce/deliver/ack sites emit into the
+    // exporter's queue. `None` on a non-tracing broker (a zero-cost no-op at every emission site).
+    span_sink: Option<ironbus_server::obs::SpanSink>,
     reload: ReloadSource<'_>,
     out: &mut impl Write,
 ) -> Result<(), CliError> {
@@ -8926,6 +8961,13 @@ fn run_broker<F: Filesystem + Clone + 'static>(
         Some(slot) => shared.with_client_ack_slot(slot),
         None => shared,
     };
+    // Install the SHARED span-emission sink (#770) onto the base handle BEFORE any per-connection clone,
+    // so every connection's produce/deliver/ack sites reach the ONE sink over the exporter's bounded
+    // queue. `None` (export off) installs nothing, so `EngineAccess::span_sink` stays `None` and every
+    // emission site is a zero-cost no-op — the byte-for-byte default hot path.
+    if let Some(sink) = span_sink {
+        shared.set_span_sink(sink);
+    }
     // Arm the append-actor wedge watchdog (#862) BEFORE any produce can run: a durability fsync that
     // hangs longer than this bound flips `/healthz` and `/readyz` to 503 (instead of leaving liveness
     // green and hanging readyz), so an orchestrator restarts a node whose disk has stalled. `0` disables

--- a/crates/ironbus-core/src/lib.rs
+++ b/crates/ironbus-core/src/lib.rs
@@ -40,6 +40,7 @@ pub mod resolve_cache;
 pub mod segment;
 pub mod subject;
 pub mod sublist;
+pub mod trace_context;
 pub mod ttl;
 pub mod txn;
 pub mod types;

--- a/crates/ironbus-core/src/trace_context.rs
+++ b/crates/ironbus-core/src/trace_context.rs
@@ -1,0 +1,336 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! W3C Trace Context (`traceparent`) parse and format for distributed tracing (#770).
+//!
+//! IronBus does NOT invent a wire field for trace context: the client stamps a W3C `traceparent`
+//! into the message HEADERS (the record's already-arbitrary, already-durable header blob), and the
+//! broker reads it back off the stored record on delivery. This module is the pure, dependency-free
+//! codec for that value — it links no `opentelemetry` crate, adds no dependency to the IO-free
+//! `ironbus-core`, and is compiled into every build (the default and `edge-min` binaries pay only the
+//! cost of this small plain-data parser, never the OTLP exporter, which stays behind the `otlp`
+//! feature in `ironbus-server::obs`).
+//!
+//! The value format is the W3C Trace Context `traceparent` field
+//! (`00-<32 hex trace-id>-<16 hex span-id>-<2 hex flags>`, the version-0 form): a 1-byte version, a
+//! 16-byte trace id, an 8-byte parent (span) id, and a 1-byte flags field. Parsing is DEFENSIVE by
+//! construction — a malformed, truncated, all-zero, or absent value is treated as "no context"
+//! (`None`), NEVER an error, so a bad `traceparent` can never wedge or reject a produce. Formatting
+//! always emits the canonical lowercase version-0 form, so a value parsed and re-formatted round-trips
+//! byte-for-byte.
+
+/// A parsed W3C `traceparent`: the distributed trace context a client hands the bus in the message
+/// headers (#770). Carries the 16-byte trace id, the 8-byte parent (span) id, and the 1-byte trace
+/// flags. Pure plain data with no `opentelemetry` dependency; `ironbus-server::obs` maps it onto an
+/// exported span's parent (on produce) or link (on deliver) only when the `otlp` feature is compiled
+/// in.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TraceParent {
+    /// The 16-byte trace id. Never all-zero for a parsed value (an all-zero trace id is the W3C
+    /// "invalid" sentinel and is rejected as absent).
+    pub trace_id: [u8; 16],
+    /// The 8-byte parent (span) id — the id of the span that produced this message. Never all-zero
+    /// for a parsed value (an all-zero id is invalid and is rejected as absent). On produce this
+    /// becomes the produce span's parent; on deliver it becomes the linked span id.
+    pub parent_id: [u8; 8],
+    /// The 1-byte W3C trace flags (bit 0 = sampled). Carried verbatim so the sampled bit survives the
+    /// hop; not otherwise interpreted here.
+    pub flags: u8,
+}
+
+/// The canonical serialized length of a version-0 `traceparent` value: `2 + 1 + 32 + 1 + 16 + 1 + 2`.
+pub const TRACEPARENT_LEN: usize = 55;
+
+/// The ASCII header name a client uses to carry the trace context inside the message header blob, per
+/// the W3C convention. [`TraceParent::from_headers`] also accepts a header blob that is nothing but a
+/// bare `traceparent` value (no name), so both a single-value blob and an HTTP-header-like
+/// `traceparent: <value>` line are recognized.
+pub const TRACEPARENT_HEADER_NAME: &[u8] = b"traceparent";
+
+impl TraceParent {
+    /// Parses one W3C `traceparent` VALUE from `value` (`00-<trace>-<span>-<flags>`), returning `None`
+    /// for anything malformed — wrong length, non-hex, an unknown-but-`ff` version, or an all-zero
+    /// trace/parent id (the W3C invalid sentinels). Hex is accepted in either case on input; the
+    /// caller gets the raw bytes. This is the defensive, never-erroring core the produce path relies
+    /// on: a broken value is simply "no context".
+    ///
+    /// For the version-0 (`00`) form the value must be EXACTLY the four dash-separated fields; a
+    /// trailing field is rejected. A higher (future) version is accepted so long as its first four
+    /// fields parse, per the W3C forward-compatibility rule, with any trailing fields ignored. The
+    /// reserved `ff` version is rejected.
+    #[must_use]
+    pub fn parse(value: &[u8]) -> Option<TraceParent> {
+        let mut parts = value.split(|&b| b == b'-');
+        let version_s = parts.next()?;
+        let trace_s = parts.next()?;
+        let parent_s = parts.next()?;
+        let flags_s = parts.next()?;
+        let version = hex_byte(version_s)?;
+        // `ff` is the reserved "invalid" version; reject it outright.
+        if version == 0xff {
+            return None;
+        }
+        // Version 0 is EXACTLY four fields: a trailing field makes the value malformed. Future
+        // versions may carry a suffix, which the W3C rule says to ignore.
+        if version == 0x00 && parts.next().is_some() {
+            return None;
+        }
+        let trace_id = hex_bytes::<16>(trace_s)?;
+        let parent_id = hex_bytes::<8>(parent_s)?;
+        let flags = hex_byte(flags_s)?;
+        // All-zero trace or span id is the W3C invalid sentinel: treat as absent.
+        if trace_id == [0u8; 16] || parent_id == [0u8; 8] {
+            return None;
+        }
+        Some(TraceParent {
+            trace_id,
+            parent_id,
+            flags,
+        })
+    }
+
+    /// Locates a W3C `traceparent` in an opaque message-header blob and parses it, returning `None`
+    /// when none is present or the one present is malformed (#770). Two carrier conventions are
+    /// accepted, in order: (1) the WHOLE trimmed blob is a bare `traceparent` value; (2) an
+    /// HTTP-header-like `traceparent: <value>` (or `traceparent=<value>`) entry among newline-separated
+    /// lines, case-insensitive on the name and tolerant of surrounding whitespace. The broker treats
+    /// the header blob as opaque bytes otherwise; this only READS a `traceparent` when the client put
+    /// one there, and never mutates or injects.
+    #[must_use]
+    pub fn from_headers(headers: &[u8]) -> Option<TraceParent> {
+        // (1) The whole blob is a bare value (the leanest carrier: a header blob that is just the
+        // traceparent).
+        if let Some(tp) = TraceParent::parse(trim_ascii(headers)) {
+            return Some(tp);
+        }
+        // (2) An HTTP-header-like `traceparent: <value>` line among newline-separated entries.
+        for line in headers.split(|&b| b == b'\n') {
+            let line = trim_ascii(line);
+            let Some(sep) = line.iter().position(|&b| b == b':' || b == b'=') else {
+                continue;
+            };
+            let (name, rest) = line.split_at(sep);
+            if trim_ascii(name).eq_ignore_ascii_case(TRACEPARENT_HEADER_NAME) {
+                // `rest` includes the separator byte at index 0; skip it before trimming the value.
+                if let Some(tp) = TraceParent::parse(trim_ascii(&rest[1..])) {
+                    return Some(tp);
+                }
+            }
+        }
+        None
+    }
+
+    /// Serializes this context back to the canonical W3C version-0 `traceparent` value
+    /// (`00-<trace>-<span>-<flags>`, lowercase hex), the exact form a client would put in the headers.
+    /// A value parsed from a canonical lowercase input and re-formatted is byte-identical, so context
+    /// round-trips across the bus without loss.
+    #[must_use]
+    pub fn to_header_value(&self) -> String {
+        use std::fmt::Write as _;
+        let mut s = String::with_capacity(TRACEPARENT_LEN);
+        // Always emit version 0 (the only form IronBus produces); lowercase hex per the W3C spec.
+        s.push_str("00-");
+        for b in self.trace_id {
+            let _ = write!(s, "{b:02x}");
+        }
+        s.push('-');
+        for b in self.parent_id {
+            let _ = write!(s, "{b:02x}");
+        }
+        let _ = write!(s, "-{:02x}", self.flags);
+        s
+    }
+}
+
+/// Maps one ASCII hex digit to its 0..=15 value, in either case. `None` for a non-hex byte.
+fn hex_val(c: u8) -> Option<u8> {
+    match c {
+        b'0'..=b'9' => Some(c - b'0'),
+        b'a'..=b'f' => Some(c - b'a' + 10),
+        b'A'..=b'F' => Some(c - b'A' + 10),
+        _ => None,
+    }
+}
+
+/// Parses exactly two ASCII hex digits into one byte; `None` unless the slice is exactly two hex
+/// digits.
+fn hex_byte(s: &[u8]) -> Option<u8> {
+    if s.len() != 2 {
+        return None;
+    }
+    Some((hex_val(s[0])? << 4) | hex_val(s[1])?)
+}
+
+/// Parses `2 * N` ASCII hex digits into `N` bytes; `None` unless the slice is exactly `2 * N` hex
+/// digits. Length-checked up front so a short or long field is rejected as malformed.
+fn hex_bytes<const N: usize>(s: &[u8]) -> Option<[u8; N]> {
+    if s.len() != N * 2 {
+        return None;
+    }
+    let mut out = [0u8; N];
+    let mut i = 0;
+    while i < N {
+        out[i] = (hex_val(s[i * 2])? << 4) | hex_val(s[i * 2 + 1])?;
+        i += 1;
+    }
+    Some(out)
+}
+
+/// Trims leading and trailing ASCII whitespace from a byte slice. A local helper (not the standard
+/// `<[u8]>::trim_ascii`, which stabilized after the 1.78 MSRV floor) so the parser stays buildable on
+/// the pinned toolchain.
+fn trim_ascii(mut s: &[u8]) -> &[u8] {
+    while let [first, rest @ ..] = s {
+        if first.is_ascii_whitespace() {
+            s = rest;
+        } else {
+            break;
+        }
+    }
+    while let [rest @ .., last] = s {
+        if last.is_ascii_whitespace() {
+            s = rest;
+        } else {
+            break;
+        }
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A known-good version-0 value round-trips byte-for-byte through parse then format.
+    #[test]
+    fn parse_then_format_round_trips_a_canonical_value() {
+        let value = b"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+        let tp = TraceParent::parse(value).expect("a canonical value parses");
+        assert_eq!(
+            tp.trace_id,
+            [
+                0x4b, 0xf9, 0x2f, 0x35, 0x77, 0xb3, 0x4d, 0xa6, 0xa3, 0xce, 0x92, 0x9d, 0x0e, 0x0e,
+                0x47, 0x36
+            ]
+        );
+        assert_eq!(
+            tp.parent_id,
+            [0x00, 0xf0, 0x67, 0xaa, 0x0b, 0xa9, 0x02, 0xb7]
+        );
+        assert_eq!(tp.flags, 0x01);
+        assert_eq!(
+            tp.to_header_value().as_bytes(),
+            value,
+            "the re-serialized value is byte-identical to the input"
+        );
+        assert_eq!(tp.to_header_value().len(), TRACEPARENT_LEN);
+    }
+
+    /// Uppercase hex on input is tolerated (parsed to the same bytes) and normalized to lowercase on
+    /// output — defensive leniency without breaking the canonical output contract.
+    #[test]
+    fn uppercase_hex_is_accepted_and_normalized() {
+        let upper = b"00-4BF92F3577B34DA6A3CE929D0E0E4736-00F067AA0BA902B7-01";
+        let lower = b"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+        let tp = TraceParent::parse(upper).expect("uppercase hex parses");
+        assert_eq!(
+            tp.to_header_value().as_bytes(),
+            lower,
+            "output is always canonical lowercase"
+        );
+    }
+
+    /// Every malformed shape is treated as ABSENT (`None`), never an error: this is the property the
+    /// produce path relies on so a broken `traceparent` can never reject a publish.
+    #[test]
+    fn malformed_values_are_absent_not_errors() {
+        let cases: &[&[u8]] = &[
+            b"",                                                              // empty
+            b"garbage",                                                       // not dashed
+            b"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7",          // missing flags
+            b"00-4bf9-00f067aa0ba902b7-01",                                   // short trace id
+            b"00-4bf92f3577b34da6a3ce929d0e0e4736-00f0-01",                   // short span id
+            b"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-0",        // short flags
+            b"zz-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",       // non-hex version
+            b"00-zzf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",       // non-hex trace id
+            b"00-00000000000000000000000000000000-00f067aa0ba902b7-01",       // all-zero trace id
+            b"00-4bf92f3577b34da6a3ce929d0e0e4736-0000000000000000-01",       // all-zero span id
+            b"ff-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",       // reserved ff version
+            b"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01-extra", // v0 trailing field
+        ];
+        for &c in cases {
+            assert!(
+                TraceParent::parse(c).is_none(),
+                "malformed value must parse as absent: {:?}",
+                std::str::from_utf8(c).unwrap_or("<bytes>")
+            );
+        }
+    }
+
+    /// A future (non-`ff`) version with a trailing suffix still yields the first four fields, per the
+    /// W3C forward-compatibility rule.
+    #[test]
+    fn a_future_version_with_a_suffix_still_parses_the_base_fields() {
+        let value = b"cc-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01-99";
+        let tp = TraceParent::parse(value).expect("a future version parses its base fields");
+        assert_eq!(
+            tp.parent_id,
+            [0x00, 0xf0, 0x67, 0xaa, 0x0b, 0xa9, 0x02, 0xb7]
+        );
+        assert_eq!(tp.flags, 0x01);
+    }
+
+    /// The header carrier: a blob that is nothing but a bare value is found.
+    #[test]
+    fn from_headers_finds_a_bare_value() {
+        let headers = b"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+        let tp = TraceParent::from_headers(headers).expect("bare value found");
+        assert_eq!(
+            tp.parent_id,
+            [0x00, 0xf0, 0x67, 0xaa, 0x0b, 0xa9, 0x02, 0xb7]
+        );
+    }
+
+    /// The header carrier: an HTTP-header-like `traceparent: <value>` entry among other lines is
+    /// found, case-insensitively, and other headers are ignored.
+    #[test]
+    fn from_headers_finds_a_named_line_among_others() {
+        let headers = b"content-type: application/octet-stream\nTraceParent: 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01\nx-other: 1";
+        let tp = TraceParent::from_headers(headers).expect("named traceparent line found");
+        assert_eq!(tp.flags, 0x01);
+        assert_eq!(
+            tp.parent_id,
+            [0x00, 0xf0, 0x67, 0xaa, 0x0b, 0xa9, 0x02, 0xb7]
+        );
+    }
+
+    /// The header carrier: a `traceparent=<value>` (equals separator) entry is also accepted.
+    #[test]
+    fn from_headers_accepts_an_equals_separator() {
+        let headers = b"traceparent=00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00";
+        let tp = TraceParent::from_headers(headers).expect("equals-separated value found");
+        assert_eq!(tp.flags, 0x00);
+    }
+
+    /// The header carrier: no `traceparent` anywhere is simply absent (`None`), the common case for a
+    /// client that does not participate in tracing.
+    #[test]
+    fn from_headers_is_absent_when_none_present() {
+        assert!(TraceParent::from_headers(b"").is_none());
+        assert!(TraceParent::from_headers(b"content-type: text/plain\nx-foo: bar").is_none());
+        assert!(TraceParent::from_headers(b"traceparent: not-a-valid-value").is_none());
+    }
+
+    /// The flags byte survives verbatim (both the sampled and the un-sampled bit patterns).
+    #[test]
+    fn flags_byte_is_carried_verbatim() {
+        for flags in [0x00u8, 0x01, 0xfe] {
+            let tp = TraceParent {
+                trace_id: [1u8; 16],
+                parent_id: [2u8; 8],
+                flags,
+            };
+            let reparsed = TraceParent::parse(tp.to_header_value().as_bytes())
+                .expect("a formatted value re-parses");
+            assert_eq!(reparsed.flags, flags);
+        }
+    }
+}

--- a/crates/ironbus-server/src/actor.rs
+++ b/crates/ironbus-server/src/actor.rs
@@ -709,6 +709,13 @@ pub struct EngineHandle<F: Filesystem, C: Clock> {
     /// connection (one per actor), so a `clone` keeps the SAME `Arc` (like `cap_gate`). Consulted only
     /// when `consume_longpoll_ms > 0`; the default-off path never touches it.
     commit_notify: Arc<CommitNotify>,
+    /// The distributed-tracing span-emission sink (#770): a set-once slot, EMPTY until the serve path
+    /// installs it via [`set_span_sink`](Self::set_span_sink) when `--enable-otlp-export` is on. SHARED
+    /// across every per-connection clone (an `Arc`, like `client_ack`), so the ONE sink the CLI built
+    /// from the bounded span queue reaches every connection's produce/deliver/ack emission sites.
+    /// `None`/empty on a non-tracing broker, so [`EngineAccess::span_sink`] returns `None` and emission
+    /// is a zero-cost no-op — the byte-for-byte default hot path.
+    span_sink: Arc<OnceLock<crate::obs::SpanSink>>,
 }
 
 /// The shared, set-once slot holding the clustered [`ClientAckGate`] (#719). Created empty at serve
@@ -745,6 +752,9 @@ impl<F: Filesystem, C: Clock + Clone> Clone for EngineHandle<F, C> {
             // The SAME shared commit-notify seam (push delivery): one per actor, bumped by the actor
             // and waited on by every idle long-polling consumer, so the `Arc` is shared on clone.
             commit_notify: Arc::clone(&self.commit_notify),
+            // The SAME shared span-emission sink (#770): the ONE sink the serve path installed reaches
+            // every connection, so the `Arc<OnceLock>` is shared on clone (like `client_ack`).
+            span_sink: Arc::clone(&self.span_sink),
         }
     }
 }
@@ -769,6 +779,17 @@ impl<F: Filesystem + 'static, C: Clock + 'static> EngineHandle<F, C> {
     /// The bound is shared across every connection's handle clone (one watchdog per actor).
     pub fn set_actor_watchdog_bound(&self, bound_nanos: u64) {
         self.actor_watchdog.set_bound_nanos(bound_nanos);
+    }
+
+    /// Install the SHARED distributed-tracing span-emission sink (#770) on this base handle. Called
+    /// ONCE at serve start (when `--enable-otlp-export` is on), RIGHT AFTER [`spawn_actor_with_gather`]
+    /// and BEFORE any per-connection clone, so every connection's produce/deliver/ack emission sites
+    /// reach the ONE sink the CLI built from the bounded span queue. Set-once via the shared `OnceLock`
+    /// (a second call is ignored); the shed/sampling discipline lives in the sink. A serve that never
+    /// calls this leaves the slot empty, so [`EngineAccess::span_sink`] returns `None` and emission is a
+    /// zero-cost no-op.
+    pub fn set_span_sink(&self, sink: crate::obs::SpanSink) {
+        let _ = self.span_sink.set(sink);
     }
 
     /// The shared cluster produce-ack gate (#719), once the data-plane bootstrap has filled the slot;
@@ -1183,6 +1204,17 @@ pub trait EngineAccess<F: Filesystem, C: Clock> {
         false
     }
 
+    /// The process span-emission sink for distributed tracing (#770), or `None` when OTLP span export
+    /// is not wired (the DEFAULT for every engine, and for a broker started without
+    /// `--enable-otlp-export`). The produce/deliver/ack sites read this to offer a head-sampled
+    /// Producer/Consumer span to the exporter's bounded-lossy queue; a `None` sink makes emission a
+    /// compiled-in but zero-cost no-op (no atomic, no push), so a non-tracing broker's hot path is
+    /// byte-for-byte unchanged. A cheap LOCAL read (a clone of an `Arc` + an `f64`), never an actor
+    /// round-trip. [`EngineHandle`] overrides it to return the sink the serve path installed.
+    fn span_sink(&self) -> Option<crate::obs::SpanSink> {
+        None
+    }
+
     /// Whether the append actor's IN-FLIGHT command batch has overrun the watchdog bound at
     /// `now_monotonic_nanos` — i.e. a HUNG durability fsync has wedged the actor thread (#862). A cheap
     /// LOCAL, non-blocking atomic read (it does NOT go through the actor, so it answers even while the
@@ -1374,6 +1406,12 @@ impl<F: Filesystem + Clone + 'static, C: Clock + Clone + 'static> EngineAccess<F
         self.client_ack_gate().is_some()
     }
 
+    fn span_sink(&self) -> Option<crate::obs::SpanSink> {
+        // A cheap local read: a clone of the installed sink (an `Arc` + an `f64`), or `None` when the
+        // serve path never installed one (`--enable-otlp-export` off). Never an actor round-trip.
+        self.span_sink.get().cloned()
+    }
+
     fn actor_watchdog_overran(&self, now_monotonic_nanos: u64) -> bool {
         // A non-blocking atomic read of the shared watchdog (#862): does NOT go through the actor, so
         // it answers even while the actor is wedged on a hung fsync. `false` until the serve path arms
@@ -1482,6 +1520,9 @@ impl<F: Filesystem + Clone + 'static, C: Clock + Clone + 'static> EngineAccess<F
 #[cfg(test)]
 pub struct DirectEngine<F: Filesystem, C: Clock> {
     engine: std::cell::RefCell<Engine<F, C>>,
+    /// The optional distributed-tracing span sink (#770), so a test can drive the produce/deliver/ack
+    /// emission sites and assert what landed on the queue. `None` (the default) keeps emission a no-op.
+    span_sink: Option<crate::obs::SpanSink>,
 }
 
 #[cfg(test)]
@@ -1490,7 +1531,16 @@ impl<F: Filesystem, C: Clock + Clone> DirectEngine<F, C> {
     pub fn new(engine: Engine<F, C>) -> Self {
         DirectEngine {
             engine: std::cell::RefCell::new(engine),
+            span_sink: None,
         }
+    }
+
+    /// Attaches a span-emission sink (#770) so the produce/deliver/ack sites emit into it, for the
+    /// end-to-end distributed-tracing test.
+    #[must_use]
+    pub fn with_span_sink(mut self, sink: crate::obs::SpanSink) -> Self {
+        self.span_sink = Some(sink);
+        self
     }
 
     /// Borrows the engine mutably for a direct read or mutation the test does outside a session.
@@ -1520,6 +1570,10 @@ impl<F: Filesystem, C: Clock + Clone> EngineAccess<F, C> for DirectEngine<F, C> 
     fn consumer_credit_caps(&self) -> (u32, u64) {
         let e = self.engine.borrow();
         (e.consumer_credit(), e.consumer_credit_bytes())
+    }
+
+    fn span_sink(&self) -> Option<crate::obs::SpanSink> {
+        self.span_sink.clone()
     }
 }
 
@@ -1842,6 +1896,11 @@ where
             // The consume long-poll budget snapshot + shared commit-notify seam (push delivery).
             consume_longpoll_ms,
             commit_notify,
+            // No span-emission sink by default (#770): a non-tracing broker never installs one, so
+            // emission is a zero-cost no-op. A serve started with `--enable-otlp-export` installs the
+            // shared sink via [`EngineHandle::set_span_sink`] right after this returns, BEFORE any
+            // connection's handle is cloned, so every connection sees it.
+            span_sink: Arc::new(OnceLock::new()),
         },
         join,
     )

--- a/crates/ironbus-server/src/obs.rs
+++ b/crates/ironbus-server/src/obs.rs
@@ -430,6 +430,78 @@ impl BoundedSpanQueue {
     }
 }
 
+/// The process-wide monotonic source of span ids (#770). Each emitted produce/deliver/ack span takes a
+/// fresh id here, which drives BOTH its exported span id and the deterministic head-sampling position
+/// ([`sampling_position`]). Starts at 1 (never the all-zero invalid id) and wraps harmlessly. Relaxed:
+/// it is a pure id generator, never a synchronization point.
+static NEXT_SPAN_ID: AtomicU64 = AtomicU64::new(1);
+
+/// Returns a fresh, process-unique span id for an emitted span (#770). Monotonic and allocation-free,
+/// so the emission sites pay only an atomic increment. Wrapping past `u64::MAX` is harmless (the
+/// exporter forces a non-zero span id regardless).
+#[must_use]
+pub fn next_span_id() -> u64 {
+    NEXT_SPAN_ID.fetch_add(1, Ordering::Relaxed)
+}
+
+/// The process span-EMISSION sink (#770): the handle the produce/deliver/ack hot-path sites use to
+/// offer a span for export, or `None` (via [`crate::actor::EngineAccess::span_sink`]) when tracing
+/// export is not wired, in which case emission is a compiled-in but zero-cost no-op. It pairs the
+/// SAME [`BoundedSpanQueue`] the OTLP exporter drains (#352) with the head-sampling ratio (#99), so
+/// [`SpanSink::emit`] applies the identical [`should_sample`] gate the exporter uses BEFORE the
+/// bounded-lossy push — a non-sampled span never even touches the queue, keeping the produce path
+/// bounded. This type carries NO `opentelemetry`: it is always-on plain data (an `Arc` + an `f64`),
+/// so the default and `edge-min` builds link none of the exporter; only the DRAIN is feature-gated.
+#[derive(Clone, Debug)]
+pub struct SpanSink {
+    /// The bounded-lossy queue the OTLP exporter drains. Shared (`Arc`) so the emitting connection
+    /// threads and the drain thread reference the one queue.
+    queue: std::sync::Arc<BoundedSpanQueue>,
+    /// The head-sampling ratio in `[0.0, 1.0]` applied at emission time (the same gate the exporter
+    /// applies at drain), so a non-tracing ratio (`0.0`, the default) admits only ERROR/WARN and drops
+    /// the Info-level produce/deliver spans at the cheapest point.
+    sample_ratio: f64,
+}
+
+impl SpanSink {
+    /// Builds an emission sink over `queue` (the exporter's bounded-lossy queue) at `sample_ratio`.
+    #[must_use]
+    pub fn new(queue: std::sync::Arc<BoundedSpanQueue>, sample_ratio: f64) -> SpanSink {
+        SpanSink {
+            queue,
+            sample_ratio,
+        }
+    }
+
+    /// Offers `record` for export, HEAD-SAMPLED and NON-BLOCKING (#770, #99). Applies the same
+    /// [`should_sample`] decision the exporter uses (an ERROR/WARN span is always admitted; an
+    /// Info-level produce/deliver span passes only under the ratio), then a bounded-lossy
+    /// [`BoundedSpanQueue::push`] that DROPS-and-counts when full rather than blocking the produce
+    /// path. A sampled-out span is skipped before the push, so the hot path pays only the sampling
+    /// hash when tracing is on and nothing when the sink is absent (the `None` fast-path lives at the
+    /// call site). The push outcome is intentionally not surfaced: a full-queue drop is the
+    /// bounded-lossy contract, counted on the queue, never the producing thread's concern.
+    pub fn emit(&self, record: SpanRecord) {
+        if !should_sample(record, self.sample_ratio, sampling_position(record.id)) {
+            return;
+        }
+        let _ = self.queue.push(record);
+    }
+
+    /// The sink's head-sampling ratio (for diagnostics/tests).
+    #[must_use]
+    pub fn sample_ratio(&self) -> f64 {
+        self.sample_ratio
+    }
+
+    /// A clone of the underlying bounded-lossy queue handle (for diagnostics/tests that assert what
+    /// was emitted).
+    #[must_use]
+    pub fn queue(&self) -> std::sync::Arc<BoundedSpanQueue> {
+        std::sync::Arc::clone(&self.queue)
+    }
+}
+
 /// The runtime tracing/export configuration (#99). The JSON log layer is always installed by
 /// `init_tracing`; the OTLP fields are inert unless the `otlp` feature is compiled in AND export is
 /// turned on, so the default and `edge-min` builds carry no opentelemetry cost.
@@ -1701,5 +1773,41 @@ mod tests {
     fn a_server_span_carries_the_server_kind() {
         let rec = SpanRecord::server(1, Severity::Info);
         assert_eq!(rec.ctx.kind, SpanKindTag::Server);
+    }
+
+    #[test]
+    fn the_span_sink_emits_under_a_full_sample_ratio() {
+        // At ratio 1.0 an Info-level produce span is enqueued onto the SAME queue the exporter drains.
+        let queue = std::sync::Arc::new(BoundedSpanQueue::with_capacity(8));
+        let sink = SpanSink::new(std::sync::Arc::clone(&queue), 1.0);
+        sink.emit(SpanRecord::produce(next_span_id(), Severity::Info, None));
+        assert_eq!(
+            queue.len(),
+            1,
+            "a full-ratio Info produce span is pushed onto the exporter's queue"
+        );
+    }
+
+    #[test]
+    fn the_span_sink_head_samples_out_info_at_zero_ratio() {
+        // At the default 0.0 ratio an Info-level produce/deliver span is dropped at the sampling gate
+        // BEFORE the push, so a non-tracing broker's produce path never even touches the queue.
+        let queue = std::sync::Arc::new(BoundedSpanQueue::with_capacity(8));
+        let sink = SpanSink::new(std::sync::Arc::clone(&queue), 0.0);
+        sink.emit(SpanRecord::produce(next_span_id(), Severity::Info, None));
+        assert_eq!(
+            queue.len(),
+            0,
+            "a 0.0-ratio Info span is sampled out, not pushed"
+        );
+        assert_eq!(queue.dropped(), 0, "a sampled-out span is not a queue drop");
+    }
+
+    #[test]
+    fn next_span_id_is_monotonic_and_never_zero() {
+        let a = next_span_id();
+        let b = next_span_id();
+        assert_ne!(a, 0, "a span id is never the all-zero invalid id");
+        assert_ne!(a, b, "successive span ids differ");
     }
 }

--- a/crates/ironbus-server/src/obs.rs
+++ b/crates/ironbus-server/src/obs.rs
@@ -64,19 +64,219 @@ impl Severity {
     }
 }
 
-/// One span queued for export. Carries only its severity and a small opaque id; no payload bytes and
-/// no secret material, so the export queue never widens the trust boundary the way `/admin` mutation
-/// would. The concrete exporter (`otlp::record_to_span_data`, behind the `otlp` feature) maps this
-/// onto an OTLP span.
+/// The OTLP span kind of a recorded span (#770), our own dependency-free tag so the default and
+/// `edge-min` builds carry it without linking `opentelemetry`. The `otlp` exporter maps it onto
+/// `opentelemetry::trace::SpanKind`. `Internal` is the neutral default (today's behavior); `Server`
+/// is the connection handler, `Producer` a produce, `Consumer` a deliver/ack — the messaging lifecycle
+/// the W3C-propagation half of tracing needs to speak.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum SpanKindTag {
+    /// A local, un-kinded span: the neutral default, the behavior before distributed tracing.
+    #[default]
+    Internal,
+    /// The connection handler / server-side request span.
+    Server,
+    /// A client-side request span (reserved; the broker rarely originates one).
+    Client,
+    /// A produce span: the message-bus PRODUCER side of the OTLP messaging convention.
+    Producer,
+    /// A deliver/ack span: the message-bus CONSUMER side of the OTLP messaging convention.
+    Consumer,
+}
+
+/// The cap on the number of producer -> consumer links a single consume span may carry (#770). A
+/// batch delivery can fan in many produced records; without a bound the link list would grow with the
+/// batch. We keep only the first [`MAX_SPAN_LINKS`] DISTINCT producer contexts and drop the rest, so a
+/// span's link surface is fixed-size and `Copy`, never an unbounded allocation on the export path.
+pub const MAX_SPAN_LINKS: usize = 8;
+
+/// One producer -> consumer span LINK (#770): the (trace-id, span-id) of a span this span links to.
+/// Dependency-free plain data (24 bytes, `Copy`); the `otlp` exporter maps it onto an
+/// `opentelemetry` `Link`. An all-zero link is the empty/unused slot in a [`SpanTraceContext`]'s fixed
+/// link array.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub struct SpanLink {
+    /// The 16-byte trace id of the linked span.
+    pub trace_id: [u8; 16],
+    /// The 8-byte span id of the linked span.
+    pub span_id: [u8; 8],
+}
+
+/// The distributed-trace linkage a span carries (#770): its kind, the trace it belongs to, its
+/// parent, and a bounded set of producer -> consumer links. ALWAYS-ON plain data (no `opentelemetry`
+/// dependency, present on the default and `edge-min` builds); the `otlp` exporter reads it to populate
+/// the exported span's `span_kind`, `parent_span_id`, and `links` instead of the old
+/// `Internal`/`INVALID`/empty defaults. The `Default` is exactly the pre-#770 behavior: an `Internal`
+/// span with a trace id derived from the span id (a new root) and no parent and no links.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SpanTraceContext {
+    /// The span kind (drives the exported `span_kind`).
+    pub kind: SpanKindTag,
+    /// The trace id this span belongs to. ALL-ZERO means "derive a trace id from the span id" (the
+    /// root-span behavior): a produce that continues a client's trace sets this to the client's trace
+    /// id, a root produce leaves it zero.
+    pub trace_id: [u8; 16],
+    /// The parent span id. ALL-ZERO means "no parent" (exported as `SpanId::INVALID`): a produce
+    /// continuing a client's trace sets this to the inbound `traceparent`'s span id, a root leaves it
+    /// zero.
+    pub parent_span_id: [u8; 8],
+    /// The bounded producer -> consumer links; only the first `link_count` slots are populated. A
+    /// consume span links back to the producing span(s) here.
+    pub links: [SpanLink; MAX_SPAN_LINKS],
+    /// How many of `links` are populated (`0..=MAX_SPAN_LINKS`).
+    pub link_count: usize,
+}
+
+impl Default for SpanTraceContext {
+    fn default() -> SpanTraceContext {
+        SpanTraceContext {
+            kind: SpanKindTag::Internal,
+            trace_id: [0u8; 16],
+            parent_span_id: [0u8; 8],
+            links: [SpanLink::default(); MAX_SPAN_LINKS],
+            link_count: 0,
+        }
+    }
+}
+
+impl SpanTraceContext {
+    /// The context for a plain internal event/span: the pre-#770 behavior (Internal kind, root trace
+    /// derived from the span id, no parent, no links).
+    #[must_use]
+    pub fn internal() -> SpanTraceContext {
+        SpanTraceContext::default()
+    }
+
+    /// The context for the connection-handler SERVER span: `Server` kind, otherwise a root (no inbound
+    /// context is threaded to the handler span today).
+    #[must_use]
+    pub fn server() -> SpanTraceContext {
+        SpanTraceContext {
+            kind: SpanKindTag::Server,
+            ..SpanTraceContext::default()
+        }
+    }
+
+    /// The context for a PRODUCE span (#770): `Producer` kind, and — when the produce carried an
+    /// inbound W3C `traceparent` — CONTINUING the client's trace by adopting its trace id and making
+    /// the inbound span id this span's PARENT. With no inbound context it is a new root (today's
+    /// behavior), still tagged `Producer`.
+    #[must_use]
+    pub fn producer(parent: Option<ironbus_core::trace_context::TraceParent>) -> SpanTraceContext {
+        match parent {
+            Some(tp) => SpanTraceContext {
+                kind: SpanKindTag::Producer,
+                trace_id: tp.trace_id,
+                parent_span_id: tp.parent_id,
+                ..SpanTraceContext::default()
+            },
+            None => SpanTraceContext {
+                kind: SpanKindTag::Producer,
+                ..SpanTraceContext::default()
+            },
+        }
+    }
+
+    /// The context for a DELIVER/ACK CONSUME span (#770): `Consumer` kind with a producer -> consumer
+    /// LINK back to each DISTINCT producing span read off the delivered record(s)' stored
+    /// `traceparent`. Per the OTLP messaging convention a consume span LINKS to (not parents on) the
+    /// producing span, because one deliver/fetch can batch many produced records. The links are
+    /// DEDUPED by (trace-id, span-id) and CAPPED at [`MAX_SPAN_LINKS`]: extra distinct producers are
+    /// dropped so the link surface stays bounded. The consume span itself is a root (its own trace is
+    /// derived from its span id); a malformed/absent stored `traceparent` simply contributes no link.
+    #[must_use]
+    pub fn consumer(producers: &[ironbus_core::trace_context::TraceParent]) -> SpanTraceContext {
+        let mut ctx = SpanTraceContext {
+            kind: SpanKindTag::Consumer,
+            ..SpanTraceContext::default()
+        };
+        for tp in producers {
+            if ctx.link_count >= MAX_SPAN_LINKS {
+                break;
+            }
+            let link = SpanLink {
+                trace_id: tp.trace_id,
+                span_id: tp.parent_id,
+            };
+            // Dedup: link once per distinct producer span even across a batch.
+            if ctx.links[..ctx.link_count].contains(&link) {
+                continue;
+            }
+            ctx.links[ctx.link_count] = link;
+            ctx.link_count += 1;
+        }
+        ctx
+    }
+}
+
+/// One span queued for export. Carries a small opaque id, its severity, and its distributed-trace
+/// context ([`SpanTraceContext`]) — no payload bytes and no secret material, so the export queue never
+/// widens the trust boundary the way `/admin` mutation would. The concrete exporter
+/// (`otlp::record_to_span_data`, behind the `otlp` feature) maps this onto an OTLP span, reading the
+/// context for the exported `span_kind`, parent, and links.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct SpanRecord {
     /// A monotonic-ish span id, opaque to this module.
     pub id: u64,
     /// The span's severity, which drives the always-record rule.
     pub severity: Severity,
+    /// The distributed-trace linkage (kind, trace/parent ids, producer -> consumer links). Defaults to
+    /// [`SpanTraceContext::internal`], the pre-#770 behavior.
+    pub ctx: SpanTraceContext,
 }
 
 impl SpanRecord {
+    /// A plain internal event/span record (the pre-#770 shape): id + severity with the neutral
+    /// [`SpanTraceContext::internal`] context. This is the constructor the resilience-event path uses.
+    #[must_use]
+    pub fn event(id: u64, severity: Severity) -> SpanRecord {
+        SpanRecord {
+            id,
+            severity,
+            ctx: SpanTraceContext::internal(),
+        }
+    }
+
+    /// A connection-handler SERVER span record (#770): `Server` kind.
+    #[must_use]
+    pub fn server(id: u64, severity: Severity) -> SpanRecord {
+        SpanRecord {
+            id,
+            severity,
+            ctx: SpanTraceContext::server(),
+        }
+    }
+
+    /// A PRODUCE span record (#770): `Producer` kind, continuing the client's trace when `parent` (the
+    /// inbound W3C `traceparent`) is present, otherwise a new root.
+    #[must_use]
+    pub fn produce(
+        id: u64,
+        severity: Severity,
+        parent: Option<ironbus_core::trace_context::TraceParent>,
+    ) -> SpanRecord {
+        SpanRecord {
+            id,
+            severity,
+            ctx: SpanTraceContext::producer(parent),
+        }
+    }
+
+    /// A DELIVER/ACK CONSUME span record (#770): `Consumer` kind with producer -> consumer links to the
+    /// delivered record(s)' stored producers (deduped and capped at [`MAX_SPAN_LINKS`]).
+    #[must_use]
+    pub fn consume(
+        id: u64,
+        severity: Severity,
+        producers: &[ironbus_core::trace_context::TraceParent],
+    ) -> SpanRecord {
+        SpanRecord {
+            id,
+            severity,
+            ctx: SpanTraceContext::consumer(producers),
+        }
+    }
+
     /// Whether this span must be recorded regardless of the sampling ratio (ERROR/WARN always are).
     #[must_use]
     pub fn force_recorded(self) -> bool {
@@ -432,13 +632,15 @@ fn install_json_log_layer() {
 /// verifiable property, not a stub.
 #[cfg(feature = "otlp")]
 pub mod otlp {
-    use super::{sampling_position, should_sample, BoundedSpanQueue, Severity, SpanRecord};
+    use super::{
+        sampling_position, should_sample, BoundedSpanQueue, Severity, SpanKindTag, SpanRecord,
+    };
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
     use std::time::Duration;
 
     use opentelemetry::trace::{
-        SpanContext, SpanId, SpanKind, Status, TraceFlags, TraceId, TraceState,
+        Link, SpanContext, SpanId, SpanKind, Status, TraceFlags, TraceId, TraceState,
     };
     use opentelemetry::{InstrumentationScope, KeyValue};
     use opentelemetry_otlp::{SpanExporter, WithExportConfig};
@@ -500,40 +702,100 @@ pub mod otlp {
         }
     }
 
-    /// Maps one in-process [`SpanRecord`] onto an OTLP [`SpanData`] for the wire (#352). The record
-    /// carries only an opaque id and a severity (no payload, no secret material, by design, so export
-    /// never widens the trust boundary), so the mapping derives a deterministic span/trace id from the
-    /// record id and stamps the severity as the span name plus a `severity` attribute. The start and
-    /// end time are both `now` (the record is a point event, not a duration); the scope is `ironbus`.
+    /// Maps our dependency-free [`SpanKindTag`] onto the `opentelemetry` [`SpanKind`] (#770). The tag
+    /// is plain data on every build; this mapping lives only in the `otlp`-gated exporter, so the
+    /// default build never names the `opentelemetry` kind.
+    #[must_use]
+    pub fn map_span_kind(kind: SpanKindTag) -> SpanKind {
+        match kind {
+            SpanKindTag::Internal => SpanKind::Internal,
+            SpanKindTag::Server => SpanKind::Server,
+            SpanKindTag::Client => SpanKind::Client,
+            SpanKindTag::Producer => SpanKind::Producer,
+            SpanKindTag::Consumer => SpanKind::Consumer,
+        }
+    }
+
+    /// Maps one in-process [`SpanRecord`] onto an OTLP [`SpanData`] for the wire (#352, #770). The
+    /// record carries an opaque id, a severity, and its distributed-trace context (no payload, no
+    /// secret material, by design, so export never widens the trust boundary). The mapping derives a
+    /// deterministic, non-zero span id from the record id, and takes the TRACE id and PARENT from the
+    /// record's [`super::SpanTraceContext`] when set (a produce that continued a client's
+    /// `traceparent`) or derives a root trace id from the span id otherwise (today's behavior). The
+    /// span kind, the producer -> consumer LINKS, and the OTLP `messaging.*` attributes come from the
+    /// context, replacing the old `Internal`/`INVALID`/empty defaults. Start and end time are both
+    /// `now` (a point event); the scope is `ironbus`.
     #[must_use]
     pub fn record_to_span_data(record: SpanRecord, scope: &InstrumentationScope) -> SpanData {
         let now = std::time::SystemTime::now();
-        // A deterministic, non-zero trace id from the record id: the low 8 bytes are the id, the high
-        // 8 bytes a fixed mix so the trace id is never all-zero (which OTLP treats as invalid). The
-        // span id is the record id (also forced non-zero).
         let id = record.id;
-        let mut trace_bytes = [0u8; 16];
-        trace_bytes[..8].copy_from_slice(&id.wrapping_add(1).to_be_bytes());
-        trace_bytes[8..].copy_from_slice(&id.to_be_bytes());
+        let ctx = record.ctx;
+        // The span's OWN id: the record id forced non-zero (OTLP treats an all-zero id as invalid).
         let span_bytes = id.max(1).to_be_bytes();
+        // The TRACE id: the context's carried trace id when the produce continued a client's trace,
+        // else a deterministic root trace id derived from the span id (low 8 bytes = id, high 8 = a
+        // fixed mix so it is never the all-zero invalid id).
+        let trace_id = if ctx.trace_id == [0u8; 16] {
+            let mut trace_bytes = [0u8; 16];
+            trace_bytes[..8].copy_from_slice(&id.wrapping_add(1).to_be_bytes());
+            trace_bytes[8..].copy_from_slice(&id.to_be_bytes());
+            TraceId::from_bytes(trace_bytes)
+        } else {
+            TraceId::from_bytes(ctx.trace_id)
+        };
+        // The PARENT: the context's parent span id (a produce continuing a client's trace) or the
+        // invalid id for a root span (the pre-#770 behavior).
+        let parent_span_id = if ctx.parent_span_id == [0u8; 8] {
+            SpanId::INVALID
+        } else {
+            SpanId::from_bytes(ctx.parent_span_id)
+        };
         let span_context = SpanContext::new(
-            TraceId::from_bytes(trace_bytes),
+            trace_id,
             SpanId::from_bytes(span_bytes),
             TraceFlags::SAMPLED,
             false,
             TraceState::NONE,
         );
+        // Producer -> consumer LINKS from the context, each a REMOTE span context (the linked span
+        // lives on another connection/client). Bounded by `link_count` (<= MAX_SPAN_LINKS).
+        let mut links = SpanLinks::default();
+        for link in &ctx.links[..ctx.link_count] {
+            let link_ctx = SpanContext::new(
+                TraceId::from_bytes(link.trace_id),
+                SpanId::from_bytes(link.span_id),
+                TraceFlags::SAMPLED,
+                true,
+                TraceState::NONE,
+            );
+            links.links.push(Link::new(link_ctx, Vec::new(), 0));
+        }
+        // Attributes: the severity, plus the OTLP messaging-convention keys for the producer/consumer
+        // kinds (system + operation). The destination/stream name is not carried on the span record,
+        // so it is intentionally omitted (a follow-up can thread it through).
+        let mut attributes = vec![KeyValue::new("severity", severity_name(record.severity))];
+        match ctx.kind {
+            SpanKindTag::Producer => {
+                attributes.push(KeyValue::new("messaging.system", "ironbus"));
+                attributes.push(KeyValue::new("messaging.operation", "publish"));
+            }
+            SpanKindTag::Consumer => {
+                attributes.push(KeyValue::new("messaging.system", "ironbus"));
+                attributes.push(KeyValue::new("messaging.operation", "deliver"));
+            }
+            SpanKindTag::Internal | SpanKindTag::Server | SpanKindTag::Client => {}
+        }
         SpanData {
             span_context,
-            parent_span_id: SpanId::INVALID,
-            span_kind: SpanKind::Internal,
+            parent_span_id,
+            span_kind: map_span_kind(ctx.kind),
             name: severity_name(record.severity).into(),
             start_time: now,
             end_time: now,
-            attributes: vec![KeyValue::new("severity", severity_name(record.severity))],
+            attributes,
             dropped_attributes_count: 0,
             events: SpanEvents::default(),
-            links: SpanLinks::default(),
+            links,
             status: Status::Unset,
             instrumentation_scope: scope.clone(),
         }
@@ -717,10 +979,7 @@ pub mod otlp {
         fn encode_span_frames_tag_then_big_endian_id() {
             let mut out = Vec::new();
             encode_span(
-                SpanRecord {
-                    id: 0x0102_0304_0506_0708,
-                    severity: Severity::Warn,
-                },
+                SpanRecord::event(0x0102_0304_0506_0708, Severity::Warn),
                 &mut out,
             );
             assert_eq!(out, vec![2, 1, 2, 3, 4, 5, 6, 7, 8]);
@@ -730,18 +989,9 @@ pub mod otlp {
         fn encode_batch_respects_sampling() {
             // At ratio 0.0 only ERROR/WARN are encoded; INFO is dropped from the batch.
             let spans = [
-                SpanRecord {
-                    id: 1,
-                    severity: Severity::Error,
-                },
-                SpanRecord {
-                    id: 2,
-                    severity: Severity::Info,
-                },
-                SpanRecord {
-                    id: 3,
-                    severity: Severity::Warn,
-                },
+                SpanRecord::event(1, Severity::Error),
+                SpanRecord::event(2, Severity::Info),
+                SpanRecord::event(3, Severity::Warn),
             ];
             let bytes = encode_batch(&spans, 0.0);
             // Two 9-byte frames (the Error and the Warn), the Info excluded by sampling.
@@ -754,10 +1004,7 @@ pub mod otlp {
         fn drain_and_encode_empties_the_queue() {
             let q = Arc::new(BoundedSpanQueue::with_capacity(8));
             for id in 0..3 {
-                q.push(SpanRecord {
-                    id,
-                    severity: Severity::Error,
-                });
+                q.push(SpanRecord::event(id, Severity::Error));
             }
             let bytes = drain_and_encode(&q, 0.0);
             assert_eq!(bytes.len(), 27, "three 9-byte error frames");
@@ -778,7 +1025,7 @@ pub mod otlp {
                 Severity::Trace,
             ] {
                 // id 0 is the boundary: the mapping forces a non-zero span id even for id 0.
-                let span = record_to_span_data(SpanRecord { id: 0, severity }, &scope);
+                let span = record_to_span_data(SpanRecord::event(0, severity), &scope);
                 assert_ne!(
                     span.span_context.trace_id(),
                     TraceId::INVALID,
@@ -851,10 +1098,7 @@ pub mod otlp {
 
             let queue = Arc::new(BoundedSpanQueue::with_capacity(16));
             for id in 1..=4 {
-                queue.push(SpanRecord {
-                    id,
-                    severity: Severity::Error,
-                });
+                queue.push(SpanRecord::event(id, Severity::Error));
             }
             // One drain-and-ship: maps the four ERROR spans (always sampled at ratio 0.0) and ships
             // them to the sink. The export may surface a gRPC-level error AFTER the bytes are on the
@@ -909,6 +1153,122 @@ pub mod otlp {
             // Returns promptly (the stop flag is already set, so the loop body never runs).
             run_drain_loop(&queue, 0.0, &scope, &mut exporter, &rt);
             STOP_DRAIN.store(false, Ordering::Relaxed);
+        }
+
+        // ---- Distributed-trace export mapping (#770): the exporter reads the span context ----
+
+        use ironbus_core::trace_context::TraceParent;
+
+        fn sample_traceparent() -> TraceParent {
+            TraceParent::parse(b"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+                .expect("the sample context parses")
+        }
+
+        fn has_attr(span: &SpanData, key: &str, value: &str) -> bool {
+            span.attributes
+                .iter()
+                .any(|kv| kv.key.as_str() == key && kv.value.as_str() == value)
+        }
+
+        #[test]
+        fn a_produce_span_exports_with_the_inbound_parent_and_producer_kind() {
+            // Acceptance #1 (produce half): a produce carrying an inbound `traceparent` exports a
+            // PRODUCER span whose PARENT is the inbound span id (not `SpanId::INVALID`) and whose
+            // TRACE id is the client's, so it continues the client's trace. The messaging attributes
+            // are present per the OTLP messaging convention.
+            let tp = sample_traceparent();
+            let scope = InstrumentationScope::builder(SCOPE_NAME).build();
+            let span =
+                record_to_span_data(SpanRecord::produce(42, Severity::Info, Some(tp)), &scope);
+            assert_eq!(span.span_kind, SpanKind::Producer);
+            assert_eq!(
+                span.parent_span_id,
+                SpanId::from_bytes(tp.parent_id),
+                "the produce span's parent is the inbound span id, not INVALID"
+            );
+            assert_ne!(span.parent_span_id, SpanId::INVALID);
+            assert_eq!(
+                span.span_context.trace_id(),
+                TraceId::from_bytes(tp.trace_id),
+                "the produce span shares the client's trace id"
+            );
+            assert!(span.links.links.is_empty(), "a producer span has no links");
+            assert!(has_attr(&span, "messaging.system", "ironbus"));
+            assert!(has_attr(&span, "messaging.operation", "publish"));
+        }
+
+        #[test]
+        fn a_consume_span_exports_with_a_link_to_the_producing_span_and_consumer_kind() {
+            // Acceptance #1 (deliver/ack half): the matching deliver exports a CONSUMER span carrying
+            // a `SpanLink` back to the producing span — same trace id, the producing span id — read
+            // off the record's stored `traceparent`. This is the producer -> consumer link.
+            let tp = sample_traceparent();
+            let scope = InstrumentationScope::builder(SCOPE_NAME).build();
+            let span =
+                record_to_span_data(SpanRecord::consume(1000, Severity::Info, &[tp]), &scope);
+            assert_eq!(span.span_kind, SpanKind::Consumer);
+            assert_eq!(
+                span.parent_span_id,
+                SpanId::INVALID,
+                "a consume span parents on nothing"
+            );
+            assert_eq!(span.links.links.len(), 1, "one producer -> consumer link");
+            let link_ctx = &span.links.links[0].span_context;
+            assert_eq!(
+                link_ctx.span_id(),
+                SpanId::from_bytes(tp.parent_id),
+                "the link targets the producing span id"
+            );
+            assert_eq!(
+                link_ctx.trace_id(),
+                TraceId::from_bytes(tp.trace_id),
+                "the link is in the producer's trace"
+            );
+            assert!(link_ctx.is_remote(), "the linked producing span is remote");
+            assert!(has_attr(&span, "messaging.system", "ironbus"));
+            assert!(has_attr(&span, "messaging.operation", "deliver"));
+        }
+
+        #[test]
+        fn a_batch_consume_span_exports_capped_links() {
+            // A large batch exports at most MAX_SPAN_LINKS links: the export link surface is bounded.
+            let mut producers = Vec::new();
+            for i in 0..(crate::obs::MAX_SPAN_LINKS + 10) {
+                let mut trace_id = [0u8; 16];
+                trace_id[0] = 0xBB;
+                trace_id[15] = u8::try_from(i + 1).unwrap_or(0xFF);
+                let mut parent_id = [0u8; 8];
+                parent_id[7] = u8::try_from(i + 1).unwrap_or(0xFF);
+                producers.push(TraceParent {
+                    trace_id,
+                    parent_id,
+                    flags: 1,
+                });
+            }
+            let scope = InstrumentationScope::builder(SCOPE_NAME).build();
+            let span =
+                record_to_span_data(SpanRecord::consume(1, Severity::Info, &producers), &scope);
+            assert_eq!(span.links.links.len(), crate::obs::MAX_SPAN_LINKS);
+        }
+
+        #[test]
+        fn an_internal_event_span_exports_the_pre_770_shape() {
+            // Regression: a plain event/severity span exports EXACTLY as before #770 — Internal kind,
+            // an INVALID parent, no links, a non-zero derived trace id — so the resilience-event path
+            // is untouched.
+            let scope = InstrumentationScope::builder(SCOPE_NAME).build();
+            let span = record_to_span_data(SpanRecord::event(0, Severity::Error), &scope);
+            assert_eq!(span.span_kind, SpanKind::Internal);
+            assert_eq!(span.parent_span_id, SpanId::INVALID);
+            assert!(span.links.links.is_empty());
+            assert_ne!(
+                span.span_context.trace_id(),
+                TraceId::INVALID,
+                "the derived root trace id is never the invalid all-zero id"
+            );
+            assert_ne!(span.span_context.span_id(), SpanId::INVALID);
+            // No messaging attributes on an internal span.
+            assert!(!has_attr(&span, "messaging.system", "ironbus"));
         }
     }
 }
@@ -987,10 +1347,7 @@ mod tests {
         let q = BoundedSpanQueue::with_capacity(4);
         for id in 0..4 {
             assert!(
-                q.push(SpanRecord {
-                    id,
-                    severity: Severity::Info
-                }),
+                q.push(SpanRecord::event(id, Severity::Info)),
                 "the first {} pushes fit",
                 q.capacity()
             );
@@ -1000,10 +1357,7 @@ mod tests {
         // Offer 10 more under pressure: each is dropped and counted, the buffer stays bounded.
         for id in 4..14 {
             assert!(
-                !q.push(SpanRecord {
-                    id,
-                    severity: Severity::Info
-                }),
+                !q.push(SpanRecord::event(id, Severity::Info)),
                 "a push to a full queue is rejected, not blocked"
             );
         }
@@ -1025,27 +1379,15 @@ mod tests {
         // Drain takes the buffered spans and leaves the queue ready to accept again, so a working
         // exporter relieves pressure (the drop counter stays put; it is a cumulative total).
         let q = BoundedSpanQueue::with_capacity(2);
-        assert!(q.push(SpanRecord {
-            id: 1,
-            severity: Severity::Info
-        }));
-        assert!(q.push(SpanRecord {
-            id: 2,
-            severity: Severity::Info
-        }));
-        assert!(!q.push(SpanRecord {
-            id: 3,
-            severity: Severity::Info
-        }));
+        assert!(q.push(SpanRecord::event(1, Severity::Info)));
+        assert!(q.push(SpanRecord::event(2, Severity::Info)));
+        assert!(!q.push(SpanRecord::event(3, Severity::Info)));
         assert_eq!(q.dropped(), 1);
         let drained = q.drain();
         assert_eq!(drained.len(), 2, "drain takes both buffered spans");
         assert!(q.is_empty(), "the queue is empty after a drain");
         // Room again: a push now succeeds, and the cumulative drop counter is unchanged.
-        assert!(q.push(SpanRecord {
-            id: 4,
-            severity: Severity::Info
-        }));
+        assert!(q.push(SpanRecord::event(4, Severity::Info)));
         assert_eq!(
             q.dropped(),
             1,
@@ -1059,14 +1401,8 @@ mod tests {
         // config error as total loss); it is floored to one usable slot.
         let q = BoundedSpanQueue::with_capacity(0);
         assert_eq!(q.capacity(), 1);
-        assert!(q.push(SpanRecord {
-            id: 1,
-            severity: Severity::Info
-        }));
-        assert!(!q.push(SpanRecord {
-            id: 2,
-            severity: Severity::Info
-        }));
+        assert!(q.push(SpanRecord::event(1, Severity::Info)));
+        assert!(!q.push(SpanRecord::event(2, Severity::Info)));
         assert_eq!(q.dropped(), 1);
     }
 
@@ -1075,7 +1411,7 @@ mod tests {
         // The resilience rule (#16): ERROR/WARN are NEVER sampled out, so a freeze or a skip event
         // is always recorded even on the leanest 0.0-ratio edge profile.
         for severity in [Severity::Error, Severity::Warn] {
-            let rec = SpanRecord { id: 7, severity };
+            let rec = SpanRecord::event(7, severity);
             assert!(rec.force_recorded(), "{severity:?} is always recorded");
             assert!(
                 should_sample(rec, 0.0, sampling_position(7)),
@@ -1094,7 +1430,7 @@ mod tests {
         // so the default edge build pays nothing for trace export.
         for severity in [Severity::Info, Severity::Debug, Severity::Trace] {
             for id in 0..10_000u64 {
-                let rec = SpanRecord { id, severity };
+                let rec = SpanRecord::event(id, severity);
                 assert!(
                     !should_sample(rec, 0.0, sampling_position(id)),
                     "{severity:?} id {id} must be sampled out at ratio 0.0"
@@ -1108,10 +1444,7 @@ mod tests {
         // The other endpoint: at ratio 1.0 every span passes, so the sampling decision is a real
         // gate across the whole [0,1] range, not a constant.
         for id in 0..10_000u64 {
-            let rec = SpanRecord {
-                id,
-                severity: Severity::Info,
-            };
+            let rec = SpanRecord::event(id, Severity::Info);
             assert!(
                 should_sample(rec, 1.0, sampling_position(id)),
                 "id {id} must pass at ratio 1.0"
@@ -1141,10 +1474,7 @@ mod tests {
             (0..10_000u64)
                 .filter(|&id| {
                     should_sample(
-                        SpanRecord {
-                            id,
-                            severity: Severity::Info,
-                        },
+                        SpanRecord::event(id, Severity::Info),
                         ratio,
                         sampling_position(id),
                     )
@@ -1206,16 +1536,10 @@ mod tests {
         let q2 = init_tracing(&TracingConfig::default());
         // Both calls return a usable queue; with export off, pushing still drops-and-counts when
         // full, proving the queue is real independent of the exporter.
-        assert!(q1.push(SpanRecord {
-            id: 1,
-            severity: Severity::Info
-        }));
+        assert!(q1.push(SpanRecord::event(1, Severity::Info)));
         // The second queue is a distinct, usable, empty buffer (a fresh allocation per call).
         assert!(q2.is_empty(), "a fresh queue starts empty");
-        assert!(q2.push(SpanRecord {
-            id: 2,
-            severity: Severity::Info
-        }));
+        assert!(q2.push(SpanRecord::event(2, Severity::Info)));
         assert_eq!(q2.len(), 1, "the second queue accepts a push");
     }
 
@@ -1233,10 +1557,7 @@ mod tests {
         // buffer (an exporter, were one running, would have drained them). This is the observable that
         // no export work happened.
         for id in 0..8 {
-            assert!(queue.push(SpanRecord {
-                id,
-                severity: Severity::Info
-            }));
+            assert!(queue.push(SpanRecord::event(id, Severity::Info)));
         }
         assert_eq!(
             queue.len(),
@@ -1248,5 +1569,137 @@ mod tests {
             before_dropped,
             "no drop occurred below capacity and no background export touched the counter"
         );
+    }
+
+    // ---- Distributed-trace context (#770), the ALWAYS-ON plain-data half (no `otlp` feature) ----
+
+    use ironbus_core::trace_context::TraceParent;
+
+    /// A known W3C context for the distributed-tracing tests.
+    fn sample_traceparent() -> TraceParent {
+        TraceParent::parse(b"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+            .expect("the sample context parses")
+    }
+
+    #[test]
+    fn a_produce_with_a_traceparent_continues_the_client_trace() {
+        // A produce carrying an inbound `traceparent` (found in the headers blob) builds a PRODUCER
+        // span that CONTINUES the client's trace: same trace id, and the inbound span id as PARENT.
+        let headers = b"traceparent: 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+        let parent = TraceParent::from_headers(headers);
+        let rec = SpanRecord::produce(42, Severity::Info, parent);
+        assert_eq!(rec.ctx.kind, SpanKindTag::Producer);
+        assert_eq!(
+            rec.ctx.trace_id,
+            sample_traceparent().trace_id,
+            "the produce span adopts the client's trace id"
+        );
+        assert_eq!(
+            rec.ctx.parent_span_id,
+            sample_traceparent().parent_id,
+            "the inbound span id becomes the produce span's parent"
+        );
+        assert_eq!(rec.ctx.link_count, 0, "a producer span carries no links");
+    }
+
+    #[test]
+    fn a_produce_without_a_traceparent_is_a_root_producer() {
+        // No inbound context => a NEW ROOT producer span (today's behavior), still tagged Producer.
+        let rec = SpanRecord::produce(7, Severity::Info, TraceParent::from_headers(b"no context"));
+        assert_eq!(rec.ctx.kind, SpanKindTag::Producer);
+        assert_eq!(
+            rec.ctx.trace_id, [0u8; 16],
+            "root: trace id derived from span id"
+        );
+        assert_eq!(rec.ctx.parent_span_id, [0u8; 8], "root: no parent");
+    }
+
+    #[test]
+    fn a_deliver_links_the_consume_span_back_to_the_producing_span() {
+        // The OTLP messaging convention: a deliver/ack opens a CONSUMER span that LINKS to the
+        // producing context read off the delivered record's stored `traceparent` (same trace id, the
+        // producing span id). It is a LINK, not a parent, because one deliver can batch many records.
+        let tp = sample_traceparent();
+        let rec = SpanRecord::consume(99, Severity::Info, &[tp]);
+        assert_eq!(rec.ctx.kind, SpanKindTag::Consumer);
+        assert_eq!(rec.ctx.link_count, 1);
+        assert_eq!(
+            rec.ctx.links[0].trace_id, tp.trace_id,
+            "link is in the producer's trace"
+        );
+        assert_eq!(
+            rec.ctx.links[0].span_id, tp.parent_id,
+            "link targets the producing span id"
+        );
+        assert_eq!(
+            rec.ctx.parent_span_id, [0u8; 8],
+            "a consume span parents on nothing"
+        );
+    }
+
+    #[test]
+    fn a_batch_deliver_dedups_and_caps_its_producer_links() {
+        // A batch deliver links to each DISTINCT producer, deduped, and CAPPED at MAX_SPAN_LINKS so
+        // the link surface stays bounded no matter how large the batch.
+        let mut producers = Vec::new();
+        // 3 copies of one producer (must collapse to a single link) ...
+        for _ in 0..3 {
+            producers.push(sample_traceparent());
+        }
+        // ... then MAX_SPAN_LINKS + 5 DISTINCT producers (only the cap's worth are kept).
+        for i in 0..(MAX_SPAN_LINKS + 5) {
+            let mut trace_id = [0u8; 16];
+            trace_id[0] = 0xAA;
+            trace_id[15] = u8::try_from(i + 1).unwrap_or(0xFF);
+            let mut parent_id = [0u8; 8];
+            parent_id[7] = u8::try_from(i + 1).unwrap_or(0xFF);
+            producers.push(TraceParent {
+                trace_id,
+                parent_id,
+                flags: 1,
+            });
+        }
+        let rec = SpanRecord::consume(1, Severity::Info, &producers);
+        assert_eq!(
+            rec.ctx.link_count, MAX_SPAN_LINKS,
+            "the link count is capped at MAX_SPAN_LINKS"
+        );
+        // The kept links are all distinct.
+        for i in 0..rec.ctx.link_count {
+            for j in (i + 1)..rec.ctx.link_count {
+                assert_ne!(
+                    rec.ctx.links[i], rec.ctx.links[j],
+                    "kept links are distinct"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn a_deliver_of_a_record_with_no_stored_traceparent_carries_no_link() {
+        // A record whose stored headers hold no (or a malformed) `traceparent` contributes no link:
+        // the consume span is a plain Consumer with an empty link set, never an error.
+        let none: Vec<TraceParent> = Vec::new();
+        let rec = SpanRecord::consume(5, Severity::Info, &none);
+        assert_eq!(rec.ctx.kind, SpanKindTag::Consumer);
+        assert_eq!(rec.ctx.link_count, 0);
+    }
+
+    #[test]
+    fn an_event_span_is_the_pre_770_internal_default() {
+        // The plain event/severity path is byte-for-byte the pre-#770 shape: Internal kind, a root
+        // trace derived from the id, no parent, no links.
+        let rec = SpanRecord::event(3, Severity::Error);
+        assert_eq!(rec.ctx.kind, SpanKindTag::Internal);
+        assert_eq!(rec.ctx, SpanTraceContext::internal());
+        assert_eq!(rec.ctx.trace_id, [0u8; 16]);
+        assert_eq!(rec.ctx.parent_span_id, [0u8; 8]);
+        assert_eq!(rec.ctx.link_count, 0);
+    }
+
+    #[test]
+    fn a_server_span_carries_the_server_kind() {
+        let rec = SpanRecord::server(1, Severity::Info);
+        assert_eq!(rec.ctx.kind, SpanKindTag::Server);
     }
 }

--- a/crates/ironbus-server/src/session.rs
+++ b/crates/ironbus-server/src/session.rs
@@ -1673,6 +1673,12 @@ impl Session {
             // accepted record to its level (c0/c1/c2) for the per-ack-level produce counters.
             ack_level,
         };
+        // DISTRIBUTED-TRACING PRODUCER span (#770): emitted for an ACCEPTED produce (all pre-submit
+        // rejections/redirects returned above), CONTINUING the client's trace when the produce carried
+        // a W3C `traceparent` in its headers (else a new root); a malformed/absent context is treated
+        // as absent and never rejects the produce. Head-sampled + bounded-lossy; a `None` sink (export
+        // off) is a zero-cost no-op. Emitted BEFORE `append` moves into the submit below.
+        emit_produce_span(engine.span_sink(), msg.headers);
         // LEVEL 0 (no-ack fast path, #495): submit the produce with NO reply channel and return
         // immediately — do NOT park. The producer fired and forgot, so there is no PubAck to write, no
         // reply-channel allocation, and no fsync to wait for. The connection-thread byte-cap pre-check
@@ -2334,6 +2340,11 @@ impl Session {
         let longpoll_cell = engine.commit_notify().map(|n| n.cell(&self.stream));
         let longpoll_budget = std::time::Duration::from_millis(self.consume_longpoll_ms);
         let longpoll_start = std::time::Instant::now();
+        // DISTRIBUTED-TRACING sink (#770): hoisted ONCE per flow, so a delivered record emits a
+        // CONSUMER span linking back to its producer WITHOUT a per-record sink lookup. `None` (a broker
+        // without `--enable-otlp-export`) makes every per-record emission a zero-cost no-op, so the
+        // deliver hot path is byte-for-byte unchanged by default.
+        let span_sink = engine.span_sink();
         loop {
             // FRESH per-pass generation snapshot, taken BEFORE this pass's drain (lost-wakeup safety and
             // stale-snapshot avoidance, see above).
@@ -2409,6 +2420,16 @@ impl Session {
                         // error the partial frame is rolled off `out` and the batch stops.
                         if encode_deliver_frame(&msg, out).is_err() {
                             break;
+                        }
+                        // DISTRIBUTED-TRACING CONSUMER span (#770): a delivered record opens a Consumer
+                        // span that LINKS back to the PRODUCING span read off the record's STORED
+                        // `traceparent` header (same trace id, the producing span id) — the
+                        // producer -> consumer link. Per the OTLP messaging convention a consume span
+                        // LINKS (not parents), since one flow can deliver many produced records. A
+                        // malformed/absent stored `traceparent` simply contributes no link. Head-sampled
+                        // + bounded-lossy; `None` sink is a zero-cost no-op.
+                        if let Some(sink) = &span_sink {
+                            emit_consume_span(sink, &d.record.headers);
                         }
                         // Record ownership so only this session can later act on this lease (#175), and
                         // the message's byte size so the byte budget (#275) is derived from `leased`. The
@@ -4902,6 +4923,40 @@ fn lease_bytes(record: &ironbus_storage::segment::OwnedRecord) -> u64 {
         .saturating_add(record.headers.len())
         .saturating_add(record.payload.len());
     u64::try_from(len).unwrap_or(u64::MAX)
+}
+
+/// Emits a distributed-tracing PRODUCER span (#770) for an accepted produce over the produce's wire
+/// `headers`. When the headers carry a W3C `traceparent`, the span CONTINUES the client's trace
+/// (adopts the trace id, parents on the inbound span id); a malformed or absent context yields a new
+/// ROOT producer span. Head-sampled + bounded-lossy through the `sink`; a `None` sink (a broker
+/// without OTLP export) returns immediately (a zero-cost no-op), so the produce hot path is byte-for-
+/// byte unchanged by default. Takes the resolved `Option<SpanSink>` (not the engine) so it needs no
+/// generic engine bound.
+fn emit_produce_span(sink: Option<crate::obs::SpanSink>, headers: &[u8]) {
+    if let Some(sink) = sink {
+        let parent = ironbus_core::trace_context::TraceParent::from_headers(headers);
+        sink.emit(crate::obs::SpanRecord::produce(
+            crate::obs::next_span_id(),
+            crate::obs::Severity::Info,
+            parent,
+        ));
+    }
+}
+
+/// Emits a distributed-tracing CONSUMER span (#770) for a delivered record over its STORED `headers`,
+/// LINKING back to the producing span read off the record's `traceparent` (same trace id, the
+/// producing span id) — the producer -> consumer link. A malformed or absent stored context simply
+/// contributes no link (the consume span is still emitted). Head-sampled + bounded-lossy through the
+/// `sink`. Called only when a sink is present (hoisted once per flow), so the caller owns the
+/// `None` fast-path.
+fn emit_consume_span(sink: &crate::obs::SpanSink, headers: &[u8]) {
+    let producer = ironbus_core::trace_context::TraceParent::from_headers(headers);
+    let producers: Vec<ironbus_core::trace_context::TraceParent> = producer.into_iter().collect();
+    sink.emit(crate::obs::SpanRecord::consume(
+        crate::obs::next_span_id(),
+        crate::obs::Severity::Info,
+        &producers,
+    ));
 }
 
 /// Combines two byte budgets into the EFFECTIVE one, where `0` means UNLIMITED on EITHER side (#489,
@@ -9061,6 +9116,161 @@ mod tests {
         s.process(e, &frame(FrameType::Pub, &pub_body), &mut out)
             .unwrap();
         out
+    }
+
+    #[test]
+    fn distributed_tracing_links_a_produce_span_to_the_matching_consume_span_end_to_end() {
+        // The #770 END-TO-END proof: a produce carrying a W3C `traceparent` in its headers, driven
+        // THROUGH the session's produce path, emits a PRODUCER span parented to the inbound span id
+        // onto the SAME bounded queue the OTLP exporter drains; the matching deliver (Flow) emits a
+        // CONSUMER span carrying a SpanLink back to that producing span. This exercises the real
+        // emission sites (`handle_pub` + `handle_flow`), not the data model in isolation.
+        use crate::obs::{BoundedSpanQueue, SpanKindTag, SpanSink};
+        use ironbus_core::trace_context::TraceParent;
+
+        // The known W3C context the "client" stamps into the produce headers (the W3C example vector).
+        let traceparent: &[u8] =
+            b"traceparent: 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+        let expected = TraceParent::from_headers(traceparent).expect("the sample context parses");
+
+        // An engine wired to a REAL span sink at full sampling, so emission actually lands on the queue.
+        let queue = Arc::new(BoundedSpanQueue::with_capacity(64));
+        let e = DirectEngine::new(engine()).with_span_sink(SpanSink::new(Arc::clone(&queue), 1.0));
+        let mut s = Session::new();
+        let mut out = Vec::new();
+        s.process(&e, &frame(FrameType::Connect, b""), &mut out)
+            .unwrap();
+
+        // PRODUCE through the session carrying the traceparent in the headers.
+        out.clear();
+        let mut pub_body = Vec::new();
+        encode_pub(
+            &PubBody {
+                flags: 0,
+                timestamp_ms: 0,
+                key: b"",
+                headers: traceparent,
+                dedup: None,
+                fire_and_forget: false,
+                payload: b"p",
+            },
+            &mut pub_body,
+        )
+        .unwrap();
+        s.process(&e, &frame(FrameType::Pub, &pub_body), &mut out)
+            .unwrap();
+
+        // CONSUME (Flow): the record is delivered, emitting the Consumer span.
+        out.clear();
+        s.process(&e, &frame(FrameType::Flow, &1u32.to_le_bytes()), &mut out)
+            .unwrap();
+        assert!(
+            !delivered_tokens(&out).is_empty(),
+            "the produced record was delivered"
+        );
+        // ROUND-TRIP (#770 acceptance 2): the traceparent read back off the DURABLE record's stored
+        // headers is byte-identical to what the client sent in.
+        let frames = decode_all(&out);
+        let deliver = frames
+            .iter()
+            .find(|(ty, _)| *ty == FrameType::Deliver)
+            .expect("a Deliver frame");
+        let delivered =
+            ironbus_proto::message::decode_deliver(&deliver.1).expect("a valid Deliver body");
+        assert_eq!(
+            delivered.headers, traceparent,
+            "the traceparent round-trips byte-identically off the durable record"
+        );
+
+        // Drain the queue the exporter would drain, and inspect the emitted spans.
+        let spans = queue.drain();
+        let producer = spans
+            .iter()
+            .find(|r| r.ctx.kind == SpanKindTag::Producer)
+            .expect("a Producer span was emitted for the produce");
+        assert_eq!(
+            producer.ctx.trace_id, expected.trace_id,
+            "the produce span continues the client's trace"
+        );
+        assert_eq!(
+            producer.ctx.parent_span_id, expected.parent_id,
+            "the produce span parents on the inbound span id (not a root)"
+        );
+
+        let consumer = spans
+            .iter()
+            .find(|r| r.ctx.kind == SpanKindTag::Consumer)
+            .expect("a Consumer span was emitted for the deliver");
+        assert_eq!(
+            consumer.ctx.link_count, 1,
+            "the consume span links to exactly the producing span"
+        );
+        assert_eq!(
+            consumer.ctx.links[0].trace_id, expected.trace_id,
+            "the link is in the producer's trace"
+        );
+        assert_eq!(
+            consumer.ctx.links[0].span_id, expected.parent_id,
+            "the link targets the producing span id (producer -> consumer correlation)"
+        );
+    }
+
+    #[test]
+    fn a_malformed_produce_traceparent_is_absent_and_the_produce_still_succeeds() {
+        // A malformed `traceparent` in the produce headers is treated as ABSENT: the produce is NOT
+        // rejected (it is durably produced and delivered), and its Producer span is a ROOT (no parent),
+        // never an error. This is the defensive-parse contract on the live produce path.
+        use crate::obs::{BoundedSpanQueue, SpanKindTag, SpanSink};
+
+        let queue = Arc::new(BoundedSpanQueue::with_capacity(16));
+        let e = DirectEngine::new(engine()).with_span_sink(SpanSink::new(Arc::clone(&queue), 1.0));
+        let mut s = Session::new();
+        let mut out = Vec::new();
+        s.process(&e, &frame(FrameType::Connect, b""), &mut out)
+            .unwrap();
+
+        out.clear();
+        let mut pub_body = Vec::new();
+        encode_pub(
+            &PubBody {
+                flags: 0,
+                timestamp_ms: 0,
+                key: b"",
+                headers: b"traceparent: not-a-valid-w3c-value",
+                dedup: None,
+                fire_and_forget: false,
+                payload: b"p",
+            },
+            &mut pub_body,
+        )
+        .unwrap();
+        // The produce SUCCEEDS (process returns Ok, the connection stays open) despite the bad context.
+        s.process(&e, &frame(FrameType::Pub, &pub_body), &mut out)
+            .expect("a malformed traceparent must not reject the produce");
+
+        // The record is durably produced: a Flow delivers it.
+        out.clear();
+        s.process(&e, &frame(FrameType::Flow, &1u32.to_le_bytes()), &mut out)
+            .unwrap();
+        assert!(
+            !delivered_tokens(&out).is_empty(),
+            "the produce still committed and delivered despite the malformed traceparent"
+        );
+
+        // The Producer span is a ROOT: the malformed context was dropped (absent), not adopted.
+        let spans = queue.drain();
+        let producer = spans
+            .iter()
+            .find(|r| r.ctx.kind == SpanKindTag::Producer)
+            .expect("a Producer span was still emitted");
+        assert_eq!(
+            producer.ctx.parent_span_id, [0u8; 8],
+            "a malformed traceparent yields a root producer span (no parent)"
+        );
+        assert_eq!(
+            producer.ctx.trace_id, [0u8; 16],
+            "a malformed traceparent yields a root trace (derived from the span id)"
+        );
     }
 
     /// A mock whose produce path always reports the durable-log byte cap (drop-new) shed.


### PR DESCRIPTION
## What & why

Closes #770 — the **distributed half** of OpenTelemetry tracing and the last open item in **V2-M6**.

The observability seam already recorded spans (bounded-lossy queue #99) and could export them (otlp-gated OTLP exporter #352), but every exported span was **disconnected** (`parent_span_id: INVALID`, `span_kind: Internal`, `links: default`) **and nothing pushed per-message spans to the queue** — so a produce on one connection and its matching deliver on another could not be correlated. This PR (1) propagates the W3C trace context across the bus and (2) **emits** the produce/deliver spans so the correlation actually happens end-to-end in a running broker.

First principle (from the issue): distributed correlation is a **context-propagation** problem — the only thing that must cross the bus is the W3C context bytes on the record.

## How

**Carrier = the message HEADERS.** No new frame tag, no on-disk format change. The **client** stamps a W3C `traceparent` into the record's header blob; the broker reads it back off the stored record on delivery. Headers survive byte-for-byte, so round-trip fidelity is free.

**Trace-context codec** (`ironbus-core::trace_context`, pure, dep-free, always-on): `TraceParent::parse` / `from_headers` / `to_header_value`. Defensive — malformed/all-zero/reserved-`ff`/wrong-length → `None`, never an error.

**Span data model** (`obs.rs`, always-on plain data, no `opentelemetry` on the default build): `SpanRecord` carries a `SpanTraceContext { kind, trace_id, parent_span_id, links[MAX_SPAN_LINKS=8], link_count }`. Produce → `SpanKind::Producer` continuing the client's trace (adopts trace-id, parents on the inbound span-id) or a new root; deliver → `SpanKind::Consumer` with a `SpanLink` back to each **distinct** producing span (deduped, capped at 8).

**Exporter** (`record_to_span_data`, feature-gated): populates `parent_span_id`, `span_kind`, `links`, and `messaging.system`/`messaging.operation` from the context.

**Emission wiring (this makes it real end-to-end):**
- `SpanSink` (obs.rs): the always-on emission handle pairing the **same** bounded-lossy queue the exporter drains with the head-sampling ratio. `emit` applies the identical `should_sample` gate #99 uses **before** the bounded push; a sampled-out span never touches the queue. `next_span_id` is a process-monotonic id source. No `opentelemetry` — only the drain is gated.
- Engine ferry (actor.rs): `EngineAccess::span_sink()` (default `None` = zero-cost no-op). `EngineHandle` carries an `Arc<OnceLock<SpanSink>>` installed once at serve start via `set_span_sink` (mirrors the client-ack slot / watchdog setter), shared on clone so every connection reaches the one sink.
- Sites (session.rs): `handle_pub` emits the Producer span over the produce's headers; `handle_flow` emits a Consumer span per delivered record over the record's stored headers. `None` sink → zero-cost no-op, so the **default hot path is byte-for-byte unchanged**.
- CLI (main.rs): builds the `SpanSink` from the retained span queue when `--enable-otlp-export` is on and installs it on the engine handle in `run_broker`. The head-sampling ratio is **env-tunable** (`IRONBUS_OTLP_SAMPLE_RATIO`, clamped `[0,1]`), defaulting to full sampling when export is on (the bounded-lossy queue sheds excess) and `0.0` off — so enabling export now actually produces traces (the #352 exporter was itself dormant at ratio 0.0 with no way to raise it).

## Zero-otel on the default build (proven)

```
DEFAULT graph opentelemetry crates: ironbus-cli 0, ironbus-server 0
--features otlp graph: opentelemetry / opentelemetry_sdk / opentelemetry-otlp v0.27 linked (contrast)
Cargo.lock: byte-unchanged   ·   format.rs / frame.rs untouched -> format-registry unchanged
```
The `traceparent` parse + span-kind/link/emission fields are lightweight always-on plain data; only the **export** is feature-gated.

## Tests (all green, foreground)

- `trace_context` (9): parse/format round-trip, uppercase tolerance, malformed->absent battery, future-version suffix, header carriers, flags verbatim.
- `obs` (25+): produce continues trace / root; deliver links; batch dedup+cap; internal-event = pre-#770 shape; `SpanSink` emits at ratio 1.0 / samples-out at 0.0; `record_to_span_data` Producer parent + Consumer link + messaging attrs + capped links (otlp).
- **End-to-end (session.rs):** a produce carrying a `traceparent` driven **through the session** yields a Producer span parented to the inbound span-id **on the exporter's queue**; the matching deliver yields a Consumer span **linking** to that producer; the traceparent **round-trips byte-identically** off the durable record; a **malformed** traceparent is absent (root span) and the produce still **commits and delivers**.

Gates: `fmt` OK · `clippy 1.97 --workspace --all-targets --all-features -D warnings` OK · `cargo build --all-features` OK · `cargo test --workspace --all-features` **0 failed** · golden-path acceptance **PASS** · format-registry unchanged. **Runtime-verified:** the broker boots with `--enable-otlp-export` (the `set_span_sink` path).

## For reviewer attention

- **Malformed handling:** parsing is total (`Option`), never erroring — a bad `traceparent` is treated as absent, so it can never reject a produce (proven by the malformed end-to-end test: produce still commits + delivers).
- **Link semantics:** the consume span links to the record's **stored producing context** (client trace-id + span-id) — the only thing that crosses the bus. The produce span shares that trace-id and parents on that same span-id, so produce and consume land in one trace.
- **Link cap** = 8, deduped by `(trace-id, span-id)`; excess distinct producers dropped.
- **Head-sampling / bounded-lossy discipline:** `emit` reuses #99's `should_sample` gate before the bounded push; a `None` sink is a zero-cost no-op, so a non-tracing broker's hot path is unchanged. Ratio is env-tunable; the fixed full-sampling default when export is on relies on the bounded-lossy queue as the safety valve (a dedicated `--otlp-sample-ratio` flag was deliberately left out to avoid touching ~15 `ServeConfig` construction sites — the env knob provides tunability without that churn).
- **`messaging.destination.name`** is intentionally not carried: the plain-PUB default-log path has no per-message destination string, and adding a name buffer to the bounded `Copy` span record is a deliberate follow-up; the required `messaging.system` + `messaging.operation` anchor keys are emitted.
- **No format / no default-dep leak:** headers already carry arbitrary bytes; `Cargo.lock` unchanged, default graph opentelemetry-free.
- **Ack/settle span** is not emitted: settling by (offset, generation) has no record headers in scope without an engine read, and the deliver span already carries the producer->consumer link (the #770 correlation). Flagged as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01McmNfYNWPmohVS8umY9Lkp
