### PR TITLE
feat(delivery): opt-in message priorities via priority lanes (#553)

### DIFF
--- a/crates/ironbus-client-async/src/lib.rs
+++ b/crates/ironbus-client-async/src/lib.rs
@@ -1340,11 +1340,41 @@ impl AsyncClient {
     /// a malformed/over-long name), [`ClientError::Body`] on an over-large field, or a frame/connection
     /// error.
     pub async fn declare_stream(&mut self, stream: &str) -> Result<(), ClientError> {
+        self.declare_stream_with(stream, 1, false).await
+    }
+
+    /// CREATE-OR-ENSURE a PRIORITY-MODE stream with `levels` priority lanes (#553): the async port of
+    /// [`ironbus_client::Client::declare_priority_stream`]. `levels` must be `>= 2`; delivery drains the
+    /// highest-priority non-empty lane first. MUTUALLY EXCLUSIVE with key-partitioning.
+    ///
+    /// # Errors
+    /// As [`AsyncClient::declare_stream`], plus a server rejection for `levels < 2` or a mode conflict.
+    pub async fn declare_priority_stream(
+        &mut self,
+        stream: &str,
+        levels: u32,
+    ) -> Result<(), ClientError> {
+        self.declare_stream_with(stream, levels, true).await
+    }
+
+    /// The shared `StreamDeclare` path behind [`AsyncClient::declare_stream`] and
+    /// [`AsyncClient::declare_priority_stream`], sending the additive `partition_count` + `priority`
+    /// flag and awaiting the body-less `Ok`.
+    ///
+    /// # Errors
+    /// As [`AsyncClient::declare_stream`].
+    async fn declare_stream_with(
+        &mut self,
+        stream: &str,
+        partition_count: u32,
+        priority: bool,
+    ) -> Result<(), ClientError> {
         let mut body = Vec::new();
         encode_stream_declare(
             &StreamDeclareBody {
                 stream_id: stream.as_bytes(),
-                partition_count: 1,
+                partition_count,
+                priority,
             },
             &mut body,
         )
@@ -1452,6 +1482,22 @@ impl AsyncClient {
         stream: &str,
         message: &PubBody<'_>,
     ) -> Result<u64, ClientError> {
+        self.publish_to_with_priority(stream, 0, message).await
+    }
+
+    /// PUBLISH `message` to a PRIORITY-MODE stream at priority `priority` (#553): the async port of
+    /// [`ironbus_client::Client::publish_to_with_priority`]. The broker routes the record to the lane of
+    /// this priority (higher delivered first; over-max saturates to the top lane). `priority = 0` is
+    /// exactly [`AsyncClient::publish_to`]. At-least-once (server-ack, Level 1).
+    ///
+    /// # Errors
+    /// As [`AsyncClient::publish_to`].
+    pub async fn publish_to_with_priority(
+        &mut self,
+        stream: &str,
+        priority: u8,
+        message: &PubBody<'_>,
+    ) -> Result<u64, ClientError> {
         // Force at-least-once server-ack (Level 1) on the carried body: the named-stream path accepts
         // only that level this phase, mirroring the sync `publish_to` exactly. An old caller never set a
         // level bit, so this is a no-op for them and a guard against a mismatched method/wire for everyone.
@@ -1465,6 +1511,7 @@ impl AsyncClient {
         encode_pub_to(
             &PubToBody {
                 stream_id: stream.as_bytes(),
+                priority,
                 pub_body: &pub_body,
             },
             &mut body,

--- a/crates/ironbus-client/src/lib.rs
+++ b/crates/ironbus-client/src/lib.rs
@@ -2994,11 +2994,45 @@ impl Client {
     /// a malformed/over-long name), [`ClientError::Body`] on an over-large field, or a frame/connection
     /// error.
     pub fn declare_stream(&mut self, stream: &str) -> Result<(), ClientError> {
+        self.declare_stream_with(stream, 1, false)
+    }
+
+    /// CREATE-OR-ENSURE a PRIORITY-MODE stream with `levels` priority lanes (M4-I3, #553): the
+    /// `StreamDeclare` verb with the priority flag set. A produce to this stream via
+    /// [`Client::publish_to_with_priority`] routes to the lane of its priority, and delivery drains the
+    /// highest-priority non-empty lane first (strict priority). `levels` must be `>= 2` (a single lane
+    /// has no priorities to order). Idempotent — re-declaring with the SAME `levels` is a no-op success;
+    /// a name already resident in another mode is rejected. A priority stream is MUTUALLY EXCLUSIVE with
+    /// key-partitioning. Requires the stream-addressing capability (see [`Client::declare_stream`]).
+    ///
+    /// # Errors
+    /// As [`Client::declare_stream`], plus a server rejection for `levels < 2` or a mode conflict.
+    pub fn declare_priority_stream(
+        &mut self,
+        stream: &str,
+        levels: u32,
+    ) -> Result<(), ClientError> {
+        self.declare_stream_with(stream, levels, true)
+    }
+
+    /// The shared `StreamDeclare` path behind [`Client::declare_stream`] (single-log) and
+    /// [`Client::declare_priority_stream`] (priority lanes): sends the additive `partition_count` +
+    /// `priority` flag and awaits the body-less `Ok`.
+    ///
+    /// # Errors
+    /// As [`Client::declare_stream`].
+    fn declare_stream_with(
+        &mut self,
+        stream: &str,
+        partition_count: u32,
+        priority: bool,
+    ) -> Result<(), ClientError> {
         let mut body = Vec::new();
         encode_stream_declare(
             &StreamDeclareBody {
                 stream_id: stream.as_bytes(),
-                partition_count: 1,
+                partition_count,
+                priority,
             },
             &mut body,
         )
@@ -3105,6 +3139,24 @@ impl Client {
     /// malformed name, or a non-server-ack level), [`ClientError::Body`] on an over-large field,
     /// [`ClientError::BadResponse`] on a malformed ack, or a frame/connection error.
     pub fn publish_to(&mut self, stream: &str, message: &PubBody<'_>) -> Result<u64, ClientError> {
+        self.publish_to_with_priority(stream, 0, message)
+    }
+
+    /// PUBLISH `message` to a PRIORITY-MODE stream at priority `priority` (M4-I3, #553): the broker
+    /// routes the record to the lane of this priority (higher = delivered first; a priority above the
+    /// stream's top level saturates to the top lane), and it is an ordinary FIFO-by-offset record WITHIN
+    /// that lane. `priority = 0` is exactly [`Client::publish_to`] (the lowest priority AND the
+    /// byte-for-byte historical `PubTo` body). Ignored for a non-priority stream. At-least-once
+    /// (server-ack, Level 1), as [`Client::publish_to`].
+    ///
+    /// # Errors
+    /// As [`Client::publish_to`].
+    pub fn publish_to_with_priority(
+        &mut self,
+        stream: &str,
+        priority: u8,
+        message: &PubBody<'_>,
+    ) -> Result<u64, ClientError> {
         // Force at-least-once server-ack (Level 1) on the carried body: the named-stream path accepts
         // only that level this phase, and an old caller never set a level bit, so this is a no-op for
         // them and a guard against a mismatched method/wire for everyone.
@@ -3118,6 +3170,7 @@ impl Client {
         encode_pub_to(
             &PubToBody {
                 stream_id: stream.as_bytes(),
+                priority,
                 pub_body: &pub_body,
             },
             &mut body,

--- a/crates/ironbus-proto/src/message.rs
+++ b/crates/ironbus-proto/src/message.rs
@@ -2471,15 +2471,28 @@ pub struct StreamDeclareBody<'a> {
     /// It is an ADDITIVE wire field emitted ONLY when `> 1`, so an old client (or any single-partition
     /// declare) is byte-for-byte the historical `StreamDeclare` body and a partitioned stream is opt-in.
     pub partition_count: u32,
+    /// Whether the `partition_count` sub-logs are PRIORITY LANES rather than key-hash partitions
+    /// (M4-I3, #553): `false` (the DEFAULT) is a key-partitioned stream (or, with `partition_count <= 1`,
+    /// a plain single-log stream); `true` opts the stream into PRIORITY MODE, where the `P = partition_count`
+    /// sub-logs are priority levels `0..P` — a produce routes to the lane of its priority and delivery
+    /// drains the highest-priority non-empty lane first. It is an ADDITIVE wire field (a single `u8`
+    /// appended AFTER `partition_count`) emitted ONLY when `true`; a non-priority declare omits it and is
+    /// byte-for-byte the historical `StreamDeclare` body. Priority mode requires `partition_count >= 2`
+    /// (a single lane has no priorities to order) and is MUTUALLY EXCLUSIVE with key-partitioning — the
+    /// broker rejects `priority = true` with `partition_count <= 1` and never treats one stream as both.
+    pub priority: bool,
 }
 
 /// Encodes a `StreamDeclare` body onto the end of `out` (#588, #693).
 ///
 /// The `partition_count` is appended INSIDE the field-length block AFTER the stream id, and ONLY when
 /// it exceeds `1` (the default single partition), so a single-partition declare is byte-for-byte the
-/// pre-#693 body. It must remain the LAST additive field of the v1 block: a future field appends after
-/// it and, when set alongside a single-partition declare, must still emit `partition_count = 1` to keep
-/// the positional order the decoder reads.
+/// pre-#693 body. The `priority` flag (#553) is a single `u8` (`1`) appended AFTER `partition_count`,
+/// and ONLY when `true`; since priority mode requires `partition_count >= 2`, the count is always
+/// present when the flag is, so the decoder's positional read (count, then flag) is unambiguous. A
+/// non-priority declare omits the flag and is byte-for-byte the pre-#553 body. These two remain the
+/// LAST additive fields of the v1 block, in this order (count, then priority): a future field appends
+/// after them.
 ///
 /// # Errors
 /// Returns [`BodyError::FieldTooLarge`] if the stream id (or the framed block) exceeds the `u16` wire
@@ -2489,7 +2502,7 @@ pub fn encode_stream_declare(
     out: &mut Vec<u8>,
 ) -> Result<(), BodyError> {
     let id_len = u16::try_from(req.stream_id.len()).map_err(|_| BodyError::FieldTooLarge)?;
-    let extra = usize::from(req.partition_count > 1) * 4;
+    let extra = usize::from(req.partition_count > 1) * 4 + usize::from(req.priority);
     let field_len =
         u16::try_from(2 + req.stream_id.len() + extra).map_err(|_| BodyError::FieldTooLarge)?;
     out.push(STREAM_WIRE_BODY_VERSION);
@@ -2498,6 +2511,12 @@ pub fn encode_stream_declare(
     out.extend_from_slice(req.stream_id);
     if req.partition_count > 1 {
         out.extend_from_slice(&req.partition_count.to_le_bytes());
+    }
+    // The priority-mode flag (#553) is the LAST additive field, a single `1` byte emitted only when
+    // set. It rides after `partition_count` (always present in priority mode, which requires P >= 2),
+    // so a non-priority declare is byte-for-byte the pre-#553 body.
+    if req.priority {
+        out.push(1);
     }
     Ok(())
 }
@@ -2528,9 +2547,16 @@ pub fn decode_stream_declare(body: &[u8]) -> Result<StreamDeclareBody<'_>, BodyE
     // folds to the default `1`. A missing/short remainder, or an out-of-range `0`, folds to `1` (never
     // an error), so the field stays forward-compatible and a partitioned stream is strictly opt-in.
     let partition_count = fr.u32().ok().filter(|&p| p >= 1).unwrap_or(1);
+    // The priority-mode flag (#553) is an ADDITIVE `u8` after the partition count: a priority-aware
+    // client emits `1`, while an old client (or any non-priority declare) omits it and it folds to
+    // `false`. A missing/short remainder folds to `false` (never an error), so the field stays
+    // forward-compatible and priority mode is strictly opt-in. Server-side validation rejects the
+    // meaningless `priority = true` with `partition_count <= 1`.
+    let priority = fr.u8().is_ok_and(|b| b != 0);
     Ok(StreamDeclareBody {
         stream_id,
         partition_count,
+        priority,
     })
 }
 
@@ -2642,32 +2668,52 @@ pub fn decode_stream_info_response(body: &[u8]) -> Result<StreamInfoResponseBody
 pub struct PubToBody<'a> {
     /// The target stream name (empty routes to the default stream, byte-for-byte a plain `Pub`).
     pub stream_id: &'a [u8],
+    /// The message PRIORITY (M4-I3, #553): the priority level for a produce to a PRIORITY-MODE stream,
+    /// where the broker routes the record to the lane of this priority and delivers higher priorities
+    /// first. `0` (the DEFAULT) is the lowest priority AND the byte-for-byte historical `PubTo` body (no
+    /// priority byte is emitted). It rides INSIDE the field-length block after the stream id, so the
+    /// `pub_body` tail is unchanged. Ignored (not stored) for a non-priority stream; a priority above
+    /// the stream's top level `P-1` saturates to the top lane, so a producer need not know `P`. The
+    /// record's priority is FIXED at produce (it is which lane the record lands in), never re-ordered.
+    pub priority: u8,
     /// The verbatim [`PubBody`] bytes, decoded by the caller with [`decode_pub`] (so the publish body
     /// codec is shared UNCHANGED with the default-stream `Pub`).
     pub pub_body: &'a [u8],
 }
 
-/// Encodes a `PubTo` body onto the end of `out` (#588): the version byte, the field-block length over
-/// the stream id, the stream id, then the verbatim `pub_body` bytes. The caller produces `pub_body`
-/// with [`encode_pub`].
+/// Encodes a `PubTo` body onto the end of `out` (#588, #553): the version byte, the field-block length
+/// over the stream id (plus the priority byte when non-zero), the stream id, the optional `priority`
+/// byte, then the verbatim `pub_body` bytes. The caller produces `pub_body` with [`encode_pub`].
+///
+/// The `priority` byte (#553) rides INSIDE the block after the stream id and ONLY when non-zero, so a
+/// default (priority-0) publish is byte-for-byte the pre-#553 body; the `pub_body` tail is unchanged
+/// either way (it is everything after the block).
 ///
 /// # Errors
-/// Returns [`BodyError::FieldTooLarge`] if the stream id exceeds the `u16` wire limit.
+/// Returns [`BodyError::FieldTooLarge`] if the stream id (or the framed block) exceeds the `u16` wire
+/// limit.
 pub fn encode_pub_to(req: &PubToBody<'_>, out: &mut Vec<u8>) -> Result<(), BodyError> {
     let id_len = u16::try_from(req.stream_id.len()).map_err(|_| BodyError::FieldTooLarge)?;
-    let field_len = u16::try_from(2 + req.stream_id.len()).map_err(|_| BodyError::FieldTooLarge)?;
+    let extra = usize::from(req.priority != 0);
+    let field_len =
+        u16::try_from(2 + req.stream_id.len() + extra).map_err(|_| BodyError::FieldTooLarge)?;
     out.push(STREAM_WIRE_BODY_VERSION);
     out.extend_from_slice(&field_len.to_le_bytes());
     out.extend_from_slice(&id_len.to_le_bytes());
     out.extend_from_slice(req.stream_id);
+    // The priority byte (#553) is the LAST field of the block, emitted only when non-zero so a
+    // default-priority publish is byte-for-byte the pre-#553 body.
+    if req.priority != 0 {
+        out.push(req.priority);
+    }
     out.extend_from_slice(req.pub_body);
     Ok(())
 }
 
-/// Decodes a `PubTo` body (#588) into its `stream_id` and the verbatim `pub_body` tail, cap-before-alloc
-/// and panic-free. The caller decodes `pub_body` with [`decode_pub`]. A body too short for its declared
-/// block, or a stream id over [`MAX_STREAM_ID_LEN`], is a typed [`BodyError`] (fail-closed). An EMPTY
-/// body is NOT valid, so it is [`BodyError::Truncated`].
+/// Decodes a `PubTo` body (#588, #553) into its `stream_id`, optional `priority`, and the verbatim
+/// `pub_body` tail, cap-before-alloc and panic-free. The caller decodes `pub_body` with [`decode_pub`].
+/// A body too short for its declared block, or a stream id over [`MAX_STREAM_ID_LEN`], is a typed
+/// [`BodyError`] (fail-closed). An EMPTY body is NOT valid, so it is [`BodyError::Truncated`].
 ///
 /// # Errors
 /// [`BodyError::Truncated`] for a short body, [`BodyError::BadLength`] for an over-cap id, or
@@ -2685,8 +2731,13 @@ pub fn decode_pub_to(body: &[u8]) -> Result<PubToBody<'_>, BodyError> {
     let pub_body = r.rest();
     let mut fr = Reader::new(block);
     let stream_id = read_stream_id(&mut fr)?;
+    // The priority byte (#553) is an ADDITIVE field after the stream id: a priority-aware client emits
+    // it, while an old client (or any priority-0 publish) omits it and it folds to `0` (the lowest
+    // priority AND the historical body). A missing remainder folds to `0` (never an error).
+    let priority = fr.u8().unwrap_or(0);
     Ok(PubToBody {
         stream_id,
+        priority,
         pub_body,
     })
 }
@@ -4734,7 +4785,7 @@ mod tests {
         ) {
             // PubTo (verbatim carrier): stream_id + arbitrary pub_body tail.
             let mut buf = Vec::new();
-            encode_pub_to(&PubToBody { stream_id: &stream_id, pub_body: &pub_body }, &mut buf).unwrap();
+            encode_pub_to(&PubToBody { stream_id: &stream_id, priority: 0, pub_body: &pub_body }, &mut buf).unwrap();
             let v = decode_pub_to(&buf).unwrap();
             prop_assert_eq!(v.stream_id, stream_id.as_slice());
             prop_assert_eq!(v.pub_body, pub_body.as_slice());
@@ -5945,6 +5996,7 @@ mod tests {
                 &StreamDeclareBody {
                     stream_id: id,
                     partition_count: 1,
+                    priority: false,
                 },
                 &mut buf,
             )
@@ -6000,6 +6052,7 @@ mod tests {
         encode_pub_to(
             &PubToBody {
                 stream_id: b"orders",
+                priority: 0,
                 pub_body: &pub_body,
             },
             &mut buf,
@@ -6346,6 +6399,7 @@ mod tests {
             }
             let msg = PubToBody {
                 stream_id: &stream_id,
+                priority: 0,
                 pub_body: &pub_body,
             };
             let mut buf = Vec::new();
@@ -6447,6 +6501,7 @@ mod tests {
         encode_pub_to(
             &PubToBody {
                 stream_id: &at_stream_cap,
+                priority: 0,
                 pub_body: &[],
             },
             &mut buf,
@@ -6540,6 +6595,7 @@ mod tests {
             &StreamDeclareBody {
                 stream_id: b"orders",
                 partition_count: 4,
+                priority: false,
             },
             &mut with_p,
         )
@@ -6553,6 +6609,7 @@ mod tests {
             &StreamDeclareBody {
                 stream_id: b"orders",
                 partition_count: 1,
+                priority: false,
             },
             &mut single,
         )
@@ -6577,6 +6634,103 @@ mod tests {
         zero.extend_from_slice(b"o");
         zero.extend_from_slice(&0u32.to_le_bytes());
         assert_eq!(decode_stream_declare(&zero).unwrap().partition_count, 1);
+    }
+
+    #[test]
+    fn stream_declare_carries_an_additive_priority_flag() {
+        // #553: a PRIORITY-mode declare appends a `1` byte AFTER the partition count; a non-priority
+        // declare omits it and is byte-for-byte the pre-#553 body (the byte-identity proof).
+        let mut prio = Vec::new();
+        encode_stream_declare(
+            &StreamDeclareBody {
+                stream_id: b"jobs",
+                partition_count: 3,
+                priority: true,
+            },
+            &mut prio,
+        )
+        .unwrap();
+        let d = decode_stream_declare(&prio).unwrap();
+        assert_eq!(d.stream_id, b"jobs");
+        assert_eq!(d.partition_count, 3);
+        assert!(d.priority, "the priority flag round-trips");
+
+        // A NON-priority declare (even partitioned) is byte-for-byte the pre-#553 body: no priority byte.
+        let mut plain = Vec::new();
+        encode_stream_declare(
+            &StreamDeclareBody {
+                stream_id: b"jobs",
+                partition_count: 3,
+                priority: false,
+            },
+            &mut plain,
+        )
+        .unwrap();
+        let mut legacy = vec![STREAM_WIRE_BODY_VERSION];
+        let field_len = u16::try_from(2 + "jobs".len() + 4).unwrap();
+        legacy.extend_from_slice(&field_len.to_le_bytes());
+        legacy.extend_from_slice(&u16::try_from("jobs".len()).unwrap().to_le_bytes());
+        legacy.extend_from_slice(b"jobs");
+        legacy.extend_from_slice(&3u32.to_le_bytes());
+        assert_eq!(
+            plain, legacy,
+            "a non-priority declare is byte-for-byte the pre-#553 body"
+        );
+        // The priority body is exactly the plain body plus the trailing `1` (one byte longer).
+        assert_eq!(prio.len(), plain.len() + 1);
+        assert_eq!(*prio.last().unwrap(), 1);
+        // And an OLD-client body (no priority byte) decodes to priority = false.
+        assert!(!decode_stream_declare(&legacy).unwrap().priority);
+    }
+
+    #[test]
+    fn pub_to_carries_an_additive_priority_byte() {
+        // #553: a PubTo carries an additive PRIORITY byte INSIDE its block (after the stream id); a
+        // priority-0 publish omits it and is byte-for-byte the pre-#553 body (the byte-identity proof).
+        let pub_body = b"\x00\x2a\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00payload"; // a sample PubBody
+        let mut prio = Vec::new();
+        encode_pub_to(
+            &PubToBody {
+                stream_id: b"jobs",
+                priority: 7,
+                pub_body,
+            },
+            &mut prio,
+        )
+        .unwrap();
+        let d = decode_pub_to(&prio).unwrap();
+        assert_eq!(d.stream_id, b"jobs");
+        assert_eq!(d.priority, 7, "the priority byte round-trips");
+        assert_eq!(
+            d.pub_body, pub_body,
+            "the pub_body tail is intact past the priority byte"
+        );
+
+        // A priority-0 publish is byte-for-byte the pre-#553 body: no priority byte in the block.
+        let mut plain = Vec::new();
+        encode_pub_to(
+            &PubToBody {
+                stream_id: b"jobs",
+                priority: 0,
+                pub_body,
+            },
+            &mut plain,
+        )
+        .unwrap();
+        let mut legacy = vec![STREAM_WIRE_BODY_VERSION];
+        let field_len = u16::try_from(2 + "jobs".len()).unwrap();
+        legacy.extend_from_slice(&field_len.to_le_bytes());
+        legacy.extend_from_slice(&u16::try_from("jobs".len()).unwrap().to_le_bytes());
+        legacy.extend_from_slice(b"jobs");
+        legacy.extend_from_slice(pub_body);
+        assert_eq!(
+            plain, legacy,
+            "a priority-0 PubTo is byte-for-byte the pre-#553 body"
+        );
+        // An OLD-client body (no priority byte) decodes to priority = 0 with the same pub_body.
+        let old = decode_pub_to(&legacy).unwrap();
+        assert_eq!(old.priority, 0);
+        assert_eq!(old.pub_body, pub_body);
     }
 
     #[test]

--- a/crates/ironbus-proto/tests/export_go_vectors.rs
+++ b/crates/ironbus-proto/tests/export_go_vectors.rs
@@ -764,6 +764,7 @@ fn build_vectors() -> Vec<Vector> {
         &StreamDeclareBody {
             stream_id: b"orders",
             partition_count: 1,
+            priority: false,
         },
         &mut body,
     )
@@ -813,6 +814,7 @@ fn build_vectors() -> Vec<Vector> {
     encode_pub_to(
         &PubToBody {
             stream_id: b"orders",
+            priority: 0,
             pub_body: &pub_body,
         },
         &mut body,

--- a/crates/ironbus-server/src/engine.rs
+++ b/crates/ironbus-server/src/engine.rs
@@ -2943,6 +2943,33 @@ where
     Ok((partitioned, consumers, priority, recoveries))
 }
 
+/// The bit shift separating the LANE (top 8 bits) from the lane OFFSET (low 56 bits) in a composite
+/// priority delivery offset (#553). 56 bits of offset is `~7.2e16` records per lane — unreachable in
+/// practice — and 8 bits of lane covers the 256-lane `Engine::MAX_PRIORITY_LEVELS` ceiling.
+pub(crate) const PRIORITY_LANE_SHIFT: u64 = 56;
+
+/// Composes a priority stream's COMPOSITE delivery offset (#553): the `lane` in the top 8 bits, the
+/// per-lane `raw` offset in the low 56. Globally unique across a stream's lanes for one consumer, so the
+/// offset-keyed lease map and the wire ack need no lane field. See [`decompose_priority_offset`] for the
+/// inverse. A free `pub(crate)` fn (not an `Engine` method) so the session layer's lease bookkeeping can
+/// lane-scope its composite offsets with the SAME encoding.
+#[must_use]
+pub(crate) fn compose_priority_offset(lane: PartitionIndex, raw: Offset) -> u64 {
+    let mask = (1u64 << PRIORITY_LANE_SHIFT) - 1;
+    (u64::from(lane.get()) << PRIORITY_LANE_SHIFT) | (raw.get() & mask)
+}
+
+/// Decomposes a composite priority delivery offset (#553) back into `(lane, lane offset)` — the inverse
+/// of [`compose_priority_offset`]. Used by `Engine::ack_priority` to route an ack (whose offset the
+/// consumer echoed verbatim) to the right lane's cursor, and by the session's `Poll::Truncated` lease
+/// prune to lane-SCOPE the pruning so a reap in one lane never drops another lane's in-flight leases.
+#[must_use]
+pub(crate) fn decompose_priority_offset(composite: u64) -> (u32, Offset) {
+    let mask = (1u64 << PRIORITY_LANE_SHIFT) - 1;
+    let lane = u32::try_from(composite >> PRIORITY_LANE_SHIFT).unwrap_or(u32::MAX);
+    (lane, Offset::new(composite & mask))
+}
+
 /// Reconstructs a group's carried attempt counts from a recovered `attempts.ckpt` payload, clamped
 /// to the durable log head `flushed` and the resumed committed watermark `committed`: a carried
 /// count is only meaningful for an offset that still exists (`< flushed`) and has NOT been committed
@@ -7320,38 +7347,13 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
     /// every representable priority maps to a lane (saturating at the top when `priority >= P`).
     const MAX_PRIORITY_LEVELS: u32 = 256;
 
-    /// The bit shift separating the LANE (top 8 bits) from the lane OFFSET (low 56 bits) in a composite
-    /// priority delivery offset (#553). 56 bits of offset is `~7.2e16` records per lane — unreachable in
-    /// practice — and 8 bits of lane covers the `256`-lane [`Engine::MAX_PRIORITY_LEVELS`] ceiling.
-    const PRIORITY_LANE_SHIFT: u64 = 56;
-
-    /// Composes a priority stream's COMPOSITE delivery offset (#553): the `lane` in the top 8 bits, the
-    /// per-lane `raw` offset in the low 56. Globally unique across a stream's lanes for one consumer, so
-    /// the offset-keyed lease map and the wire ack need no lane field. See [`Engine::ack_priority`] for
-    /// the inverse.
-    #[must_use]
-    fn compose_priority_offset(lane: PartitionIndex, raw: Offset) -> u64 {
-        let mask = (1u64 << Self::PRIORITY_LANE_SHIFT) - 1;
-        (u64::from(lane.get()) << Self::PRIORITY_LANE_SHIFT) | (raw.get() & mask)
-    }
-
-    /// Decomposes a composite priority delivery offset (#553) back into `(lane, lane offset)` — the
-    /// inverse of [`Engine::compose_priority_offset`], used by [`Engine::ack_priority`] to route an ack
-    /// (whose offset the consumer echoed verbatim) to the right lane's cursor.
-    #[must_use]
-    fn decompose_priority_offset(composite: u64) -> (u32, Offset) {
-        let mask = (1u64 << Self::PRIORITY_LANE_SHIFT) - 1;
-        let lane = u32::try_from(composite >> Self::PRIORITY_LANE_SHIFT).unwrap_or(u32::MAX);
-        (lane, Offset::new(composite & mask))
-    }
-
     /// Rewrites every offset a lane's [`Poll`] surfaces into the COMPOSITE lane-tagged offset (#553), so
     /// a priority consumer's leases, acks, and in-band advisories all carry the globally-unique offset.
     /// `Poll::Idle` never reaches here (the scan continues past an idle lane); every other variant has
     /// its `Offset` fields tagged with `lane`.
     #[must_use]
     fn compose_priority_poll(lane: PartitionIndex, poll: Poll) -> Poll {
-        let tag = |o: Offset| Offset::new(Self::compose_priority_offset(lane, o));
+        let tag = |o: Offset| Offset::new(compose_priority_offset(lane, o));
         match poll {
             Poll::Message(mut d) => {
                 d.token.offset = tag(d.token.offset);
@@ -7635,7 +7637,7 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         if !self.is_priority_stream(stream) {
             return AckResult::Fenced;
         }
-        let (lane, raw) = Self::decompose_priority_offset(token.offset.get());
+        let (lane, raw) = decompose_priority_offset(token.offset.get());
         self.ack_partition(
             stream,
             lane,
@@ -30834,14 +30836,21 @@ mod tests {
     fn priority_composite_offset_round_trips() {
         for lane in [0u32, 1, 7, 42, 255] {
             for raw in [0u64, 1, 1000, (1u64 << 55) - 1] {
-                let composite = Engine::<InMemoryFs, ManualClock>::compose_priority_offset(
-                    PartitionIndex::new(lane),
-                    Offset::new(raw),
-                );
-                let (dl, doff) =
-                    Engine::<InMemoryFs, ManualClock>::decompose_priority_offset(composite);
+                let composite =
+                    compose_priority_offset(PartitionIndex::new(lane), Offset::new(raw));
+                let (dl, doff) = decompose_priority_offset(composite);
                 assert_eq!(dl, lane);
                 assert_eq!(doff.get(), raw);
+                // Same-lane composites are ORDER-PRESERVING on the low 56 bits — the property the
+                // session's lane-scoped `Poll::Truncated` prune relies on.
+                if raw > 0 {
+                    let lower =
+                        compose_priority_offset(PartitionIndex::new(lane), Offset::new(raw - 1));
+                    assert!(
+                        lower < composite,
+                        "within a lane, offset order is preserved"
+                    );
+                }
             }
         }
     }

--- a/crates/ironbus-server/src/engine.rs
+++ b/crates/ironbus-server/src/engine.rs
@@ -50,7 +50,9 @@ use ironbus_storage::checkpoint::{
 };
 use ironbus_storage::dlq::{DeadLetterExchange, DeadLetterReason, DlqSink, DLQ_SUBDIR};
 use ironbus_storage::fs::Filesystem;
-use ironbus_storage::layout::{PARTITIONED_STREAMS_SUBDIR, SHARED_WAL_SUBDIR, STREAMS_SUBDIR};
+use ironbus_storage::layout::{
+    PARTITIONED_STREAMS_SUBDIR, PRIORITY_STREAMS_SUBDIR, SHARED_WAL_SUBDIR, STREAMS_SUBDIR,
+};
 use ironbus_storage::log::{Append, Log, LogConfig, RetentionBounds, SyncTicket};
 use ironbus_storage::loss::LossReport;
 use ironbus_storage::naming::{
@@ -2857,6 +2859,90 @@ where
     Ok((partitioned, consumers, recoveries))
 }
 
+/// The recovered PRIORITY-LANE stream state (#553): the reopened priority-mode [`PartitionedStream`]s
+/// (keyed by [`StreamId`], to be merged into [`Engine::partitioned`]), each lane's resumed per-group
+/// consumer state (keyed `(stream, lane index)`, merged into [`Engine::partition_consumers`]), the SET
+/// of priority-mode stream names ([`Engine::priority_streams`]), and every lane sub-log's INDEPENDENT
+/// recovery summary. Named so the tuple does not trip `type_complexity`.
+type PriorityRecovery<F, C> = (
+    BTreeMap<StreamId, PartitionedStream<F, C>>,
+    BTreeMap<(StreamId, u32), NamedStream>,
+    std::collections::BTreeSet<StreamId>,
+    Vec<PartitionRecovery>,
+);
+
+/// Reopens every PRIORITY-LANE stream (#553) under `prstreams/<hex(name)>/`, the priority-mode twin of
+/// [`recover_partitioned_streams`]. It is byte-for-byte the same machinery — reopen the `P` lane
+/// sub-logs (with `P` derived from the materialized `p-<08x>/` lane-subdir count) as a
+/// [`PartitionedStream`], and resume each lane's per-group consumer cursor from its own lane subdir —
+/// except that it reads the SEPARATE `prstreams/` subtree, so a stream found here is KNOWN to be
+/// priority-mode (the mode is encoded in the path, needing no marker file), and it collects the set of
+/// recovered names so the engine can re-mark them in [`Engine::priority_streams`]. The recovered maps
+/// are MERGED into the same `partitioned` / `partition_consumers` the partitioned recovery populates
+/// (the two modes share the storage/consumer machinery but live in disjoint subtrees, so their keys
+/// never collide). A data dir with no `prstreams/` subtree returns empty state and never materializes
+/// it (the non-priority image is unchanged).
+///
+/// # Errors
+/// Propagates a storage error from enumerating `prstreams/`, opening/recovering a lane's log, or
+/// reading a lane's checkpoint files.
+fn recover_priority_streams<F, C>(
+    root_log: &Log<F, C>,
+    lease: LeaseConfig,
+    opened_at: u64,
+) -> Result<PriorityRecovery<F, C>, EngineError>
+where
+    F: Filesystem + Clone,
+    C: Clock + Clone,
+{
+    let mut partitioned = BTreeMap::new();
+    let mut consumers = BTreeMap::new();
+    let mut priority = std::collections::BTreeSet::new();
+    let mut recoveries = Vec::new();
+    let root = root_log.filesystem();
+    if !root.subdir_exists(PRIORITY_STREAMS_SUBDIR)? {
+        return Ok((partitioned, consumers, priority, recoveries));
+    }
+    let pfs = root.subdir(PRIORITY_STREAMS_SUBDIR)?;
+    let config = root_log.config();
+    for dir in pfs.list_subdirs()? {
+        let Some(name) = parse_stream_subdir_name(&dir) else {
+            continue;
+        };
+        let Ok(id) = StreamId::named(&name) else {
+            continue;
+        };
+        let stream_root = pfs.subdir(&dir)?;
+        // P = the count of canonical `p-<08x>/` lane subdirs materialized under this priority stream.
+        let count = stream_root
+            .list_subdirs()?
+            .iter()
+            .filter(|d| parse_partition_subdir_name(d).is_some())
+            .count();
+        let Some(pc) = u32::try_from(count).ok().and_then(PartitionCount::new) else {
+            continue;
+        };
+        let (ps, lane_recoveries) =
+            PartitionedStream::open(&stream_root, root_log.clock_clone(), config, pc)
+                .map_err(EngineError::Storage)?;
+        recoveries.extend(lane_recoveries);
+        // Resume each lane's per-group consumer cursor from its own lane subdir (identical to a
+        // partition's cursor resume — a lane IS a partition sub-log, only the delivery order differs).
+        for i in 0..pc.get() {
+            let idx = PartitionIndex::new(i);
+            if let Some(plog) = ps.partition(idx) {
+                let ns = recover_one_named_stream(plog, lease, opened_at)?;
+                if !ns.groups.is_empty() || !ns.group_last_checkpointed.is_empty() {
+                    consumers.insert((id.clone(), i), ns);
+                }
+            }
+        }
+        priority.insert(id.clone());
+        partitioned.insert(id, ps);
+    }
+    Ok((partitioned, consumers, priority, recoveries))
+}
+
 /// Reconstructs a group's carried attempt counts from a recovered `attempts.ckpt` payload, clamped
 /// to the durable log head `flushed` and the resumed committed watermark `committed`: a carried
 /// count is only meaningful for an offset that still exists (`< flushed`) and has NOT been committed
@@ -3765,6 +3851,19 @@ pub struct Engine<F: Filesystem, C: Clock> {
     /// A partition's cursor lives in ITS sub-log's `pstreams/<hex(name)>/p-<08x(i)>/cursor-<hex>.ckpt`,
     /// so it recovers beside its own records. EMPTY until a partitioned stream is consumed.
     partition_consumers: BTreeMap<(StreamId, u32), NamedStream>,
+    /// The MODE marker for PRIORITY-LANE streams (M4-I3, #553): the subset of [`Engine::partitioned`]
+    /// keys whose `P` sub-logs are PRIORITY LANES (levels `0..P`) rather than key-hash partitions. A
+    /// priority-mode stream reuses the SAME [`PartitionedStream`] storage (in `partitioned`) and the
+    /// SAME per-lane consumer state (in `partition_consumers`) as a key-partitioned stream — only the
+    /// PRODUCE routing (to the record's priority lane, not `xxh3_64(key) % P`) and the CONSUME order
+    /// (drain the highest-priority non-empty lane first) differ. Membership here is the ONLY thing that
+    /// distinguishes the two modes at the engine layer; on disk they are physically disjoint (a priority
+    /// stream lives under `prstreams/`, a key-partitioned one under `pstreams/`), so the mode survives a
+    /// restart WITHOUT any marker file — recovery re-derives it from which subtree the stream was found
+    /// in. The two modes are MUTUALLY EXCLUSIVE: a name is in `partitioned`, and if so it is in this set
+    /// (priority) XOR not (key-partition), never both. EMPTY until a stream declares priority mode, so a
+    /// deployment that never uses priorities is byte-for-byte unchanged.
+    priority_streams: std::collections::BTreeSet<StreamId>,
     /// The durable TRANSACTIONAL HALF-MESSAGE store (V2-M8, #640): the `txn/` sub-log that buffers
     /// prepared (half) messages INVISIBLE to consumers and their commit/rollback op-markers, plus the
     /// in-memory lifecycle table it rebuilds at open. Opened LAZILY on the first `TxnPrepare` (so a
@@ -4374,8 +4473,19 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         // partition's own subdir — the per-partition twin of `recover_named_stream_groups` above. A
         // deployment that never declared `P > 1` has no `pstreams/` subtree, so this is a no-op and the
         // on-disk image is byte-for-byte unchanged.
-        let (partitioned, partition_consumers, partition_recoveries) =
+        let (mut partitioned, mut partition_consumers, mut partition_recoveries) =
             recover_partitioned_streams(&log, config.lease, opened_at)?;
+        // Recover each PRIORITY-LANE stream (#553) from its SEPARATE `prstreams/<hex(name)>/` subtree,
+        // marking the recovered names as priority-mode and MERGING its lanes into the SAME `partitioned`
+        // / `partition_consumers` maps (the two modes share the storage/consumer machinery but live in
+        // disjoint subtrees, so keys never collide). The lane sub-log loss reports fold into the same
+        // recovery-event accounting below. A deployment that never used priorities has no `prstreams/`
+        // subtree, so this is a no-op and the on-disk image is byte-for-byte unchanged.
+        let (priority_partitioned, priority_consumers, priority_streams, priority_recoveries) =
+            recover_priority_streams(&log, config.lease, opened_at)?;
+        partitioned.extend(priority_partitioned);
+        partition_consumers.extend(priority_consumers);
+        partition_recoveries.extend(priority_recoveries);
 
         // Recovery-EVENT counters (#575), folded in ONCE per open across EVERY recovery path
         // (#1130): the root log, each NAMED per-stream recovery, the SHARED WAL's single recovery
@@ -4591,9 +4701,13 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
             // recovered stream whose `dlq/` subdir already exists; the rest open lazily on first poison.
             named_dlq,
             // The per-partitioned-stream storage + per-partition consumer state (#693), recovered above
-            // from `pstreams/`. Empty for a deployment that never declared `P > 1`.
+            // from `pstreams/`, plus every priority-lane stream (#553) merged in from `prstreams/`.
+            // Empty for a deployment that never declared `P > 1`.
             partitioned,
             partition_consumers,
+            // The priority-lane MODE marker (#553): the subset of `partitioned` recovered from
+            // `prstreams/`. Empty for a deployment that never used priorities.
+            priority_streams,
             // The transactional half-message store (V2-M8, #640): opened above iff the `txn/` subdir
             // already exists, else `None` until the first `TxnPrepare` lazily creates it. A
             // non-transactional broker keeps this `None`, so the produce/consume hot path is unchanged.
@@ -4818,6 +4932,14 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
                         "this data directory holds partitioned streams (pstreams/), which are \
                          per-stream-log storage; the shared-WAL storage mode does not support \
                          partitioned streams — reopen with the default per-stream-logs mode"
+                            .to_string(),
+                    ));
+                }
+                if fs.subdir_exists(PRIORITY_STREAMS_SUBDIR)? {
+                    return Err(storage_mode_mismatch(
+                        "this data directory holds priority-lane streams (prstreams/), which are \
+                         per-stream-log storage; the shared-WAL storage mode does not support \
+                         priority streams — reopen with the default per-stream-logs mode"
                             .to_string(),
                     ));
                 }
@@ -6213,6 +6335,50 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
     where
         F: Clone,
     {
+        self.produce_in_stream_inner(stream, message, subject, 0)
+    }
+
+    /// The PRIORITY-carrying named-stream produce entry (M4-I3, #553): identical to
+    /// [`Engine::produce_in_stream`], but a produce to a PRIORITY-MODE stream (declared via
+    /// [`Engine::declare_priority_stream`]) routes the record to the LANE of `priority` (higher =
+    /// delivered first; a priority above the top level saturates to the top lane) instead of the
+    /// default lowest lane. For any NON-priority stream — the default stream, a single named stream, or
+    /// a key-partitioned stream — `priority` is IGNORED and the append is byte-for-byte the historical
+    /// path, so a `priority = 0` call is exactly [`Engine::produce_in_stream`]. It stores no subject (a
+    /// priority stream does not compose with subject filters this phase, a documented follow-up).
+    ///
+    /// # Errors
+    /// Same as [`Engine::produce_in_stream`].
+    pub fn produce_in_stream_prioritized(
+        &mut self,
+        stream: &str,
+        message: &Append<'_>,
+        priority: u8,
+    ) -> Result<Offset, EngineError>
+    where
+        F: Clone,
+    {
+        self.produce_in_stream_inner(stream, message, b"", priority)
+    }
+
+    /// The shared named-stream produce body behind [`Engine::produce_in_stream_with_subject`] (subject,
+    /// priority 0) and [`Engine::produce_in_stream_prioritized`] (no subject, a priority): resolves the
+    /// delayed-delivery seam once, then routes to the stream's backing — a PRIORITY-mode stream by
+    /// `priority` (#553), a KEY-partitioned stream by key hash (#693), the shared WAL, or the stream's
+    /// own single log — so both entry points share one delay/mirror/cap/retention path.
+    ///
+    /// # Errors
+    /// Same as [`Engine::produce_in_stream`].
+    fn produce_in_stream_inner(
+        &mut self,
+        stream: &str,
+        message: &Append<'_>,
+        subject: &[u8],
+        priority: u8,
+    ) -> Result<Offset, EngineError>
+    where
+        F: Clone,
+    {
         // The default stream is today's root log, byte-for-byte: route straight to the existing
         // single-log produce on `self.log`, persisting the subject (#594). NOTHING about the default
         // path changes when a stream id is supplied as `""` — an old client (no stream id) and a new
@@ -6269,6 +6435,16 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
             }
         };
         let id = StreamId::named(stream)?;
+        // #553: a PRIORITY-mode stream routes the produce to the LANE of its priority (higher =
+        // delivered first), NOT by key hash. Checked BEFORE the key-partition branch because a priority
+        // stream lives in the SAME `partitioned` map (so the next branch would otherwise key-route it),
+        // distinguished only by `priority_streams` membership. A no-op for the common case (no priority
+        // streams declared): one set lookup.
+        if self.priority_streams.contains(&id) {
+            return self
+                .produce_priority(&id, message, priority)
+                .map(|(_, offset)| offset);
+        }
         // #693: a PARTITIONED stream (declared with `P > 1`) routes the produce BY KEY to its partition
         // sub-log (`xxh3_64(key) % P`, #591), NOT to a single named-stream log. This runs BEFORE the
         // single-stream path below so a partitioned name never materializes a plain `streams/<hex>/`
@@ -6557,6 +6733,15 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
             PartitionCount::new(partition_count).ok_or_else(|| EngineError::InvalidStreamName {
                 name: stream.to_string(),
             })?;
+        // A name already resident as a PRIORITY-lane stream (#553) cannot be re-declared key-partitioned
+        // — the two partitioned modes are mutually exclusive. Checked BEFORE the count comparison below,
+        // because a priority stream shares the `partitioned` map and could otherwise look like an
+        // idempotent same-count re-declare.
+        if self.priority_streams.contains(&id) {
+            return Err(EngineError::InvalidStreamName {
+                name: stream.to_string(),
+            });
+        }
         // Idempotent re-declare: SAME P -> Ok(false); DIFFERENT P -> fail-closed (no live repartition).
         if let Some(existing) = self.partitioned.get(&id) {
             if existing.count() == pc {
@@ -7092,6 +7277,388 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
                 .insert(group.to_string(), committed);
         }
         Ok(())
+    }
+
+    // ===================================================================================
+    // PRIORITY-LANE WIRING (#553, V2-M4-I3): OPT-IN message priorities. A priority-mode stream reuses
+    // the SAME `PartitionedStream` (#591/#693) storage primitive as a key-partitioned stream — `P`
+    // independent sub-logs — but its `P` sub-logs are PRIORITY LANES (levels `0..P`) rather than
+    // key-hash partitions. The two differences from key-partitioning, and NOTHING else:
+    //   1. PRODUCE routes to the LANE OF THE RECORD'S PRIORITY (`min(priority, P-1)`), not
+    //      `xxh3_64(key) % P`. A record's priority is FIXED at produce (it IS which lane it lands in),
+    //      so there is no re-prioritization race and, within a lane, records stay STRICT FIFO-by-offset.
+    //   2. CONSUME drains the HIGHEST-priority non-empty lane FIRST (lanes scanned `P-1 .. 0`), so a
+    //      higher-priority record is delivered ahead of a lower-priority one. Each lane keeps its OWN
+    //      durable per-lane cursor + lease table (`ack_partition`/`deliver_from_partition`, reused
+    //      VERBATIM), so at-least-once + MaxDeliver->park + delayed-delivery + per-lane retention all
+    //      compose per lane exactly as for a partition.
+    //
+    // STARVATION POLICY: STRICT priority (RabbitMQ-style, the documented Phase-1 behavior). A sustained
+    // stream of high-priority records CAN starve lower lanes indefinitely; a bounded-fairness / aging
+    // policy is a documented follow-up. This is the honest tradeoff the issue names ("trades the log's
+    // O(1) append/scan locality for priority-bucketed delivery; matches RabbitMQ priority queues").
+    //
+    // ACK DISAMBIGUATION (the one subtlety): a priority consumer draws from MULTIPLE lanes, and each
+    // lane has its OWN offset space (every lane starts at 0), so a raw offset is ambiguous across lanes.
+    // `poll_priority` therefore delivers a COMPOSITE offset — the lane in the top 8 bits, the lane
+    // offset in the low 56 — which is globally unique across lanes for one consumer, exactly as a
+    // single-partition consumer's raw offsets are unique. The consumer treats the offset as OPAQUE (it
+    // echoes it in the ack), and `ack_priority` decomposes it back to `(lane, offset)` and routes to
+    // that lane's cursor. This needs NO wire-format change (the offset field is already a `u64`) and
+    // reuses the existing offset-keyed lease map unchanged.
+    //
+    // MUTUAL EXCLUSION: a priority stream is stored in the SAME `partitioned` map as a key-partitioned
+    // one, distinguished ONLY by `priority_streams` membership, and on disk lives under a SEPARATE
+    // `prstreams/` subtree. A name is one mode XOR the other, never both — every declare fail-closed
+    // rejects a cross-mode or repartition conflict. `P == 1` is meaningless for priority (one lane has
+    // no priorities to order), so priority mode requires `P >= 2`.
+    // ===================================================================================
+
+    /// The maximum number of priority LEVELS (lanes) a priority-mode stream may declare (#553): the top
+    /// 8 bits of the composite delivery offset carry the lane, so at most `256` lanes are addressable.
+    /// A wire `priority` byte is a `u8` (`0..=255`), so this also matches the produce field's range —
+    /// every representable priority maps to a lane (saturating at the top when `priority >= P`).
+    const MAX_PRIORITY_LEVELS: u32 = 256;
+
+    /// The bit shift separating the LANE (top 8 bits) from the lane OFFSET (low 56 bits) in a composite
+    /// priority delivery offset (#553). 56 bits of offset is `~7.2e16` records per lane — unreachable in
+    /// practice — and 8 bits of lane covers the `256`-lane [`Engine::MAX_PRIORITY_LEVELS`] ceiling.
+    const PRIORITY_LANE_SHIFT: u64 = 56;
+
+    /// Composes a priority stream's COMPOSITE delivery offset (#553): the `lane` in the top 8 bits, the
+    /// per-lane `raw` offset in the low 56. Globally unique across a stream's lanes for one consumer, so
+    /// the offset-keyed lease map and the wire ack need no lane field. See [`Engine::ack_priority`] for
+    /// the inverse.
+    #[must_use]
+    fn compose_priority_offset(lane: PartitionIndex, raw: Offset) -> u64 {
+        let mask = (1u64 << Self::PRIORITY_LANE_SHIFT) - 1;
+        (u64::from(lane.get()) << Self::PRIORITY_LANE_SHIFT) | (raw.get() & mask)
+    }
+
+    /// Decomposes a composite priority delivery offset (#553) back into `(lane, lane offset)` — the
+    /// inverse of [`Engine::compose_priority_offset`], used by [`Engine::ack_priority`] to route an ack
+    /// (whose offset the consumer echoed verbatim) to the right lane's cursor.
+    #[must_use]
+    fn decompose_priority_offset(composite: u64) -> (u32, Offset) {
+        let mask = (1u64 << Self::PRIORITY_LANE_SHIFT) - 1;
+        let lane = u32::try_from(composite >> Self::PRIORITY_LANE_SHIFT).unwrap_or(u32::MAX);
+        (lane, Offset::new(composite & mask))
+    }
+
+    /// Rewrites every offset a lane's [`Poll`] surfaces into the COMPOSITE lane-tagged offset (#553), so
+    /// a priority consumer's leases, acks, and in-band advisories all carry the globally-unique offset.
+    /// `Poll::Idle` never reaches here (the scan continues past an idle lane); every other variant has
+    /// its `Offset` fields tagged with `lane`.
+    #[must_use]
+    fn compose_priority_poll(lane: PartitionIndex, poll: Poll) -> Poll {
+        let tag = |o: Offset| Offset::new(Self::compose_priority_offset(lane, o));
+        match poll {
+            Poll::Message(mut d) => {
+                d.token.offset = tag(d.token.offset);
+                d.offset = tag(d.offset);
+                Poll::Message(d)
+            }
+            Poll::Parked { offset, record } => Poll::Parked {
+                offset: tag(offset),
+                record,
+            },
+            Poll::Truncated {
+                earliest_retained,
+                skipped,
+            } => Poll::Truncated {
+                earliest_retained: tag(earliest_retained),
+                skipped,
+            },
+            Poll::Compacted { from, to } => Poll::Compacted {
+                from: tag(from),
+                to: tag(to),
+            },
+            Poll::Filtered { from, to } => Poll::Filtered {
+                from: tag(from),
+                to: tag(to),
+            },
+            Poll::Idle => Poll::Idle,
+        }
+    }
+
+    /// Whether `stream` is an OPT-IN PRIORITY-LANE stream (#553): declared via
+    /// [`Engine::declare_priority_stream`], so a produce routes by priority and a consume drains the
+    /// highest-priority lane first. `false` for the default stream, a single named stream, and a
+    /// KEY-partitioned stream (#693) — the two partitioned modes are mutually exclusive. The query the
+    /// wire/session layer uses to route a produce/consume through the priority path and to reject a
+    /// lane-addressed subscribe on a priority stream.
+    #[must_use]
+    pub fn is_priority_stream(&self, stream: &str) -> bool {
+        StreamId::named(stream).is_ok_and(|id| self.priority_streams.contains(&id))
+    }
+
+    /// Declares a stream with `levels` PRIORITY LANES (#553): the engine-side of the additive `priority`
+    /// flag on the `StreamDeclare` wire verb. Opens (or idempotently re-ensures) a [`PartitionedStream`]
+    /// of `P = levels` independent sub-logs under `prstreams/<hex(name)>/`, marked priority-mode, where
+    /// lane `i` is priority level `i` (higher = delivered first). Requires `2 <= levels <= 256` (a single
+    /// lane has no priorities to order; the ceiling is [`Engine::MAX_PRIORITY_LEVELS`]).
+    ///
+    /// Idempotent: re-declaring an existing priority stream with the SAME `levels` is `Ok(false)`; a
+    /// FIRST declare is `Ok(true)`. Re-declaring with a DIFFERENT `levels` (a repartition, which would
+    /// reshuffle every record's lane), or declaring a name already resident as a single named stream OR
+    /// a KEY-partitioned stream, is rejected fail-closed — the two partitioned modes never overlap.
+    ///
+    /// # Errors
+    /// [`EngineError::InvalidStreamName`] for `levels < 2` or `> 256`, the empty/default name, a
+    /// malformed named name, a name already resident in another mode, or a re-declare with a different
+    /// level count; [`EngineError::TooManyStreams`] at the distinct-stream cap; a
+    /// [`shared_mode_unsupported`] reject in shared-WAL mode (priority streams are per-stream-log
+    /// storage); else a storage error from opening the priority stream's lane sub-logs.
+    pub fn declare_priority_stream(
+        &mut self,
+        stream: &str,
+        levels: u32,
+    ) -> Result<bool, EngineError>
+    where
+        F: Clone,
+    {
+        // Priority mode needs at least two lanes (nothing to order with one), and at most one lane per
+        // representable priority level (the composite-offset lane field is 8 bits).
+        if !(2..=Self::MAX_PRIORITY_LEVELS).contains(&levels) {
+            return Err(EngineError::InvalidStreamName {
+                name: stream.to_string(),
+            });
+        }
+        // SHARED-WAL mode (#597): priority streams are per-stream-log storage (P lane sub-logs under
+        // prstreams/) and do not compose with the one shared commit log — fail-closed typed reject,
+        // matching the open-time prstreams/ layout refusal.
+        if self.shared_wal.is_some() {
+            return Err(shared_mode_unsupported(
+                "a priority-lane stream declare (#553, priority mode)",
+            ));
+        }
+        // The default stream is the root log and is never priority-partitioned.
+        if stream.is_empty() {
+            return Err(EngineError::InvalidStreamName {
+                name: String::new(),
+            });
+        }
+        let id = StreamId::named(stream)?;
+        let pc = PartitionCount::new(levels).ok_or_else(|| EngineError::InvalidStreamName {
+            name: stream.to_string(),
+        })?;
+        // Idempotent re-declare of an EXISTING priority stream (same levels -> Ok(false)); a different
+        // level count, or a name already resident in the OTHER mode (a key-partitioned stream shares the
+        // `partitioned` map but is NOT in `priority_streams`), is a fail-closed conflict.
+        if let Some(existing) = self.partitioned.get(&id) {
+            if self.priority_streams.contains(&id) && existing.count() == pc {
+                return Ok(false);
+            }
+            return Err(EngineError::InvalidStreamName {
+                name: stream.to_string(),
+            });
+        }
+        // A name already resident as a SINGLE named stream cannot also be a priority stream.
+        if self.known_named_streams.contains(&id) {
+            return Err(EngineError::InvalidStreamName {
+                name: stream.to_string(),
+            });
+        }
+        // Distinct-stream cap (#863): priority streams live in `partitioned`, counted alongside named +
+        // key-partitioned streams (inode/fd bound).
+        if self.max_streams != 0
+            && self.known_named_streams.len() + self.partitioned.len() >= self.max_streams
+        {
+            return Err(EngineError::TooManyStreams {
+                max: self.max_streams,
+            });
+        }
+        let root = self.priority_stream_root(&id)?;
+        let (ps, _recoveries) =
+            PartitionedStream::open(&root, self.log.clock_clone(), self.log.config(), pc)
+                .map_err(EngineError::Storage)?;
+        self.partitioned.insert(id.clone(), ps);
+        self.priority_streams.insert(id);
+        Ok(true)
+    }
+
+    /// Resolves the `prstreams/<hex(name)>/` root filesystem for a priority stream `id` (#553), creating
+    /// the `prstreams/` subtree + the stream's subdir on first use. The [`PartitionedStream`] then roots
+    /// its `P` lane sub-logs under this handle. The priority-mode twin of
+    /// [`Engine::partitioned_stream_root`] — a SEPARATE subtree so the mode is encoded in the path.
+    fn priority_stream_root(&self, id: &StreamId) -> Result<F, EngineError>
+    where
+        F: Clone,
+    {
+        let pfs = self.log.filesystem().subdir(PRIORITY_STREAMS_SUBDIR)?;
+        let root = pfs.subdir(&stream_subdir_name(id.name()))?;
+        Ok(root)
+    }
+
+    /// Produces `message` to the priority stream `id` at `priority` (#553), routing it to the LANE of
+    /// its priority — `min(priority, P-1)`, so a priority at or above the top level saturates to the top
+    /// lane and a producer need not know `P`. Appends to that ONE lane's sub-log and commits it with the
+    /// stream's OWN [`PartitionedStream::commit_tick`] group-commit barrier. Returns the lane it landed
+    /// in and the [`Offset`] within that lane. The record's priority is FIXED here (it IS the lane), so
+    /// there is no re-prioritization; within a lane records stay strict FIFO-by-offset.
+    ///
+    /// The durability contract is per LANE, identical to [`Engine::produce_partitioned`]: the record is
+    /// acked only after its lane's covering `fdatasync`; a lane whose barrier FROZE surfaces a fatal
+    /// [`StorageError::WriterFrozen`] rather than acking a non-durable record (I2). Per-lane retention
+    /// runs after the durable commit.
+    ///
+    /// # Errors
+    /// [`EngineError::UnknownStream`] if `id` is not a priority stream, a storage error from the append,
+    /// or [`StorageError::WriterFrozen`] if the chosen lane's commit barrier froze.
+    fn produce_priority(
+        &mut self,
+        id: &StreamId,
+        message: &Append<'_>,
+        priority: u8,
+    ) -> Result<(PartitionIndex, Offset), EngineError> {
+        // Route + append to the priority's lane (short mutable borrow of the storage map). The lane is
+        // `min(priority, P-1)`: priority mode requires `P >= 2`, so `P - 1 >= 1` never underflows, and a
+        // priority >= P saturates to the top (highest) lane.
+        let (idx, offset) = {
+            let ps = self
+                .partitioned
+                .get_mut(id)
+                .ok_or_else(|| EngineError::UnknownStream {
+                    name: id.name().to_string(),
+                })?;
+            let top = ps.count().get() - 1;
+            let idx = PartitionIndex::new(u32::from(priority).min(top));
+            let log = ps
+                .partition_mut(idx)
+                .ok_or_else(|| EngineError::UnknownStream {
+                    name: id.name().to_string(),
+                })?;
+            let offset = log.append(message).map_err(EngineError::Storage)?;
+            (idx, offset)
+        };
+        // Per-stream PRODUCE throughput (#571), keyed by the stream name (bounded/overflow-folded).
+        self.registry.record_stream_produced(id.name().as_bytes());
+        // ONE cross-lane group-commit tick (#591): a lane whose covering fdatasync FAILED is FROZEN
+        // (its durable head did not advance) -> surface WriterFrozen rather than ack a non-durable
+        // record (I2), exactly as the key-partitioned produce path does on a froze.
+        let froze = {
+            let ps = self
+                .partitioned
+                .get_mut(id)
+                .expect("priority stream present after append");
+            ps.commit_tick().froze.contains(&idx)
+        };
+        if froze {
+            return Err(EngineError::Storage(StorageError::WriterFrozen));
+        }
+        // Per-LANE retention + compaction (#566, reused per lane): reclaim disk on the chosen lane's own
+        // sub-log, floored at that lane's min-committed offset so a slow consumer's records are never
+        // reaped. A no-op unless retention/compaction is configured.
+        self.reap_partition_for_retention(id, idx)?;
+        Ok((idx, offset))
+    }
+
+    /// Polls the priority stream `stream` in competing work-group `group` (#553), delivering the next
+    /// record off the HIGHEST-priority non-empty lane. It scans the lanes `P-1 .. 0` (highest priority
+    /// first) and returns the first lane's delivery, so a higher-priority record is always delivered
+    /// ahead of a lower-priority one (STRICT priority — a sustained high-priority load can starve lower
+    /// lanes, the documented Phase-1 tradeoff). Each lane drains on its OWN durable per-lane cursor +
+    /// lease table via the reused [`Engine::deliver_from_partition`], so at-least-once, MaxDeliver->park,
+    /// delayed-delivery, and per-lane retention all hold per lane. The delivered offset is a COMPOSITE
+    /// (lane in the top 8 bits, lane offset in the low 56) so it is globally unique across lanes for one
+    /// consumer; the consumer echoes it verbatim and [`Engine::ack_priority`] routes the ack back to the
+    /// right lane.
+    ///
+    /// # Errors
+    /// [`EngineError::InvalidStreamName`] for a malformed name, [`EngineError::UnknownStream`] if
+    /// `stream` is not a priority stream, [`EngineError::InvalidGroupName`] /
+    /// [`EngineError::TooManyGroups`] from the per-lane group gate, else a storage error from a read.
+    pub fn poll_priority(
+        &mut self,
+        stream: &str,
+        group: &str,
+        now: u64,
+    ) -> Result<Poll, EngineError> {
+        let id = StreamId::named(stream)?;
+        // Resolve the lane count, rejecting a stream that is not priority-mode (a key-partitioned or
+        // single stream is consumed through its own path, never here).
+        let count = match self.partitioned.get(&id) {
+            Some(ps) if self.priority_streams.contains(&id) => ps.count(),
+            _ => {
+                return Err(EngineError::UnknownStream {
+                    name: stream.to_string(),
+                })
+            }
+        };
+        validate_group_name(group)?;
+        // Ensure the group's work-group exists in EVERY lane (idempotent, under the per-lane group cap),
+        // so a lane the scan has not yet reached still has a tracked cursor — which the per-lane
+        // retention floor reads to PROTECT that lane's undelivered records from a reap (a starved low
+        // lane must not be reaped out from under a consumer that has simply not drained down to it yet).
+        let lease_config = self.lease_config;
+        let max_groups = self.max_groups;
+        for i in 0..count.get() {
+            let ns = self
+                .partition_consumers
+                .entry((id.clone(), i))
+                .or_insert_with(NamedStream::new);
+            if !ns.groups.contains_key(group) {
+                if max_groups != 0 && ns.groups.len() >= max_groups {
+                    return Err(EngineError::TooManyGroups { max: max_groups });
+                }
+                ns.groups
+                    .insert(group.to_string(), WorkGroup::new(lease_config, now));
+            }
+        }
+        // Scan lanes HIGH -> LOW: deliver from the highest-priority lane that yields anything but
+        // `Poll::Idle`. An idle lane (nothing deliverable now — caught up, window full, or holding an
+        // un-due delayed record) falls through to the next lower priority; a Message/Parked/Truncated/
+        // Compacted is returned immediately with its offsets tagged to the lane (strict priority).
+        for lane_i in (0..count.get()).rev() {
+            let idx = PartitionIndex::new(lane_i);
+            let flushed = self
+                .partitioned
+                .get(&id)
+                .and_then(|ps| ps.partition(idx))
+                .map_or(0, |log| log.flushed_offset().get());
+            match self.deliver_from_partition(&id, idx, group, now, flushed)? {
+                Poll::Idle => {}
+                other => return Ok(Self::compose_priority_poll(idx, other)),
+            }
+        }
+        Ok(Poll::Idle)
+    }
+
+    /// Acks a priority-stream delivery (#553): decomposes the COMPOSITE offset the consumer echoed back
+    /// into `(lane, lane offset)` and commits that lane's work-group cursor past it, reusing
+    /// [`Engine::ack_partition`] verbatim (a priority lane IS a partition sub-log). A stale token
+    /// (already acked or redelivered) is a [`AckResult::Fenced`] no-op, and the durable per-lane cursor
+    /// checkpoint is interval-gated exactly as the partition ack. `stream` must be a priority stream (a
+    /// composite offset on any other stream fences).
+    #[must_use]
+    pub fn ack_priority(&mut self, stream: &str, group: &str, token: &LeaseToken) -> AckResult {
+        if !self.is_priority_stream(stream) {
+            return AckResult::Fenced;
+        }
+        let (lane, raw) = Self::decompose_priority_offset(token.offset.get());
+        self.ack_partition(
+            stream,
+            lane,
+            group,
+            &LeaseToken {
+                offset: raw,
+                generation: token.generation,
+            },
+        )
+    }
+
+    /// The current committed offset of priority stream `(stream, group)`'s lane `lane` (#553): the
+    /// exclusive next-to-deliver position on that lane's OWN cursor, for tests and observability of a
+    /// priority group's per-lane progress. Reuses [`Engine::committed_offset_in_partition`] (a lane IS a
+    /// partition sub-log). `0` for an unknown stream/lane/group.
+    #[must_use]
+    pub fn committed_offset_in_priority_lane(
+        &self,
+        stream: &str,
+        lane: u32,
+        group: &str,
+    ) -> Offset {
+        self.committed_offset_in_partition(stream, lane, group)
     }
 
     // ===================================================================================
@@ -7881,9 +8448,10 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         let Ok(id) = StreamId::named(stream) else {
             return false;
         };
-        // A stream EXISTS if it is a known single named stream OR a declared PARTITIONED stream (#693):
-        // the two are disjoint namespaces, but both are client-reachable and both must report existence
-        // (e.g. a `SubTo` / `StreamInfo` on a partitioned stream).
+        // A stream EXISTS if it is a known single named stream OR a declared PARTITIONED stream (#693)
+        // OR a declared PRIORITY-lane stream (#553, which also lives in `partitioned`): the namespaces
+        // are disjoint, but all are client-reachable and must report existence (e.g. a `SubTo` /
+        // `StreamInfo` on a partitioned or priority stream).
         self.known_named_streams.contains(&id) || self.partitioned.contains_key(&id)
     }
 
@@ -29984,6 +30552,298 @@ mod tests {
             r.counters().segments_reaped >= 1,
             "per-partition retention reaped at least one old sealed segment"
         );
+    }
+
+    // ===================== OPT-IN MESSAGE PRIORITIES (#553, V2-M4-I3) =====================
+
+    /// A produce to a priority stream at `priority` (no key routing — the lane IS the priority).
+    fn prio_append(payload: &[u8]) -> Append<'_> {
+        Append {
+            timestamp_ms: 0,
+            flags: RecordFlags::EMPTY,
+            key: b"",
+            headers: b"",
+            payload,
+        }
+    }
+
+    /// Produces `payload` to priority stream `stream` at `priority`, returning the lane offset.
+    fn produce_prio(
+        e: &mut Engine<InMemoryFs, ManualClock>,
+        stream: &str,
+        priority: u8,
+        payload: &[u8],
+    ) -> Offset {
+        e.produce_in_stream_prioritized(stream, &prio_append(payload), priority)
+            .unwrap()
+    }
+
+    /// Drains a priority stream via `poll_priority`, acking each delivery, returning the payloads in
+    /// DELIVERY order (which is the priority order: highest-priority lane first, FIFO within a lane).
+    fn drain_priority(
+        e: &mut Engine<InMemoryFs, ManualClock>,
+        stream: &str,
+        group: &str,
+    ) -> Vec<Vec<u8>> {
+        let mut out = Vec::new();
+        loop {
+            let now = e.now_monotonic();
+            match e.poll_priority(stream, group, now).unwrap() {
+                Poll::Message(d) => {
+                    out.push(d.record.payload.to_vec());
+                    assert_eq!(e.ack_priority(stream, group, &d.token), AckResult::Acked);
+                }
+                Poll::Idle => break,
+                other => panic!("unexpected priority poll: {other:?}"),
+            }
+        }
+        out
+    }
+
+    /// #553 (headline): higher-priority records are delivered AHEAD of lower ones, and within one
+    /// priority level records stay strict FIFO-by-offset. Priorities produced INTERLEAVED still drain
+    /// strictly highest-first.
+    #[test]
+    fn priority_delivery_drains_highest_lane_first_fifo_within_a_level() {
+        let mut e = open(config(64, 5));
+        assert!(e.declare_priority_stream("jobs", 3).unwrap());
+        assert!(e.is_priority_stream("jobs"));
+        assert_eq!(e.partition_count_of("jobs").unwrap().get(), 3);
+        // Produce interleaved across three priority levels (0 = lowest, 2 = highest).
+        produce_prio(&mut e, "jobs", 0, b"lo-a");
+        produce_prio(&mut e, "jobs", 2, b"hi-a");
+        produce_prio(&mut e, "jobs", 1, b"mid-a");
+        produce_prio(&mut e, "jobs", 2, b"hi-b");
+        produce_prio(&mut e, "jobs", 0, b"lo-b");
+        produce_prio(&mut e, "jobs", 1, b"mid-b");
+        // Delivery order: BOTH priority-2 first (in produce order), then both priority-1, then both
+        // priority-0 — strict priority, FIFO within each level.
+        assert_eq!(
+            drain_priority(&mut e, "jobs", "w"),
+            vec![
+                b"hi-a".to_vec(),
+                b"hi-b".to_vec(),
+                b"mid-a".to_vec(),
+                b"mid-b".to_vec(),
+                b"lo-a".to_vec(),
+                b"lo-b".to_vec(),
+            ]
+        );
+    }
+
+    /// #553: a produce at a priority AT OR ABOVE the top level saturates to the TOP lane (a producer
+    /// need not know `P`), and priority `0` (the default) is the LOWEST lane, delivered last.
+    #[test]
+    fn priority_saturates_above_top_and_zero_is_lowest() {
+        let mut e = open(config(64, 5));
+        e.declare_priority_stream("jobs", 3).unwrap(); // lanes 0,1,2
+        produce_prio(&mut e, "jobs", 0, b"floor");
+        produce_prio(&mut e, "jobs", 250, b"way-over"); // saturates to lane 2 (top)
+        produce_prio(&mut e, "jobs", 2, b"top-explicit");
+        // The two top-lane records (saturated + explicit) deliver first in produce order, then the floor.
+        assert_eq!(
+            drain_priority(&mut e, "jobs", "w"),
+            vec![
+                b"way-over".to_vec(),
+                b"top-explicit".to_vec(),
+                b"floor".to_vec(),
+            ]
+        );
+    }
+
+    /// #553: each lane keeps its OWN durable per-lane cursor, and the composite delivery offset routes
+    /// an ack to the RIGHT lane even when two lanes both hold a record at lane-offset 0 (the ambiguity
+    /// the composite offset resolves). Acking one lane's delivery never commits another's.
+    #[test]
+    fn priority_composite_offset_acks_route_to_the_right_lane() {
+        let mut e = open(config(64, 5));
+        e.declare_priority_stream("jobs", 3).unwrap();
+        produce_prio(&mut e, "jobs", 2, b"hi"); // lane 2, offset 0
+        produce_prio(&mut e, "jobs", 0, b"lo"); // lane 0, offset 0 — SAME lane offset
+                                                // First poll delivers the high-lane record; hold its lease (do NOT ack yet).
+        let now = e.now_monotonic();
+        let hi = message(e.poll_priority("jobs", "w", now).unwrap());
+        assert_eq!(&*hi.record.payload, b"hi");
+        // Next poll falls through the (now in-flight) high lane to the low lane.
+        let now = e.now_monotonic();
+        let lo = message(e.poll_priority("jobs", "w", now).unwrap());
+        assert_eq!(&*lo.record.payload, b"lo");
+        // The two composite offsets are DISTINCT even though both are lane-offset 0.
+        assert_ne!(
+            hi.offset.get(),
+            lo.offset.get(),
+            "composite offsets disambiguate the two lanes"
+        );
+        // Ack the LOW-lane delivery: it commits lane 0 only, lane 2 is untouched.
+        assert_eq!(e.ack_priority("jobs", "w", &lo.token), AckResult::Acked);
+        assert_eq!(e.committed_offset_in_priority_lane("jobs", 0, "w").get(), 1);
+        assert_eq!(
+            e.committed_offset_in_priority_lane("jobs", 2, "w").get(),
+            0,
+            "acking lane 0 never advanced lane 2"
+        );
+        // Ack the HIGH-lane delivery: now lane 2 commits.
+        assert_eq!(e.ack_priority("jobs", "w", &hi.token), AckResult::Acked);
+        assert_eq!(e.committed_offset_in_priority_lane("jobs", 2, "w").get(), 1);
+    }
+
+    /// #553: a priority stream + its P per-lane cursors survive a restart (recovered from `prstreams/`),
+    /// resuming past each lane's durable committed offset — no redelivery of acked records, and priority
+    /// order continues across the restart.
+    #[test]
+    fn priority_stream_and_per_lane_cursors_survive_restart() {
+        let fs = InMemoryFs::new();
+        {
+            let mut e = Engine::open(fs.clone(), ManualClock::new(), config(64, 5)).unwrap();
+            e.declare_priority_stream("jobs", 3).unwrap();
+            produce_prio(&mut e, "jobs", 2, b"hi-0");
+            produce_prio(&mut e, "jobs", 2, b"hi-1");
+            produce_prio(&mut e, "jobs", 0, b"lo-0");
+            // Drain + ack ONLY the two high-priority records; leave the low one un-consumed.
+            let now = e.now_monotonic();
+            let d0 = message(e.poll_priority("jobs", "w", now).unwrap());
+            assert_eq!(&*d0.record.payload, b"hi-0");
+            assert_eq!(e.ack_priority("jobs", "w", &d0.token), AckResult::Acked);
+            let now = e.now_monotonic();
+            let d1 = message(e.poll_priority("jobs", "w", now).unwrap());
+            assert_eq!(&*d1.record.payload, b"hi-1");
+            assert_eq!(e.ack_priority("jobs", "w", &d1.token), AckResult::Acked);
+            assert_eq!(e.committed_offset_in_priority_lane("jobs", 2, "w").get(), 2);
+            e.checkpoint_all_groups().unwrap(); // clean-shutdown durable flush
+        }
+        // Reopen over the SAME storage: the priority stream + its lane cursors recover from prstreams/.
+        {
+            let mut e = Engine::open(fs.clone(), ManualClock::new(), config(64, 5)).unwrap();
+            assert!(
+                e.is_priority_stream("jobs"),
+                "the priority MODE recovered (from the prstreams/ subtree, no marker file)"
+            );
+            assert_eq!(e.partition_count_of("jobs").unwrap().get(), 3);
+            assert_eq!(
+                e.committed_offset_in_priority_lane("jobs", 2, "w").get(),
+                2,
+                "the high lane's cursor resumed at its durable committed offset"
+            );
+            // Only the un-consumed low-priority record remains — the acked high ones do NOT redeliver.
+            assert_eq!(drain_priority(&mut e, "jobs", "w"), vec![b"lo-0".to_vec()]);
+        }
+        // On disk: the priority stream lives under prstreams/, NEVER pstreams/ (mode-disjoint subtrees).
+        let e = Engine::open(fs, ManualClock::new(), config(64, 5)).unwrap();
+        assert!(e
+            .log
+            .filesystem()
+            .subdir_exists(PRIORITY_STREAMS_SUBDIR)
+            .unwrap());
+        assert!(
+            !e.log
+                .filesystem()
+                .subdir_exists(PARTITIONED_STREAMS_SUBDIR)
+                .unwrap(),
+            "a priority stream never materializes the key-partition pstreams/ subtree"
+        );
+    }
+
+    /// #553: STARVATION is STRICT priority (the documented Phase-1 behavior). A sustained high-priority
+    /// load keeps a lower lane from ever delivering — this test PINS that honest property (so a future
+    /// fairness/aging policy is a deliberate change, not an accident).
+    #[test]
+    fn priority_strict_high_first_can_starve_a_lower_lane() {
+        let mut e = open(config(64, 5));
+        e.declare_priority_stream("jobs", 2).unwrap();
+        produce_prio(&mut e, "jobs", 0, b"starved"); // one low-priority record, present the whole time
+                                                     // A steady stream of high-priority work: every poll serves the HIGH lane, never the low one.
+        for n in 0..5u8 {
+            produce_prio(&mut e, "jobs", 1, &[b'h', n]);
+            let now = e.now_monotonic();
+            let d = message(e.poll_priority("jobs", "w", now).unwrap());
+            assert_eq!(
+                &*d.record.payload,
+                &[b'h', n][..],
+                "the high lane is always served first"
+            );
+            assert_eq!(e.ack_priority("jobs", "w", &d.token), AckResult::Acked);
+        }
+        // The low-priority record was NEVER delivered while high-priority work kept arriving.
+        assert_eq!(
+            e.committed_offset_in_priority_lane("jobs", 0, "w").get(),
+            0,
+            "strict priority starved the low lane (documented Phase-1 behavior)"
+        );
+        // Once the high lane drains, the starved low record finally delivers (no loss).
+        assert_eq!(
+            drain_priority(&mut e, "jobs", "w"),
+            vec![b"starved".to_vec()]
+        );
+    }
+
+    /// #553: `MaxDeliver` composes PER LANE — a poison in one lane parks after `max_deliver` attempts
+    /// (committed past, surfaced as `Poll::Parked`) exactly as on a partition, and a lower lane keeps
+    /// delivering. Neither dropped nor duplicated beyond the at-least-once redelivery budget.
+    #[test]
+    fn priority_max_deliver_parks_per_lane() {
+        let mut e = open(config(64, 1)); // max_deliver = 1 (lease visibility 30ns, hard cap 100ns)
+        e.declare_priority_stream("jobs", 2).unwrap();
+        produce_prio(&mut e, "jobs", 1, b"poison"); // high lane
+        produce_prio(&mut e, "jobs", 0, b"good"); // low lane
+                                                  // First delivery of the high-lane poison (now = 0), left un-acked.
+        let d = message(e.poll_priority("jobs", "w", 0).unwrap());
+        assert_eq!(&*d.record.payload, b"poison");
+        // Expire the lease (now = 40, past the 30ns visibility) WITHOUT acking: the 2nd attempt exceeds
+        // max_deliver = 1 and PARKS the poison (committed past) — per-lane MaxDeliver.
+        match e.poll_priority("jobs", "w", 40).unwrap() {
+            Poll::Parked { record, .. } => assert_eq!(record.payload.as_ref(), b"poison"),
+            other => panic!("expected Parked, got {other:?}"),
+        }
+        // With the high lane's poison committed past, the low lane now delivers its good record.
+        let d = message(e.poll_priority("jobs", "w", 80).unwrap());
+        assert_eq!(&*d.record.payload, b"good");
+        assert_eq!(e.ack_priority("jobs", "w", &d.token), AckResult::Acked);
+    }
+
+    /// #553: priority mode is MUTUALLY EXCLUSIVE with key-partitioning and requires `2 <= levels <= 256`.
+    /// Every cross-mode / out-of-range declare is rejected fail-closed (no stream is ever both modes).
+    #[test]
+    fn priority_and_partitioned_are_mutually_exclusive_and_bounded() {
+        let mut e = open(config(64, 5));
+        // A first priority declare succeeds; an identical re-declare is idempotent.
+        assert!(e.declare_priority_stream("p", 3).unwrap());
+        assert!(!e.declare_priority_stream("p", 3).unwrap());
+        // A DIFFERENT level count is a fail-closed conflict (no live repartition).
+        assert!(e.declare_priority_stream("p", 4).is_err());
+        // The SAME name cannot be re-declared as a KEY-partitioned stream (cross-mode reject).
+        assert!(e.declare_partitioned_stream("p", 4).is_err());
+        assert!(e.is_priority_stream("p"));
+        // And a KEY-partitioned name cannot be re-declared priority.
+        assert!(e.declare_partitioned_stream("kp", 4).unwrap());
+        assert!(e.declare_priority_stream("kp", 4).is_err());
+        assert!(!e.is_priority_stream("kp"));
+        // A single named stream cannot be re-declared priority.
+        e.declare_stream("single").unwrap();
+        assert!(e.declare_priority_stream("single", 3).is_err());
+        // Level bounds: `< 2` (nothing to order) and `> 256` (composite lane field is 8 bits) reject.
+        assert!(e.declare_priority_stream("bad-lo", 1).is_err());
+        assert!(e.declare_priority_stream("bad-hi", 257).is_err());
+        assert!(!e.is_priority_stream("bad-lo"));
+        // The valid ceiling is accepted.
+        assert!(e.declare_priority_stream("max", 256).unwrap());
+    }
+
+    /// #553: the composite delivery-offset encoding round-trips lane + lane-offset losslessly across the
+    /// full lane range and a large offset — the property the ack routing depends on.
+    #[test]
+    fn priority_composite_offset_round_trips() {
+        for lane in [0u32, 1, 7, 42, 255] {
+            for raw in [0u64, 1, 1000, (1u64 << 55) - 1] {
+                let composite = Engine::<InMemoryFs, ManualClock>::compose_priority_offset(
+                    PartitionIndex::new(lane),
+                    Offset::new(raw),
+                );
+                let (dl, doff) =
+                    Engine::<InMemoryFs, ManualClock>::decompose_priority_offset(composite);
+                assert_eq!(dl, lane);
+                assert_eq!(doff.get(), raw);
+            }
+        }
     }
 
     // ===================== EPHEMERAL CONSUMER GROUPS (#771, V2-M1) =====================

--- a/crates/ironbus-server/src/session.rs
+++ b/crates/ironbus-server/src/session.rs
@@ -430,6 +430,15 @@ pub struct Session {
     /// on its OWN durable per-partition cursor); when `None` they use the unchanged
     /// `poll_in_stream_member` / `ack_in_stream`, or the default-stream path when `stream` is empty.
     partition: Option<u32>,
+    /// Whether this connection is subscribed to a PRIORITY-LANE stream (#553, M4-I3): set by a
+    /// whole-stream `SubTo` onto a priority stream, cleared by any other (re)bind alongside `partition`.
+    /// When `true` the Flow poll loop routes through the engine's `poll_priority` (drain the highest
+    /// non-empty lane first) and the Ack path through `ack_priority` (the composite delivery offset the
+    /// consumer echoes decodes to the lane). A priority stream is consumed as a WHOLE (the broker picks
+    /// the lane), so this is mutually exclusive with a bound `partition` — a lane-addressed subscribe on
+    /// a priority stream is rejected by `handle_sub_to`. `false` for every non-priority subscription
+    /// (byte-for-byte the pre-#553 paths).
+    priority_bound: bool,
     /// Whether this connection has EVER published a Level-2 (server+client-ack) produce (#497): set
     /// when an L2 publish is registered for confirmation, and NEVER cleared. It is the gate that keeps
     /// the per-pass `ProduceConfirm` drain off the actor for a connection that never opted into Level 2
@@ -1344,6 +1353,8 @@ impl Session {
         self.stream = GroupName::default();
         // #693: resetting to the default stream clears any partition binding (whole-stream consume).
         self.partition = None;
+        // #553: and any priority-stream binding (the default stream is never priority-mode).
+        self.priority_bound = false;
         // The server caps, read LOCALLY off the handle (NO actor round-trip), so the handshake never
         // touches the actor's checkpoint/fsync path and a stalled produce on one connection cannot
         // head-of-line-block this Connect (invariant 4, #177). The caps are static engine config.
@@ -1787,6 +1798,13 @@ impl Session {
             return self
                 .handle_ack_in_partition(engine, stream, partition, group, ack, &token, out);
         }
+        // #553: a PRIORITY-bound consumer routes its ACK through `ack_priority`, which decodes the
+        // composite delivery offset (which the consumer echoed) back to the lane it came from. Plain
+        // ack-or-fence, mirroring the partition path; a nack/term/progress fences (as the named/partition
+        // paths do this phase). Mutually exclusive with a bound partition (a priority sub is whole-stream).
+        if self.priority_bound {
+            return self.handle_ack_in_priority(engine, stream, group, ack, &token, out);
+        }
         if !stream.is_empty() {
             return self.handle_ack_in_stream(engine, stream, group, ack, &token, out);
         }
@@ -1962,6 +1980,45 @@ impl Session {
                 let status = match engine
                     .with(move |e| e.ack_partition(&stream, partition, &group, &token))?
                 {
+                    AckResult::Acked => 1u8,
+                    AckResult::Fenced => 0u8,
+                };
+                self.leased.remove(&ack.offset);
+                reply(out, FrameType::AckStatus, &[status]);
+                Ok(())
+            }
+            AckOp::Nack | AckOp::Term | AckOp::Progress => {
+                self.leased.remove(&ack.offset);
+                reply(out, FrameType::AckStatus, &[0]);
+                Ok(())
+            }
+        }
+    }
+
+    /// Handles the ACK of a PRIORITY-stream delivery (#553), the priority twin of
+    /// [`Session::handle_ack_in_partition`]: routes an `Ack` to the lane the delivery came from via
+    /// [`Engine::ack_priority`], which decodes the COMPOSITE delivery offset (`token.offset`, which the
+    /// consumer echoed back) into the lane + lane offset and commits that lane's OWN durable cursor. The
+    /// lease-ownership check ran in [`Session::handle_ack`] before this. Nack/Term/Progress are not on
+    /// the priority consume path this phase (mirroring the partition scope): they reply FENCED, so the
+    /// lease expires and redelivers on schedule.
+    fn handle_ack_in_priority<
+        F: Filesystem + Clone + 'static,
+        C: Clock + Clone + 'static,
+        E: EngineAccess<F, C>,
+    >(
+        &mut self,
+        engine: &E,
+        stream: GroupName,
+        group: GroupName,
+        ack: ironbus_proto::message::AckBody,
+        token: &LeaseToken,
+        out: &mut Vec<u8>,
+    ) -> Result<(), SessionError> {
+        match ack.op {
+            AckOp::Ack => {
+                let token = *token;
+                let status = match engine.with(move |e| e.ack_priority(&stream, &group, &token))? {
                     AckResult::Acked => 1u8,
                     AckResult::Fenced => 0u8,
                 };
@@ -2378,13 +2435,19 @@ impl Session {
                 let stream = self.stream.clone();
                 // #693: a PARTITION-addressed consumer (`SubTo` carried a partition selector) drains ONE
                 // partition's sub-log via `poll_partition` (plain competing, its OWN durable per-partition
-                // cursor); `stream` is guaranteed non-empty here (SubTo validated it). A whole-stream or
-                // default-stream consumer takes the unchanged member-aware paths below.
+                // cursor); `stream` is guaranteed non-empty here (SubTo validated it). #553: a
+                // PRIORITY-bound consumer drains the highest-priority non-empty lane via `poll_priority`
+                // (the composite delivery offset carries the lane). A whole-stream or default-stream
+                // consumer takes the unchanged member-aware paths below.
                 let partition = self.partition;
+                let priority_bound = self.priority_bound;
                 let poll = engine.with(move |e| {
                     if let Some(partition) = partition {
                         let now = e.now_monotonic();
                         e.poll_partition(&stream, partition, &group, now)
+                    } else if priority_bound {
+                        let now = e.now_monotonic();
+                        e.poll_priority(&stream, &group, now)
                     } else if stream.is_empty() {
                         e.poll_now_in_member(&group, member)
                     } else {
@@ -3540,6 +3603,8 @@ impl Session {
         self.stream = GroupName::default();
         // #693: resetting to the default stream clears any partition binding (whole-stream consume).
         self.partition = None;
+        // #553: and any priority-stream binding.
+        self.priority_bound = false;
         self.leased.clear();
         // If the new group is configured key_shared (#64), put it into that mode and join as a
         // member so this connection's keys route to it. A failure to enable the mode (an invalid
@@ -3630,15 +3695,25 @@ impl Session {
             return Ok(());
         }
         let stream = stream.to_string();
-        // #693: the additive `partition_count` decides the backing. `P <= 1` delegates to the plain
-        // single-log declare BYTE-FOR-BYTE; `P > 1` opts the stream into a `PartitionedStream` of `P`
-        // key-routed sub-logs. Both reply a body-less `Ok` (idempotent); a conflict (a different `P`, or
-        // a name already a single named stream) fails closed with the engine's typed reason.
+        // #693/#553: the additive `partition_count` + `priority` flag decide the backing. `priority =
+        // true` opts the stream into PRIORITY MODE (`P = partition_count` priority lanes, delivered
+        // highest-first); otherwise `P <= 1` delegates to the plain single-log declare BYTE-FOR-BYTE and
+        // `P > 1` opts into a key-partitioned `PartitionedStream`. All reply a body-less `Ok`
+        // (idempotent); a conflict (a different `P`/levels, a cross-mode name, `priority` with `P < 2`)
+        // fails closed with the engine's typed reason. The two partitioned modes are mutually exclusive.
         let partition_count = decoded.partition_count;
-        match engine.with(move |e| e.declare_partitioned_stream(&stream, partition_count))? {
+        let priority = decoded.priority;
+        let result = engine.with(move |e| {
+            if priority {
+                e.declare_priority_stream(&stream, partition_count)
+            } else {
+                e.declare_partitioned_stream(&stream, partition_count)
+            }
+        })?;
+        match result {
             // Idempotent: a first declare (`true`) and a re-declare (`false`) both reply a body-less Ok.
             Ok(_) => reply(out, FrameType::Ok, &[]),
-            // A malformed/over-long NAMED name (or a partition conflict) fails closed with the reason.
+            // A malformed/over-long NAMED name (or a partition/priority conflict) fails closed.
             Err(e) => reply_err_coded(out, e.code().as_str(), &e.to_string()),
         }
         Ok(())
@@ -3820,6 +3895,11 @@ impl Session {
             ack_level: ironbus_proto::message::pub_ack_level(msg.flags),
         };
         let stream = stream.to_string();
+        // #553: the wire PubTo carries an additive PRIORITY byte, threaded to the engine's
+        // priority-carrying produce. It is IGNORED for a non-priority stream (a `priority = 0` call is
+        // byte-for-byte `produce_in_stream`), so only a produce to a declared priority stream routes to
+        // the record's priority lane. Captured before the job moves `stream`.
+        let priority = decoded.priority;
         // Route the named-stream produce to its append SHARD (#811): hash the name (by ref) BEFORE the
         // job moves it, so no extra allocation. With one shard (today) this is always 0 and `with_on_shard`
         // is byte-for-byte `with`.
@@ -3833,7 +3913,7 @@ impl Session {
                 payload: &append.payload,
             };
             let level = append.ack_level;
-            let result = e.produce_in_stream(&stream, &view);
+            let result = e.produce_in_stream_prioritized(&stream, &view, priority);
             // Per-ack-level PRODUCE throughput (#571) for the named-stream produce path (which does not
             // route through the actor drain that counts the default path): attribute the accepted record
             // to its level only on a successful append, so the per-level sum matches the fresh-append
@@ -4260,11 +4340,28 @@ impl Session {
                 );
                 return Ok(());
             }
+            // A PRIORITY-lane stream (#553) is consumed as a WHOLE — the broker drains the highest
+            // non-empty lane — so a LANE-addressed subscribe on it is a typed reject (you do not address
+            // a priority lane; subscribe to the stream and the broker picks). Checked alongside the range
+            // check in one engine query.
             let stream_q = stream.to_string();
-            let in_range = engine.with(move |e| {
-                e.partition_count_of(&stream_q)
-                    .is_some_and(|pc| partition < pc.get())
+            let (in_range, is_priority) = engine.with(move |e| {
+                (
+                    e.partition_count_of(&stream_q)
+                        .is_some_and(|pc| partition < pc.get()),
+                    e.is_priority_stream(&stream_q),
+                )
             })?;
+            if is_priority {
+                reply_err(
+                    out,
+                    &format!(
+                        "stream {stream:?} is a priority stream (subscribe to it as a whole; the broker \
+                         drains the highest-priority lane first — a lane is not addressable)"
+                    ),
+                );
+                return Ok(());
+            }
             if !in_range {
                 reply_err(
                     out,
@@ -4282,6 +4379,9 @@ impl Session {
             self.stream = GroupName::from(stream);
             self.subscription = GroupName::from(group);
             self.partition = Some(partition);
+            // A lane-addressed subscribe is never priority-mode (rejected above): clear the flag in case
+            // this rebinds away from a prior priority subscription.
+            self.priority_bound = false;
             self.registered_subscription = false;
             self.ephemeral_subscription = false;
             self.joined_key_shared = false;
@@ -4347,6 +4447,12 @@ impl Session {
         self.subscription = GroupName::from(group);
         // A whole-stream SubTo consumes the stream as a whole (#693): clear any prior partition binding.
         self.partition = None;
+        // #553: a whole-stream SubTo onto a PRIORITY stream binds the priority consume path (the Flow
+        // poll + Ack route through `poll_priority` / `ack_priority`, draining the highest-priority lane
+        // first). A non-priority whole-stream subscribe clears it (byte-for-byte the pre-#553 path). One
+        // engine query; a false for every non-priority stream.
+        let stream_p = stream.to_string();
+        self.priority_bound = engine.with(move |e| e.is_priority_stream(&stream_p))?;
         // A DURABLE named-stream consume does not register in the default-stream broadcast subscriber
         // set (#676); an EPHEMERAL one registers per-stream membership (#771) that the leave path
         // routes by `self.stream`.
@@ -4743,6 +4849,8 @@ impl Session {
             self.subscription = GroupName::from(group);
             // A subject subscribe binds the stream as a whole (#693): clear any partition binding.
             self.partition = None;
+            // #553: a subject subscribe is never priority-mode (priority streams have no subjects).
+            self.priority_bound = false;
             self.registered_subscription = false;
             self.ephemeral_subscription = false;
             self.joined_key_shared = false;
@@ -4787,6 +4895,8 @@ impl Session {
         self.subscription = GroupName::from(group);
         // A subject subscribe binds the stream as a whole (#693): clear any partition binding.
         self.partition = None;
+        // #553: a subject subscribe is never priority-mode (priority streams have no subjects).
+        self.priority_bound = false;
         self.registered_subscription = false;
         self.ephemeral_subscription = false;
         self.joined_key_shared = false;
@@ -4828,6 +4938,8 @@ impl Session {
         self.stream = GroupName::default();
         // #693: resetting to the default stream clears any partition binding (whole-stream consume).
         self.partition = None;
+        // #553: and any priority-stream binding.
+        self.priority_bound = false;
         self.leased.clear();
         if !leaving.is_empty() {
             engine.with(move |e| {
@@ -13784,6 +13896,7 @@ mod tests {
             &ironbus_proto::message::StreamDeclareBody {
                 stream_id: b"orders",
                 partition_count: 2,
+                priority: false,
             },
             &mut declare,
         )
@@ -13902,6 +14015,155 @@ mod tests {
                 .get(),
             2,
             "partition 1's cursor committed both its records"
+        );
+    }
+
+    #[test]
+    #[allow(clippy::too_many_lines)]
+    fn priority_wire_declare_produce_and_consume_high_first_end_to_end() {
+        // #553 THE wire end-to-end: a `StreamDeclare` carrying `priority = true`, `partition_count = 3`
+        // backs "jobs" with a PRIORITY-mode stream; `PubTo`s carrying the additive priority byte route
+        // to their lane; a WHOLE-stream `SubTo` binds the priority consume path, and a `Flow` delivers
+        // HIGHEST-PRIORITY FIRST over the wire; each ack routes back to the right lane (status 1).
+        let (e, mut s, mut out) = connect_streams();
+
+        // Declare priority mode with 3 levels over the wire.
+        let mut declare = Vec::new();
+        ironbus_proto::message::encode_stream_declare(
+            &ironbus_proto::message::StreamDeclareBody {
+                stream_id: b"jobs",
+                partition_count: 3,
+                priority: true,
+            },
+            &mut declare,
+        )
+        .unwrap();
+        s.process(&e, &frame(FrameType::StreamDeclare, &declare), &mut out)
+            .unwrap();
+        assert_eq!(
+            one_response(&out).0,
+            FrameType::Ok,
+            "priority declare acked"
+        );
+        out.clear();
+        assert!(e.engine_mut().is_priority_stream("jobs"));
+
+        // A LANE-addressed SubTo on a priority stream is REJECTED (consume it as a whole).
+        let mut lane_sub = Vec::new();
+        ironbus_proto::message::encode_sub_to(
+            &ironbus_proto::message::SubToBody {
+                ephemeral: false,
+                stream_id: b"jobs",
+                group: b"w",
+                partition: Some(0),
+            },
+            &mut lane_sub,
+        )
+        .unwrap();
+        s.process(&e, &frame(FrameType::SubTo, &lane_sub), &mut out)
+            .unwrap();
+        assert_eq!(
+            one_response(&out).0,
+            FrameType::Err,
+            "a lane-addressed subscribe on a priority stream is rejected"
+        );
+        out.clear();
+
+        // Publish at interleaved priorities over the wire (0 = lowest, 2 = highest).
+        let pubto = |priority: u8, payload: &[u8]| -> Vec<u8> {
+            let mut p = Vec::new();
+            ironbus_proto::message::encode_pub_to(
+                &ironbus_proto::message::PubToBody {
+                    stream_id: b"jobs",
+                    priority,
+                    pub_body: &pub_body(payload),
+                },
+                &mut p,
+            )
+            .unwrap();
+            frame(FrameType::PubTo, &p)
+        };
+        for f in [
+            pubto(0, b"lo"),
+            pubto(2, b"hi-a"),
+            pubto(1, b"mid"),
+            pubto(2, b"hi-b"),
+        ] {
+            s.process(&e, &f, &mut out).unwrap();
+            assert_eq!(
+                one_response(&out).0,
+                FrameType::PubAck,
+                "priority publish acked"
+            );
+            out.clear();
+        }
+
+        // WHOLE-stream SubTo (no partition selector) binds the priority consume path.
+        let mut sub = Vec::new();
+        ironbus_proto::message::encode_sub_to(
+            &ironbus_proto::message::SubToBody {
+                ephemeral: false,
+                stream_id: b"jobs",
+                group: b"w",
+                partition: None,
+            },
+            &mut sub,
+        )
+        .unwrap();
+        s.process(&e, &frame(FrameType::SubTo, &sub), &mut out)
+            .unwrap();
+        assert_eq!(
+            one_response(&out).0,
+            FrameType::Ok,
+            "whole-stream SubTo acked"
+        );
+        out.clear();
+
+        // Flow: the two highest-priority records first (in produce order), then mid, then lo.
+        s.process(&e, &frame(FrameType::Flow, &10u32.to_le_bytes()), &mut out)
+            .unwrap();
+        assert_eq!(
+            delivered_payloads(&out),
+            vec![
+                b"hi-a".to_vec(),
+                b"hi-b".to_vec(),
+                b"mid".to_vec(),
+                b"lo".to_vec(),
+            ],
+            "the priority consumer sees highest-priority records first over the wire"
+        );
+
+        // Ack every delivered record; each composite offset routes back to its own lane (status 1).
+        for (ty, body) in decode_all(&out) {
+            if ty != FrameType::Deliver {
+                continue;
+            }
+            let d = decode_deliver(&body).unwrap();
+            let mut ack = Vec::new();
+            encode_ack(
+                &AckBody {
+                    offset: d.offset,
+                    generation: d.generation,
+                    op: AckOp::Ack,
+                    delay_ms: 0,
+                },
+                &mut ack,
+            );
+            let mut aout = Vec::new();
+            s.process(&e, &frame(FrameType::Ack, &ack), &mut aout)
+                .unwrap();
+            let (aty, abody) = one_response(&aout);
+            assert_eq!(aty, FrameType::AckStatus);
+            assert_eq!(abody, vec![1u8], "the priority ack committed to its lane");
+        }
+        out.clear();
+
+        // Nothing more to deliver (all lanes drained + acked).
+        s.process(&e, &frame(FrameType::Flow, &10u32.to_le_bytes()), &mut out)
+            .unwrap();
+        assert!(
+            delivered_payloads(&out).is_empty(),
+            "no more records after every lane is acked"
         );
     }
 
@@ -14466,6 +14728,7 @@ mod tests {
         ironbus_proto::message::encode_pub_to(
             &ironbus_proto::message::PubToBody {
                 stream_id: b"orders",
+                priority: 0,
                 pub_body: &pub_body(b"P"),
             },
             &mut pubto,
@@ -14651,6 +14914,7 @@ mod tests {
         ironbus_proto::message::encode_pub_to(
             &ironbus_proto::message::PubToBody {
                 stream_id: b"shipments",
+                priority: 0,
                 pub_body: &pub_body(b"s0"),
             },
             &mut pubto,

--- a/crates/ironbus-server/src/session.rs
+++ b/crates/ironbus-server/src/session.rs
@@ -2057,6 +2057,18 @@ impl Session {
             reply_err(out, "not connected");
             return Ok(());
         }
+        // #553: a PRIORITY-bound consumer must not send a broadcast `CumulativeAck` — its `self.leased`
+        // holds COMPOSITE lane-tagged offsets, so the raw `up_to`-exclusive prune below would corrupt its
+        // cross-lane lease bookkeeping (fencing lower-lane acks). A priority consumer acks per-message
+        // (each composite offset routes to its lane); reject the frame rather than mis-prune. Cheap
+        // insurance — it is a misuse of a broadcast-group verb on a competing named-stream consumer.
+        if self.priority_bound {
+            reply_err(
+                out,
+                "cumulative-ack is not supported on a priority-stream consumer (ack per message)",
+            );
+            return Ok(());
+        }
         let Ok(ack) = decode_cumulative_ack(body) else {
             reply_err(out, "malformed cumulative-ack body");
             return Ok(());
@@ -2207,6 +2219,31 @@ impl Session {
             .values()
             .map(|l| l.bytes)
             .fold(0u64, u64::saturating_add)
+    }
+
+    /// Drops the now-meaningless in-flight leases at or below a `Poll::Truncated` reset (#82/#84): a
+    /// force-reap moved the group's cursor UP to `earliest_retained`, so any lease this session held
+    /// below it is a reaped offset a later ack must NOT act on (it would fence, or worse act on a
+    /// recycled offset).
+    ///
+    /// For a NON-priority consumer this prunes every lease below the reset offset (raw offsets, the
+    /// historical behavior). For a PRIORITY consumer (#553) `earliest_retained` is a COMPOSITE offset
+    /// (its reaped LANE in the top 8 bits) and `self.leased` multiplexes composite offsets from ALL
+    /// lanes, so the prune is LANE-SCOPED: only leases in the SAME lane as the reaped one are dropped —
+    /// and, because same-lane composites are order-preserving on the low 56 bits, the within-lane
+    /// `>= reset` comparison is correct — while every OTHER lane's in-flight leases are RETAINED. A reap
+    /// in one lane must never fence another lane's acks (a cross-lane composite compare would drop every
+    /// lease in the lower-numbered lanes, spuriously redelivering them).
+    fn prune_leases_below_truncation(&mut self, earliest_retained: Offset) {
+        let reset = earliest_retained.get();
+        if self.priority_bound {
+            let (reaped_lane, _) = crate::engine::decompose_priority_offset(reset);
+            self.leased.retain(|&o, _| {
+                crate::engine::decompose_priority_offset(o).0 != reaped_lane || o >= reset
+            });
+        } else {
+            self.leased.retain(|&o, _| o >= reset);
+        }
     }
 
     /// Drops every `leased` entry the engine no longer holds as an ACTIVE (live and not expired)
@@ -2536,8 +2573,9 @@ impl Session {
                         earliest_retained,
                         skipped,
                     }) => {
-                        self.leased
-                            .retain(|&offset, _| offset >= earliest_retained.get());
+                        // Lane-scoped for a priority consumer (#553): a reap in one lane never fences
+                        // another lane's in-flight leases (see `prune_leases_below_truncation`).
+                        self.prune_leases_below_truncation(earliest_retained);
                         self.emit_truncation(
                             out,
                             &mut frame_body,
@@ -2825,14 +2863,13 @@ impl Session {
                         reply(out, FrameType::DeadLetter, &frame_body);
                     }
                     // A below-earliest truncation: identical handling to `handle_flow` — drop the now-meaningless
-                    // leases below the reset and emit the in-band advisory (GapMarker or Truncated per the
-                    // negotiated capability), then keep draining.
+                    // leases below the reset (lane-scoped for a priority consumer, #553) and emit the in-band
+                    // advisory (GapMarker or Truncated per the negotiated capability), then keep draining.
                     Ok(Poll::Truncated {
                         earliest_retained,
                         skipped,
                     }) => {
-                        self.leased
-                            .retain(|&offset, _| offset >= earliest_retained.get());
+                        self.prune_leases_below_truncation(earliest_retained);
                         self.emit_truncation(
                             out,
                             &mut frame_body,
@@ -14164,6 +14201,90 @@ mod tests {
         assert!(
             delivered_payloads(&out).is_empty(),
             "no more records after every lane is acked"
+        );
+    }
+
+    /// #553 (regression): the `Poll::Truncated` lease prune is LANE-SCOPED for a priority consumer. A
+    /// force-reap in ONE lane must drop only THAT lane's below-earliest in-flight leases and RETAIN
+    /// every other lane's — the composite offsets must not be compared cross-lane (which would fence a
+    /// lower-numbered lane's acks and spuriously redeliver them). The non-priority path is unchanged.
+    #[test]
+    fn priority_truncation_prune_is_lane_scoped_not_cross_lane() {
+        use crate::engine::compose_priority_offset;
+        use ironbus_core::partition::PartitionIndex;
+        let comp = |lane: u32, off: u64| {
+            compose_priority_offset(PartitionIndex::new(lane), Offset::new(off))
+        };
+
+        // A priority-bound consumer holding in-flight leases across THREE lanes.
+        let mut s = Session::new();
+        s.priority_bound = true;
+        for (lane, off) in [(0u32, 5u64), (1, 2), (1, 3), (2, 0), (2, 1)] {
+            s.leased.insert(
+                comp(lane, off),
+                Lease {
+                    generation: 1,
+                    bytes: 4,
+                },
+            );
+        }
+
+        // Lane 2 force-reaped up to offset 1 (Poll::Truncated{earliest = compose(2, 1)}): ONLY lane 2's
+        // below-earliest lease (off 0) is pruned; lanes 0 and 1 are UNTOUCHED. The cross-lane bug would
+        // have dropped every lease with a smaller composite = ALL of lanes 0 and 1 (2<<56 > any lane-0/1
+        // composite).
+        s.prune_leases_below_truncation(Offset::new(comp(2, 1)));
+        assert!(
+            s.leased.contains_key(&comp(0, 5)),
+            "lane 0 lease retained (its lane was NOT reaped)"
+        );
+        assert!(s.leased.contains_key(&comp(1, 2)), "lane 1 lease retained");
+        assert!(s.leased.contains_key(&comp(1, 3)), "lane 1 lease retained");
+        assert!(
+            !s.leased.contains_key(&comp(2, 0)),
+            "lane 2 below-earliest lease pruned"
+        );
+        assert!(
+            s.leased.contains_key(&comp(2, 1)),
+            "lane 2 at-earliest lease retained"
+        );
+        // The lane-0 lease survives with its generation intact, so its later ack PASSES the ownership
+        // gate (offset + generation match a live lease) and is NOT spuriously fenced — the concrete
+        // symptom of the fixed bug (fenced ack -> engine lease expires -> spurious duplicate).
+        assert_eq!(s.leased.get(&comp(0, 5)).map(|l| l.generation), Some(1));
+
+        // Reaping lane 1 up to offset 3 DOES prune lane 1's below-earliest lease (within-lane path
+        // works), while lane 0 STILL survives across the lane-1 reap.
+        s.prune_leases_below_truncation(Offset::new(comp(1, 3)));
+        assert!(
+            !s.leased.contains_key(&comp(1, 2)),
+            "lane 1 below-earliest lease pruned by a lane-1 reap"
+        );
+        assert!(
+            s.leased.contains_key(&comp(1, 3)),
+            "lane 1 at-earliest lease retained"
+        );
+        assert!(
+            s.leased.contains_key(&comp(0, 5)),
+            "lane 0 STILL retained across a lane-1 reap"
+        );
+
+        // The NON-priority path is unchanged: raw offsets, prune everything strictly below the reset.
+        let mut r = Session::new();
+        for off in [1u64, 4, 9] {
+            r.leased.insert(
+                off,
+                Lease {
+                    generation: 1,
+                    bytes: 4,
+                },
+            );
+        }
+        r.prune_leases_below_truncation(Offset::new(5));
+        assert!(!r.leased.contains_key(&1) && !r.leased.contains_key(&4));
+        assert!(
+            r.leased.contains_key(&9),
+            "raw offsets >= reset retained (byte-for-byte the pre-#553 behavior)"
         );
     }
 

--- a/crates/ironbus-storage/src/layout.rs
+++ b/crates/ironbus-storage/src/layout.rs
@@ -77,6 +77,20 @@ pub const STREAMS_SUBDIR: &str = "streams";
 /// so a deployment that never partitions never materializes `pstreams/` (its disk image is unchanged).
 pub const PARTITIONED_STREAMS_SUBDIR: &str = "pstreams";
 
+/// The reserved data-dir subtree for PRIORITY-LANE streams (M4-I3, #553): an OPT-IN priority-mode
+/// stream is backed by the SAME [`crate::partitioned::PartitionedStream`] primitive as a partitioned
+/// stream, but its `P` sub-logs are PRIORITY LANES (one per priority level `0..P`) rather than
+/// key-hash partitions — a produce routes to the lane of its priority and delivery drains the
+/// highest-priority non-empty lane first. It is a SEPARATE subtree from [`PARTITIONED_STREAMS_SUBDIR`]
+/// so the MODE (priority-lane vs key-partition) is encoded in the path itself: recovery reading
+/// `prstreams/` knows a stream is priority-mode without any marker file, and the two modes are
+/// physically MUTUALLY EXCLUSIVE (a name is a subdir under exactly one of the two). Each priority
+/// stream is rooted at `prstreams/<hex(name)>/`, whose `P` lane sub-logs live under
+/// `prstreams/<hex(name)>/p-<08x(i)>/` (the same lane-subdir naming as a partition). NOT created until
+/// a stream declares priority mode, so a deployment that never uses priorities never materializes
+/// `prstreams/` and its on-disk image is byte-for-byte unchanged.
+pub const PRIORITY_STREAMS_SUBDIR: &str = "prstreams";
+
 /// The reserved data-dir subtree for the SHARED WAL (M2-I13, #597 — the shared-WAL fallback for high
 /// stream counts): ONE [`crate::shared_wal::SharedWal`] commit log holding every shared-mode named
 /// stream's records interleaved and tagged, rooted at `shared-wal/`. It is a SEPARATE subtree from


### PR DESCRIPTION
## What

OPT-IN message priorities (V2-M4-I3, closes #553): higher-priority messages are delivered ahead of lower ones within a stream/group. The **DEFAULT mode is unchanged** — strictly FIFO-by-offset and byte-identical (the conformance format-registry + Go golden-vector gates prove it). Priority is a distinct, per-stream opt-in.

## Design — priority LANES reuse the partition machinery

A priority-mode stream is backed by the **same `PartitionedStream` sub-log-per-lane primitive** (#591/#693) as a key-partitioned stream — `P` independent, independently-recovered logs — but its `P` sub-logs are **priority lanes** (levels `0..P`) instead of key-hash partitions. Only two things differ from key-partitioning:

1. **Produce** routes to the lane of the record's priority — `min(priority, P-1)`, saturating — not `xxh3_64(key) % P`. A record's priority is **fixed at produce** (it *is* which lane it lands in), so there is no re-prioritization race, and within a lane records stay **strict FIFO-by-offset**.
2. **Consume** drains the **highest-priority non-empty lane first** (lanes scanned `P-1..0`), reusing `deliver_from_partition` / `ack_partition` **verbatim** per lane — so at-least-once, `MaxDeliver`→park, delayed-delivery (#555), the durable per-lane cursor (#681), and per-lane retention all compose per lane.

**Starvation policy:** STRICT priority (RabbitMQ-style), documented as a known Phase-1 property (a sustained high-priority load *can* starve lower lanes). A weighted/aging policy is a documented follow-up. A pinning test asserts the honest behavior.

**Ack disambiguation:** a priority consumer draws from multiple lanes, each with its own offset space, so a raw offset is ambiguous across lanes. `poll_priority` therefore delivers a **composite offset** (lane in the top 8 bits, lane offset in the low 56) — globally unique for one consumer, exactly as a single-partition consumer's raw offsets are. The consumer echoes it verbatim; `ack_priority` decomposes it back to `(lane, offset)`. **No wire-format change** (the offset field is already `u64`), and the offset-keyed lease map is reused unchanged.

**Mutual exclusion + recovery:** a priority stream lives in the same engine `partitioned` map, distinguished only by a `priority_streams` marker set, and on disk under a **separate `prstreams/` subtree** — so the mode is encoded in the path and survives a restart with **no marker file** (recovery re-derives it). A name is one mode XOR the other; every declare fail-closed rejects a cross-mode or repartition conflict, and shared-WAL mode rejects priority streams like it does partitioned ones. Priority mode requires `2 <= levels <= 256`.

## Wire (additive, no new frame tag)

- `StreamDeclare` gains a `priority` flag (a single byte after `partition_count`, emitted only when set) — a non-priority declare is byte-for-byte the pre-#553 body.
- `PubTo` gains a `priority` byte inside its framed block (after the stream id, emitted only when non-zero) — a priority-0 publish is byte-for-byte the pre-#553 body; the `pub_body` tail is untouched.
- Sync + async clients gain `declare_priority_stream` / `publish_to_with_priority`.

## Tests

Priority delivery order (interleaved → high-first) + FIFO within a level; saturate-above-top + zero-is-lowest; composite-offset acks route to the right lane (two lanes both holding offset 0); per-lane cursor + priority stream survive restart (recovered from `prstreams/`, no redelivery of acked records); strict-priority starvation (pinned); per-lane `MaxDeliver`→park; mutual-exclusion + level-bound rejects; composite-offset round-trip; wire byte-identity for both additive fields; full end-to-end wire test (declare → publish at priorities → whole-stream subscribe → `Flow` delivers high-first → ack routes per lane; a lane-addressed subscribe on a priority stream is rejected).

## Gates (all green, native macOS, rustc/clippy 1.97.0 + cmake for `--all-features`)

- `cargo test --workspace --all-features`: **0 failed** (server lib 1311, proto 173, storage 525, …).
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean.
- `cargo fmt --all --check`: clean.
- `check-format-registry.sh`: on-disk format layout **and** wire FrameType tag map digests **unchanged** (byte-identity: no new frame tags, no new on-disk format).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01McmNfYNWPmohVS8umY9Lkp
