### PR TITLE
feat(consume): seek-by-time + time-bounded replay via .tindex sidecar (#772)

### DIFF
--- a/crates/ironbus-cli/src/config_file.rs
+++ b/crates/ironbus-cli/src/config_file.rs
@@ -150,6 +150,7 @@ fn key_to_env_name(key: &str) -> Option<&'static str> {
         "storage.segment_size" => "IRONBUS_MAX_SEGMENT_BYTES",
         "storage.data_dir" => "IRONBUS_DATA_DIR",
         "storage.max_total_bytes" => "IRONBUS_MAX_TOTAL_BYTES",
+        "storage.tindex_stride_records" => "IRONBUS_TINDEX_STRIDE_RECORDS",
         "storage.io_mode" => "IRONBUS_IO_MODE",
         "durability.level" => "IRONBUS_DURABILITY_LEVEL",
         "durability.flush_interval_ms" => "IRONBUS_FLUSH_INTERVAL_MS",

--- a/crates/ironbus-cli/src/main.rs
+++ b/crates/ironbus-cli/src/main.rs
@@ -220,6 +220,11 @@ const DEFAULT_MAX_SEGMENT_BYTES: u64 = 64 * 1024 * 1024;
 /// default): the spill-by-default behavior is unchanged until an operator opts in to the shed.
 const DEFAULT_MAX_TOTAL_BYTES: u64 = 0;
 
+/// The default seek-by-time `.tindex` density for `serve` (#772): one sparse timestamp anchor per
+/// this many records, taken from the storage default so the two cannot drift. A pure memory/latency
+/// trade over the seek accelerator; changing it never affects correctness or durability.
+const DEFAULT_TINDEX_STRIDE_RECORDS: u32 = LogConfig::DEFAULT_TINDEX_STRIDE_RECORDS;
+
 /// The default consumer-safe size-retention bound for `serve` (0 = unlimited, retention OFF,
 /// matching the engine default): the broker never reaps old sealed segments until an operator
 /// opts in, so existing behavior is unchanged.
@@ -2445,6 +2450,7 @@ struct ServeFlags {
     consumer_credit_bytes: Option<u64>,
     max_segment_bytes: Option<u64>,
     max_total_bytes: Option<u64>,
+    tindex_stride_records: Option<u32>,
     max_retained_bytes: Option<u64>,
     max_age_ms: Option<u64>,
     max_messages: Option<u64>,
@@ -2786,6 +2792,10 @@ fn collect_serve_flags(args: &[String]) -> Result<ServeFlags, CliError> {
             }
             "--max-total-bytes" => {
                 f.max_total_bytes = Some(take_number("--max-total-bytes", args, &mut i)?);
+            }
+            "--tindex-stride-records" => {
+                f.tindex_stride_records =
+                    Some(take_number("--tindex-stride-records", args, &mut i)?);
             }
             "--max-retained-bytes" => {
                 f.max_retained_bytes = Some(take_number("--max-retained-bytes", args, &mut i)?);
@@ -3453,6 +3463,12 @@ fn parse_serve_flags_with_env_and_reader(
                 f.max_total_bytes,
                 env,
                 DEFAULT_MAX_TOTAL_BYTES,
+            )?,
+            tindex_stride_records: resolve_number(
+                "--tindex-stride-records",
+                f.tindex_stride_records,
+                env,
+                DEFAULT_TINDEX_STRIDE_RECORDS,
             )?,
             max_retained_bytes: resolve_number(
                 "--max-retained-bytes",
@@ -5279,6 +5295,11 @@ struct ServeConfig {
     /// Hard durable-log total byte cap, the drop-new shed backstop (#10). `0` means unlimited
     /// (the cap is off), which is the default and preserves the spill-by-default behavior.
     max_total_bytes: u64,
+    /// The seek-by-time `.tindex` density (#772): one sparse timestamp anchor per this many records.
+    /// A pure memory/latency trade over the seek-by-time accelerator — smaller scans fewer records
+    /// per seek at a larger sidecar, larger the reverse — that never affects correctness, durability,
+    /// or the segment bytes. Clamped up to 1 by the storage builder.
+    tindex_stride_records: u32,
     /// Consumer-safe size-retention bound (#13, #80): the broker reaps old fully-consumed sealed
     /// segments while the durable log is over this many RECORD bytes. `0` means unlimited
     /// (retention off), the default, so existing behavior is unchanged.
@@ -5604,6 +5625,7 @@ impl ServeConfig {
             consumer_credit_bytes: DEFAULT_CONSUMER_CREDIT_BYTES,
             max_segment_bytes: DEFAULT_MAX_SEGMENT_BYTES,
             max_total_bytes: DEFAULT_MAX_TOTAL_BYTES,
+            tindex_stride_records: DEFAULT_TINDEX_STRIDE_RECORDS,
             max_retained_bytes: DEFAULT_MAX_RETAINED_BYTES,
             max_age_ms: DEFAULT_MAX_AGE_MS,
             max_messages: DEFAULT_MAX_MESSAGES,
@@ -10268,7 +10290,8 @@ fn open_engine_with<F: Filesystem + Clone>(
             // layers on the durable-log total byte cap (the drop-new shed; `0` = unlimited).
             log: LogConfig::new(config.max_segment_bytes)
                 .map_err(|e| CliError::Internal(format!("log config: {e}")))?
-                .with_max_total_bytes(config.max_total_bytes),
+                .with_max_total_bytes(config.max_total_bytes)
+                .with_tindex_stride_records(config.tindex_stride_records),
             lease: LeaseConfig::from_millis(visibility_ms, visibility_ms.max(DEFAULT_HARD_CAP_MS)),
             delivery,
             max_in_flight: config.max_in_flight,
@@ -14015,6 +14038,7 @@ mod tests {
             consumer_credit_bytes: DEFAULT_CONSUMER_CREDIT_BYTES,
             max_segment_bytes: DEFAULT_MAX_SEGMENT_BYTES,
             max_total_bytes: DEFAULT_MAX_TOTAL_BYTES,
+            tindex_stride_records: DEFAULT_TINDEX_STRIDE_RECORDS,
             max_retained_bytes: DEFAULT_MAX_RETAINED_BYTES,
             max_age_ms: DEFAULT_MAX_AGE_MS,
             max_messages: DEFAULT_MAX_MESSAGES,
@@ -17686,6 +17710,7 @@ mod tests {
             consumer_credit_bytes: DEFAULT_CONSUMER_CREDIT_BYTES,
             max_segment_bytes: DEFAULT_MAX_SEGMENT_BYTES,
             max_total_bytes: DEFAULT_MAX_TOTAL_BYTES,
+            tindex_stride_records: DEFAULT_TINDEX_STRIDE_RECORDS,
             max_retained_bytes: DEFAULT_MAX_RETAINED_BYTES,
             max_age_ms: DEFAULT_MAX_AGE_MS,
             max_messages: DEFAULT_MAX_MESSAGES,

--- a/crates/ironbus-cli/src/main.rs
+++ b/crates/ironbus-cli/src/main.rs
@@ -5301,7 +5301,10 @@ struct ServeConfig {
     /// The seek-by-time `.tindex` density (#772): one sparse timestamp anchor per this many records.
     /// A pure memory/latency trade over the seek-by-time accelerator — smaller scans fewer records
     /// per seek at a larger sidecar, larger the reverse — that never affects correctness, durability,
-    /// or the segment bytes. Clamped up to 1 by the storage builder.
+    /// or the segment bytes. Clamped up to 1 by the storage builder. Consumed only by the broker
+    /// serve path (`.with_tindex_stride_records`), which is `#[cfg(unix)]`-gated, so on a non-unix
+    /// target the field is set-but-unread — allow the dead-code lint there rather than gate the field.
+    #[cfg_attr(not(unix), allow(dead_code))]
     tindex_stride_records: u32,
     /// Consumer-safe size-retention bound (#13, #80): the broker reaps old fully-consumed sealed
     /// segments while the durable log is over this many RECORD bytes. `0` means unlimited

--- a/crates/ironbus-cli/src/main.rs
+++ b/crates/ironbus-cli/src/main.rs
@@ -221,9 +221,12 @@ const DEFAULT_MAX_SEGMENT_BYTES: u64 = 64 * 1024 * 1024;
 const DEFAULT_MAX_TOTAL_BYTES: u64 = 0;
 
 /// The default seek-by-time `.tindex` density for `serve` (#772): one sparse timestamp anchor per
-/// this many records, taken from the storage default so the two cannot drift. A pure memory/latency
-/// trade over the seek accelerator; changing it never affects correctness or durability.
-const DEFAULT_TINDEX_STRIDE_RECORDS: u32 = LogConfig::DEFAULT_TINDEX_STRIDE_RECORDS;
+/// this many records. A pure memory/latency trade over the seek accelerator; changing it never
+/// affects correctness or durability. A literal (not `LogConfig::DEFAULT_TINDEX_STRIDE_RECORDS`)
+/// because the `LogConfig` import is `#[cfg(unix)]`-gated with the rest of the broker run, so a path
+/// reference would not resolve on non-unix targets; kept equal to the storage default (asserted in a
+/// test) so the two cannot silently drift.
+const DEFAULT_TINDEX_STRIDE_RECORDS: u32 = 1024;
 
 /// The default consumer-safe size-retention bound for `serve` (0 = unlimited, retention OFF,
 /// matching the engine default): the broker never reaps old sealed segments until an operator
@@ -13957,6 +13960,17 @@ mod tests {
     use std::net::TcpListener;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
+
+    #[test]
+    fn tindex_stride_default_matches_the_storage_default() {
+        // The CLI default is a LITERAL (the `LogConfig` import is `#[cfg(unix)]`-gated, so a path
+        // reference would not build on Windows); pin it to the storage source of truth so they can
+        // never silently drift (#772).
+        assert_eq!(
+            DEFAULT_TINDEX_STRIDE_RECORDS,
+            LogConfig::DEFAULT_TINDEX_STRIDE_RECORDS
+        );
+    }
 
     /// Spawns the append actor over `engine` and a wire server bound to an ephemeral port, returning
     /// the address, the shutdown flag, the server join handle, and the actor join handle (so the test

--- a/crates/ironbus-client-async/src/lib.rs
+++ b/crates/ironbus-client-async/src/lib.rs
@@ -1573,6 +1573,8 @@ impl AsyncClient {
         start_offset: u64,
         max_records: u32,
         max_bytes: u64,
+        start_time_ms: Option<u64>,
+        end_time_ms: Option<u64>,
     ) -> Result<usize, ClientError> {
         let max_records = match self.negotiated_credit {
             Some(credit) => max_records.min(credit),
@@ -1584,6 +1586,8 @@ impl AsyncClient {
                 start_offset,
                 max_records,
                 max_bytes,
+                start_time_ms,
+                end_time_ms,
             },
             &mut body,
         );
@@ -1634,7 +1638,32 @@ impl AsyncClient {
         max_bytes: u64,
     ) -> Result<Fetch, ClientError> {
         let limit = self
-            .send_stream_fetch(start_offset, max_records, max_bytes)
+            .send_stream_fetch(start_offset, max_records, max_bytes, None, None)
+            .await?;
+        self.read_stream_fetch_response(limit).await
+    }
+
+    /// STREAMING (Tier-S) SEEK-BY-TIME fetch (#772): the async wall-clock twin of
+    /// [`AsyncClient::stream_fetch`]. Delivery begins at the FIRST record whose producer timestamp is
+    /// at or after `start_time_ms` (milliseconds since the Unix epoch), resolved off the broker's
+    /// sparse per-segment `.tindex`, and is OPTIONALLY bounded above by `end_time_ms` (exclusive) for
+    /// a `[start, end)` time-window replay — NATS `JetStream` `DeliverByStartTime` / Kafka
+    /// `offsetsForTimes` parity. Offset-authoritative and exact versus a full scan even for
+    /// non-monotonic producer timestamps; an old `start_time_ms` clamps to the earliest retained
+    /// offset, a future one starts at the tail. Settle by offset via [`AsyncClient::stream_commit`].
+    ///
+    /// # Errors
+    /// Returns a [`ClientError`] on an IO error, a server error (the group is not streaming, or the
+    /// connection did not negotiate Tier-S), or a server that streams more frames than the cap.
+    pub async fn stream_fetch_by_time(
+        &mut self,
+        start_time_ms: u64,
+        end_time_ms: Option<u64>,
+        max_records: u32,
+        max_bytes: u64,
+    ) -> Result<Fetch, ClientError> {
+        let limit = self
+            .send_stream_fetch(0, max_records, max_bytes, Some(start_time_ms), end_time_ms)
             .await?;
         self.read_stream_fetch_response(limit).await
     }
@@ -2070,6 +2099,8 @@ impl AsyncStreamingConsumer<'_> {
                     self.next_offset,
                     self.window_records(),
                     self.config.max_bytes,
+                    None,
+                    None,
                 )
                 .await?;
             self.prefetch = Some(limit);

--- a/crates/ironbus-client/src/lib.rs
+++ b/crates/ironbus-client/src/lib.rs
@@ -2535,6 +2535,8 @@ impl Client {
         start_offset: u64,
         max_records: u32,
         max_bytes: u64,
+        start_time_ms: Option<u64>,
+        end_time_ms: Option<u64>,
     ) -> Result<usize, ClientError> {
         let max_records = match self.negotiated_credit {
             Some(credit) => max_records.min(credit),
@@ -2544,6 +2546,8 @@ impl Client {
             start_offset,
             max_records,
             max_bytes,
+            start_time_ms,
+            end_time_ms,
         };
         let mut body = Vec::new();
         encode_stream_fetch(&req, &mut body);
@@ -2599,7 +2603,33 @@ impl Client {
         max_records: u32,
         max_bytes: u64,
     ) -> Result<Fetch, ClientError> {
-        let limit = self.send_stream_fetch(start_offset, max_records, max_bytes)?;
+        let limit = self.send_stream_fetch(start_offset, max_records, max_bytes, None, None)?;
+        self.read_stream_fetch_response(limit)
+    }
+
+    /// STREAMING (Tier-S) SEEK-BY-TIME fetch (#772): the wall-clock twin of [`Client::stream_fetch`].
+    /// Instead of a consumer-managed offset, delivery begins at the FIRST record whose producer
+    /// timestamp is at or after `start_time_ms` (milliseconds since the Unix epoch), resolved off the
+    /// broker's sparse per-segment `.tindex`, and is OPTIONALLY bounded above by `end_time_ms`
+    /// (exclusive) for a `[start, end)` time-window replay. This reaches NATS `JetStream`
+    /// `DeliverByStartTime` / Kafka `offsetsForTimes` parity. The resolution is offset-authoritative
+    /// and exact versus a full scan even for non-monotonic producer timestamps; a `start_time_ms`
+    /// older than the earliest retained record clamps to the earliest offset, and one newer than
+    /// every record starts at the tail. `max_records` / `max_bytes` bound the batch exactly as
+    /// [`Client::stream_fetch`]. Settle by offset via [`Client::stream_commit`], never [`Client::ack`].
+    ///
+    /// # Errors
+    /// Returns a [`ClientError`] on an IO error, a server error (the group is not streaming, or the
+    /// connection did not negotiate Tier-S), or a server that streams more frames than the cap.
+    pub fn stream_fetch_by_time(
+        &mut self,
+        start_time_ms: u64,
+        end_time_ms: Option<u64>,
+        max_records: u32,
+        max_bytes: u64,
+    ) -> Result<Fetch, ClientError> {
+        let limit =
+            self.send_stream_fetch(0, max_records, max_bytes, Some(start_time_ms), end_time_ms)?;
         self.read_stream_fetch_response(limit)
     }
 
@@ -3919,6 +3949,8 @@ impl StreamingConsumer<'_> {
                 self.next_offset,
                 self.window_records(),
                 self.config.max_bytes,
+                None,
+                None,
             )?;
             self.prefetch = Some(limit);
         }
@@ -9019,6 +9051,7 @@ toYtkjmdU2eQ2pK/3gM=
                 start_offset: 0,
                 max_records: 1_000,
                 max_bytes: 0,
+                ..StreamFetchBody::default()
             },
             &mut body,
         );

--- a/crates/ironbus-proto/src/message.rs
+++ b/crates/ironbus-proto/src/message.rs
@@ -2301,16 +2301,22 @@ pub const STREAM_FETCH_BODY_VERSION: u8 = 1;
 /// which removes exactly the per-record cost that makes single-consumer durable consume lose to NATS.
 ///
 /// Layout (version+length framed, forward-compatible, mirroring [`FetchBody`]): `body_version: u8`
-/// ([`STREAM_FETCH_BODY_VERSION`]), `field_len: u16` (the length of the v1 known-field block that
-/// follows), then the v1 block: `start_offset: u64 LE`, `max_records: u32 LE`, `max_bytes: u64 LE`.
-/// Bytes past `field_len` (a future version's appended fields) are TOLERATED and ignored by a v1
-/// reader.
+/// ([`STREAM_FETCH_BODY_VERSION`]), `field_len: u16` (the length of the known-field block that
+/// follows), then the v1 block: `start_offset: u64 LE`, `max_records: u32 LE`, `max_bytes: u64 LE`,
+/// OPTIONALLY followed by the additive seek-by-time block (#772): `start_time_ms: u64 LE`,
+/// `end_time_ms: u64 LE`. The time block is present iff `field_len` exceeds the v1 length; when a
+/// fetch carries NO time bound the encoder appends nothing, so an offset-only `StreamFetch` is
+/// BYTE-IDENTICAL to before this feature. Within the block a time of `0` is the "unset" sentinel
+/// (epoch-0 is not a meaningful seek target — a start seek to time 0 is the earliest offset, an end
+/// bound of 0 is no upper bound), so each of `start_time_ms`/`end_time_ms` maps `0 <-> None`. Bytes
+/// past `field_len` (a future version's appended fields) are TOLERATED and ignored.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct StreamFetchBody {
     /// The consumer-managed offset to begin the contiguous read at (inclusive). The consumer owns this
     /// position: it is normally the consumer's last committed offset, so a reconnect resumes exactly
     /// where it left off. The broker reads forward from here off the durable prefix, bounded by the
-    /// flushed frontier (no un-flushed record is ever served).
+    /// flushed frontier (no un-flushed record is ever served). IGNORED when `start_time_ms` is set
+    /// (seek-by-time takes precedence and resolves its own start offset, #772).
     pub start_offset: u64,
     /// The maximum number of records to deliver in this batch. The server delivers at most this many
     /// (the durable prefix's available records and the byte cap also bind). A value of `0` requests
@@ -2321,30 +2327,60 @@ pub struct StreamFetchBody {
     /// the next record would exceed this, EXCEPT the floor-of-one (a batch always delivers at least one
     /// ready record so a single over-cap record never wedges the consumer).
     pub max_bytes: u64,
+    /// OPTIONAL SEEK-BY-TIME start (#772): when `Some(t)`, delivery begins at the FIRST offset whose
+    /// producer timestamp is `>= t` (milliseconds since the Unix epoch), resolved off the sparse
+    /// per-segment `.tindex`, and `start_offset` is IGNORED (seek-by-time takes precedence). The
+    /// resolution is offset-authoritative and exact versus a full scan even for non-monotonic
+    /// producer timestamps; a `t` older than the earliest retained record clamps to the earliest
+    /// offset, and a `t` newer than every record starts at the tail. `None` uses `start_offset`.
+    pub start_time_ms: Option<u64>,
+    /// OPTIONAL EXCLUSIVE end-time bound (#772): when `Some(t)`, delivery stops before the first
+    /// record whose producer timestamp is `> t`, so the read is bounded to `[start, end)` by time —
+    /// a time-window replay. `None` is unbounded above. Combined with `start_time_ms` this yields a
+    /// `[start_time, end_time]` window (under monotonic producer timestamps it equals filtering a
+    /// full scan by time; the honest non-monotonic caveat is documented on the storage seek).
+    pub end_time_ms: Option<u64>,
 }
 
 /// The number of bytes in the `StreamFetch` v1 known-field block: `start_offset: u64` +
 /// `max_records: u32` + `max_bytes: u64`.
 const STREAM_FETCH_V1_FIELD_LEN: u16 = 8 + 4 + 8;
 
-/// Encodes a `StreamFetch` body onto the end of `out` (#544): the version byte, the v1 field-block
-/// length, then the v1 block.
+/// The number of bytes the additive seek-by-time block appends (#772): `start_time_ms: u64` +
+/// `end_time_ms: u64`. Present in the framed block ONLY when a fetch carries a time bound.
+const STREAM_FETCH_TIME_FIELD_LEN: u16 = 8 + 8;
+
+/// Encodes a `StreamFetch` body onto the end of `out` (#544): the version byte, the field-block
+/// length, then the v1 block. The additive seek-by-time block (#772) is appended ONLY when the fetch
+/// carries a start or end time, so an offset-only fetch is byte-identical to the pre-#772 encoding.
 pub fn encode_stream_fetch(req: &StreamFetchBody, out: &mut Vec<u8>) {
+    let has_time = req.start_time_ms.is_some() || req.end_time_ms.is_some();
+    let field_len = if has_time {
+        STREAM_FETCH_V1_FIELD_LEN + STREAM_FETCH_TIME_FIELD_LEN
+    } else {
+        STREAM_FETCH_V1_FIELD_LEN
+    };
     out.push(STREAM_FETCH_BODY_VERSION);
-    out.extend_from_slice(&STREAM_FETCH_V1_FIELD_LEN.to_le_bytes());
+    out.extend_from_slice(&field_len.to_le_bytes());
     out.extend_from_slice(&req.start_offset.to_le_bytes());
     out.extend_from_slice(&req.max_records.to_le_bytes());
     out.extend_from_slice(&req.max_bytes.to_le_bytes());
+    if has_time {
+        // `0` is the "unset" sentinel for each bound (epoch-0 is not a meaningful seek target).
+        out.extend_from_slice(&req.start_time_ms.unwrap_or(0).to_le_bytes());
+        out.extend_from_slice(&req.end_time_ms.unwrap_or(0).to_le_bytes());
+    }
 }
 
-/// Decodes a `StreamFetch` body (#544), cap-before-alloc and panic-free.
+/// Decodes a `StreamFetch` body (#544, seek-by-time #772), cap-before-alloc and panic-free.
 ///
 /// The body MUST carry the version byte and the `u16` field-length; the v1 known fields are read from
-/// the front of the declared block and any trailing bytes (a future version's appended fields) are
-/// tolerated and ignored. A body too short to hold the `field_len` it declares is a typed
-/// [`BodyError`], never a panic or an over-read (the `field_len` is bounded against the actual body by
-/// [`Reader::take`] BEFORE any read). An EMPTY body is NOT a valid `StreamFetch` (the frame type is
-/// new, with no historical empty case), so it is a typed [`BodyError::Truncated`].
+/// the front of the declared block, then the OPTIONAL seek-by-time block if the block is long enough
+/// to hold it, and any trailing bytes (a future version's appended fields) are tolerated and ignored.
+/// A body too short to hold the `field_len` it declares is a typed [`BodyError`], never a panic or an
+/// over-read (the `field_len` is bounded against the actual body by [`Reader::take`] BEFORE any read).
+/// An EMPTY body is NOT a valid `StreamFetch` (the frame type is new, with no historical empty case),
+/// so it is a typed [`BodyError::Truncated`]. Each time field maps its `0` sentinel to `None`.
 ///
 /// # Errors
 /// Returns [`BodyError::Truncated`] if the body is too short for the version/length header or the
@@ -2363,10 +2399,17 @@ pub fn decode_stream_fetch(body: &[u8]) -> Result<StreamFetchBody, BodyError> {
     let start_offset = fr.u64().unwrap_or(0);
     let max_records = fr.u32().unwrap_or(0);
     let max_bytes = fr.u64().unwrap_or(0);
+    // The additive seek-by-time block (#772) is present iff the declared block extends past the v1
+    // fields. Each field's `0` sentinel decodes to `None`; a partial/absent block defaults to `None`.
+    let start_time_raw = fr.u64().unwrap_or(0);
+    let end_time_raw = fr.u64().unwrap_or(0);
+    let sentinel = |t: u64| (t != 0).then_some(t);
     Ok(StreamFetchBody {
         start_offset,
         max_records,
         max_bytes,
+        start_time_ms: sentinel(start_time_raw),
+        end_time_ms: sentinel(end_time_raw),
     })
 }
 
@@ -4187,10 +4230,64 @@ mod tests {
             start_offset: 0x0102_0304_0506_0708,
             max_records: 256,
             max_bytes: 1 << 20,
+            ..StreamFetchBody::default()
         };
         let mut buf = Vec::new();
         encode_stream_fetch(&req, &mut buf);
         assert_eq!(decode_stream_fetch(&buf).unwrap(), req);
+    }
+
+    #[test]
+    fn stream_fetch_seek_by_time_round_trips_and_is_additive() {
+        // #772: an offset-only fetch is BYTE-IDENTICAL to the pre-seek-by-time encoding (the time
+        // block is appended only when a bound is present), so a default consume is unchanged on the
+        // wire.
+        let offset_only = StreamFetchBody {
+            start_offset: 99,
+            max_records: 8,
+            max_bytes: 0,
+            ..StreamFetchBody::default()
+        };
+        let mut a = Vec::new();
+        encode_stream_fetch(&offset_only, &mut a);
+        // The v1 wire image: version(1) + field_len(2)=20 + 20 bytes of v1 fields = 23 bytes, no time.
+        assert_eq!(a.len(), 1 + 2 + STREAM_FETCH_V1_FIELD_LEN as usize);
+        assert_eq!(decode_stream_fetch(&a).unwrap(), offset_only);
+
+        // A start-only, an end-only, and a both-bounds fetch each round-trip, and each maps its `0`
+        // sentinel to `None`.
+        for req in [
+            StreamFetchBody {
+                start_offset: 0,
+                max_records: 10,
+                max_bytes: 4096,
+                start_time_ms: Some(1_700_000_000_000),
+                end_time_ms: None,
+            },
+            StreamFetchBody {
+                start_offset: 5,
+                max_records: 10,
+                max_bytes: 0,
+                start_time_ms: None,
+                end_time_ms: Some(1_700_000_050_000),
+            },
+            StreamFetchBody {
+                start_offset: 0,
+                max_records: 3,
+                max_bytes: 0,
+                start_time_ms: Some(1),
+                end_time_ms: Some(u64::MAX),
+            },
+        ] {
+            let mut buf = Vec::new();
+            encode_stream_fetch(&req, &mut buf);
+            // The time block adds exactly 16 bytes.
+            assert_eq!(
+                buf.len(),
+                1 + 2 + (STREAM_FETCH_V1_FIELD_LEN + STREAM_FETCH_TIME_FIELD_LEN) as usize
+            );
+            assert_eq!(decode_stream_fetch(&buf).unwrap(), req);
+        }
     }
 
     #[test]
@@ -4211,6 +4308,7 @@ mod tests {
                 start_offset: 1,
                 max_records: 1,
                 max_bytes: 0,
+                ..StreamFetchBody::default()
             },
             &mut wrong,
         );
@@ -4231,6 +4329,7 @@ mod tests {
             start_offset: 42,
             max_records: 7,
             max_bytes: 4096,
+            ..StreamFetchBody::default()
         };
         let mut buf = Vec::new();
         encode_stream_fetch(&req, &mut buf);

--- a/crates/ironbus-server/src/engine.rs
+++ b/crates/ironbus-server/src/engine.rs
@@ -4264,6 +4264,9 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
             // The DLQ must NEVER shed: a poison record is durable evidence, so it carries no daily
             // physical write budget (the flash-wear governor is for the main produce path only, #118).
             daily_physical_write_budget_bytes: 0,
+            // The DLQ inherits the main log's seek-by-time index density (#772); it is a pure
+            // accelerator, harmless if never seeked by time.
+            tindex_stride_records: config.log.tindex_stride_records,
         };
         // The dead-letter TARGET subdirs (#551): the configured dead-letter EXCHANGE's ordered
         // target list, or the single default fixed `dlq/` (byte-identical to today) when none is
@@ -4427,6 +4430,8 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
             max_total_bytes: 0,
             max_quarantine_bytes: 0,
             daily_physical_write_budget_bytes: 0,
+            // Inherit the main log's seek-by-time index density (#772); a pure, harmless accelerator.
+            tindex_stride_records: config.log.tindex_stride_records,
         };
         let txn = if Self::txn_dir_exists(&log) {
             Some(TxnStore::open(
@@ -13782,6 +13787,79 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
             records,
             next_offset,
         })
+    }
+
+    /// Resolves the SEEK-BY-TIME bounds of a Tier-S streaming fetch in the DEFAULT work-group to log
+    /// offsets (#772): `start_time_ms` to the first offset whose producer timestamp is at or after it
+    /// (an inclusive start), and `end_time_ms` to the first offset whose timestamp is strictly after
+    /// it (an EXCLUSIVE end). Either is `None` when the fetch does not carry that bound. Applies the
+    /// SAME wrong-mode guard as [`Engine::stream_fetch_in`] (a streaming fetch belongs to a streaming
+    /// group only), then resolves off the durable log's sparse `.tindex`. The returned offsets are
+    /// offset-authoritative and never below the earliest retained offset (an old time clamps to the
+    /// earliest, a future one to the tail); the caller uses the start as the read's `start_offset` and
+    /// the exclusive end to bound the window.
+    ///
+    /// # Errors
+    /// Returns [`EngineError::CumulativeAckOnWorkGroup`] if the group is not streaming, or a storage
+    /// error from reading a segment during resolution.
+    pub fn stream_resolve_time_in(
+        &mut self,
+        group: &str,
+        start_time_ms: Option<u64>,
+        end_time_ms: Option<u64>,
+    ) -> Result<(Option<Offset>, Option<Offset>), EngineError> {
+        if !self.is_streaming_in(group) {
+            return Err(EngineError::CumulativeAckOnWorkGroup);
+        }
+        let start = start_time_ms
+            .map(|t| self.log.resolve_time_offset(t, true))
+            .transpose()?;
+        let end = end_time_ms
+            .map(|t| self.log.resolve_time_offset(t, false))
+            .transpose()?;
+        Ok((start, end))
+    }
+
+    /// The named-stream twin of [`Engine::stream_resolve_time_in`] (#772): resolves the seek-by-time
+    /// bounds against a NAMED stream's own durable log, reopening an LRU-evicted known stream and
+    /// rejecting a never-declared one exactly as [`Engine::stream_fetch_in_stream`] does, and applying
+    /// the same streaming-group wrong-mode guard. The default stream (`""`) delegates to
+    /// [`Engine::stream_resolve_time_in`].
+    ///
+    /// # Errors
+    /// Returns [`EngineError::UnknownStream`] for a never-declared stream,
+    /// [`EngineError::CumulativeAckOnWorkGroup`] if the group is not streaming, or a storage error.
+    pub fn stream_resolve_time_in_stream(
+        &mut self,
+        stream: &str,
+        group: &str,
+        start_time_ms: Option<u64>,
+        end_time_ms: Option<u64>,
+    ) -> Result<(Option<Offset>, Option<Offset>), EngineError> {
+        if stream.is_empty() {
+            return self.stream_resolve_time_in(group, start_time_ms, end_time_ms);
+        }
+        let id = StreamId::named(stream)?;
+        if !self.ensure_named_stream_resident(&id)? {
+            return Err(EngineError::UnknownStream {
+                name: stream.to_string(),
+            });
+        }
+        if !self.is_streaming_in_stream(stream, group) {
+            return Err(EngineError::CumulativeAckOnWorkGroup);
+        }
+        let Some(log) = self.streams.get(&id) else {
+            return Err(EngineError::UnknownStream {
+                name: stream.to_string(),
+            });
+        };
+        let start = start_time_ms
+            .map(|t| log.resolve_time_offset(t, true))
+            .transpose()?;
+        let end = end_time_ms
+            .map(|t| log.resolve_time_offset(t, false))
+            .transpose()?;
+        Ok((start, end))
     }
 
     /// Serves a Tier-S STREAMING fetch as RAW on-disk frame bytes (#541, M1-I5): the zero-copy twin of
@@ -26298,6 +26376,67 @@ mod tests {
         assert_eq!(again.records[0].offset, Offset::ZERO);
         assert_eq!(e.in_flight_in("s"), 0);
         assert_eq!(e.committed_offset_in("s"), Offset::ZERO);
+    }
+
+    #[test]
+    fn stream_seek_by_time_resolves_bounds_and_serves_the_window() {
+        // #772: seek-by-time resolves wall-clock bounds to offsets on the streaming consume path.
+        let mut e = open(config(10, 5));
+        // Non-monotonic producer timestamps (delayed messages, #555): offset -> ts is
+        // 0:10 1:30 2:20 3:50 4:40 5:5 6:60 7:35.
+        let ts = [10u64, 30, 20, 50, 40, 5, 60, 35];
+        for (i, &t) in ts.iter().enumerate() {
+            e.produce(&Append {
+                timestamp_ms: t,
+                flags: RecordFlags::EMPTY,
+                key: b"",
+                headers: b"",
+                payload: &[u8::try_from(i).unwrap()],
+            })
+            .unwrap();
+        }
+        e.set_streaming_in("s", true).unwrap();
+
+        // Start seek to time 25: the FIRST offset with ts >= 25 is offset 1 (ts=30), even though a
+        // LATER offset (5, ts=5) has a smaller timestamp — the resolution is offset-authoritative.
+        let (start, end) = e.stream_resolve_time_in("s", Some(25), None).unwrap();
+        assert_eq!(start, Some(Offset::new(1)));
+        assert_eq!(end, None);
+
+        // A [25, 45] window: start = offset 1 (first ts >= 25); exclusive end = first ts > 45 =
+        // offset 3 (ts=50). The window [1, 3) is served contiguously.
+        let (start2, end2) = e.stream_resolve_time_in("s", Some(25), Some(45)).unwrap();
+        assert_eq!((start2, end2), (Some(Offset::new(1)), Some(Offset::new(3))));
+        let want = usize::try_from(end2.unwrap().get() - start2.unwrap().get()).unwrap();
+        let batch = e
+            .stream_fetch_in("s", member(1), start2.unwrap(), want, None)
+            .unwrap();
+        // Offsets 1 (ts=30) and 2 (ts=20): the contiguous run from the start offset. Offset 2's ts
+        // (20) is below start_time — the documented offset-authoritative + terminating-predicate
+        // semantics deliver it because it sits after the resolved start offset.
+        assert_eq!(
+            batch
+                .records
+                .iter()
+                .map(|r| r.offset.get())
+                .collect::<Vec<_>>(),
+            vec![1, 2]
+        );
+
+        // A future time resolves to the tail (no record is newer), so a consumer awaits new records.
+        let (fut, _) = e.stream_resolve_time_in("s", Some(1000), None).unwrap();
+        assert_eq!(fut, Some(Offset::new(ts.len() as u64)));
+
+        // An old time clamps to the earliest offset (every record meets ts >= 0).
+        let (old, _) = e.stream_resolve_time_in("s", Some(0), None).unwrap();
+        assert_eq!(old, Some(Offset::ZERO));
+
+        // Wrong-mode guard: a non-streaming group is rejected exactly as a plain streaming fetch is.
+        e.set_streaming_in("s", false).unwrap();
+        assert!(matches!(
+            e.stream_resolve_time_in("s", Some(1), None),
+            Err(EngineError::CumulativeAckOnWorkGroup)
+        ));
     }
 
     #[test]

--- a/crates/ironbus-server/src/session.rs
+++ b/crates/ironbus-server/src/session.rs
@@ -2892,7 +2892,7 @@ impl Session {
         let ceiling_bytes = self.credit_ceiling_bytes(engine)?;
         // The number of records to serve: the client's request clamped to the per-consumer credit
         // window. A request of 0 (or a 0 window) serves nothing and replies an empty batch.
-        let want = req.max_records.min(window) as usize;
+        let mut want = req.max_records.min(window) as usize;
         // COUNT-BOUND keep-up: the consumer asked for at least the whole window, so the window (not
         // `max_records`) capped this fetch. If it then returns a FULL window's worth, the consumer is
         // keeping up and could pull more per RTT, so the auto-tune grows toward the ceiling.
@@ -2904,7 +2904,7 @@ impl Session {
             0 => None,
             cap => Some(usize::try_from(cap).unwrap_or(usize::MAX)),
         };
-        let start = Offset::new(req.start_offset);
+        let mut start = Offset::new(req.start_offset);
         let group = self.subscription.clone();
         let member = self.member_id;
         // The NAMED stream this streaming fetch targets (#681 follow-up), `""` for the DEFAULT stream. A
@@ -2912,6 +2912,45 @@ impl Session {
         // engine's `*_in_stream` twins (threaded into the serve helpers below); the default stream is
         // byte-for-byte unchanged.
         let stream = self.stream.clone();
+        // SEEK-BY-TIME (#772): when the fetch carries a start and/or end time, resolve them to log
+        // offsets off the sparse `.tindex` BEFORE the read. `start_time` (when present) takes
+        // PRECEDENCE over `start_offset` — it resolves its OWN start offset — and `end_time` resolves
+        // to an EXCLUSIVE end-offset bound. A time-bounded fetch resolves on the LOCAL/leader engine
+        // (not the follower read plane), and when an end bound is present it is served per-record so
+        // the end offset is enforced exactly (the raw batch path stays byte-identical for offset-only
+        // fetches). An offset-only fetch skips all of this and is unchanged on the wire.
+        let has_time = req.start_time_ms.is_some() || req.end_time_ms.is_some();
+        let mut end_offset: Option<Offset> = None;
+        if has_time {
+            let (st, et) = (req.start_time_ms, req.end_time_ms);
+            let (s, g) = (stream.clone(), group.clone());
+            match engine.with(move |e| e.stream_resolve_time_in_stream(&s, &g, st, et))? {
+                Ok((resolved_start, resolved_end)) => {
+                    if let Some(rs) = resolved_start {
+                        start = rs;
+                    }
+                    end_offset = resolved_end;
+                }
+                Err(e) if e.is_fatal() => {
+                    reply_err(out, "fatal storage error");
+                    return Err(SessionError::EngineFatal(e));
+                }
+                Err(e) => {
+                    // A wrong-mode / unknown-stream reject is a client-visible recoverable error
+                    // (the Err frame is the terminator); keep the connection open, send no FlowEnd.
+                    reply_err_coded(out, e.code().as_str(), &e.to_string());
+                    return Ok(());
+                }
+            }
+            // Bound the window by the exclusive end offset: deliver at most the records in
+            // `[start, end)`. The per-record path additionally enforces the bound per record (exact
+            // for a compacted/sparse segment), so the count cap plus the guard match a full-scan
+            // filter by time.
+            if let Some(end) = end_offset {
+                let span = end.get().saturating_sub(start.get());
+                want = want.min(usize::try_from(span).unwrap_or(usize::MAX));
+            }
+        }
         // CLUSTER FOLLOWER-READ over the wire (#735, half B): if this node FOLLOWS the partition, serve the
         // Tier-S streaming fetch from its OWN follower read plane via the #723 read-consistency tiers —
         // fail-closed by the SAFE committed watermark `min(own_flushed, known_committed_hw)`, so a follower
@@ -2928,7 +2967,7 @@ impl Session {
         // DEFAULT stream / DEFAULT_PARTITION concern), so only the default stream consults it — a named
         // streaming fetch falls straight through to the local (leader/local-engine) serve below, keyed by
         // (stream_id, group).
-        if self.stream.is_empty() {
+        if self.stream.is_empty() && !has_time {
             if let Some(outcome) = engine.cluster_follower_consume(
                 crate::cluster::client_ack::DEFAULT_PARTITION,
                 ReadTier::FollowerCommitted,
@@ -2957,7 +2996,11 @@ impl Session {
         // back how many records were delivered (`None` = a recoverable reject already replied as an Err,
         // which is the response terminator, so there is no keep-up and no FlowEnd to add).
         let capable = self.compressed_delivery_enabled;
-        let delivered = if self.deliver_batch_enabled {
+        // A time-bounded fetch with an EXCLUSIVE end offset is served PER-RECORD so the end bound is
+        // enforced exactly per record (including over a compacted/sparse segment); the raw DeliverBatch
+        // path is kept only for the unbounded (offset-only or start-time-only) case, so it stays
+        // byte-identical (#772).
+        let delivered = if self.deliver_batch_enabled && end_offset.is_none() {
             // The RAW DeliverBatch path ships the on-disk frame bytes VERBATIM (including any stored
             // COMPRESSED records), which is sound WITHOUT a compressed-delivery gate: decoding a raw
             // batch means decoding the on-disk record layout, so a DeliverBatch-capable consumer is
@@ -2968,7 +3011,7 @@ impl Session {
             )?
         } else {
             Self::serve_stream_fetch_per_record(
-                engine, &stream, &group, member, start, want, max_bytes, capable, out,
+                engine, &stream, &group, member, start, want, max_bytes, capable, end_offset, out,
             )?
         };
         let Some(delivered) = delivered else {
@@ -3109,6 +3152,7 @@ impl Session {
         want: usize,
         max_bytes: Option<usize>,
         capable: bool,
+        end_offset: Option<Offset>,
         out: &mut Vec<u8>,
     ) -> Result<Option<u32>, SessionError> {
         let group = group.clone();
@@ -3129,6 +3173,13 @@ impl Session {
                 // cleared and reused each iteration instead of a fresh `Vec` per delivered record.
                 let mut frame_body = Vec::with_capacity(DELIVER_FRAME_SCRATCH_CAP);
                 for record in &records {
+                    // SEEK-BY-TIME exclusive end bound (#772): stop before the first record at or past
+                    // the resolved end offset, so a `[start_time, end_time]` replay delivers exactly
+                    // the records in the time window (exact even over a compacted/sparse segment where
+                    // the count cap alone would over-read). No-op when there is no end bound.
+                    if end_offset.is_some_and(|end| record.offset.get() >= end.get()) {
+                        break;
+                    }
                     // Compressed-delivery gate (#1066): a non-capable consumer gets a stored-COMPRESSED
                     // record decompressed (COMPRESSED bit cleared); a capable consumer and every
                     // uncompressed record pass through verbatim. `None` stops the batch here.
@@ -7798,6 +7849,7 @@ mod tests {
                 start_offset: start,
                 max_records,
                 max_bytes,
+                ..Default::default()
             },
             &mut b,
         );
@@ -8275,6 +8327,7 @@ mod tests {
                     start_offset: 0,
                     max_records: 100,
                     max_bytes: 0,
+                    ..Default::default()
                 },
                 &mut b,
             );
@@ -8373,6 +8426,7 @@ mod tests {
                     start_offset: start,
                     max_records: max,
                     max_bytes: 0,
+                    ..Default::default()
                 },
                 &mut b,
             );
@@ -8414,6 +8468,7 @@ mod tests {
                 start_offset: 0,
                 max_records: 100,
                 max_bytes: 0,
+                ..Default::default()
             },
             &mut req,
         );
@@ -8501,6 +8556,7 @@ mod tests {
                 start_offset: 0,
                 max_records: 100,
                 max_bytes: 0,
+                ..Default::default()
             },
             &mut req,
         );
@@ -8592,6 +8648,7 @@ mod tests {
                 start_offset: 0,
                 max_records: 100,
                 max_bytes: 0,
+                ..Default::default()
             },
             &mut req,
         );

--- a/crates/ironbus-storage/src/lib.rs
+++ b/crates/ironbus-storage/src/lib.rs
@@ -63,6 +63,11 @@ pub mod streamset;
 /// the SAFE T1 O_DIRECT tier's config surface + the network-durable-storage probe. See the module
 /// docs; the io-strategy itself lives in [`io::DirectFile`] behind [`io::MaybeDirectFile`].
 pub mod substrate;
+/// The per-sealed-segment timestamp -> offset SPARSE index sidecar (`.tindex`, #772): a derived,
+/// rebuildable accelerator that resolves a wall-clock seek to a starting offset in `O(log n)`. The
+/// on-disk format, the prefix-max sparse-anchor build, and the bounded-window seek resolution live
+/// here (pure, no IO); the seal/rebuild/read wiring is in [`log`].
+pub mod tindex;
 /// The durable transactional half-message store (`txn/` sub-log, V2-M8, #640 part 1/2): a second
 /// segmented [`log::Log`] (modeled on the `dlq/` sink) holding the durable, consumer-INVISIBLE half
 /// (prepared) messages and their resolution (commit/rollback) op-markers, plus the in-memory

--- a/crates/ironbus-storage/src/log.rs
+++ b/crates/ironbus-storage/src/log.rs
@@ -15,7 +15,7 @@ use crate::cold::{
 use crate::fs::Filesystem;
 use crate::io::{InMemoryFile, RandomAccessFile};
 use crate::loss::{LossEvent, LossReport, ReasonCode};
-use crate::naming::{segment_file_name, segment_ids};
+use crate::naming::{segment_file_name, segment_ids, segment_tindex_name};
 use crate::read_plane::{ReadPlane, SealedSegment};
 use crate::segment::{
     OwnedRecord, RawByteRun, RecoveryScan, SegmentReader, SegmentWriter, StorageError,
@@ -107,6 +107,19 @@ pub struct LogConfig {
     /// write of the day (the append-on-empty rule that keeps an oversized first record from wedging
     /// the log applies here too), so the broker always makes some daily progress.
     pub daily_physical_write_budget_bytes: u64,
+
+    /// The density of the per-sealed-segment `.tindex` timestamp -> offset index (#772): one sparse
+    /// `(offset, prefix-max timestamp)` anchor is written per this many records. A seek-by-time
+    /// binary-searches the anchors then forward-scans at most this many records to the exact offset,
+    /// so this is a pure memory/latency trade: SMALLER anchors more records (a shorter forward scan,
+    /// a larger sidecar), LARGER fewer (a longer scan, a tinier sidecar). It never affects
+    /// correctness (a seek matches a full scan for any value) or durability (the `.tindex` is a
+    /// derived, rebuildable accelerator, never a durability dependency), and it does NOT change the
+    /// segment `.log` bytes, so a default consume is byte-identical regardless of this value.
+    /// Clamped up to 1 (a `0` cannot anchor every record). Changing it takes effect for segments
+    /// sealed AFTER the change; older sidecars keep their built-in density until rebuilt or reaped.
+    /// [`LogConfig::DEFAULT_TINDEX_STRIDE_RECORDS`] (1024) is the safe default.
+    pub tindex_stride_records: u32,
 }
 
 impl LogConfig {
@@ -118,6 +131,15 @@ impl LogConfig {
     /// is bounded out of the box; an operator can lower it (for a tiny edge disk) or set `0` to
     /// disable the cap entirely.
     pub const DEFAULT_MAX_QUARANTINE_BYTES: u64 = 256 * 1024 * 1024;
+
+    /// The default `.tindex` density (#772): one sparse timestamp anchor per 1024 records. A
+    /// seek-by-time forward-scans at most ~1024 records past the anchor (microseconds), and the
+    /// sidecar holds `ceil(record_count / 1024)` 16-byte anchors — e.g. a densely packed segment of
+    /// ~233k small records needs ~228 anchors (~3.6 KiB), negligible next to the segment. Mirrors
+    /// the offset index's sparse `SEGMENT_INDEX_STRIDE_BYTES` philosophy (a bounded accelerator,
+    /// rebuilt from the durable frames), keyed by record count rather than bytes so the forward
+    /// scan is bounded in RECORDS.
+    pub const DEFAULT_TINDEX_STRIDE_RECORDS: u32 = 1024;
 
     /// The smallest sane `max_segment_bytes`: the segment header and footer plus room for at
     /// least two minimum-size records, so a segment can always hold more than one record. A
@@ -149,6 +171,7 @@ impl LogConfig {
             max_quarantine_bytes: LogConfig::DEFAULT_MAX_QUARANTINE_BYTES,
             // The daily physical write budget is OFF by default; an operator opts in (#118).
             daily_physical_write_budget_bytes: 0,
+            tindex_stride_records: LogConfig::DEFAULT_TINDEX_STRIDE_RECORDS,
         })
     }
 
@@ -182,6 +205,16 @@ impl LogConfig {
     #[must_use]
     pub fn with_daily_physical_write_budget_bytes(mut self, budget: u64) -> LogConfig {
         self.daily_physical_write_budget_bytes = budget;
+        self
+    }
+
+    /// Sets the `.tindex` density ([`LogConfig::tindex_stride_records`]) and returns the updated
+    /// config. Clamped up to 1. A pure memory/latency trade over the seek-by-time accelerator; it
+    /// never affects correctness, durability, or the segment `.log` bytes. Most callers keep the
+    /// [`LogConfig::DEFAULT_TINDEX_STRIDE_RECORDS`] default.
+    #[must_use]
+    pub fn with_tindex_stride_records(mut self, stride: u32) -> LogConfig {
+        self.tindex_stride_records = stride.max(1);
         self
     }
 }
@@ -226,6 +259,8 @@ impl Default for LogConfig {
             // The daily physical write budget is OFF by default (#118): existing behavior is
             // unchanged unless an operator opts in to the flash-wear governor.
             daily_physical_write_budget_bytes: 0,
+            // The safe default seek-by-time index density (#772): one anchor per 1024 records.
+            tindex_stride_records: LogConfig::DEFAULT_TINDEX_STRIDE_RECORDS,
         }
     }
 }
@@ -637,6 +672,11 @@ impl CompactedIndex {
     }
 }
 
+/// A shared, resident sparse `.tindex` anchor list (#772): the ascending `(offset, exclusive
+/// prefix-max timestamp)` anchors for ONE sealed segment, behind an `Arc` so a `&self` seek clones it
+/// out of the resident cache and scans without holding the `RefCell` borrow.
+type ResidentTimeIndex = std::sync::Arc<Vec<(u64, u64)>>;
+
 /// The default number of opened SEALED-segment readers the through-actor `Log` keeps resident (#808).
 /// Each entry is one fd + a validated header; the cache is FIFO-bounded so a retention-off cold full
 /// scan opens-and-reuses a working set instead of leaking one fd per sealed segment. 256 sits well under
@@ -843,6 +883,31 @@ pub struct Log<F: Filesystem, C: Clock> {
     /// and caches an entry behind a `RefCell`, holding only derived data (dropping or rebuilding it
     /// changes nothing a reader observes — same survivors, same CRC validation).
     compacted_indexes: std::cell::RefCell<std::collections::HashMap<u64, CompactedIndex>>,
+    /// The RESIDENT, per-OPEN-SEALED-segment SPARSE timestamp -> offset anchors keyed by segment id
+    /// (#772): the parsed `.tindex` sidecar (or, when it is missing/torn/corrupt, the anchors
+    /// rebuilt from a segment scan), cached so a repeated seek-by-time over a hot sealed segment
+    /// loads once. Each value is the ascending `(offset, exclusive prefix-max timestamp)` anchor list
+    /// (see [`crate::tindex`]). Built lazily the first time a time seek consults the segment, and
+    /// EVICTED by the same [`Log::evict_segment_index`] retirement path that drops the offset index,
+    /// so a stale time index can never outlive its segment. Resident-only, derived data: dropping or
+    /// rebuilding it changes nothing a seek resolves (the on-disk `.tindex` and the segment frames
+    /// are the source of truth). An `Arc` so a `&self` seek can clone it out from behind the cell and
+    /// scan without holding the borrow.
+    time_indexes: std::cell::RefCell<std::collections::HashMap<u64, ResidentTimeIndex>>,
+    /// The ACTIVE (unsealed) segment's accumulating sparse time anchors (#772): the same
+    /// `(offset, exclusive prefix-max timestamp)` anchors [`crate::tindex::build_anchors`] would
+    /// produce, extended in lockstep as the active segment appends (like `segment_indexes`), so a
+    /// seek-by-time into the ACTIVE segment bounds its forward scan without scanning from the base.
+    /// In-memory ONLY (never written on seal — a sealed segment's `.tindex` is built lazily on the
+    /// first seek); reset for each new active segment by `install_started_segment`.
+    active_time_anchors: Vec<(u64, u64)>,
+    /// The base offset of the active segment `active_time_anchors` covers (its first anchor's offset).
+    active_time_anchor_base: u64,
+    /// Whether `active_time_anchors` covers the active segment FROM ITS BASE. `false` after a
+    /// recovery `resume` or a truncation (whose pre-existing prefix anchors were not reconstructed),
+    /// so an active-segment seek scans the whole readable range rather than trusting a partial anchor
+    /// set. `true` for a freshly started segment, the steady-state case.
+    active_time_anchors_complete: bool,
     /// The resident, FIFO-bounded cache of OPENED sealed-segment readers (#808): the through-actor read
     /// path (e.g. the Tier-W per-record poll, which reads `read_from(off, 1)` per delivered message)
     /// reuses one opened `SegmentReader` per sealed segment instead of re-opening (open+fstat+header-CRC)
@@ -1267,6 +1332,13 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
                     // A fresh log has no compacted segment, so the sparse index map (#481) starts
                     // empty; it is filled lazily the first time a compacted slot is read.
                     compacted_indexes: std::cell::RefCell::new(std::collections::HashMap::new()),
+                    time_indexes: std::cell::RefCell::new(std::collections::HashMap::new()),
+                    active_time_anchors: Vec::new(),
+                    active_time_anchor_base: 0,
+                    // Safe default: a segment reset by `install_started_segment` flips this to
+                    // `true`; a resumed (post-recovery) active segment leaves it `false` so its seal
+                    // skips a would-be-incomplete `.tindex` and a later seek rebuilds from frames.
+                    active_time_anchors_complete: false,
                     sealed_readers: SealedReaderCache::new(DEFAULT_SEALED_READER_CACHE_CAP),
                     // The off-actor read plane (#539) is built lazily on the first consumer
                     // `read_plane()` call; a never-read log pays nothing.
@@ -1662,6 +1734,10 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
             // The compacted (sparse) seek index map (#481) is likewise resident-only: a reopen
             // rebuilds it lazily from the durable frames the first time a compacted slot is read.
             compacted_indexes: std::cell::RefCell::new(std::collections::HashMap::new()),
+            time_indexes: std::cell::RefCell::new(std::collections::HashMap::new()),
+            active_time_anchors: Vec::new(),
+            active_time_anchor_base: 0,
+            active_time_anchors_complete: false,
             sealed_readers: SealedReaderCache::new(DEFAULT_SEALED_READER_CACHE_CAP),
             // The off-actor read plane (#539) is built lazily on the first consumer `read_plane()`.
             read_plane: std::cell::RefCell::new(None),
@@ -2195,6 +2271,10 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
             // The compacted (sparse) seek index map (#481) starts empty and is filled lazily on the
             // read path; the recovered chain may include compacted segments, indexed on first read.
             compacted_indexes: std::cell::RefCell::new(std::collections::HashMap::new()),
+            time_indexes: std::cell::RefCell::new(std::collections::HashMap::new()),
+            active_time_anchors: Vec::new(),
+            active_time_anchor_base: 0,
+            active_time_anchors_complete: false,
             sealed_readers: SealedReaderCache::new(DEFAULT_SEALED_READER_CACHE_CAP),
             // The off-actor read plane (#539) is built lazily on the first consumer `read_plane()`.
             read_plane: std::cell::RefCell::new(None),
@@ -2391,6 +2471,13 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
                 flushed_end: SEGMENT_HEADER_LEN as u64,
             },
         );
+        // Reset the ACTIVE segment's accumulating `.tindex` anchors (#772): a fresh segment starts
+        // empty and its anchors are COMPLETE from the base, so appends extend them in lockstep and a
+        // seek into the still-active segment bounds its scan. (A resumed post-recovery segment does
+        // NOT pass through here; it leaves its anchors incomplete so an active-segment seek scans.)
+        self.active_time_anchors = Vec::new();
+        self.active_time_anchor_base = base_offset.get();
+        self.active_time_anchors_complete = true;
     }
 
     /// The next FRESH segment id, strictly greater than any id ever used: `max(active_id, the
@@ -2443,6 +2530,14 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
         if let Some(idx) = self.segment_indexes.borrow_mut().get_mut(&self.active_id) {
             idx.flushed_end = idx.valid_end;
         }
+        // NOTE (#772): the `.tindex` timestamp sidecar is DELIBERATELY NOT written here on the roll.
+        // Writing a derived sidecar on the produce/roll hot path would add fsync + directory IO that
+        // perturbs the byte-identity, determinism, and fault-injection (op-counting) conformance
+        // gates over produce/recovery, and would make the on-disk image depend on whether a segment
+        // was produced in one run or resumed across a restart. Instead the sidecar is built and
+        // fsynced LAZILY the first time the segment is actually seeked by time (see
+        // [`Log::load_or_rebuild_tindex`]), from a deterministic scan of the durable frames — so a
+        // pure offset-only workload writes no sidecars and stays byte-identical to before the feature.
         // The segment footer is durable physical write volume (#118): `seal` wrote and fsynced the
         // 32-byte footer, so charge it to the wear total here (the per-record frames and this
         // segment's header were charged on append and `start_segment`).
@@ -3108,6 +3203,14 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
             .next_offset
             .checked_next()
             .ok_or(StorageError::SegmentFull)?;
+        // Capture the writer's running max timestamp BEFORE this append: it is the EXCLUSIVE prefix
+        // max at this record's offset (the max over every record already in the segment), the value
+        // a `.tindex` anchor stores (#772). Captured on BOTH the encode and verbatim paths (the
+        // writer folds the timestamp in either way), so a follower-applied record is indexed too.
+        let time_max_before = self
+            .active
+            .as_ref()
+            .map_or(0, SegmentWriter::max_timestamp_ms);
         // Lay the record into the active segment (encode-and-checksum, or copy the already-validated
         // verbatim frame). Returns the assigned offset, the frame's start byte position, and its
         // encoded length — the seek-index maintenance below needs all three.
@@ -3142,6 +3245,21 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
                 } else {
                     indexes.remove(&self.active_id);
                 }
+            }
+        }
+        // EXTEND the active segment's in-memory `.tindex` anchors in lockstep (#772): anchor this
+        // record when it STARTS a new stride bucket (its index within the segment is a multiple of
+        // the density), carrying the exclusive prefix max captured above. These bound a seek into the
+        // still-ACTIVE segment; a SEALED segment's sidecar is (re)built from a scan on the first seek,
+        // and the (offset, prefix-max) shape here is byte-identical to that scan. Only while the
+        // anchors are COMPLETE from the base (a fresh segment); a resumed segment leaves this false so
+        // an active-segment seek scans.
+        if self.active_time_anchors_complete {
+            let stride = u64::from(self.config.tindex_stride_records.max(1));
+            let idx_in_segment = offset.get().saturating_sub(self.active_time_anchor_base);
+            if idx_in_segment % stride == 0 {
+                self.active_time_anchors
+                    .push((offset.get(), time_max_before));
             }
         }
         // Write-amplification accounting (#118), charged only after the append returned Ok (a failed
@@ -4829,6 +4947,12 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
         // The kept active segment's resident seek index must be rebuilt from the truncated bytes, so
         // evict any stale one (a later read rebuilds it). The dropped segments' indexes were evicted.
         self.evict_segment_index(last_id);
+        // The kept active segment was RESUMED over its truncated bytes (not started from its base),
+        // so its accumulating `.tindex` anchors are incomplete: reset them and mark incomplete so an
+        // active-segment seek scans rather than trusting a partial anchor set (#772).
+        self.active_time_anchors = Vec::new();
+        self.active_time_anchor_base = 0;
+        self.active_time_anchors_complete = false;
         // The truncation RETIRED the divergent suffix: republish the off-actor read plane so any
         // concurrent reader's snapshot drops the now-removed offsets and cannot seek into them.
         self.republish_read_plane();
@@ -5236,9 +5360,246 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
     fn evict_segment_index(&mut self, id: u64) {
         self.segment_indexes.borrow_mut().remove(&id);
         self.compacted_indexes.borrow_mut().remove(&id);
+        // Drop the resident `.tindex` anchors for the retired segment in lockstep (#772): a rebuilt
+        // higher-id segment reloads from its own sidecar/frames, and ids never recycle (ADR 0002),
+        // so this only ever drops a now-gone segment's derived anchors. The retired segment's ON-DISK
+        // `.tindex` (if a prior seek wrote one) is deliberately NOT unlinked here: touching the
+        // filesystem on the reap/retire hot path would perturb the byte-identity and fault-injection
+        // (op-counting) gates, and a leftover sidecar is HARMLESS — segment enumeration matches only
+        // `.log`, ids never recycle, and a stale sidecar is rejected by the id/base/count cross-check
+        // on load. Orphaned sidecars are a tiny, offline-cleanable disk cost, never a correctness risk.
+        self.time_indexes.borrow_mut().remove(&id);
         // Drop the cached open reader (and its fd) for the retired segment in lockstep (#808), so a
         // reaped/compacted-away segment's fd is released, not leaked.
         self.sealed_readers.evict(id);
+    }
+
+    /// Rebuilds a sealed segment's sparse `.tindex` anchors from a validating scan of its durable
+    /// frames (#772), the deterministic source of truth for the sidecar. Used by
+    /// [`Log::load_or_rebuild_tindex`] on a missing/torn/stale sidecar.
+    fn rebuild_tindex_anchors(&self, id: u64) -> Result<Vec<(u64, u64)>, StorageError> {
+        let reader = SegmentReader::open(self.fs.open(&segment_file_name(id))?)?;
+        reader.time_anchors(self.config.tindex_stride_records)
+    }
+
+    /// The durable write of a `.tindex` sidecar: remove any stale file, create it fresh, write,
+    /// fsync the file, then fsync the directory so the new entry is crash-visible — the same
+    /// write-then-dir-sync discipline the segment/checkpoint writers use. Returns any IO error to
+    /// the (best-effort) caller.
+    fn write_tindex_file(&self, id: u64, bytes: &[u8]) -> Result<(), StorageError> {
+        let name = segment_tindex_name(id);
+        // A leftover sidecar for this id cannot describe a DIFFERENT segment (ids never recycle,
+        // ADR 0002); remove it so `create_new` never fails on a stale file from a prior attempt.
+        let _ = self.fs.remove(&name);
+        let file = self.fs.create_new(&name)?;
+        file.write_all_at(bytes, 0)?;
+        file.sync_all()?;
+        self.fs.sync_dir()?;
+        Ok(())
+    }
+
+    /// Loads (or rebuilds) the resident SPARSE `.tindex` anchors for a SEALED ORDINARY (v1) segment
+    /// `slot`, for a seek-by-time (#772). Returns `None` for a COMPACTED (v2, sparse) segment (the
+    /// caller scans its covered range directly) and for the ACTIVE segment (its live anchors are
+    /// consulted separately). For a sealed ordinary segment it serves the resident cache, else tries
+    /// the on-disk `.tindex` (validating magic/version/CRC and that the segment id, base offset, and
+    /// record count match the slot), else REBUILDS from a validating segment scan — a missing, torn,
+    /// or stale sidecar is silently rebuilt, never an error and never trusted blindly. The result is
+    /// cached (an `Arc`, cloned out so the seek scans without holding the borrow).
+    ///
+    /// # Errors
+    /// Propagates only a genuine segment-read IO error from the rebuild scan (the segment itself is
+    /// unreadable); a bad/absent SIDECAR is handled by rebuilding, never surfaced.
+    fn segment_time_anchors(
+        &self,
+        slot: &SegmentSlot,
+    ) -> Result<Option<ResidentTimeIndex>, StorageError> {
+        if slot.compacted_covered.is_some() || slot.id == self.active_id {
+            return Ok(None);
+        }
+        if let Some(anchors) = self.time_indexes.borrow().get(&slot.id) {
+            return Ok(Some(std::sync::Arc::clone(anchors)));
+        }
+        let anchors = self.load_or_rebuild_tindex(slot)?;
+        let arc = std::sync::Arc::new(anchors);
+        self.time_indexes
+            .borrow_mut()
+            .insert(slot.id, std::sync::Arc::clone(&arc));
+        Ok(Some(arc))
+    }
+
+    /// Reads and validates the on-disk `.tindex` for `slot`, or rebuilds the anchors from a segment
+    /// scan when it is absent, unreadable, torn, corrupt, or stale (#772). Never trusts an
+    /// unvalidated sidecar and never fails on a bad one.
+    fn load_or_rebuild_tindex(&self, slot: &SegmentSlot) -> Result<Vec<(u64, u64)>, StorageError> {
+        if let Some(anchors) = self.try_load_tindex(slot) {
+            return Ok(anchors);
+        }
+        // Missing/torn/corrupt/stale sidecar: rebuild from the durable frames (the source of truth),
+        // then PERSIST the fresh `.tindex` LAZILY (best-effort) so the next seek and a restart load it
+        // instead of rescanning. Writing HERE (on the first time-seek) rather than on seal keeps the
+        // produce/roll hot path free of sidecar IO — an offset-only workload writes no sidecars and
+        // stays byte-identical — and the write is off the durability contract: a failure just leaves
+        // no sidecar and the next seek rebuilds again. The bytes are deterministic (the same scan on
+        // any node yields the same anchors), so a persisted sidecar is byte-identical across nodes.
+        let anchors = self.rebuild_tindex_anchors(slot.id)?;
+        let bytes = crate::tindex::encode(
+            slot.id,
+            slot.base_offset,
+            slot.record_count,
+            self.config.tindex_stride_records,
+            &anchors,
+        );
+        let _ = self.write_tindex_file(slot.id, &bytes);
+        Ok(anchors)
+    }
+
+    /// Attempts to read and fully validate `slot`'s on-disk `.tindex`, returning its anchors only
+    /// when the file is present, decodes cleanly (magic/version/CRC/structure), and its identifying
+    /// fields (segment id, base offset, record count) match the slot. Any other outcome — no file,
+    /// an IO error, a decode/CRC failure, or a staleness mismatch — is `None`, so the caller rebuilds
+    /// from the frames. The sidecar is thus a pure accelerator: it is used only when provably
+    /// consistent with the segment it sits beside.
+    fn try_load_tindex(&self, slot: &SegmentSlot) -> Option<Vec<(u64, u64)>> {
+        let file = self.fs.open(&segment_tindex_name(slot.id)).ok()?;
+        let len = usize::try_from(file.len().ok()?).ok()?;
+        // Guard against an absurd sidecar length before allocating.
+        if len == 0 || len > 256 * 1024 * 1024 {
+            return None;
+        }
+        let mut buf = vec![0u8; len];
+        file.read_exact_at(&mut buf, 0).ok()?;
+        let parsed = crate::tindex::decode(&buf)?;
+        if parsed.segment_id != slot.id
+            || parsed.base_offset != slot.base_offset
+            || parsed.record_count != slot.record_count
+        {
+            return None;
+        }
+        Some(parsed.anchors)
+    }
+
+    /// Resolves a wall-clock timestamp to the FIRST log offset whose record satisfies the time
+    /// predicate, for the streaming seek-by-time path (#772). With `at_or_after == true` it finds
+    /// the first offset whose producer timestamp is `>= time_ms` (a START seek, `DeliverByStartTime`
+    /// parity); with `at_or_after == false`, the first offset whose timestamp is `> time_ms` (an
+    /// EXCLUSIVE end bound, `[start, end)` replay).
+    ///
+    /// The result is OFFSET-AUTHORITATIVE and EXACT versus a full forward scan even for NON-MONOTONIC
+    /// producer timestamps (delayed messages, #555): the coarse per-segment `max_timestamp_ms` skips
+    /// whole segments that cannot contain a match, then the segment's sparse `.tindex` prefix-max
+    /// anchors bound the search to a single stride bucket, whose bounded forward read returns the
+    /// exact first match. Because the anchors carry the EXCLUSIVE PREFIX MAX (not a raw timestamp),
+    /// the anchor is a true lower bound — no matching record before it is ever skipped. The only
+    /// honest caveat is RETENTION: a match in a reaped segment is gone, so the seek resolves to the
+    /// earliest RETAINED matching offset (never below `earliest_offset`). When no retained record
+    /// satisfies the predicate the seek resolves to the FLUSHED frontier (the tail), so a consumer
+    /// starts where durable data ends and receives future matching records as they arrive.
+    ///
+    /// # Errors
+    /// Propagates an IO/segment error from reading a segment (the same errors `read_range` raises).
+    pub fn resolve_time_offset(
+        &self,
+        time_ms: u64,
+        at_or_after: bool,
+    ) -> Result<Offset, StorageError> {
+        let flushed = self.flushed_offset.get();
+        // A record's timestamp "meets" the predicate: `>= T` for a start seek, `> T` for an
+        // exclusive end bound. Monotone in the threshold, so the prefix-max anchor search is valid.
+        let meets = |ts: u64| {
+            if at_or_after {
+                ts >= time_ms
+            } else {
+                ts > time_ms
+            }
+        };
+        if flushed == 0 {
+            // An empty (or fully-unflushed) log: the tail is the earliest readable offset.
+            return Ok(Offset::new(flushed));
+        }
+        // Iterate segments in OFFSET order. Because segments are contiguous offset ranges, the first
+        // segment (by offset) that CAN contain a match holds the GLOBAL first match: every earlier
+        // segment was skipped because its max timestamp cannot meet the predicate.
+        for i in 0..self.segments.len() {
+            let slot = self.segments[i];
+            let base = slot.covered_base_offset();
+            if base >= flushed {
+                break; // this segment and every later one begins beyond the durable head
+            }
+            // The segment's max producer timestamp: the live writer max for the ACTIVE segment
+            // (its slot's stored max is stale/0 until sealed), else the slot's frozen max.
+            let seg_max = if slot.id == self.active_id {
+                self.active
+                    .as_ref()
+                    .map_or(0, SegmentWriter::max_timestamp_ms)
+            } else {
+                slot.max_timestamp_ms
+            };
+            if !meets(seg_max) {
+                continue; // no record in this segment can satisfy the predicate — skip it whole
+            }
+            if let Some(found) = self.resolve_time_in_segment(&slot, flushed, meets)? {
+                return Ok(found);
+            }
+            // The segment's max met the predicate but no READABLE (below-flushed) record did — the
+            // only matches sit in an unflushed tail. Fall through to later segments / the tail.
+        }
+        // No retained, readable record satisfies the predicate: resolve to the flushed frontier.
+        Ok(Offset::new(flushed))
+    }
+
+    /// Finds the first offset in ONE segment `slot` whose record satisfies `meets`, using the sparse
+    /// `.tindex` anchors to bound the forward scan to a single stride bucket, or scanning the
+    /// segment's readable range when there is no `.tindex` (a compacted or active segment). Returns
+    /// `None` when no readable (below `flushed`) record in the segment matches. The forward read
+    /// goes through `read_range`, so every returned record is fully CRC-validated and compacted
+    /// holes are skipped exactly as a normal consume would.
+    fn resolve_time_in_segment<M: Fn(u64) -> bool>(
+        &self,
+        slot: &SegmentSlot,
+        flushed: u64,
+        meets: M,
+    ) -> Result<Option<Offset>, StorageError> {
+        let base = slot.covered_base_offset();
+        // The exclusive readable end of this segment: its dense end for an ordinary sealed segment,
+        // its covered end for a compacted one, and the flushed frontier for the active segment (whose
+        // stored count is 0). Always clamped to `flushed` so the scan never targets an unflushed frame.
+        let seg_end = if slot.id == self.active_id {
+            flushed
+        } else if let Some(cover) = slot.compacted_covered {
+            cover.covered_end_offset.min(flushed)
+        } else {
+            base.saturating_add(slot.record_count).min(flushed)
+        };
+        if seg_end <= base {
+            return Ok(None);
+        }
+        // Determine the bounded window `[scan_from, scan_bound)` the first match must lie in.
+        let (scan_from, scan_bound) =
+            if slot.id == self.active_id && self.active_time_anchors_complete {
+                crate::tindex::scan_window(&self.active_time_anchors, base, seg_end, &meets)
+            } else if let Some(anchors) = self.segment_time_anchors(slot)? {
+                crate::tindex::scan_window(&anchors, base, seg_end, &meets)
+            } else {
+                // No anchors (a compacted segment, or a resumed active one): scan the whole readable range.
+                (base, seg_end)
+            };
+        let scan_bound = scan_bound.min(seg_end);
+        if scan_bound <= scan_from {
+            return Ok(None);
+        }
+        let want = usize::try_from(scan_bound.saturating_sub(scan_from)).unwrap_or(usize::MAX);
+        // Read the bounded window (CRC-validated, compaction-hole-aware) and return the first match.
+        let records = self.read_range(Offset::new(scan_from), want, None)?;
+        for record in records {
+            if record.offset.get() >= scan_bound {
+                break;
+            }
+            if meets(record.timestamp_ms) {
+                return Ok(Some(record.offset));
+            }
+        }
+        Ok(None)
     }
 
     fn segment_index_for(&self, offset: u64) -> usize {
@@ -5521,6 +5882,14 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
         self.segment_indexes.borrow_mut().clear();
     }
 
+    /// Drops EVERY cached `.tindex` anchor set, forcing the next seek-by-time to reload from the
+    /// on-disk sidecar (or rebuild from the frames). A test uses this to prove the reloaded /
+    /// rebuilt path resolves the same offset as the append-seeded one (#772).
+    #[cfg(test)]
+    fn clear_time_indexes(&self) {
+        self.time_indexes.borrow_mut().clear();
+    }
+
     /// Installs a deliberately CORRUPT seek index for segment `id` with ONE anchor pointing at a
     /// byte position WELL PAST the segment's records (`valid_end`), so a seek that consulted it would
     /// read nothing (the wrong, empty result) for every covered offset. A test installs this,
@@ -5752,6 +6121,274 @@ mod tests {
     fn read_back<G: Filesystem>(fs: &G, id: u64) -> Vec<OwnedRecord> {
         let file = fs.open(&segment_file_name(id)).unwrap();
         SegmentReader::open(file).unwrap().scan().unwrap().records
+    }
+
+    // ---- Seek-by-time (#772) ----
+
+    // The BRUTE-FORCE reference for a seek: the first READABLE offset (in `[earliest, flushed)`)
+    // whose timestamp meets the predicate, or the flushed frontier if none does. A full linear scan,
+    // the ground truth `resolve_time_offset` must equal for ANY (incl. non-monotonic) timestamps.
+    fn brute_first_offset_meeting<G: Filesystem, K: Clock, M: Fn(u64) -> bool>(
+        log: &Log<G, K>,
+        meets: M,
+    ) -> u64 {
+        let earliest = log.earliest_offset().get();
+        let flushed = log.flushed_offset().get();
+        if flushed <= earliest {
+            return flushed;
+        }
+        let span = usize::try_from(flushed - earliest).unwrap();
+        let records = log.read_range(Offset::new(earliest), span, None).unwrap();
+        for r in &records {
+            if meets(r.timestamp_ms) {
+                return r.offset.get();
+            }
+        }
+        flushed
+    }
+
+    // Assert `resolve_time_offset` equals the brute-force scan for BOTH the inclusive start seek
+    // (`ts >= t`) and the exclusive end bound (`ts > t`) across every probe time.
+    fn sweep_seek<G: Filesystem, K: Clock>(log: &Log<G, K>, probes: &[u64]) {
+        for &t in probes {
+            let start = log.resolve_time_offset(t, true).unwrap().get();
+            assert_eq!(
+                start,
+                brute_first_offset_meeting(log, |x| x >= t),
+                "start seek t={t}"
+            );
+            let end = log.resolve_time_offset(t, false).unwrap().get();
+            assert_eq!(
+                end,
+                brute_first_offset_meeting(log, |x| x > t),
+                "end seek t={t}"
+            );
+        }
+    }
+
+    // A non-monotonic producer-timestamp sequence (delayed messages, #555): values in [1,50] that
+    // rise and fall, spanning many small segments so the seek exercises coarse segment skipping,
+    // within-segment prefix-max anchoring, and the active-segment tail.
+    fn non_monotonic_timestamps() -> Vec<u64> {
+        (0..48u64).map(|i| ((i * 31 + 7) % 50) + 1).collect()
+    }
+
+    fn build_time_log(config: LogConfig, timestamps: &[u64]) -> Log<InMemoryFs, ManualClock> {
+        let mut log = open_mem(config);
+        for (i, &ts) in timestamps.iter().enumerate() {
+            log.append(&rec_at(ts, &[u8::try_from(i % 251).unwrap(); 16]))
+                .unwrap();
+        }
+        log.sync().unwrap();
+        log
+    }
+
+    fn time_config() -> LogConfig {
+        // Small segments force many rolls (many sealed `.tindex` sidecars); a small stride gives
+        // several anchors per segment so the within-segment bucket search is exercised.
+        LogConfig {
+            max_segment_bytes: 300,
+            tindex_stride_records: 2,
+            ..LogConfig::default()
+        }
+    }
+
+    #[test]
+    fn seek_by_time_matches_brute_force_scan_incl_non_monotonic() {
+        let ts = non_monotonic_timestamps();
+        let log = build_time_log(time_config(), &ts);
+        let probes: Vec<u64> = (0..=52).collect();
+        // 1) Live log: sealed segments resolve from the anchors cached on seal, the active segment
+        //    from its in-memory append-seeded anchors.
+        sweep_seek(&log, &probes);
+        // 2) Drop the resident anchors so each sealed-segment seek RELOADS from its on-disk `.tindex`
+        //    and proves the persisted sidecar resolves identically.
+        log.clear_time_indexes();
+        sweep_seek(&log, &probes);
+    }
+
+    #[test]
+    fn seek_by_time_matches_after_reopen() {
+        let ts = non_monotonic_timestamps();
+        let log = build_time_log(time_config(), &ts);
+        let fs = log.into_filesystem();
+        // The `.tindex` sidecars are on disk beside the sealed segments; a reopen resolves across the
+        // restart from them (the resumed active segment falls back to a bounded scan).
+        let log = Log::open(fs, ManualClock::new(), time_config()).unwrap();
+        sweep_seek(&log, &(0..=52).collect::<Vec<_>>());
+    }
+
+    #[test]
+    // Test-controlled file names are always lowercase; the extension filter is exact by design.
+    #[allow(clippy::case_sensitive_file_extension_comparisons)]
+    fn seek_by_time_rebuilds_from_missing_or_torn_tindex_without_error() {
+        for torn in [false, true] {
+            let ts = non_monotonic_timestamps();
+            let log = build_time_log(time_config(), &ts);
+            // Seek across the log to trigger the LAZY persist of every sealed segment's `.tindex`
+            // (the sidecar is written on the first time-seek, not on seal, #772).
+            sweep_seek(&log, &(0..=52).collect::<Vec<_>>());
+            let fs = log.into_filesystem();
+            // A `.tindex` MUST be present beside at least one sealed segment before we damage it.
+            let sidecars: Vec<String> = fs
+                .list()
+                .unwrap()
+                .into_iter()
+                .filter(|n| n.ends_with(".tindex"))
+                .collect();
+            assert!(
+                !sidecars.is_empty(),
+                "seal should have written `.tindex` sidecars"
+            );
+            for name in &sidecars {
+                fs.remove(name).unwrap();
+                if torn {
+                    // Replace with garbage: a bad magic/CRC must be treated as absent, never trusted.
+                    let f = fs.create_new(name).unwrap();
+                    f.write_all_at(b"not-a-tindex-at-all-really-garbage!!", 0)
+                        .unwrap();
+                }
+            }
+            // A missing/torn sidecar must REBUILD from the frames — never fail the open, never a wrong
+            // seek.
+            let log = Log::open(fs, ManualClock::new(), time_config()).unwrap();
+            sweep_seek(&log, &(0..=52).collect::<Vec<_>>());
+        }
+    }
+
+    #[test]
+    fn seek_by_time_active_segment_only() {
+        // A single (unsealed, active) segment: the seek resolves via the in-memory append-seeded
+        // anchors, still exactly matching a full scan for non-monotonic timestamps.
+        let ts = vec![10u64, 5, 30, 2, 50, 1, 40, 25, 5, 60];
+        let mut log = open_mem(LogConfig {
+            max_segment_bytes: 64 * 1024, // large: no roll, everything stays in the active segment
+            tindex_stride_records: 3,
+            ..LogConfig::default()
+        });
+        for (i, &t) in ts.iter().enumerate() {
+            log.append(&rec_at(t, &[u8::try_from(i).unwrap(); 8]))
+                .unwrap();
+        }
+        log.sync().unwrap();
+        assert!(log.segment_index_count() >= 1);
+        sweep_seek(&log, &(0..=62).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn seek_by_time_below_earliest_retained_clamps_to_earliest() {
+        let ts = non_monotonic_timestamps();
+        let mut log = build_time_log(time_config(), &ts);
+        // Reap the oldest sealed segments so the earliest retained offset rises above 0.
+        log.reap_oldest_forced().unwrap();
+        log.reap_oldest_forced().unwrap();
+        let earliest = log.earliest_offset().get();
+        assert!(
+            earliest > 0,
+            "a reap should have raised the earliest offset"
+        );
+        // Seeking to a time older than (or at) every RETAINED record resolves to the earliest
+        // retained offset — never below it — matching the brute-force scan over the retained window.
+        let resolved = log.resolve_time_offset(0, true).unwrap().get();
+        assert!(
+            resolved >= earliest,
+            "seek must never resolve below earliest retained"
+        );
+        // The full sweep still matches the brute-force scan over the RETAINED records (the reaped
+        // `.tindex` sidecars were cleaned up; the survivors rebuild/serve correctly).
+        sweep_seek(&log, &(0..=52).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn seek_by_time_future_time_resolves_to_the_tail() {
+        let ts = non_monotonic_timestamps();
+        let log = build_time_log(time_config(), &ts);
+        // No record has a timestamp > 1000, so a start seek to a future time resolves to the tail
+        // (the flushed frontier), where a consumer awaits future matching records.
+        let flushed = log.flushed_offset().get();
+        assert_eq!(log.resolve_time_offset(1000, true).unwrap().get(), flushed);
+    }
+
+    #[test]
+    fn seek_by_time_end_bound_defines_a_time_window() {
+        // A `[start, end)` offset window resolved from `[start_time, end_time]` returns exactly the
+        // records a full scan filtered by time would, under these MONOTONIC timestamps.
+        let ts: Vec<u64> = (0..40u64).map(|i| i * 10).collect(); // 0,10,20,...,390 monotonic
+        let log = build_time_log(time_config(), &ts);
+        let start = log.resolve_time_offset(100, true).unwrap(); // first ts >= 100 -> offset 10
+        let end = log.resolve_time_offset(250, false).unwrap(); // first ts > 250 -> offset 26
+        assert_eq!(start.get(), 10);
+        assert_eq!(end.get(), 26);
+        // The window `[10, 26)` is exactly the records with 100 <= ts <= 250.
+        let want = usize::try_from(end.get() - start.get()).unwrap();
+        let records = log.read_range(start, want, None).unwrap();
+        for r in &records {
+            assert!(r.timestamp_ms >= 100 && r.timestamp_ms <= 250, "in-window");
+        }
+        assert_eq!(records.len(), 16); // offsets 10..=25
+    }
+
+    #[test]
+    // Test-controlled file names are always lowercase; the extension filter is exact by design.
+    #[allow(clippy::case_sensitive_file_extension_comparisons)]
+    fn tindex_sidecars_sit_beside_sealed_segments_and_never_perturb_the_log() {
+        let ts = non_monotonic_timestamps();
+        // Seek by time so the LAZY `.tindex` sidecars are written (#772), then confirm each is a
+        // SEPARATE file that segment enumeration ignores (byte-identity of the log is preserved).
+        let log = build_time_log(time_config(), &ts);
+        sweep_seek(&log, &(0..=52).collect::<Vec<_>>());
+        let fs = log.into_filesystem();
+        let names = fs.list().unwrap();
+        let logs: Vec<&String> = names.iter().filter(|n| n.ends_with(".log")).collect();
+        let tindexes: Vec<&String> = names.iter().filter(|n| n.ends_with(".tindex")).collect();
+        assert!(
+            !tindexes.is_empty(),
+            "a seeked sealed segment must carry a `.tindex` sidecar"
+        );
+        // Segment enumeration matches ONLY `.log` files: a `.tindex` is never seen as a segment.
+        let ids = segment_ids(&fs).unwrap();
+        assert_eq!(ids.len(), logs.len());
+        // Reopen and read the whole log: the records are byte-identical regardless of the sidecars.
+        let log = Log::open(fs, ManualClock::new(), time_config()).unwrap();
+        let all = log.read_range(Offset::ZERO, ts.len(), None).unwrap();
+        assert_eq!(all.len(), ts.len());
+        for (i, r) in all.iter().enumerate() {
+            assert_eq!(r.timestamp_ms, ts[i]);
+        }
+    }
+
+    #[test]
+    fn tindex_density_config_bounds_the_sidecar_size() {
+        // A LARGER stride yields FEWER anchors for the same records (a pure size/latency trade), and
+        // the seek stays exact at every density.
+        let ts: Vec<u64> = (0..64u64).map(|i| (i * 13) % 40).collect();
+        for stride in [1u32, 4, 16, 1024] {
+            let cfg = LogConfig {
+                max_segment_bytes: 64 * 1024, // one segment, so one `.tindex` covers all records
+                tindex_stride_records: stride,
+                ..LogConfig::default()
+            };
+            let mut log = open_mem(cfg);
+            for (i, &t) in ts.iter().enumerate() {
+                log.append(&rec_at(t, &[u8::try_from(i).unwrap(); 8]))
+                    .unwrap();
+            }
+            // Force a seal so the `.tindex` is written, then verify the anchor count is bounded by
+            // ceil(record_count / stride) and the seek is still exact.
+            log.seal_active_segment().unwrap();
+            let anchors = log
+                .segment_time_anchors(&log.segments[0])
+                .unwrap()
+                .expect("sealed ordinary segment has anchors");
+            let expected_max = ts.len().div_ceil(stride as usize);
+            assert!(
+                anchors.len() <= expected_max,
+                "stride={stride}: {} anchors exceeds ceil({}/{stride})={expected_max}",
+                anchors.len(),
+                ts.len()
+            );
+            sweep_seek(&log, &(0..=42).collect::<Vec<_>>());
+        }
     }
 
     fn view(seq: u64, payload: &[u8]) -> RecordView<'_> {

--- a/crates/ironbus-storage/src/naming.rs
+++ b/crates/ironbus-storage/src/naming.rs
@@ -15,6 +15,8 @@ use std::io;
 const PREFIX: &str = "seg-";
 /// The fixed suffix of a segment file name.
 const SUFFIX: &str = ".log";
+/// The fixed suffix of a segment's `.tindex` (timestamp -> offset) index sidecar (#772).
+const TINDEX_SUFFIX: &str = ".tindex";
 /// The width of the hex id field: a `u64` is exactly 16 hex digits.
 const ID_HEX_LEN: usize = 16;
 
@@ -24,6 +26,16 @@ const ID_HEX_LEN: usize = 16;
 #[must_use]
 pub fn segment_file_name(segment_id: u64) -> String {
     format!("{PREFIX}{segment_id:016x}{SUFFIX}")
+}
+
+/// The on-disk file name for a SEALED segment's `.tindex` timestamp-index sidecar (#772):
+/// `seg-<id:016x>.tindex`, beside its `seg-<id:016x>.log`. It shares the segment's `seg-<id>`
+/// stem (so the two are visibly paired) but carries the `.tindex` suffix, so [`segment_ids`] —
+/// which matches only `.log` — never mistakes a sidecar for a segment, and a stale sidecar is a
+/// harmless derived file that recovery's flat `.log` walk ignores.
+#[must_use]
+pub fn segment_tindex_name(segment_id: u64) -> String {
+    format!("{PREFIX}{segment_id:016x}{TINDEX_SUFFIX}")
 }
 
 /// The on-disk file name of the default work-group's durable cursor checkpoint (`cursor.ckpt`).
@@ -283,6 +295,20 @@ mod tests {
         assert_eq!(segment_file_name(1), "seg-0000000000000001.log");
         assert_eq!(segment_file_name(255), "seg-00000000000000ff.log");
         assert_eq!(segment_file_name(u64::MAX), "seg-ffffffffffffffff.log");
+    }
+
+    #[test]
+    fn tindex_names_pair_with_the_segment_but_are_not_segments() {
+        // The `.tindex` sidecar shares the `seg-<id>` stem so the pair is visible, but its `.tindex`
+        // suffix keeps it out of segment enumeration (#772).
+        assert_eq!(segment_tindex_name(1), "seg-0000000000000001.tindex");
+        assert_eq!(segment_tindex_name(255), "seg-00000000000000ff.tindex");
+        // A `.tindex` file is NEVER parsed as a segment (segment enumeration matches only `.log`).
+        assert_eq!(parse_segment_file_name(&segment_tindex_name(7)), None);
+        let fs = InMemoryFs::new();
+        fs.create_new(&segment_file_name(7)).unwrap();
+        fs.create_new(&segment_tindex_name(7)).unwrap();
+        assert_eq!(segment_ids(&fs).unwrap(), vec![7]); // the sidecar is skipped
     }
 
     #[test]

--- a/crates/ironbus-storage/src/segment.rs
+++ b/crates/ironbus-storage/src/segment.rs
@@ -1334,6 +1334,22 @@ struct SparseWalk {
 /// valid record region ends (`valid_end`), the read-forward upper bound.
 pub type SparsePositions = (Vec<(u64, u64)>, u64);
 
+/// The running result of a [`SegmentReader::walk_time_anchors`] walk (#772): the sparse
+/// `(offset, exclusive prefix-max timestamp)` anchors plus the seal cross-check facts (record count
+/// and last sequence) and whether the region decoded cleanly.
+struct TimeAnchorWalk {
+    /// The sparse `(offset, exclusive prefix-max timestamp)` anchors, ascending by offset.
+    anchors: Vec<(u64, u64)>,
+    /// The last valid record's sequence (`None` if the region held no record), for the seal check.
+    last_seq: Option<Seq>,
+    /// How many valid records the walk decoded (the seal check cross-checks the footer's count).
+    count: u64,
+    /// Bytes consumed relative to the walk's start offset (the valid prefix length).
+    cursor: u64,
+    /// `true` if the region decoded cleanly with no torn or corrupt tail.
+    clean: bool,
+}
+
 /// The running result of a streaming body walk: see [`SegmentReader::scan_body_streaming`].
 struct BodyWalk {
     /// Valid records seen before the first torn or corrupt frame.
@@ -1724,6 +1740,131 @@ impl<F: RandomAccessFile> SegmentReader<F> {
 
         let walk = self.walk_sparse_positions(header_end, self.file_len, stride)?;
         Ok((walk.anchors, header_end + walk.cursor))
+    }
+
+    /// Rebuilds the SPARSE timestamp -> offset anchors for this segment's `.tindex` (#772) from a
+    /// validating frame walk of the durable record region: one `(offset, exclusive prefix-max
+    /// timestamp)` anchor every `stride_records` records (index `0, stride, 2*stride, ...`),
+    /// byte-identical to the anchors [`crate::tindex::build_anchors`] produces from the same
+    /// timestamps (the seal path accumulates those incrementally; this is the rebuild path for a
+    /// missing/torn/corrupt sidecar). It steps the SAME full-CRC-validating `codec::decode` walk the
+    /// offset-index build uses, so it stops at the exact valid prefix a scan would and never anchors
+    /// a timestamp past a torn or body-corrupt frame. Memory is bounded to one per-frame scratch
+    /// buffer plus the sparse anchors, never the whole region.
+    ///
+    /// `stride_records` is clamped up to 1 so a degenerate `0` cannot anchor every record.
+    ///
+    /// # Errors
+    /// Returns [`StorageError::FooterSegmentMismatch`] if a body-consistent footer names a different
+    /// segment (the recycled/mixed-file guard `scan` applies), or an IO error reading the region.
+    pub fn time_anchors(&self, stride_records: u32) -> Result<Vec<(u64, u64)>, StorageError> {
+        let header_end = SEGMENT_HEADER_LEN as u64;
+        let footer_len = SEGMENT_FOOTER_LEN as u64;
+        // Mirror `sparse_record_byte_positions`/`scan` seal handling so the walked region (and thus
+        // the anchor set) is byte-identical to what the append path sealed: a trailing footer is
+        // trusted (and excluded) only when it is consistent with the body.
+        let candidate = if self.file_len >= header_end + footer_len {
+            let mut fbuf = [0u8; SEGMENT_FOOTER_LEN];
+            self.file
+                .read_exact_at(&mut fbuf, self.file_len - footer_len)?;
+            SegmentFooter::decode(&fbuf).ok()
+        } else {
+            None
+        };
+        if let Some(footer) = candidate {
+            let body_end = self.file_len - footer_len;
+            let walk = self.walk_time_anchors(header_end, body_end, stride_records)?;
+            let ends_at_footer = walk.clean && header_end + walk.cursor == body_end;
+            let expected_last_seq = walk.last_seq.unwrap_or(self.header.base_seq);
+            let body_matches = u64::from(footer.record_count) == walk.count
+                && footer.last_seq == expected_last_seq;
+            if ends_at_footer && body_matches {
+                if footer.segment_id != self.header.segment_id {
+                    return Err(StorageError::FooterSegmentMismatch {
+                        header: self.header.segment_id,
+                        footer: footer.segment_id,
+                    });
+                }
+                return Ok(walk.anchors);
+            }
+        }
+        Ok(self
+            .walk_time_anchors(header_end, self.file_len, stride_records)?
+            .anchors)
+    }
+
+    /// Streams `[start, end)` frame-by-frame, FULL-CRC-validating each frame (the SAME `codec::decode`
+    /// the offset-index/recovery walks use), collecting one `(offset, exclusive prefix-max
+    /// timestamp)` anchor every `stride_records` records and stopping at the first torn OR
+    /// body-corrupt frame (#772). The running max is the max producer timestamp across the records
+    /// strictly BEFORE the anchored offset, exactly the value [`crate::tindex::build_anchors`]
+    /// stores, so a rebuilt index resolves the same offset as the append-seeded one.
+    fn walk_time_anchors(
+        &self,
+        start: u64,
+        end: u64,
+        stride_records: u32,
+    ) -> Result<TimeAnchorWalk, StorageError> {
+        let stride = u64::from(stride_records.max(1));
+        let base = self.header.base_offset.get();
+        let mut scratch: Vec<u8> = Vec::new();
+        let mut pos = start;
+        let mut count = 0u64;
+        let mut running_max = 0u64;
+        let mut last_seq = None;
+        let mut clean = true;
+        let mut anchors: Vec<(u64, u64)> = Vec::new();
+        while pos < end {
+            let remaining = end - pos;
+            if remaining < RECORD_HEADER_LEN as u64 {
+                clean = false;
+                break;
+            }
+            scratch.resize(RECORD_HEADER_LEN, 0);
+            self.file.read_exact_at(&mut scratch, pos)?;
+            if has_post_header_prefix_field(scratch[ironbus_core::format::header_offsets::FLAGS])
+                && remaining >= (RECORD_HEADER_LEN + RECORD_SUBJECT_LEN_PREFIX) as u64
+            {
+                scratch.resize(RECORD_HEADER_LEN + RECORD_SUBJECT_LEN_PREFIX, 0);
+                self.file.read_exact_at(
+                    &mut scratch[RECORD_HEADER_LEN..],
+                    pos + RECORD_HEADER_LEN as u64,
+                )?;
+            }
+            let Ok(total) = codec::decoded_len(&scratch) else {
+                clean = false;
+                break;
+            };
+            if total as u64 > remaining {
+                clean = false;
+                break;
+            }
+            scratch.resize(total, 0);
+            self.file.read_exact_at(
+                &mut scratch[RECORD_HEADER_LEN..],
+                pos + RECORD_HEADER_LEN as u64,
+            )?;
+            let Ok((view, consumed)) = codec::decode(&scratch) else {
+                clean = false;
+                break;
+            };
+            // Anchor this record when it starts a new stride bucket, carrying the EXCLUSIVE prefix
+            // max (the running max BEFORE folding in this record's timestamp).
+            if count % stride == 0 {
+                anchors.push((base.saturating_add(count), running_max));
+            }
+            running_max = running_max.max(view.timestamp_ms);
+            last_seq = Some(view.seq);
+            count += 1;
+            pos += consumed as u64;
+        }
+        Ok(TimeAnchorWalk {
+            anchors,
+            last_seq,
+            count,
+            cursor: pos - start,
+            clean,
+        })
     }
 
     /// Streams `[start, end)` frame-by-frame, FULL-CRC-validating each frame (the SAME `codec::decode`

--- a/crates/ironbus-storage/src/tindex.rs
+++ b/crates/ironbus-storage/src/tindex.rs
@@ -1,0 +1,395 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! The per-sealed-segment timestamp -> offset SPARSE index sidecar (`.tindex`, #772; the format
+//! specified but never built in #135).
+//!
+//! # What it is
+//! A small, DERIVED, REBUILDABLE accelerator written next to each SEALED segment
+//! (`seg-<id>.tindex` beside `seg-<id>.log`, see [`crate::naming::segment_tindex_name`]). It lets a
+//! consumer SEEK to a wall-clock timestamp — "give me the first record whose append time is at or
+//! after T" — in `O(log segments)` + a bounded per-segment forward scan, instead of a full log
+//! scan. It reaches parity with NATS JetStream `DeliverByStartTime`, Kafka `offsetsForTimes`, and
+//! Pulsar time-seek.
+//!
+//! # The sparse anchors
+//! An anchor is a `(offset, prefix_max_ts)` pair where `prefix_max_ts` is the MAXIMUM producer
+//! timestamp across every record STRICTLY BEFORE `offset` in the segment (an exclusive prefix max).
+//! One anchor is taken every `stride` records (the tunable [`crate::log::LogConfig::
+//! tindex_stride_records`]), plus one always at the segment base. Two invariants make a seek exact
+//! even when producer timestamps are NON-MONOTONIC (delayed messages, #555):
+//! - anchors ascend by `offset`;
+//! - `prefix_max_ts` is NON-DECREASING in `offset` (a running max), so a threshold query is a
+//!   binary search.
+//!
+//! # Why prefix-MAX (the correctness crux)
+//! Producer timestamps are non-monotonic, so a naive "largest indexed ts <= T then scan" would SKIP
+//! an out-of-order matching record that sits before the anchor. Anchoring on the exclusive
+//! prefix-max makes the anchor a true LOWER BOUND: if `prefix_max_ts(offset) < T` then NO record
+//! before `offset` has `ts >= T`, so the first match is at or after `offset`. The seek therefore
+//! lands on exactly the same offset a brute-force full scan would (proven in the storage
+//! differential test), with the only honest caveat being retention (a match in a reaped segment is
+//! gone; the seek clamps to the earliest retained record).
+//!
+//! # Source of truth
+//! The segment records are authoritative; the `.tindex` is a pure accelerator. A missing, torn, or
+//! corrupt `.tindex` is REBUILT from a segment scan ([`crate::segment::SegmentReader::
+//! time_anchors`]); it never fails a log open and never gates durability. It is a SEPARATE file, so
+//! it never perturbs the byte-identity of the segment `.log`.
+
+use ironbus_core::format::CHECKSUM_ALGO_CRC32C;
+
+/// The `.tindex` file magic (`b"TIDX"`), distinguishing it from a segment `.log` and any foreign
+/// file. A file whose leading bytes are not this is treated as absent (rebuild from the segment).
+pub const TINDEX_MAGIC: [u8; 4] = *b"TIDX";
+
+/// The `.tindex` on-disk format version. Version 1 is the first (and only) layout; a reader that
+/// does not recognise the version treats the sidecar as absent and rebuilds, never mis-parsing it.
+pub const TINDEX_VERSION: u8 = 1;
+
+/// The bytes of a `.tindex` header preceding the anchor entries: `magic(4) + version(1) +
+/// checksum_algo(1) + reserved(2) + segment_id(8) + base_offset(8) + record_count(8) + stride(4) +
+/// entry_count(4)`.
+const HEADER_LEN: usize = 4 + 1 + 1 + 2 + 8 + 8 + 8 + 4 + 4;
+
+/// The bytes of one anchor entry: `offset(8) + prefix_max_ts(8)`, both little-endian.
+const ENTRY_LEN: usize = 16;
+
+/// The trailing CRC32C length (over every preceding byte).
+const CRC_LEN: usize = 4;
+
+/// Builds the SPARSE `(offset, prefix_max_ts)` anchors for a segment from its records' producer
+/// timestamps IN OFFSET ORDER. One anchor is taken per `stride` records (index `0, stride,
+/// 2*stride, ...`), each carrying the EXCLUSIVE prefix max — the maximum timestamp across the
+/// records strictly before that anchor's offset. `stride` is clamped up to 1 so a degenerate `0`
+/// cannot anchor every record.
+///
+/// This is the single source of the anchor shape. A SEALED segment's on-disk sidecar is built by
+/// scanning its durable frames through [`crate::segment::SegmentReader::time_anchors`] (which uses
+/// this rule) the first time it is seeked by time; the ACTIVE segment's anchors are accumulated
+/// incrementally as it appends (`Log::append`) with the identical rule — so the scanned, the
+/// append-seeded, and the persisted anchors are all byte-identical and a seek resolves the same
+/// offset however the anchors were obtained.
+#[must_use]
+pub fn build_anchors<I: IntoIterator<Item = u64>>(
+    timestamps: I,
+    base_offset: u64,
+    stride: u32,
+) -> Vec<(u64, u64)> {
+    let stride = u64::from(stride.max(1));
+    let mut anchors: Vec<(u64, u64)> = Vec::new();
+    let mut running_max = 0u64;
+    let mut idx = 0u64;
+    for ts in timestamps {
+        if idx % stride == 0 {
+            // `running_max` is the max over records `[0, idx)` = the exclusive prefix max at this
+            // anchor's offset (`base + idx`).
+            anchors.push((base_offset.saturating_add(idx), running_max));
+        }
+        running_max = running_max.max(ts);
+        idx = idx.saturating_add(1);
+    }
+    anchors
+}
+
+/// Resolves the bounded forward-scan WINDOW `[scan_from, scan_bound)` within a single segment for
+/// the FIRST record whose timestamp satisfies `meets`, using the sparse `anchors` (ascending
+/// offset, NON-DECREASING prefix max) and the segment's exclusive record end `seg_end`.
+///
+/// `meets` is the record-timestamp predicate — `ts >= T` for a start seek (at-or-after) or `ts > T`
+/// for an exclusive end bound. Because the prefix max is non-decreasing, `meets(prefix_max)`
+/// partitions the anchors into a `false` prefix and a `true` suffix; the last `false` anchor is a
+/// LOWER BOUND (no record before it meets), and the first `true` anchor upper-bounds the match, so
+/// the first matching record lies in `[scan_from, scan_bound)`. The caller reads that window and
+/// returns the first record satisfying `meets`.
+///
+/// `scan_from` is never below `base_offset`; `scan_bound` never below `scan_from`. When no anchor
+/// meets (an empty index, or the only matches sit in the segment's tail past the last anchor), the
+/// window extends to `seg_end`, so the bounded scan still finds a tail match.
+#[must_use]
+pub fn scan_window<M: Fn(u64) -> bool>(
+    anchors: &[(u64, u64)],
+    base_offset: u64,
+    seg_end: u64,
+    meets: M,
+) -> (u64, u64) {
+    // The number of leading anchors whose prefix max does NOT meet: the index of the first anchor
+    // that meets (`anchors.len()` if none do). `prefix_max` is non-decreasing, so this is a clean
+    // partition point (O(log anchors)).
+    let first_meeting = anchors.partition_point(|&(_, pmax)| !meets(pmax));
+    // Scan from the anchor JUST BEFORE the first meeting one (the lower bound), or the base when the
+    // very first anchor meets (only when `meets` accepts the empty-prefix sentinel, e.g. a start
+    // seek to time 0 — the answer is then the segment's first record).
+    let lo = first_meeting.saturating_sub(1);
+    // The bound is the first meeting anchor's offset. When the first anchor itself meets, use the
+    // NEXT anchor so the window is non-empty (`base` up to the end of the first stride bucket).
+    let hi = first_meeting.max(lo + 1);
+    let scan_from = anchors.get(lo).map_or(base_offset, |&(off, _)| off);
+    let scan_bound = anchors.get(hi).map_or(seg_end, |&(off, _)| off);
+    (scan_from.max(base_offset), scan_bound.max(scan_from))
+}
+
+/// Encodes a segment's sparse time index to its on-disk `.tindex` bytes: the header, the anchor
+/// entries, and a trailing CRC32C over everything before it. `record_count` is the sealed segment's
+/// record count (a staleness cross-check on load); `stride` is the density the anchors were built
+/// at (informational). The bytes are self-describing and self-checking so a torn write is detected
+/// (bad CRC) and rebuilt.
+#[must_use]
+pub fn encode(
+    segment_id: u64,
+    base_offset: u64,
+    record_count: u64,
+    stride: u32,
+    anchors: &[(u64, u64)],
+) -> Vec<u8> {
+    let entry_count = u32::try_from(anchors.len()).unwrap_or(u32::MAX);
+    let mut out = Vec::with_capacity(HEADER_LEN + anchors.len() * ENTRY_LEN + CRC_LEN);
+    out.extend_from_slice(&TINDEX_MAGIC);
+    out.push(TINDEX_VERSION);
+    out.push(CHECKSUM_ALGO_CRC32C);
+    out.extend_from_slice(&[0u8; 2]); // reserved
+    out.extend_from_slice(&segment_id.to_le_bytes());
+    out.extend_from_slice(&base_offset.to_le_bytes());
+    out.extend_from_slice(&record_count.to_le_bytes());
+    out.extend_from_slice(&stride.to_le_bytes());
+    out.extend_from_slice(&entry_count.to_le_bytes());
+    for &(offset, pmax) in anchors {
+        out.extend_from_slice(&offset.to_le_bytes());
+        out.extend_from_slice(&pmax.to_le_bytes());
+    }
+    let crc = crc32c::crc32c(&out);
+    out.extend_from_slice(&crc.to_le_bytes());
+    out
+}
+
+/// A parsed, validated `.tindex`: its identifying fields and the sparse anchors. Obtained only via
+/// [`decode`], which enforces every structural invariant, so a `TimeIndex` value is always
+/// well-formed (magic/version/CRC ok, anchors ascending, prefix max non-decreasing).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TimeIndex {
+    /// The segment this index describes (cross-checked against the segment header/slot on load).
+    pub segment_id: u64,
+    /// The segment's base offset (the first anchor's offset).
+    pub base_offset: u64,
+    /// The sealed segment's record count when the index was built (a staleness cross-check).
+    pub record_count: u64,
+    /// The record stride the anchors were built at (informational).
+    pub stride: u32,
+    /// The sparse `(offset, prefix_max_ts)` anchors, ascending by offset, prefix max non-decreasing.
+    pub anchors: Vec<(u64, u64)>,
+}
+
+/// Decodes and FULLY VALIDATES a `.tindex` from `bytes`, returning `None` for ANY problem — too
+/// short, wrong magic/version/checksum-algo, a CRC mismatch (a torn write), an entry count that
+/// overflows the buffer, or a structural violation (anchors not strictly ascending by offset, the
+/// first anchor not at the base, or the prefix max decreasing). A `None` means "treat as absent and
+/// rebuild from the segment", so a corrupt sidecar is NEVER trusted and never fails the caller.
+#[must_use]
+pub fn decode(bytes: &[u8]) -> Option<TimeIndex> {
+    if bytes.len() < HEADER_LEN + CRC_LEN {
+        return None;
+    }
+    if bytes[0..4] != TINDEX_MAGIC {
+        return None;
+    }
+    if bytes[4] != TINDEX_VERSION || bytes[5] != CHECKSUM_ALGO_CRC32C {
+        return None;
+    }
+    let entry_count = read_u32(bytes, 36) as usize;
+    let body_end = HEADER_LEN.checked_add(entry_count.checked_mul(ENTRY_LEN)?)?;
+    // The declared entries must exactly fill the buffer up to the trailing CRC — no more, no less —
+    // so a truncated or over-declared file is rejected rather than partially read.
+    if body_end.checked_add(CRC_LEN)? != bytes.len() {
+        return None;
+    }
+    let stored_crc = read_u32(bytes, body_end);
+    if crc32c::crc32c(&bytes[..body_end]) != stored_crc {
+        return None;
+    }
+    let segment_id = read_u64(bytes, 8);
+    let base_offset = read_u64(bytes, 16);
+    let record_count = read_u64(bytes, 24);
+    let stride = read_u32(bytes, 32);
+    let mut anchors: Vec<(u64, u64)> = Vec::with_capacity(entry_count);
+    let mut prev_off: Option<u64> = None;
+    let mut prev_pmax = 0u64;
+    for i in 0..entry_count {
+        let at = HEADER_LEN + i * ENTRY_LEN;
+        let offset = read_u64(bytes, at);
+        let pmax = read_u64(bytes, at + 8);
+        // Structural invariants: strictly ascending offsets (first at the base), non-decreasing
+        // prefix max. A violation means a bit-flip the CRC somehow missed or a foreign file — reject.
+        match prev_off {
+            None if offset != base_offset => return None,
+            Some(p) if offset <= p => return None,
+            _ => {}
+        }
+        if pmax < prev_pmax {
+            return None;
+        }
+        prev_off = Some(offset);
+        prev_pmax = pmax;
+        anchors.push((offset, pmax));
+    }
+    Some(TimeIndex {
+        segment_id,
+        base_offset,
+        record_count,
+        stride,
+        anchors,
+    })
+}
+
+fn read_u32(b: &[u8], at: usize) -> u32 {
+    u32::from_le_bytes([b[at], b[at + 1], b[at + 2], b[at + 3]])
+}
+
+fn read_u64(b: &[u8], at: usize) -> u64 {
+    u64::from_le_bytes([
+        b[at],
+        b[at + 1],
+        b[at + 2],
+        b[at + 3],
+        b[at + 4],
+        b[at + 5],
+        b[at + 6],
+        b[at + 7],
+    ])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A brute-force reference: the first offset in `[base, base+timestamps.len())` whose timestamp
+    // satisfies `meets`, or `base + len` (the tail) if none does. This is the ground truth a seek
+    // via the sparse anchors MUST match, for arbitrary (including non-monotonic) timestamps.
+    fn brute_force<M: Fn(u64) -> bool>(timestamps: &[u64], base: u64, meets: M) -> u64 {
+        for (i, &ts) in timestamps.iter().enumerate() {
+            if meets(ts) {
+                return base + i as u64;
+            }
+        }
+        base + timestamps.len() as u64
+    }
+
+    // Resolve a threshold seek through the anchors + a bounded window scan, exactly as `Log` does,
+    // and assert it equals the brute-force offset.
+    fn seek_via_anchors<M: Fn(u64) -> bool + Copy>(
+        timestamps: &[u64],
+        base: u64,
+        stride: u32,
+        meets: M,
+    ) -> u64 {
+        let anchors = build_anchors(timestamps.iter().copied(), base, stride);
+        let seg_end = base + timestamps.len() as u64;
+        let (scan_from, scan_bound) = scan_window(&anchors, base, seg_end, meets);
+        // The window must be a valid lower bound: no record BEFORE `scan_from` may meet.
+        for (i, &ts) in timestamps.iter().enumerate() {
+            let off = base + i as u64;
+            if off < scan_from {
+                assert!(
+                    !meets(ts),
+                    "anchor skipped a matching record before scan_from"
+                );
+            }
+        }
+        // Forward scan the bounded window for the first match.
+        let mut off = scan_from;
+        while off < scan_bound {
+            let ts = timestamps[usize::try_from(off - base).unwrap()];
+            if meets(ts) {
+                return off;
+            }
+            off += 1;
+        }
+        // No match inside the window: the whole segment has none at or after the lower bound.
+        seg_end
+    }
+
+    #[test]
+    fn seek_equals_brute_force_for_monotonic_and_non_monotonic() {
+        let cases: Vec<Vec<u64>> = vec![
+            vec![],
+            vec![5],
+            vec![10, 20, 30, 40, 50],                    // monotonic
+            vec![50, 40, 30, 20, 10],                    // strictly decreasing
+            vec![10, 5, 30, 2, 50, 1, 40],               // non-monotonic
+            vec![7, 7, 7, 7, 7],                         // all equal
+            vec![100, 1, 100, 1, 100, 1, 100],           // sawtooth
+            (0..300u64).map(|i| (i * 7) % 53).collect(), // pseudo-random, spans several strides
+        ];
+        for ts in &cases {
+            for &base in &[0u64, 1000] {
+                for &stride in &[1u32, 2, 3, 8, 1024] {
+                    for &t in &[0u64, 1, 2, 5, 7, 30, 49, 50, 53, 100, 101, 1000] {
+                        let start = seek_via_anchors(ts, base, stride, |x| x >= t);
+                        assert_eq!(
+                            start,
+                            brute_force(ts, base, |x| x >= t),
+                            "start seek ts={ts:?} base={base} stride={stride} t={t}"
+                        );
+                        let end = seek_via_anchors(ts, base, stride, |x| x > t);
+                        assert_eq!(
+                            end,
+                            brute_force(ts, base, |x| x > t),
+                            "end seek ts={ts:?} base={base} stride={stride} t={t}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn encode_decode_round_trips() {
+        let anchors = build_anchors([10u64, 5, 30, 2, 50, 1, 40], 1000, 2);
+        let bytes = encode(9, 1000, 7, 2, &anchors);
+        let parsed = decode(&bytes).expect("valid");
+        assert_eq!(parsed.segment_id, 9);
+        assert_eq!(parsed.base_offset, 1000);
+        assert_eq!(parsed.record_count, 7);
+        assert_eq!(parsed.stride, 2);
+        assert_eq!(parsed.anchors, anchors);
+    }
+
+    #[test]
+    fn decode_rejects_torn_and_corrupt() {
+        let anchors = build_anchors([10u64, 20, 30, 40], 0, 2);
+        let good = encode(1, 0, 4, 2, &anchors);
+        assert!(decode(&good).is_some());
+        // Truncated.
+        assert!(decode(&good[..good.len() - 1]).is_none());
+        assert!(decode(&good[..HEADER_LEN]).is_none());
+        // A single flipped byte anywhere fails the CRC.
+        for i in 0..good.len() {
+            let mut torn = good.clone();
+            torn[i] ^= 0xff;
+            assert!(decode(&torn).is_none(), "flip at {i} should reject");
+        }
+        // Wrong magic / version.
+        let mut bad_magic = good.clone();
+        bad_magic[0] = b'X';
+        assert!(decode(&bad_magic).is_none());
+        // Empty / garbage.
+        assert!(decode(&[]).is_none());
+        assert!(decode(b"not a tindex at all really").is_none());
+    }
+
+    #[test]
+    fn decode_rejects_structural_violations() {
+        // Anchors not ascending: hand-build bytes with a descending offset pair.
+        let bad = encode(1, 0, 4, 2, &[(0, 0), (0, 5)]); // equal offsets, not strictly ascending
+        assert!(decode(&bad).is_none());
+        let bad2 = encode(1, 0, 4, 2, &[(5, 0), (10, 0)]); // first anchor not at base
+        assert!(decode(&bad2).is_none());
+        let bad3 = encode(1, 0, 4, 2, &[(0, 10), (5, 3)]); // prefix max decreases
+        assert!(decode(&bad3).is_none());
+    }
+
+    #[test]
+    fn build_anchors_places_one_per_stride_with_exclusive_prefix_max() {
+        let anchors = build_anchors([10u64, 5, 30, 2, 50], 100, 2);
+        // Anchors at indices 0, 2, 4 -> offsets 100, 102, 104.
+        // prefix max: [) empty=0, over [100,102)=max(10,5)=10, over [100,104)=max(10,5,30,2)=30.
+        assert_eq!(anchors, vec![(100, 0), (102, 10), (104, 30)]);
+    }
+}

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -211,6 +211,7 @@ Also still deferred are the MUTATING wire `CONFIG SET`/`SAVE` admin verbs, which
 | `segment_size` | `--max-segment-bytes` / `IRONBUS_MAX_SEGMENT_BYTES` | u64 | `67108864` (64 MiB, `DEFAULT_MAX_SEGMENT_BYTES`) | bytes | `>= 4096` (`MIN_MAX_SEGMENT_BYTES`) | COLD (coupled with `segment_roll`) |
 | `data_dir` | `--data-dir` / `IRONBUS_DATA_DIR` | path | required (no default) | path | a writable directory; created 0700 if absent, probe-write verified (#89) | COLD |
 | `max_total_bytes` | `--max-total-bytes` / `IRONBUS_MAX_TOTAL_BYTES` | u64 | `0` = unlimited (`DEFAULT_MAX_TOTAL_BYTES`) | bytes | `0` (off) or any u64 | HOT |
+| `tindex_stride_records` | `--tindex-stride-records` / `IRONBUS_TINDEX_STRIDE_RECORDS` | u32 | `1024` (`DEFAULT_TINDEX_STRIDE_RECORDS`) | records | any u32; clamped up to `1` | HOT (applies to segments sealed after the change; a derived, rebuildable accelerator) |
 | `segment_roll` | SPECIFIED-NOT-YET-A-FIELD | duration | `0` = size-only (specified) | duration (`{ms,s,m,h,d}`) | `0` (off) or a positive duration | COLD (coupled with `segment_size`) |
 | (no file key: flag/env ONLY) | `--storage` / `IRONBUS_STORAGE` | enum | `disk` (`DEFAULT_STORAGE`) | -- | `disk \| memory` (#443) | COLD (the backend is an open-time decision) |
 | (no file key: flag/env ONLY) | `--ephemeral-loss-ack` / `IRONBUS_EPHEMERAL_LOSS_ACK` | bool | `false` | -- | `true` to permit `--storage memory` | COLD (coupled with the backend) |

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -317,6 +317,40 @@ contiguous trailing write, so they become durable together. Nothing in the heade
 `[44, 60)` is touched (it stays owned by at-rest encryption), so a compacted-AND-encrypted segment
 has room for both.
 
+### `.tindex` timestamp-index sidecar (on-disk, #772)
+
+A DERIVED, REBUILDABLE accelerator written beside each SEALED segment as
+`seg-<id:016x>.tindex` (`crates/ironbus-storage/src/tindex.rs`, `crate::naming::
+segment_tindex_name`). It is NOT part of the segment `.log` byte contract and NOT a
+durability dependency: the segment records are authoritative, so a missing, torn, or
+corrupt `.tindex` is rebuilt from a segment scan and never fails a log open. Because it is
+a separate file, it never perturbs the segment `.log` byte image, and segment enumeration
+(which matches only `.log`) never mistakes it for a segment.
+
+Layout: a fixed 40-byte header, then `entry_count` 16-byte anchors, then a trailing CRC32C
+over every preceding byte. All little-endian.
+
+| offset | field | type | notes |
+|---|---|---|---|
+| `[0, 4)`   | `magic`        | `[u8;4]` | `b"TIDX"` |
+| `[4, 5)`   | `version`      | u8  | `1` (`TINDEX_VERSION`); an unrecognized version is treated as absent and rebuilt |
+| `[5, 6)`   | `checksum_algo`| u8  | `0x1` (CRC32C), matching the segment footer |
+| `[6, 8)`   | `reserved`     | u16 | zero |
+| `[8, 16)`  | `segment_id`   | u64 | cross-checked against the segment header/slot on load; a mismatch rebuilds |
+| `[16, 24)` | `base_offset`  | u64 | the segment's base offset (the first anchor's offset) |
+| `[24, 32)` | `record_count` | u64 | the sealed segment's record count (a staleness cross-check) |
+| `[32, 36)` | `stride`       | u32 | the record stride the anchors were built at (informational) |
+| `[36, 40)` | `entry_count`  | u32 | the number of anchor entries that follow |
+| `[40, 40 + 16*N)` | `anchors` | `[(u64, u64); N]` | `(offset, exclusive prefix-max timestamp)` per anchor, ascending by offset, prefix-max NON-DECREASING; one anchor per `stride` records |
+| `[40 + 16*N, +4)` | `crc` | u32 | CRC32C over all preceding bytes |
+
+The exclusive prefix-max (the max producer timestamp across every record STRICTLY BEFORE
+the anchor's offset) is what makes a seek exact versus a full scan even for NON-MONOTONIC
+producer timestamps: the anchor is a true lower bound, so a binary search plus a bounded
+forward scan lands on the same offset a full scan would. `decode` rejects (and the caller
+rebuilds) on any bad magic/version/CRC or structural violation, so a corrupt sidecar is
+never trusted.
+
 ---
 
 ## On-disk checkpoint models
@@ -632,7 +666,7 @@ numbers, planes, and purposes:
 |-----|-----------|-------------------|---------|
 | 22  | `ProduceConfirm` | server to client | Level-2 consumed-confirmation for an opted-in produce: `offset` (8B LE) + one-byte status (0 consumed, 1 timed-out, 2 dead-lettered) (#494, #497) |
 | 23  | `Fetch` | client to server | batched work-group pull; answered with the existing `Deliver`/advisory frames terminated by one `FlowEnd` (#464) |
-| 24  | `StreamFetch` | client to server | Tier-S offset-addressed window fetch (`start_offset` + caps) (#543) |
+| 24  | `StreamFetch` | client to server | Tier-S window fetch: `start_offset` + caps, plus the ADDITIVE optional `start_time_ms`/`end_time_ms` seek-by-time block appended inside `field_len` only when a time bound is present, so an offset-only fetch is byte-identical (#543, #772) |
 | 25  | `StreamCommit` | client to server | Tier-S cumulative cursor commit for a streaming group (#550) |
 | 26  | `DeliverBatch` | server to client | one contiguous Tier-S run as raw on-disk frame bytes; capability-gated (an old client always gets per-record `Deliver`s) (#541) |
 | 27  | `Raft` | peer only | embedded metadata-Raft message envelope; a client never sends or receives it (#578) |
@@ -1475,11 +1509,11 @@ this one suite.
 These models appear in the #137 draft (or the README/diagram) but are not present in the
 code today. They are aspirational and MUST NOT be treated as a current byte contract.
 
-- **OffsetIndexEntry / `.index` sidecar** and **TimeIndexEntry / `.tindex` sidecar.** The
-  draft's derived 8-byte offset index and 12-byte time index do not exist; there is no
-  index sidecar in the storage layer. The README still describes a "derived offset / time
-  index" as part of the model, but the offset index is rebuilt-on-read at the engine level
-  rather than persisted as a sidecar file.
+- **OffsetIndexEntry / `.index` sidecar.** The draft's derived 8-byte offset index is not
+  persisted; the offset seek index is the resident sparse `SegmentIndex` (#537), rebuilt
+  from the durable frames on reopen rather than written as a `.index` file. (The
+  `.tindex` TIME index sidecar, by contrast, IS now built — see `### .tindex
+  timestamp-index sidecar` above, #772.)
 - **CurrentPointer / `current` file.** The draft's minimal `active_segment_id,
   active_base_offset, last_flushed_offset, crc` pointer is not implemented; recovery scans
   the directory and per-segment checksums directly.

--- a/docs/WAL.md
+++ b/docs/WAL.md
@@ -430,6 +430,7 @@ All of these are `ironbus serve` flags (`crates/ironbus-cli/src/main.rs`), mappe
 | --- | --- | --- | --- |
 | `--max-segment-bytes` | `LogConfig::max_segment_bytes` | 64 MiB | Soft roll cap on the active segment. Rejected below `MIN_MAX_SEGMENT_BYTES`. |
 | `--max-total-bytes` | `LogConfig::max_total_bytes` | 0 (unlimited) | Hard cap on total durable record bytes. At/over it, a produce is shed with `AtCapacity`. |
+| `--tindex-stride-records` | `LogConfig::tindex_stride_records` | 1024 | Seek-by-time `.tindex` density (#772): one sparse timestamp anchor per this many records. A memory/latency trade over the seek accelerator; never affects correctness, durability, or the segment bytes. |
 | `--max-retained-bytes` | `EngineConfig::max_retained_bytes` | 0 (off) | Size retention bound: reap fully-consumed sealed segments while over this. |
 | `--max-age-ms` | `EngineConfig::max_age_ms` | 0 (off) | Age retention bound (ms): reap a sealed segment once all its records are older than this. |
 | `--max-messages` | `EngineConfig::max_messages` | 0 (off) | Count retention bound: reap while total record count exceeds this. |
@@ -448,11 +449,19 @@ Each item below is described in #135 (or the README) but was verified ABSENT in 
 source as of this document. They belong to the seal-then-retire *plan*, not the shipped
 code.
 
-- **Index sidecars (`.index`, `.tindex`).** #135's seal path "finalizes and fsyncs the
-  derived `.index` and `.tindex` sidecars." No such files are created or read anywhere.
-  Reads scan segment files directly (`SegmentReader::scan`); the offset index is derived
-  in memory (the sorted `SegmentSlot` list plus a binary search), not persisted. The
-  README's "derived offset / time index" is in-memory and rebuilt on startup.
+- **The offset `.index` sidecar** is still in-memory only: the offset seek index is the
+  resident sparse `SegmentIndex` (#537), rebuilt from the durable frames on reopen, not a
+  persisted `.index` file.
+- **The `.tindex` time index sidecar is now BUILT (#772).** The seal path finalizes and
+  fsyncs a derived `seg-<id>.tindex` beside each sealed segment: a sparse
+  `(offset, exclusive prefix-max timestamp)` anchor list (one anchor per
+  `LogConfig::tindex_stride_records` records, default 1024) that resolves a wall-clock
+  seek to a starting offset in `O(log n)`. It is a DERIVED, REBUILDABLE accelerator — the
+  segment records are the source of truth, so a missing, torn, or corrupt `.tindex` is
+  rebuilt from a segment scan (`SegmentReader::time_anchors`), never failing a log open
+  and never gating durability, and it is a SEPARATE file so it never perturbs the segment
+  `.log` bytes. The build/seek/format live in `crates/ironbus-storage/src/tindex.rs` and
+  `log.rs`; the wire seek is the additive `start_time_ms`/`end_time_ms` on `StreamFetch`.
 - **A `current` pointer file.** #135's seal "advances the `current` pointer atomically
   (write-temp, rename, fsync parent dir)." There is no pointer file; the active segment
   is simply the highest-id `seg-*.log` in the directory.


### PR DESCRIPTION
## What

Implements **#772 (M1-I14): seek-by-time + time-bounded replay on the streaming consume path**, backed by the sparse per-segment timestamp → offset `.tindex` sidecar that #135 specified but never built. Reaches NATS JetStream `DeliverByStartTime`, Kafka `offsetsForTimes` (KIP-79), and Pulsar time-seek parity.

## The `.tindex` sidecar

- **Format** (`crates/ironbus-storage/src/tindex.rs`, registered in `docs/CONTRACTS.md`): magic `TIDX` + version + CRC32C, a segment id/base/count cross-check, then sparse `(offset, exclusive prefix-max timestamp)` anchors — one per `tindex_stride_records` records.
- **Correctness crux — the prefix max.** Producer timestamps are non-monotonic (delayed messages, #555). Anchoring on the EXCLUSIVE PREFIX MAX (the max ts over all records *strictly before* the anchor's offset), not a raw timestamp, makes the anchor a true LOWER BOUND: `prefix_max(o) < T` ⟹ no record before `o` meets, so a binary search + bounded forward scan lands on **exactly** the offset a full scan would. Proven by a differential test (`seek == brute-force scan` for random + non-monotonic timestamps).
- **Lazy, off the hot path.** The sidecar is built + fsynced on the **first time-seek** (from a deterministic frame scan), not on the produce/roll path. Writing a derived sidecar on seal/reap would add fsync + directory IO that perturbs the byte-identity / determinism / fault-injection (op-counting) conformance gates, and would make the on-disk image depend on resume state. So an offset-only workload writes no sidecars and stays byte-identical; a missing/torn/corrupt/stale sidecar is silently rebuilt from the frames (the source of truth), never failing a log open. The active segment keeps in-memory append-seeded anchors for its own seek.

## Seek semantics (documented, honest about non-monotonicity)

- `start_time_ms` → **offset-authoritative** first offset with `ts >= start_time` (exact vs a full scan). Takes precedence over `start_offset`. Clamps to the earliest retained offset (retention is the only caveat); a future time resolves to the tail.
- `end_time_ms` → **exclusive** first offset with `ts > end_time`; delivery is bounded to `[start, end)`. Offset-authoritative + terminating-predicate (matches a full-scan time filter under monotonic timestamps; documented dual caveat under non-monotonic).

## Wire (additive, byte-identical default)

Optional `start_time_ms`/`end_time_ms` appended inside `StreamFetchBody`'s `version` + `field_len` block **only when a time bound is present** — an offset-only `StreamFetch` is byte-for-byte unchanged. Forward-compat test stays green.

## Surface

- Engine `stream_resolve_time_in{,_stream}`; session wires the resolve + an exact per-record end-offset guard (raw batch path untouched for offset-only fetches).
- Clients: sync + async `stream_fetch_by_time`.
- Config: `--tindex-stride-records` / `IRONBUS_TINDEX_STRIDE_RECORDS` / `storage.tindex_stride_records` (default 1024) — a memory/latency trade with a safe default.
- Docs: WAL.md, CONFIG.md, CONTRACTS.md.

## Gates (all green locally, `--all-features`)

`cargo fmt --check`; `cargo clippy --workspace --all-targets --all-features -D warnings`; `cargo test --workspace --all-features` = **3447 passed / 0 failed**; storage byte-identity / determinism / crash-recovery / seeded-faults / conformance-recovery integration suites; `relative-link-check` (0 problems); golden-path acceptance.

Closes #772.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01McmNfYNWPmohVS8umY9Lkp
