### PR TITLE
perf(storage): verify-once body-CRC for self-written/verified-resident segments (#540)

### DIFF
--- a/crates/ironbus-core/src/codec.rs
+++ b/crates/ironbus-core/src/codec.rs
@@ -723,7 +723,7 @@ pub fn decoded_len(header: &[u8]) -> Result<usize, DecodeError> {
 /// [`DecodeError::Truncated`] means more bytes may complete the frame; the other
 /// variants mean the frame is corrupt and must be skipped by recovery.
 pub fn decode(input: &[u8]) -> Result<(RecordView<'_>, usize), DecodeError> {
-    let (view, _subject, _tag, total) = decode_inner(input)?;
+    let (view, _subject, _tag, total) = decode_inner(input, true)?;
     Ok((view, total))
 }
 
@@ -736,7 +736,37 @@ pub fn decode(input: &[u8]) -> Result<(RecordView<'_>, usize), DecodeError> {
 /// # Errors
 /// Same as [`decode`], plus [`DecodeError::BadSubjectCrc`] if the stored subject's own CRC fails.
 pub fn decode_with_subject(input: &[u8]) -> Result<(RecordView<'_>, &[u8], usize), DecodeError> {
-    let (view, subject, _tag, total) = decode_inner(input)?;
+    let (view, subject, _tag, total) = decode_inner(input, true)?;
+    Ok((view, subject, total))
+}
+
+/// Decodes one record frame like [`decode_with_subject`] but SKIPS the redundant body CRC32C (and
+/// xxh3-64) recompute, for the verify-once read fast-path (#540, M1-I4): the storage layer calls this
+/// ONLY for a segment whose body integrity was ALREADY proven this process and that has stayed
+/// continuously resident since (self-written and never round-tripped through a disk read, or
+/// CRC-validated on load/recovery/cold-restore and not evicted since), so re-CRC-ing the same trusted
+/// bytes on every read is pure wasted CPU.
+///
+/// This does NOT weaken the end-to-end guarantee. Every OTHER integrity check still runs — magic,
+/// version, header CRC32C, the stream-tag CRC, the subject CRC, and the `total_len` structural check —
+/// and the frame's stored `body_crc` is UNCHANGED on disk, so a client still verifies the body
+/// end-to-end from the same field. Only the SERVER-side per-read recompute of that field is skipped.
+///
+/// SAFETY CONTRACT: a wrong skip serves corrupt bytes silently. The caller MUST have established the
+/// verified-resident predicate; the DEFAULT read path, ALL recovery, and EVERY encrypted frame
+/// (whose AEAD tag is always verified) use the full [`decode_with_subject`] instead. There is
+/// deliberately NO trusted variant of [`decode_encrypted`] — an encrypted read always AEAD-verifies.
+///
+/// # Errors
+/// Same STRUCTURAL variants as [`decode_with_subject`] ([`DecodeError::Truncated`],
+/// [`DecodeError::BadMagic`], [`DecodeError::UnsupportedVersion`], [`DecodeError::BadHeaderCrc`],
+/// [`DecodeError::BadStreamTagCrc`], [`DecodeError::BadSubjectCrc`], [`DecodeError::BadLength`],
+/// [`DecodeError::TooLarge`], [`DecodeError::Encrypted`]); it NEVER returns [`DecodeError::BadBodyCrc`]
+/// or [`DecodeError::BadXxh3`] because those checks are intentionally skipped.
+pub fn decode_with_subject_trusted(
+    input: &[u8],
+) -> Result<(RecordView<'_>, &[u8], usize), DecodeError> {
+    let (view, subject, _tag, total) = decode_inner(input, false)?;
     Ok((view, subject, total))
 }
 
@@ -749,7 +779,7 @@ pub fn decode_with_subject(input: &[u8]) -> Result<(RecordView<'_>, &[u8], usize
 /// # Errors
 /// Same as [`decode`], plus [`DecodeError::BadStreamTagCrc`] if the stored tag's own CRC fails.
 pub fn decode_with_stream_tag(input: &[u8]) -> Result<(RecordView<'_>, &[u8], usize), DecodeError> {
-    let (view, _subject, tag, total) = decode_inner(input)?;
+    let (view, _subject, tag, total) = decode_inner(input, true)?;
     Ok((view, tag, total))
 }
 
@@ -856,14 +886,21 @@ pub fn decode_encrypted(input: &[u8]) -> Result<(EncryptedRecordView<'_>, usize)
     Ok((view, total))
 }
 
-/// The shared decoder behind [`decode`], [`decode_with_subject`], and [`decode_with_stream_tag`].
-/// Validates the whole frame (header CRC, stream-tag CRC if present, subject CRC if present, body CRC,
-/// xxh3 if present) and returns the view, the stored subject slice (empty when the record carries
-/// none), the stored stream-tag slice (empty when the record carries none), and the consumed byte
-/// count. The stream tag and subject are mutually exclusive, so at most one of the two returned slices
-/// is non-empty.
+/// The shared decoder behind [`decode`], [`decode_with_subject`], [`decode_with_subject_trusted`], and
+/// [`decode_with_stream_tag`]. Validates the whole frame (header CRC, stream-tag CRC if present,
+/// subject CRC if present, and — when `verify_body` — the body CRC32C plus the xxh3-64 if present) and
+/// returns the view, the stored subject slice (empty when the record carries none), the stored
+/// stream-tag slice (empty when the record carries none), and the consumed byte count. The stream tag
+/// and subject are mutually exclusive, so at most one of the two returned slices is non-empty.
+///
+/// `verify_body` gates ONLY the body checksums (the CRC32C over `key ++ headers ++ payload` and its
+/// xxh3-64 companion): `true` for every ordinary/untrusted decode (the recompute the readers have
+/// always done), `false` for the verify-once trusted read fast-path (#540) where the body was proven
+/// once while the segment is verified-resident. All the STRUCTURAL and framing checks (magic, version,
+/// header CRC, tag/subject CRC, and the `total_len` trailer check) ALWAYS run, so `verify_body == false`
+/// never admits a mis-framed frame — it only trusts the already-verified body bytes.
 #[allow(clippy::too_many_lines)]
-fn decode_inner(input: &[u8]) -> Result<DecodedFrame<'_>, DecodeError> {
+fn decode_inner(input: &[u8], verify_body: bool) -> Result<DecodedFrame<'_>, DecodeError> {
     if input.len() < RECORD_HEADER_LEN {
         return Err(DecodeError::Truncated);
     }
@@ -1031,20 +1068,32 @@ fn decode_inner(input: &[u8]) -> Result<DecodedFrame<'_>, DecodeError> {
     let body = &input[body_start..body_start + body_len];
     let xxh3_bytes = &input[body_start + body_len..body_start + body_len + xxh3_field];
     let trailer = &input[total - RECORD_TRAILER_LEN..total];
-    let stored_body_crc = read_u32(trailer, 0);
+    // The `total_len` trailer check is a STRUCTURAL/framing check (it validates the frame's own claimed
+    // length against the size derived from the header lengths), so it ALWAYS runs — even on the trusted
+    // read fast-path — because a mis-framed frame must never be admitted regardless of body trust.
     if u64::from(read_u32(trailer, 4)) != total64 {
         return Err(DecodeError::BadLength);
     }
-    // CRC32C is the resync-gating checksum: verify it first. Only a body that passes
-    // CRC32C is then checked against the independent xxh3-64, so a corruption the CRC
-    // catches is always reported as BadBodyCrc, never BadXxh3.
-    if crc32c::crc32c(body) != stored_body_crc {
-        return Err(DecodeError::BadBodyCrc);
-    }
-    if flags.contains(RecordFlags::HAS_XXH3) {
-        let stored_xxh3 = read_u64(xxh3_bytes, 0);
-        if xxh3_64(body) != stored_xxh3 {
-            return Err(DecodeError::BadXxh3);
+    // Verify-once (#540): the body CRC32C (and its xxh3-64 companion) are the ONLY checks gated by
+    // `verify_body`. They are skipped ONLY on the verify-once trusted read fast-path
+    // ([`decode_with_subject_trusted`]), where the storage layer has proven this body's integrity while
+    // the segment is verified-resident and re-CRC-ing the same trusted bytes on every read is wasted
+    // CPU. The stored `body_crc` field is untouched on disk (a client still verifies end-to-end); only
+    // the server-side per-read recompute is elided. Every default/recovery/encrypted decode passes
+    // `verify_body == true` and recomputes as before.
+    if verify_body {
+        let stored_body_crc = read_u32(trailer, 0);
+        // CRC32C is the resync-gating checksum: verify it first. Only a body that passes
+        // CRC32C is then checked against the independent xxh3-64, so a corruption the CRC
+        // catches is always reported as BadBodyCrc, never BadXxh3.
+        if crc32c::crc32c(body) != stored_body_crc {
+            return Err(DecodeError::BadBodyCrc);
+        }
+        if flags.contains(RecordFlags::HAS_XXH3) {
+            let stored_xxh3 = read_u64(xxh3_bytes, 0);
+            if xxh3_64(body) != stored_xxh3 {
+                return Err(DecodeError::BadXxh3);
+            }
         }
     }
 
@@ -1881,6 +1930,86 @@ mod tests {
             Err(DecodeError::Truncated)
         );
         assert_eq!(decode_encrypted(&buf[..10]), Err(DecodeError::Truncated));
+    }
+
+    // #540 verify-once: the trusted decoder SKIPS the body CRC, so a body byte corrupted in memory is
+    // served without error, while the ordinary decoder catches the SAME corruption as `BadBodyCrc`.
+    // This is the load-bearing proof that the fast-path elides exactly the body recompute.
+    #[test]
+    fn trusted_decode_skips_a_corrupt_body_that_full_decode_catches() {
+        let mut buf = sample();
+        // Flip a byte inside the record body (past the 32-byte header, well before the trailer).
+        let body_byte = RECORD_HEADER_LEN + 3;
+        buf[body_byte] ^= 0x01;
+
+        // The ordinary read path recomputes the body CRC and rejects the corruption.
+        assert_eq!(decode_with_subject(&buf), Err(DecodeError::BadBodyCrc));
+        assert_eq!(decode(&buf), Err(DecodeError::BadBodyCrc));
+
+        // The verify-once trusted path skips the body CRC: it returns the frame (with the corrupted
+        // payload byte) and consumes the whole frame, proving the recompute was elided.
+        let (view, subject, consumed) =
+            decode_with_subject_trusted(&buf).expect("trusted decode skips the body CRC");
+        assert_eq!(consumed, buf.len());
+        assert!(subject.is_empty());
+        // The corrupted payload is served verbatim (the whole point of the skip): the last payload
+        // byte differs from the pristine `hello`.
+        assert_eq!(view.key, b"k");
+        assert_eq!(view.headers, b"h");
+        assert_ne!(view.payload, b"hello");
+    }
+
+    // #540: skipping the body CRC must NOT weaken any STRUCTURAL/framing check. A corrupt header CRC
+    // and a corrupt `total_len` trailer are both still caught on the trusted path.
+    #[test]
+    fn trusted_decode_still_enforces_structural_integrity() {
+        // (a) Header corruption: flip a byte inside the CRC-protected header (the seq field at off 4).
+        let mut hdr_bad = sample();
+        hdr_bad[off::SEQ] ^= 0x01;
+        assert_eq!(
+            decode_with_subject_trusted(&hdr_bad),
+            Err(DecodeError::BadHeaderCrc),
+            "trusted decode still verifies the header CRC"
+        );
+
+        // (b) Framing corruption: flip a byte in the `total_len` trailer (the last 4 bytes). The
+        // total-len structural check runs regardless of body trust.
+        let mut len_bad = sample();
+        let n = len_bad.len();
+        len_bad[n - 1] ^= 0x01;
+        assert_eq!(
+            decode_with_subject_trusted(&len_bad),
+            Err(DecodeError::BadLength),
+            "trusted decode still enforces the total_len framing check"
+        );
+
+        // (c) An ENCRYPTED frame is refused by the (plaintext) trusted decoder exactly as by `decode`,
+        // so the trusted fast-path can never be pointed at ciphertext.
+        let mut enc = sample();
+        enc[off::FLAGS] |= RecordFlags::ENCRYPTED.bits();
+        // Re-seal the header CRC so we reach the flags gate rather than the header-CRC gate.
+        let crc = crc32c::crc32c(&enc[RECORD_HEADER_CRC_RANGE]);
+        enc[off::HEADER_CRC..off::HEADER_CRC + 4].copy_from_slice(&crc.to_le_bytes());
+        assert_eq!(
+            decode_with_subject_trusted(&enc),
+            Err(DecodeError::Encrypted),
+            "the plaintext trusted decoder refuses an encrypted frame"
+        );
+    }
+
+    // #540: on a CLEAN frame the trusted and full decoders return an identical view — the skip changes
+    // nothing observable when the bytes are intact.
+    #[test]
+    fn trusted_decode_matches_full_decode_on_a_clean_frame() {
+        let buf = sample();
+        let (full, full_sub, full_n) = decode_with_subject(&buf).unwrap();
+        let (trusted, trusted_sub, trusted_n) = decode_with_subject_trusted(&buf).unwrap();
+        assert_eq!(full_n, trusted_n);
+        assert_eq!(full_sub, trusted_sub);
+        assert_eq!(full.key, trusted.key);
+        assert_eq!(full.headers, trusted.headers);
+        assert_eq!(full.payload, trusted.payload);
+        assert_eq!(full.seq, trusted.seq);
     }
 }
 

--- a/crates/ironbus-server/src/engine.rs
+++ b/crates/ironbus-server/src/engine.rs
@@ -4393,6 +4393,9 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
             // The DLQ inherits the main log's seek-by-time index density (#772); it is a pure
             // accelerator, harmless if never seeked by time.
             tindex_stride_records: config.log.tindex_stride_records,
+            // Inherit the main log's verify-once opt-out (#540): if the operator opts into
+            // always-verify, the DLQ's read path honors it too.
+            verify_always: config.log.verify_always,
         };
         // The dead-letter TARGET subdirs (#551): the configured dead-letter EXCHANGE's ordered
         // target list, or the single default fixed `dlq/` (byte-identical to today) when none is
@@ -4569,6 +4572,8 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
             daily_physical_write_budget_bytes: 0,
             // Inherit the main log's seek-by-time index density (#772); a pure, harmless accelerator.
             tindex_stride_records: config.log.tindex_stride_records,
+            // Inherit the main log's verify-once opt-out (#540).
+            verify_always: config.log.verify_always,
         };
         let txn = if Self::txn_dir_exists(&log) {
             Some(TxnStore::open(

--- a/crates/ironbus-storage/src/dlq.rs
+++ b/crates/ironbus-storage/src/dlq.rs
@@ -698,6 +698,13 @@ impl<F: Filesystem, C: Clock> DlqSink<F, C> {
         // overwrites it, so clear the original HAS_KEY bit and let the log re-derive it from the
         // (preserved) key. The other flags (e.g. COMPRESSED) are carried through unchanged.
         let flags = RecordFlags::from_bits(source.flags.bits() & !RecordFlags::HAS_KEY.bits());
+        // Verify-once (#540) INVARIANT: this re-encode computes a FRESH body CRC over `source`'s bytes.
+        // That is sound only because `source` was materialized by a read that VERIFIED its body CRC — the
+        // verify-once skip is DISARMED on every production read path (see `SegmentReader::crc_skip_armed`),
+        // so a dead-lettered record's bytes are always CRC-checked before this point. The follow-on that
+        // ARMS the skip (per-record `Deliver` body_crc) MUST NOT dead-letter a skip-read record without
+        // first re-verifying (or preserving) its original body CRC here; otherwise this would persist a
+        // fresh CRC over possibly-rotted bytes = permanent undetectable DLQ corruption.
         let offset = self.log.append(&Append {
             timestamp_ms: source.timestamp_ms,
             flags,

--- a/crates/ironbus-storage/src/log.rs
+++ b/crates/ironbus-storage/src/log.rs
@@ -121,6 +121,18 @@ pub struct LogConfig {
     /// sealed AFTER the change; older sidecars keep their built-in density until rebuilt or reaped.
     /// [`LogConfig::DEFAULT_TINDEX_STRIDE_RECORDS`] (1024) is the safe default.
     pub tindex_stride_records: u32,
+
+    /// Verify-once opt-out (#540, M1-I4): when `false` (the default), the consume read fast-path SKIPS
+    /// the redundant per-read body CRC32C recompute for a VERIFIED-RESIDENT segment — one whose body
+    /// integrity was already proven this process (self-written, or CRC-validated on load/recovery/
+    /// cold-restore) and that has stayed continuously resident since. The frame's stored `body_crc` is
+    /// untouched on disk, so a client still verifies the body end-to-end; only the server-side recompute
+    /// of already-trusted bytes is elided. When `true`, the body CRC is recomputed on EVERY read
+    /// (the pre-#540 always-verify behavior), for an operator who wants belt-and-suspenders re-validation
+    /// at the cost of read CPU. It NEVER affects an encrypted segment (whose AEAD tag is always verified)
+    /// or recovery/restore (which always fully validate). A pure CPU/robustness trade; it changes
+    /// nothing on disk, so a log is byte-identical either way.
+    pub verify_always: bool,
 }
 
 impl LogConfig {
@@ -173,6 +185,9 @@ impl LogConfig {
             // The daily physical write budget is OFF by default; an operator opts in (#118).
             daily_physical_write_budget_bytes: 0,
             tindex_stride_records: LogConfig::DEFAULT_TINDEX_STRIDE_RECORDS,
+            // Verify-once is the default (#540): the read fast-path skips the redundant body-CRC
+            // recompute for a verified-resident segment; an operator opts IN to always-verify.
+            verify_always: false,
         })
     }
 
@@ -216,6 +231,16 @@ impl LogConfig {
     #[must_use]
     pub fn with_tindex_stride_records(mut self, stride: u32) -> LogConfig {
         self.tindex_stride_records = stride.max(1);
+        self
+    }
+
+    /// Sets the verify-once opt-out ([`LogConfig::verify_always`]) and returns the updated config
+    /// (#540). `false` (the default) enables the read fast-path's body-CRC skip for a verified-resident
+    /// segment; `true` forces a body-CRC recompute on every read. A pure CPU/robustness trade that
+    /// changes nothing on disk and never affects an encrypted segment's AEAD verification.
+    #[must_use]
+    pub fn with_verify_always(mut self, verify_always: bool) -> LogConfig {
+        self.verify_always = verify_always;
         self
     }
 }
@@ -262,6 +287,9 @@ impl Default for LogConfig {
             daily_physical_write_budget_bytes: 0,
             // The safe default seek-by-time index density (#772): one anchor per 1024 records.
             tindex_stride_records: LogConfig::DEFAULT_TINDEX_STRIDE_RECORDS,
+            // Verify-once by default (#540): the read fast-path skips the redundant body-CRC recompute
+            // for a verified-resident segment. An operator opts in to always-verify.
+            verify_always: false,
         }
     }
 }
@@ -1000,6 +1028,23 @@ pub struct Log<F: Filesystem, C: Clock> {
     /// on every read. The active segment is never cached (it grows); evicted in lockstep with the seek
     /// index by [`Log::evict_segment_index`] at retirement.
     sealed_readers: SealedReaderCache<F>,
+    /// Verify-once resident set (#540, M1-I4): the ids of SEALED segments whose body integrity has been
+    /// PROVEN this process AND that have stayed continuously resident since — so the consume read
+    /// fast-path may skip the redundant per-read body-CRC recompute for them. An id is INSERTED when the
+    /// proof is established: a self-write seal (this process wrote every frame with a fresh CRC), a clean
+    /// recovery scan on load (`scan_recovery` CRC-validated the chain), or a cold-restore
+    /// (`verify_fetched_segment` CRC'd the whole fetched file). It is REMOVED at the single retirement
+    /// chokepoint [`Log::evict_segment_index`] (reap/compaction-install/offload), so a retired or
+    /// offloaded segment is NOT trusted until re-verified (a cold RELOAD re-verifies via
+    /// `verify_fetched_segment` and re-inserts). A reader-cache fd shed (cap pressure) does NOT clear an
+    /// id — it is not a "bytes left memory" event (same local file, ids never recycle, ADR 0002), so a
+    /// re-opened reader is re-stamped verified from this set, preserving the fd-cache's "dropping a
+    /// reader changes nothing a reader observes" invariant. Interior mutability: the read path is `&self`
+    /// (like `sealed_readers`), single-writer, never aliased across threads. The ACTIVE segment id is
+    /// never in this set (it grows). Holds only derived trust: a wrong membership never crashes, but a
+    /// SPURIOUS insert would serve corrupt data silently, so it is only ever inserted at the three
+    /// whole-segment-verified points above.
+    verified_segments: std::cell::RefCell<std::collections::HashSet<u64>>,
     /// The lock-free, off-actor consume READ plane (#539): the shared atomic flushed frontier plus
     /// the arc-swapped immutable snapshot of the SEALED segments + their seek anchors, which any
     /// number of reader threads observe with NO lock and NO append-actor round-trip. The single
@@ -1478,6 +1523,9 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
                     // skips a would-be-incomplete `.tindex` and a later seek rebuilds from frames.
                     active_time_anchors_complete: false,
                     sealed_readers: SealedReaderCache::new(DEFAULT_SEALED_READER_CACHE_CAP),
+                    // A fresh (empty) log has no sealed segment yet, so the verify-once resident set
+                    // (#540) starts empty; a self-write seal inserts each sealed id.
+                    verified_segments: std::cell::RefCell::new(std::collections::HashSet::new()),
                     // The off-actor read plane (#539) is built lazily on the first consumer
                     // `read_plane()` call; a never-read log pays nothing.
                     read_plane: std::cell::RefCell::new(None),
@@ -1939,6 +1987,9 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
             active_time_anchor_base: 0,
             active_time_anchors_complete: false,
             sealed_readers: SealedReaderCache::new(DEFAULT_SEALED_READER_CACHE_CAP),
+            // Verify-once resident set (#540): seeded below for a recovered chain's sealed segments,
+            // maintained on seal/restore/evict thereafter.
+            verified_segments: std::cell::RefCell::new(std::collections::HashSet::new()),
             // The off-actor read plane (#539) is built lazily on the first consumer `read_plane()`.
             read_plane: std::cell::RefCell::new(None),
             pending_roll: None,
@@ -2042,7 +2093,29 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
         // this covers the no-event paths (a roll-forward pushes nothing) so every recovery exit
         // is cap-checked exactly once against its final report.
         log.enforce_loss_caps(durable_bytes)?;
+
+        // Verify-once (#540): every SEALED segment in the recovered chain was CRC-validated by
+        // `scan_recover_chain`'s `scan_recovery` above, so mark them verified-resident — the "verify once
+        // on load" seeding point.
+        log.mark_sealed_prefix_verified();
         Ok(log)
+    }
+
+    /// Verify-once (#540): mark every SEALED segment in the current chain verified-resident. Used to
+    /// SEED the resident set after recovery ("verify once on load"), matching exactly the sealed PREFIX
+    /// that [`Log::build_sealed_descriptor`] publishes (all slots but the active tail, when one is
+    /// present), so the set stays in lockstep with the read plane. The active segment (still growing) is
+    /// never marked; a later self-write seal inserts it when it seals.
+    fn mark_sealed_prefix_verified(&self) {
+        let sealed_prefix = if self.active.is_some() {
+            self.segments.len().saturating_sub(1)
+        } else {
+            self.segments.len()
+        };
+        let mut verified = self.verified_segments.borrow_mut();
+        for slot in &self.segments[..sealed_prefix] {
+            verified.insert(slot.id);
+        }
     }
 
     /// I3: fail closed if recovery would drop more than the bounded-loss caps allow (#120),
@@ -2480,6 +2553,9 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
             active_time_anchor_base: 0,
             active_time_anchors_complete: false,
             sealed_readers: SealedReaderCache::new(DEFAULT_SEALED_READER_CACHE_CAP),
+            // Verify-once resident set (#540): seeded below for a recovered chain's sealed segments,
+            // maintained on seal/restore/evict thereafter.
+            verified_segments: std::cell::RefCell::new(std::collections::HashSet::new()),
             // The off-actor read plane (#539) is built lazily on the first consumer `read_plane()`.
             read_plane: std::cell::RefCell::new(None),
             pending_roll: None,
@@ -2755,6 +2831,12 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
         if let Some(idx) = self.segment_indexes.borrow_mut().get_mut(&self.active_id) {
             idx.flushed_end = idx.valid_end;
         }
+        // Verify-once (#540): this segment was just written and durably SEALED by THIS process — every
+        // frame carries a body CRC we computed on append and the bytes never round-tripped through a
+        // disk read — so mark it verified-resident. From here a consume read of the just-sealed
+        // predecessor skips the redundant per-read body-CRC recompute. Keyed by the OLD active id,
+        // BEFORE `create_or_defer_segment` repoints `active_id` to the new (empty, unverified) segment.
+        self.verified_segments.borrow_mut().insert(self.active_id);
         // NOTE (#772): the `.tindex` timestamp sidecar is DELIBERATELY NOT written here on the roll.
         // Writing a derived sidecar on the produce/roll hot path would add fsync + directory IO that
         // perturbs the byte-identity, determinism, and fault-injection (op-counting) conformance
@@ -4112,7 +4194,17 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
         if let Some(reader) = self.sealed_readers.get(id) {
             return Ok(reader);
         }
-        let reader = std::sync::Arc::new(self.open_reader(self.fs.open(&segment_file_name(id))?)?);
+        // Verify-once (#540): stamp the fresh reader verified-resident IFF this sealed id is in the
+        // verified set (self-written/recovered/restored + not evicted since), so the consume read
+        // fast-path may skip the redundant per-read body-CRC recompute. A fresh reader for a NOT-yet- or
+        // NO-LONGER-verified id stays unverified and fully re-validates — the fail-closed default that
+        // makes a reloaded segment re-verify. A reader-cache shed re-derives this on re-open, so a shed
+        // (fd-pressure) still observes the same records; only an evict (retirement) clears the trust.
+        let verified = self.verified_segments.borrow().contains(&id);
+        let reader = std::sync::Arc::new(
+            self.open_reader(self.fs.open(&segment_file_name(id))?)?
+                .with_verified_resident(verified),
+        );
         self.sealed_readers
             .insert(id, std::sync::Arc::clone(&reader));
         Ok(reader)
@@ -4122,13 +4214,20 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
     /// (#780 phase 2) so `scan_range`'s decrypt loop can decrypt an encrypted segment on read. A
     /// plaintext log (no keyring) opens the reader exactly as before, byte-identically; a plaintext
     /// segment ignores the ring (its header carries no AEAD params, so the plaintext decode path runs).
-    #[allow(clippy::unused_self)] // uses `self.at_rest` only under the `encryption` feature
     fn open_reader(&self, file: F::File) -> Result<SegmentReader<F::File>, StorageError> {
         #[cfg(feature = "encryption")]
-        if let Some(ring) = self.at_rest.keyring.clone() {
-            return SegmentReader::open_with_keyring(file, ring);
-        }
-        SegmentReader::open(file)
+        let reader = if let Some(ring) = self.at_rest.keyring.clone() {
+            SegmentReader::open_with_keyring(file, ring)?
+        } else {
+            SegmentReader::open(file)?
+        };
+        #[cfg(not(feature = "encryption"))]
+        let reader = SegmentReader::open(file)?;
+        // Verify-once (#540): thread the verify-always opt-out (`LogConfig::verify_always`) into every
+        // reader this log opens, so the read fast-path honors the operator's choice. The verified-resident
+        // stamp itself is applied per-id by `sealed_reader_for` (an active/uncached reader stays
+        // unverified and always full-CRCs).
+        Ok(reader.with_verify_always(self.config.verify_always))
     }
 
     /// Reads ONE segment's contribution to a [`Log::read_range`] in a single forward pass, pushing
@@ -4716,6 +4815,12 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
             Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
             Err(e) => return Err(StorageError::Io(e)),
         }
+        // Verify-once (#540): the restored bytes were just CRC-validated whole by `verify_fetched_segment`
+        // (length + CRC32C + a structural scan) BEFORE being written to local disk, so the RELOADED
+        // segment is trusted again — re-mark it verified-resident. This is the "reload re-verifies" side
+        // of the state machine: the id was CLEARED on offload (`evict_segment_index`), so it is not
+        // trusted until this fresh whole-file verify re-establishes it.
+        self.verified_segments.borrow_mut().insert(id);
         Ok(())
     }
 
@@ -5667,6 +5772,12 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
         // Drop the cached open reader (and its fd) for the retired segment in lockstep (#808), so a
         // reaped/compacted-away segment's fd is released, not leaked.
         self.sealed_readers.evict(id);
+        // Verify-once (#540): CLEAR the verified-resident mark for the retired/offloaded/compacted-away
+        // segment — the single evict chokepoint for the resident set. A segment that later RELOADS
+        // (cold restore) is NOT trusted until `ensure_segment_local` re-verifies and re-inserts it, and
+        // a compaction-installed successor took a fresh id that is verified only via its own seal. This
+        // is the "clear on evict; re-verify on reload" edge that keeps a rotted reloaded byte catchable.
+        self.verified_segments.borrow_mut().remove(&id);
     }
 
     /// Rebuilds a sealed segment's sparse `.tindex` anchors from a validating scan of its durable
@@ -5973,6 +6084,9 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
                     remote: true,
                     anchors: Vec::new(),
                     valid_end: 0,
+                    // A REMOTE slot is served through the actor (restore-on-access), never off-actor, so
+                    // it is never a verify-once fast-path candidate here (#540).
+                    verified: false,
                 });
                 continue;
             }
@@ -5990,6 +6104,9 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
                     remote: false,
                     anchors: Vec::new(),
                     valid_end: 0,
+                    // A COMPACTED slot is served through the actor's v2 scan, never off-actor, so it is
+                    // never a verify-once fast-path candidate here (#540).
+                    verified: false,
                 });
                 continue;
             }
@@ -6011,6 +6128,10 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
                 remote: false,
                 anchors,
                 valid_end,
+                // Verify-once (#540): carry the resident-trust bit from the `Log`'s verified set into the
+                // immutable snapshot, so an off-actor reader for this dense sealed slot may skip the
+                // per-read body-CRC recompute. A fresh snapshot each seal/reap keeps it in lockstep.
+                verified: self.verified_segments.borrow().contains(&slot.id),
             });
         }
         Ok((sealed, oldest, sealed_end))
@@ -6047,8 +6168,9 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
             Ok((sealed, oldest, sealed_end)) => {
                 if let Some(plane) = self.read_plane.borrow().as_ref() {
                     // The Arc<F> the plane already holds is reused for the new snapshot (the
-                    // filesystem handle is the same directory); rebuild only the segment view.
-                    plane.republish_sealed(sealed, oldest, sealed_end);
+                    // filesystem handle is the same directory); rebuild only the segment view. Carry the
+                    // verify-once opt-out (#540) into the new snapshot.
+                    plane.republish_sealed(sealed, oldest, sealed_end, self.config.verify_always);
                     plane.publish_flushed(self.flushed_offset.get());
                 }
             }
@@ -6094,6 +6216,7 @@ impl<F: Filesystem + Clone, C: Clock> Log<F, C> {
             sealed,
             oldest,
             sealed_end,
+            self.config.verify_always,
         );
         *self.read_plane.borrow_mut() = Some(plane.clone());
         Ok(plane)
@@ -6168,6 +6291,14 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
     /// assert the same evict-on-retirement contract for the reader cache.
     fn has_sealed_reader(&self, id: u64) -> bool {
         self.sealed_readers.get(id).is_some()
+    }
+
+    /// Whether segment `id` is currently VERIFIED-RESIDENT in the verify-once resident set (#540). Lets a
+    /// test assert the set/reload state machine (marked on self-write seal / recovery / cold restore,
+    /// cleared on evict) without exposing the private field.
+    #[cfg(test)]
+    fn is_verified_resident_segment(&self, id: u64) -> bool {
+        self.verified_segments.borrow().contains(&id)
     }
 
     /// The number of resident seek indexes currently cached, so a test can assert the resident set
@@ -6845,6 +6976,99 @@ mod tests {
         assert_eq!(log.next_offset(), Offset::new(7));
         assert_eq!(log.next_seq(), Seq::new(7));
         assert_eq!(log.append(&rec(b"next")).unwrap(), Offset::new(7));
+    }
+
+    // #540 verify-once state machine: a segment SEALED by this process (self-written) is marked
+    // verified-resident, while the still-growing ACTIVE segment never is.
+    #[test]
+    fn verify_once_marks_a_self_written_sealed_segment_but_not_the_active_one() {
+        let mut log = open_mem(small_config());
+        for i in 0..8u8 {
+            log.append(&rec(&[i; 20])).unwrap();
+        }
+        log.sync().unwrap();
+        let active = log.active_segment_id();
+        assert!(
+            active >= 1,
+            "cap 128 with 20-byte records rolls at least once"
+        );
+        // Every sealed predecessor was written by THIS process and is verified-resident.
+        for id in 0..active {
+            assert!(
+                log.is_verified_resident_segment(id),
+                "self-written sealed segment {id} is verified-resident"
+            );
+        }
+        // The active (growing) segment is NEVER marked — its tail is still mutating.
+        assert!(
+            !log.is_verified_resident_segment(active),
+            "the active segment is never verified-resident while it grows"
+        );
+        // A verified sealed segment still serves correct records on the read fast-path (the skip must
+        // not corrupt a correct read).
+        let got = log.read_from(Offset::new(0), 2).unwrap();
+        assert_eq!(got.len(), 2);
+        assert_eq!(got[0].offset, Offset::new(0));
+        assert_eq!(got[0].payload.as_ref(), &[0u8; 20]);
+    }
+
+    // #540: recovery is the "verify once on load" point — `scan_recovery` CRC-validated the whole chain,
+    // so every recovered SEALED segment is marked verified-resident, and the resumed active is not.
+    #[test]
+    fn verify_once_recovery_marks_recovered_sealed_segments() {
+        let mut log = open_mem(small_config());
+        for i in 0..7u8 {
+            log.append(&rec(&[i; 20])).unwrap();
+        }
+        log.sync().unwrap();
+        let fs = log.into_filesystem();
+
+        let log = Log::open(fs, ManualClock::new(), small_config()).unwrap();
+        let active = log.active_segment_id();
+        for id in 0..active {
+            assert!(
+                log.is_verified_resident_segment(id),
+                "recovered sealed segment {id} is verified-once on load"
+            );
+        }
+        assert!(
+            !log.is_verified_resident_segment(active),
+            "the resumed active segment is not verified-resident"
+        );
+    }
+
+    // #540: eviction (the retirement chokepoint) CLEARS the verified-resident mark, and a subsequently
+    // RE-OPENED reader for that id is UNVERIFIED — the "reload re-verifies" edge that keeps a rotted
+    // reloaded byte catchable. A reader-cache shed alone would not clear it, but a real evict does.
+    #[test]
+    fn verify_once_eviction_clears_the_mark_so_a_reload_re_verifies() {
+        let mut log = open_mem(small_config());
+        for i in 0..8u8 {
+            log.append(&rec(&[i; 20])).unwrap();
+        }
+        log.sync().unwrap();
+        assert!(log.is_verified_resident_segment(0));
+        // Touch segment 0 so a verified reader is cached, proving the flag rode onto the reader.
+        let reader = log.sealed_reader_for(0).unwrap();
+        assert!(
+            reader.is_verified_resident(),
+            "the cached reader for a verified segment is verified-resident"
+        );
+        drop(reader);
+
+        // Evict (retire) segment 0: the single chokepoint that reap/compaction/offload funnel through.
+        log.evict_segment_index(0);
+        assert!(
+            !log.is_verified_resident_segment(0),
+            "eviction clears the verified-resident mark"
+        );
+        // A freshly RE-OPENED reader for the evicted id is UNVERIFIED, so it re-verifies (full body CRC)
+        // — a reloaded segment is not trusted until re-verified.
+        let reopened = log.sealed_reader_for(0).unwrap();
+        assert!(
+            !reopened.is_verified_resident(),
+            "a reloaded segment's fresh reader re-verifies until re-marked"
+        );
     }
 
     #[test]

--- a/crates/ironbus-storage/src/read_plane.rs
+++ b/crates/ironbus-storage/src/read_plane.rs
@@ -173,6 +173,14 @@ pub(crate) struct SealedSegment {
     /// read-forward upper bound, so a seek never materializes the trailing footer as a record. For a
     /// sealed segment the whole region is durable, so this is the segment's full `valid_end`.
     pub(crate) valid_end: u64,
+    /// Verify-once (#540): `true` when this segment is VERIFIED-RESIDENT in the `Log` (self-written,
+    /// recovered clean, or cold-restored, and not evicted since), so the off-actor read fast-path may
+    /// skip the redundant per-read body-CRC recompute for it. Cloned by value from the `Log`'s resident
+    /// set when the snapshot is built (`build_sealed_descriptor`); a fresh snapshot on every seal/reap
+    /// re-derives it, so it stays in lockstep with the through-actor set. `false` for a remote/compacted
+    /// slot (this plane does not serve those). A reader opened for a `verified: false` slot fully
+    /// re-validates — the fail-closed default.
+    pub(crate) verified: bool,
 }
 
 impl SealedSegment {
@@ -247,6 +255,10 @@ pub(crate) struct SealedSnapshot<F: Filesystem> {
     /// The first offset NOT covered by any sealed segment (the active segment's base): a read at or
     /// above it is entirely in the active tail and falls back to the actor.
     sealed_end: u64,
+    /// Verify-once opt-out (#540, [`LogConfig::verify_always`]), captured from the `Log`'s config when
+    /// the snapshot is published. When `true`, an off-actor reader recomputes the body CRC on every
+    /// read even for a verified-resident segment. Default `false` (verify-once).
+    verify_always: bool,
 }
 
 /// The outcome of a [`SealedSnapshot::read_range`]: the records served from the sealed prefix, plus
@@ -295,6 +307,7 @@ impl<F: crate::fs::Filesystem> SealedSnapshot<F> {
         segments: Vec<SealedSegment>,
         oldest: u64,
         sealed_end: u64,
+        verify_always: bool,
     ) -> SealedSnapshot<F> {
         let readers = SlotReaders::empty(segments.len());
         SealedSnapshot {
@@ -303,6 +316,7 @@ impl<F: crate::fs::Filesystem> SealedSnapshot<F> {
             readers,
             oldest,
             sealed_end,
+            verify_always,
         }
     }
 
@@ -319,9 +333,17 @@ impl<F: crate::fs::Filesystem> SealedSnapshot<F> {
         if let Some(reader) = self.readers.slots[i].get() {
             return Ok(Arc::clone(reader));
         }
-        let opened = Arc::new(SegmentReader::open(
-            self.fs.open(&segment_file_name(slot.id))?,
-        )?);
+        // Verify-once (#540): stamp the fresh reader verified-resident from the slot descriptor (cloned
+        // from the `Log`'s resident set when this snapshot was built) and thread the verify-always
+        // opt-out, so the off-actor read fast-path skips the redundant per-read body-CRC recompute for a
+        // trusted, resident, plaintext segment. A `verified: false` slot (or the opt-out) fully
+        // re-validates. The whole snapshot (and thus this trust) is rebuilt on every seal/reap, so an
+        // evicted/offloaded segment is never served as verified from a stale snapshot.
+        let opened = Arc::new(
+            SegmentReader::open(self.fs.open(&segment_file_name(slot.id))?)?
+                .with_verified_resident(slot.verified)
+                .with_verify_always(self.verify_always),
+        );
         // Cache only while under the per-generation cap (the resident-fd bound). Past it, return the fresh
         // open UNCACHED — a per-read open exactly as before #808 — so a cold full backfill can't pin one
         // fd per sealed segment. `opened < cap` is a soft check (concurrent openers may exceed it by the
@@ -700,11 +722,16 @@ impl<F: crate::fs::Filesystem> ReadPlane<F> {
         segments: Vec<SealedSegment>,
         oldest: u64,
         sealed_end: u64,
+        verify_always: bool,
     ) -> ReadPlane<F> {
         ReadPlane {
             flushed: Arc::new(AtomicU64::new(flushed)),
             sealed: Arc::new(ArcSwap::from_pointee(SealedSnapshot::new(
-                fs, segments, oldest, sealed_end,
+                fs,
+                segments,
+                oldest,
+                sealed_end,
+                verify_always,
             ))),
         }
     }
@@ -718,10 +745,15 @@ impl<F: crate::fs::Filesystem> ReadPlane<F> {
         segments: Vec<SealedSegment>,
         oldest: u64,
         sealed_end: u64,
+        verify_always: bool,
     ) {
         let fs = Arc::clone(&self.sealed.load().fs);
         self.sealed.store(Arc::new(SealedSnapshot::new(
-            fs, segments, oldest, sealed_end,
+            fs,
+            segments,
+            oldest,
+            sealed_end,
+            verify_always,
         )));
     }
 
@@ -1201,9 +1233,9 @@ mod tests {
         // A reader that observes frontier F must see sealed_end >= F. We assert the publish helper
         // upholds it: store the snapshot (sealed_end = N) THEN the frontier (F = N).
         let fs = Arc::new(InMemoryFs::new());
-        let plane: ReadPlane<InMemoryFs> = ReadPlane::new(fs, 0, Vec::new(), 0, 0);
+        let plane: ReadPlane<InMemoryFs> = ReadPlane::new(fs, 0, Vec::new(), 0, 0, false);
         // The writer's publish order: snapshot (sealed_end = 64) FIRST, then frontier (64).
-        plane.republish_sealed(Vec::new(), 0, 64);
+        plane.republish_sealed(Vec::new(), 0, 64, false);
         plane.publish_flushed(64);
         // The reader's observe order: frontier first, then snapshot.
         let f = plane.flushed();

--- a/crates/ironbus-storage/src/segment.rs
+++ b/crates/ironbus-storage/src/segment.rs
@@ -1610,6 +1610,20 @@ pub struct SegmentReader<F: RandomAccessFile> {
     /// body CRC is recomputed on EVERY read even for a verified-resident segment, restoring the
     /// pre-#540 always-verify behavior for the paranoid. Default `false` (verify-once).
     verify_always: bool,
+    /// SAFETY ARMING for the body-CRC skip (#540). The skip removes the server's body-CRC recompute, so
+    /// it is sound ONLY when the delivered record still has an end-to-end integrity backstop — i.e. the
+    /// consumer re-verifies the body CRC itself. That holds for the raw `DeliverBatch` path (the client
+    /// re-decodes the stored frame, CRC and all) but NOT for the per-record materialized `Deliver` path,
+    /// whose wire frame (`DeliverBody`) carries NO crc field, so a default consumer has no way to catch a
+    /// server-skipped rot (`scan_range` `pread`s every read, so a page-cache-evicted disk byte can rot
+    /// and be re-read un-verified). Until the per-record `Deliver` frame carries the stored `body_crc`
+    /// for the client to verify (the tracked follow-on), this stays `false` at EVERY production reader-open
+    /// site, so the server body-CRC recompute is NEVER skipped on a no-backstop path and the end-to-end
+    /// guarantee is preserved. Only the #540 unit tests arm it (via
+    /// [`SegmentReader::with_crc_skip_armed`]) to exercise the trusted-decode fast-path in isolation.
+    /// `verified_resident` + `verify_always` (the state machine + opt-out) stay live and TESTED so the
+    /// follow-on only has to arm this bit once the wire backstop exists.
+    crc_skip_armed: bool,
     /// The at-rest AEAD parameters `(aead_suite_id, key_id)` read from the header at open, or `None`
     /// for a plaintext segment (#780). Behind the `encryption` feature.
     #[cfg(feature = "encryption")]
@@ -1649,6 +1663,10 @@ impl<F: RandomAccessFile> SegmentReader<F> {
             // fail-closed default is what makes a RELOADED segment (a fresh reader after evict) re-verify.
             verified_resident: false,
             verify_always: false,
+            // DISARMED by default: the body-CRC skip never fires unless a caller with a proven
+            // end-to-end backstop arms it. No production path arms it yet (see the field doc), so the
+            // server body-CRC recompute is always performed on the live per-record delivery path.
+            crc_skip_armed: false,
             #[cfg(feature = "encryption")]
             aead,
             #[cfg(feature = "encryption")]
@@ -1688,12 +1706,27 @@ impl<F: RandomAccessFile> SegmentReader<F> {
         self.verified_resident
     }
 
+    /// ARMS the body-CRC skip (#540) — see [`SegmentReader::crc_skip_armed`]. This is the safety gate
+    /// that keeps verify-once from skipping the server body-CRC on a path where the consumer has no
+    /// end-to-end backstop. No PRODUCTION reader-open site calls this: it stays disarmed until the
+    /// per-record `Deliver` frame carries the stored `body_crc` for the client to re-verify (the tracked
+    /// follow-on). Only the #540 unit tests arm it, to exercise the trusted-decode fast-path in
+    /// isolation. Arming it in production WITHOUT that wire backstop would reintroduce the
+    /// silent-corruption hole, so this is intentionally not wired live.
+    #[must_use]
+    pub fn with_crc_skip_armed(mut self, armed: bool) -> SegmentReader<F> {
+        self.crc_skip_armed = armed;
+        self
+    }
+
     /// Whether the consume read fast-path may SKIP the per-read body CRC recompute for this segment
-    /// (#540): only when the reader is verified-resident AND the verify-always opt-out is off. The
-    /// encrypted read path never consults this — it always AEAD-verifies.
+    /// (#540): only when the skip is ARMED (a proven end-to-end backstop exists — see
+    /// [`SegmentReader::crc_skip_armed`]), the reader is verified-resident, AND the verify-always opt-out
+    /// is off. Disarmed in production, so the server always recomputes the body CRC on the live
+    /// per-record delivery path. The encrypted read path never consults this — it always AEAD-verifies.
     #[must_use]
     fn skip_body_crc(&self) -> bool {
-        self.verified_resident && !self.verify_always
+        self.crc_skip_armed && self.verified_resident && !self.verify_always
     }
 
     /// Opens a segment WITH a loaded key ring so [`SegmentReader::scan_decrypted`] can decrypt an
@@ -2480,13 +2513,17 @@ impl<F: RandomAccessFile> SegmentReader<F> {
         if let Some((suite, key_id)) = self.aead_read_params()? {
             return self.scan_range_decrypted(&body, start_offset, max, max_bytes, suite, key_id);
         }
-        // Verify-once (#540): when this segment is VERIFIED-RESIDENT (its body integrity was already
-        // proven this process and it has stayed resident since) and the verify-always opt-out is off,
-        // the consume read fast-path DECODES WITH THE BODY CRC SKIPPED. Every structural/framing check
-        // still runs, and the stored `body_crc` is untouched on disk (a client verifies end-to-end); we
-        // only elide the redundant server-side recompute of already-trusted bytes. An unverified,
-        // freshly-reloaded, or opt-out reader takes the full-CRC branch and still catches corruption.
-        // NOTE: this is the PLAINTEXT loop only — an encrypted segment returned above via
+        // Verify-once (#540): when the body-CRC skip is ARMED (a proven end-to-end backstop exists),
+        // this segment is VERIFIED-RESIDENT, and the verify-always opt-out is off, the consume read
+        // fast-path DECODES WITH THE BODY CRC SKIPPED. Every structural/framing check still runs, and the
+        // stored `body_crc` is untouched on disk; we only elide the redundant server-side recompute.
+        // IMPORTANT: the skip is DISARMED on every production read path (`crc_skip_armed == false`),
+        // because the per-record `Deliver` wire frame does not yet carry the body_crc for a client to
+        // re-verify — so skipping the server recompute would leave a default consumer with NO integrity
+        // backstop (`read_into_fresh` `pread`s every read, so a page-cache-evicted disk byte can rot and
+        // be re-read). So in production `skip_body_crc` is always `false` and the full-CRC branch runs;
+        // only the #540 unit tests arm it to exercise the trusted decode. See `SegmentReader::
+        // crc_skip_armed`. This is the PLAINTEXT loop only — an encrypted segment returned above via
         // `scan_range_decrypted`, which always AEAD-verifies and never consults `skip_body_crc`.
         let skip_body_crc = self.skip_body_crc();
         let mut records = Vec::with_capacity(max.min(64));
@@ -3935,12 +3972,14 @@ mod tests {
             "an unverified reader re-verifies and rejects the corrupt frame"
         );
 
-        // (2) VERIFIED-RESIDENT (self-written / verified-on-load, resident since): the body CRC is
-        // SKIPPED, so the corrupted second record is served verbatim (payload no longer equals
-        // `second`) — proving the recompute was elided on the trusted fast-path.
+        // (2) VERIFIED-RESIDENT + ARMED (self-written / verified-on-load, resident since, with the skip
+        // armed as it would be once a client backstop exists): the body CRC is SKIPPED, so the corrupted
+        // second record is served verbatim (payload no longer equals `second`) — proving the recompute
+        // was elided on the trusted fast-path.
         let verified = SegmentReader::open(Arc::clone(&file))
             .unwrap()
-            .with_verified_resident(true);
+            .with_verified_resident(true)
+            .with_crc_skip_armed(true);
         assert!(verified.is_verified_resident());
         let got = verified
             .scan_from(second_pos, Offset::new(1), valid_end, 10)
@@ -3957,11 +3996,12 @@ mod tests {
             "the corrupted body was served without a CRC check"
         );
 
-        // (3) verify-always opt-out: even a verified-resident reader recomputes on every read, so the
-        // corruption is caught again — the tunable escape hatch for the paranoid.
+        // (3) verify-always opt-out: even an ARMED, verified-resident reader recomputes on every read, so
+        // the corruption is caught again — the tunable escape hatch for the paranoid overrides the skip.
         let paranoid = SegmentReader::open(Arc::clone(&file))
             .unwrap()
             .with_verified_resident(true)
+            .with_crc_skip_armed(true)
             .with_verify_always(true);
         let got = paranoid
             .scan_from(second_pos, Offset::new(1), valid_end, 10)
@@ -3994,13 +4034,14 @@ mod tests {
         file.write_all_at(&bytes, 0).unwrap();
         let verified = SegmentReader::open(Arc::clone(&file))
             .unwrap()
-            .with_verified_resident(true);
+            .with_verified_resident(true)
+            .with_crc_skip_armed(true);
         let got = verified
             .scan_from(second_pos, Offset::new(1), valid_end, 10)
             .unwrap();
         assert!(
             got.is_empty(),
-            "a corrupt header ends the prefix even for a verified-resident reader"
+            "a corrupt header ends the prefix even for an armed verified-resident reader"
         );
 
         // On INTACT bytes a verified read is byte-identical to a full read (the skip changes nothing).
@@ -4015,7 +4056,8 @@ mod tests {
         let full_recs = full.scan_from(SEGMENT_HEADER_LEN as u64, Offset::new(0), clean_end, 10);
         let verified = SegmentReader::open(Arc::clone(&clean))
             .unwrap()
-            .with_verified_resident(true);
+            .with_verified_resident(true)
+            .with_crc_skip_armed(true);
         let verified_recs =
             verified.scan_from(SEGMENT_HEADER_LEN as u64, Offset::new(0), clean_end, 10);
         assert_eq!(full_recs.unwrap(), verified_recs.unwrap());
@@ -5061,11 +5103,13 @@ mod tests {
             ring.insert(7, key(0xCD));
             let ring = Arc::new(ring);
 
-            // (a) A VERIFIED-RESIDENT encrypted reader STILL decrypts correctly on the consume fast-path
-            // (`scan_range`): the AEAD ran; the flag did not bypass it.
+            // (a) A VERIFIED-RESIDENT + ARMED encrypted reader STILL decrypts correctly on the consume
+            // fast-path (`scan_range`): even with the plaintext skip armed, the encrypted branch runs the
+            // AEAD and ignores the flag.
             let clean = SegmentReader::open_with_keyring(Arc::clone(&file), Arc::clone(&ring))
                 .unwrap()
-                .with_verified_resident(true);
+                .with_verified_resident(true)
+                .with_crc_skip_armed(true);
             let recs = clean
                 .scan_range(
                     SEGMENT_HEADER_LEN as u64,
@@ -5089,7 +5133,8 @@ mod tests {
             file.write_all_at(&bytes, 0).unwrap();
             let verified = SegmentReader::open_with_keyring(Arc::clone(&file), Arc::clone(&ring))
                 .unwrap()
-                .with_verified_resident(true);
+                .with_verified_resident(true)
+                .with_crc_skip_armed(true);
             let got = verified.scan_range(second_pos, Offset::new(1), valid_end, 10, None);
             match got {
                 // The CRC over the ciphertext + tag caught it: the prefix ends, nothing is served.

--- a/crates/ironbus-storage/src/segment.rs
+++ b/crates/ironbus-storage/src/segment.rs
@@ -1595,6 +1595,21 @@ pub struct SegmentReader<F: RandomAccessFile> {
     file: F,
     header: SegmentHeader,
     file_len: u64,
+    /// Verify-once (#540, M1-I4): `true` when this reader's segment is VERIFIED-RESIDENT — its body
+    /// integrity was ALREADY proven this process (self-written and never round-tripped through a disk
+    /// read, or CRC-validated on load/recovery/cold-restore) AND it has stayed continuously resident
+    /// since — so the consume read fast-path ([`SegmentReader::scan_range`]) may skip the redundant
+    /// per-read body CRC32C recompute for a PLAINTEXT segment. `false` (the default from
+    /// [`SegmentReader::open`]) means every read fully re-validates, so an untrusted, recovered-but-not-
+    /// yet-marked, or freshly-RELOADED (a fresh reader after evict) segment always catches corruption.
+    /// The flag lives on the reader, so dropping the reader on evict/reload clears it for free; a fresh
+    /// reader re-derives it from the resident set. It NEVER affects an encrypted read (whose AEAD tag is
+    /// always verified) — those take `scan_range`'s decrypt branch, which ignores this flag.
+    verified_resident: bool,
+    /// Verify-always opt-out (#540, tunability): when `true` (from [`LogConfig::verify_always`]), the
+    /// body CRC is recomputed on EVERY read even for a verified-resident segment, restoring the
+    /// pre-#540 always-verify behavior for the paranoid. Default `false` (verify-once).
+    verify_always: bool,
     /// The at-rest AEAD parameters `(aead_suite_id, key_id)` read from the header at open, or `None`
     /// for a plaintext segment (#780). Behind the `encryption` feature.
     #[cfg(feature = "encryption")]
@@ -1629,6 +1644,11 @@ impl<F: RandomAccessFile> SegmentReader<F> {
             file,
             header,
             file_len,
+            // A freshly-opened reader is UNVERIFIED: it always fully re-validates until a caller that has
+            // established the verified-resident predicate stamps it via `with_verified_resident`. This
+            // fail-closed default is what makes a RELOADED segment (a fresh reader after evict) re-verify.
+            verified_resident: false,
+            verify_always: false,
             #[cfg(feature = "encryption")]
             aead,
             #[cfg(feature = "encryption")]
@@ -1640,6 +1660,40 @@ impl<F: RandomAccessFile> SegmentReader<F> {
     #[must_use]
     pub fn header(&self) -> &SegmentHeader {
         &self.header
+    }
+
+    /// Marks this reader VERIFIED-RESIDENT (#540): the consume read fast-path may skip the redundant
+    /// per-read body CRC recompute for a PLAINTEXT segment. The caller MUST have established the
+    /// predicate (self-written this process, or CRC-validated on load/recovery/cold-restore, and
+    /// continuously resident since); see [`SegmentReader::verified_resident`]. Chained at reader
+    /// construction, before the reader is shared as an `Arc`. A wrong stamp serves corrupt data
+    /// silently, so this is called ONLY from the resident-reader open sites for a known-verified id.
+    #[must_use]
+    pub fn with_verified_resident(mut self, verified: bool) -> SegmentReader<F> {
+        self.verified_resident = verified;
+        self
+    }
+
+    /// Sets the verify-always opt-out (#540, [`LogConfig::verify_always`]): when `true`, the body CRC is
+    /// recomputed on EVERY read even for a verified-resident segment. Chained at reader construction.
+    #[must_use]
+    pub fn with_verify_always(mut self, verify_always: bool) -> SegmentReader<F> {
+        self.verify_always = verify_always;
+        self
+    }
+
+    /// Whether this reader is currently verified-resident (#540). For tests and the read-plane wiring.
+    #[must_use]
+    pub fn is_verified_resident(&self) -> bool {
+        self.verified_resident
+    }
+
+    /// Whether the consume read fast-path may SKIP the per-read body CRC recompute for this segment
+    /// (#540): only when the reader is verified-resident AND the verify-always opt-out is off. The
+    /// encrypted read path never consults this — it always AEAD-verifies.
+    #[must_use]
+    fn skip_body_crc(&self) -> bool {
+        self.verified_resident && !self.verify_always
     }
 
     /// Opens a segment WITH a loaded key ring so [`SegmentReader::scan_decrypted`] can decrypt an
@@ -2426,13 +2480,29 @@ impl<F: RandomAccessFile> SegmentReader<F> {
         if let Some((suite, key_id)) = self.aead_read_params()? {
             return self.scan_range_decrypted(&body, start_offset, max, max_bytes, suite, key_id);
         }
+        // Verify-once (#540): when this segment is VERIFIED-RESIDENT (its body integrity was already
+        // proven this process and it has stayed resident since) and the verify-always opt-out is off,
+        // the consume read fast-path DECODES WITH THE BODY CRC SKIPPED. Every structural/framing check
+        // still runs, and the stored `body_crc` is untouched on disk (a client verifies end-to-end); we
+        // only elide the redundant server-side recompute of already-trusted bytes. An unverified,
+        // freshly-reloaded, or opt-out reader takes the full-CRC branch and still catches corruption.
+        // NOTE: this is the PLAINTEXT loop only — an encrypted segment returned above via
+        // `scan_range_decrypted`, which always AEAD-verifies and never consults `skip_body_crc`.
+        let skip_body_crc = self.skip_body_crc();
         let mut records = Vec::with_capacity(max.min(64));
         let mut cursor = 0usize;
         let mut byte_total = 0usize;
         let mut next_offset = start_offset.get();
         while cursor < body.len() && records.len() < max {
-            // The SAME CRC-gated decode `scan_body` uses: a torn or corrupt frame ends the prefix.
-            let Ok((view, subject, consumed)) = codec::decode_with_subject(&body[cursor..]) else {
+            // The SAME CRC-gated decode `scan_body` uses (or its body-CRC-skipping trusted sibling on
+            // the verify-once fast-path): a torn or corrupt frame ends the prefix. Both variants run
+            // every structural check, so a mis-framed frame is still rejected here identically.
+            let decoded = if skip_body_crc {
+                codec::decode_with_subject_trusted(&body[cursor..])
+            } else {
+                codec::decode_with_subject(&body[cursor..])
+            };
+            let Ok((view, subject, consumed)) = decoded else {
                 break;
             };
             // Byte cap: stop BEFORE a record that would push the accumulated encoded frame bytes
@@ -3823,6 +3893,134 @@ mod tests {
         assert!(got.is_empty(), "a corrupt seeked frame is never returned");
     }
 
+    /// Builds a two-record segment, then corrupts the SECOND record's body byte in place and returns
+    /// the file, the second record's frame position, and the valid end — the exact fixture the #540
+    /// verify-once tests read through a verified vs unverified reader.
+    fn segment_with_corrupt_second_body() -> (Arc<InMemoryFile>, u64, u64) {
+        let file = Arc::new(InMemoryFile::new());
+        let mut w = SegmentWriter::create(Arc::clone(&file), header()).unwrap();
+        w.append(&rec(0, b"first")).unwrap();
+        let second_pos = w.write_pos();
+        w.append(&rec(1, b"second")).unwrap();
+        let valid_end = w.write_pos();
+        w.sync().unwrap();
+        // Corrupt the SECOND record's body in place; the frame's stored body_crc field is UNTOUCHED, so
+        // a client that recomputes the CRC still detects the corruption end-to-end.
+        let mut bytes = file.snapshot();
+        let body_byte = usize::try_from(second_pos + RECORD_HEADER_LEN as u64 + 1).unwrap();
+        bytes[body_byte] ^= 0x01;
+        file.set_len(0).unwrap();
+        file.write_all_at(&bytes, 0).unwrap();
+        (file, second_pos, valid_end)
+    }
+
+    /// #540 verify-once, the load-bearing storage proof: a VERIFIED-RESIDENT reader SKIPS the per-read
+    /// body CRC, so it SERVES a body that was corrupted in memory (the frame's own CRC field is intact,
+    /// so a downstream client still catches it); an UNVERIFIED reader over the SAME bytes still catches
+    /// it and ends the prefix; and the verify-always opt-out re-verifies even a verified-resident
+    /// reader. This is the corrupt-in-memory-byte proof the issue asks for.
+    #[test]
+    fn verified_resident_scan_range_skips_body_crc_but_unverified_and_opt_out_still_catch_it() {
+        let (file, second_pos, valid_end) = segment_with_corrupt_second_body();
+
+        // (1) UNVERIFIED (the default, e.g. a freshly-RELOADED reader after evict): the body CRC is
+        // recomputed, the corruption is caught, and the seeked prefix ends before the bad frame.
+        let unverified = SegmentReader::open(Arc::clone(&file)).unwrap();
+        assert!(!unverified.is_verified_resident());
+        let got = unverified
+            .scan_from(second_pos, Offset::new(1), valid_end, 10)
+            .unwrap();
+        assert!(
+            got.is_empty(),
+            "an unverified reader re-verifies and rejects the corrupt frame"
+        );
+
+        // (2) VERIFIED-RESIDENT (self-written / verified-on-load, resident since): the body CRC is
+        // SKIPPED, so the corrupted second record is served verbatim (payload no longer equals
+        // `second`) — proving the recompute was elided on the trusted fast-path.
+        let verified = SegmentReader::open(Arc::clone(&file))
+            .unwrap()
+            .with_verified_resident(true);
+        assert!(verified.is_verified_resident());
+        let got = verified
+            .scan_from(second_pos, Offset::new(1), valid_end, 10)
+            .unwrap();
+        assert_eq!(
+            got.len(),
+            1,
+            "the verified reader skips the CRC and serves it"
+        );
+        assert_eq!(got[0].offset, Offset::new(1));
+        assert_ne!(
+            got[0].payload.as_ref(),
+            b"second",
+            "the corrupted body was served without a CRC check"
+        );
+
+        // (3) verify-always opt-out: even a verified-resident reader recomputes on every read, so the
+        // corruption is caught again — the tunable escape hatch for the paranoid.
+        let paranoid = SegmentReader::open(Arc::clone(&file))
+            .unwrap()
+            .with_verified_resident(true)
+            .with_verify_always(true);
+        let got = paranoid
+            .scan_from(second_pos, Offset::new(1), valid_end, 10)
+            .unwrap();
+        assert!(
+            got.is_empty(),
+            "verify-always re-verifies every read even when verified-resident"
+        );
+    }
+
+    /// #540: skipping the body CRC must NOT weaken structural integrity. A corrupt record HEADER (whose
+    /// own CRC is always checked) still ends the prefix even for a verified-resident reader, and a
+    /// verified read of an INTACT segment returns exactly what a full read returns.
+    #[test]
+    fn verified_resident_still_enforces_header_crc_and_is_identical_on_intact_bytes() {
+        // A corrupt second-record HEADER byte (seq field, inside the header-CRC range) is caught even
+        // when verified-resident: the header CRC is not part of the verify-once skip.
+        let file = Arc::new(InMemoryFile::new());
+        let mut w = SegmentWriter::create(Arc::clone(&file), header()).unwrap();
+        w.append(&rec(0, b"first")).unwrap();
+        let second_pos = w.write_pos();
+        w.append(&rec(1, b"second")).unwrap();
+        let valid_end = w.write_pos();
+        w.sync().unwrap();
+        let mut bytes = file.snapshot();
+        // Byte offset 4 within the frame header is the seq field, inside the 0..32 header-CRC range.
+        let header_byte = usize::try_from(second_pos + 4).unwrap();
+        bytes[header_byte] ^= 0x01;
+        file.set_len(0).unwrap();
+        file.write_all_at(&bytes, 0).unwrap();
+        let verified = SegmentReader::open(Arc::clone(&file))
+            .unwrap()
+            .with_verified_resident(true);
+        let got = verified
+            .scan_from(second_pos, Offset::new(1), valid_end, 10)
+            .unwrap();
+        assert!(
+            got.is_empty(),
+            "a corrupt header ends the prefix even for a verified-resident reader"
+        );
+
+        // On INTACT bytes a verified read is byte-identical to a full read (the skip changes nothing).
+        let clean = Arc::new(InMemoryFile::new());
+        let mut w = SegmentWriter::create(Arc::clone(&clean), header()).unwrap();
+        for i in 0..5u64 {
+            w.append(&rec(i, &[u8::try_from(i).unwrap(); 9])).unwrap();
+        }
+        let clean_end = w.write_pos();
+        w.sync().unwrap();
+        let full = SegmentReader::open(Arc::clone(&clean)).unwrap();
+        let full_recs = full.scan_from(SEGMENT_HEADER_LEN as u64, Offset::new(0), clean_end, 10);
+        let verified = SegmentReader::open(Arc::clone(&clean))
+            .unwrap()
+            .with_verified_resident(true);
+        let verified_recs =
+            verified.scan_from(SEGMENT_HEADER_LEN as u64, Offset::new(0), clean_end, 10);
+        assert_eq!(full_recs.unwrap(), verified_recs.unwrap());
+    }
+
     #[test]
     fn scan_from_respects_max_and_empty_bounds() {
         let file = Arc::new(InMemoryFile::new());
@@ -4836,6 +5034,72 @@ mod tests {
                     // The materialized record is plaintext downstream (ENCRYPTED bit cleared).
                     assert!(!recs[i].flags.contains(RecordFlags::ENCRYPTED));
                 }
+            }
+        }
+
+        // #540 + #780: verify-once must NEVER skip an encrypted segment's integrity. An encrypted read
+        // takes the decrypt branch of `scan_range`, which always verifies the CRC over the on-disk
+        // ciphertext + tag AND AEAD-verifies the tag — it does NOT consult the verify-once skip. So even
+        // a reader explicitly marked verified-resident (a) still decrypts correctly and (b) still catches
+        // a corrupted ciphertext/tag, identically to an unverified reader.
+        #[test]
+        fn verify_once_never_skips_encrypted_integrity() {
+            let file = Arc::new(InMemoryFile::new());
+            let mut w = SegmentWriter::create_encrypted(
+                Arc::clone(&file),
+                enc_header(2, 0),
+                crypto(AeadSuite::Aes256Gcm, 7, 0xCD),
+            )
+            .unwrap();
+            w.append(&rec(0, b"first")).unwrap();
+            let second_pos = w.write_pos();
+            w.append(&rec(1, b"second")).unwrap();
+            let valid_end = w.write_pos();
+            w.seal().unwrap();
+
+            let mut ring = KeyRing::new();
+            ring.insert(7, key(0xCD));
+            let ring = Arc::new(ring);
+
+            // (a) A VERIFIED-RESIDENT encrypted reader STILL decrypts correctly on the consume fast-path
+            // (`scan_range`): the AEAD ran; the flag did not bypass it.
+            let clean = SegmentReader::open_with_keyring(Arc::clone(&file), Arc::clone(&ring))
+                .unwrap()
+                .with_verified_resident(true);
+            let recs = clean
+                .scan_range(
+                    SEGMENT_HEADER_LEN as u64,
+                    Offset::new(0),
+                    valid_end,
+                    10,
+                    None,
+                )
+                .unwrap();
+            assert_eq!(recs.len(), 2);
+            assert_eq!(recs[0].payload.as_ref(), b"first");
+            assert_eq!(recs[1].payload.as_ref(), b"second");
+
+            // (b) Corrupt the SECOND encrypted record's on-disk body (ciphertext + tag). Even a
+            // VERIFIED-RESIDENT reader catches it on `scan_range` — the encrypted path always verifies
+            // (CRC over ciphertext+tag, then AEAD), so the corrupt frame is never served as garbage.
+            let mut bytes = file.snapshot();
+            let body_byte = usize::try_from(second_pos + RECORD_HEADER_LEN as u64 + 1).unwrap();
+            bytes[body_byte] ^= 0x01;
+            file.set_len(0).unwrap();
+            file.write_all_at(&bytes, 0).unwrap();
+            let verified = SegmentReader::open_with_keyring(Arc::clone(&file), Arc::clone(&ring))
+                .unwrap()
+                .with_verified_resident(true);
+            let got = verified.scan_range(second_pos, Offset::new(1), valid_end, 10, None);
+            match got {
+                // The CRC over the ciphertext + tag caught it: the prefix ends, nothing is served.
+                Ok(v) => assert!(
+                    v.is_empty(),
+                    "a verified-resident reader must NOT serve a corrupt encrypted frame"
+                ),
+                // Or the AEAD tag verify caught it: a reported decrypt error, never silent garbage.
+                Err(StorageError::Decrypt(_)) => {}
+                Err(other) => panic!("unexpected error: {other:?}"),
             }
         }
 


### PR DESCRIPTION
## What & why

Lays the **verify-once** foundation: a segment whose body integrity was already proven this process (self-written, recovered-on-load, or cold-restored) and that has stayed continuously resident is tracked so the consume read fast-path *can* skip the redundant server-side body-CRC recompute. Closes #540 (M1-I4).

> **Review response (safety fix):** adversarial review correctly found that the body-CRC skip's only live beneficiary is the per-record materialized `Deliver` path, whose wire frame (`DeliverBody`) carries **no** crc — so a default consumer would have **no** end-to-end backstop (and `scan_range` `pread`s every read, so a page-cache-evicted disk byte can rot and be re-read un-verified). The raw `DeliverBatch` path is safe (the client re-decodes the stored frame incl. its crc) but never did a server body-CRC anyway. So this PR now **disarms** the skip on every production path (`SegmentReader::crc_skip_armed == false`) — the server body-CRC is always recomputed on the live per-record path, integrity is **identical to pre-#540 for every consumer**, and the tested state-machine foundation ships ready for the follow-on to arm safely.

## Safety model (the gate)

`skip_body_crc() == crc_skip_armed && verified_resident && !verify_always`.

- `verified_resident` — the per-segment state machine (below), **live and tested**.
- `verify_always` — the tunable opt-out, **live**.
- `crc_skip_armed` — **disarmed at every production reader-open site.** Only the #540 unit tests arm it (in isolation) to exercise the trusted decode. It stays disarmed until the per-record `Deliver` frame carries the stored `body_crc` for the client to re-verify (the follow-on). Arming it without that backstop would reintroduce the silent-corruption hole, so it is intentionally not wired live.

## State machine (live, tested — feeds `verified_resident`)

Per-`Log` `verified_segments` set, mirrored onto `SealedSegment.verified`:
- **INSERT** on self-write seal (`roll`), recovery load (`scan_recovery` validated the chain), cold restore (`verify_fetched_segment`).
- **CLEAR** at the single retirement chokepoint `evict_segment_index` (reap / compaction-install / offload). Reader-cache fd-shed does not clear it (same local file, ids never recycle). A cold reload re-verifies + re-inserts.

## Encryption

Verify-once is plaintext-only. Encrypted reads take `scan_range`'s decrypt branch, which always CRC-checks the ciphertext+tag **and** AEAD-verifies the tag, never consulting the skip. No trusted variant of `decode_encrypted` exists.

## DLQ invariant (documented)

`DlqSink::append_encoded` re-encodes a source record with a **fresh** body CRC; sound today only because the source was read with the CRC verified (skip disarmed). A code comment records that the follow-on arming the skip must re-verify/preserve the original crc before dead-lettering a skip-read record (else it persists a fresh CRC over rotted bytes = permanent undetectable DLQ corruption).

## Follow-on to realize the win (design)

Add a capability-negotiated, default-off per-record `Deliver` `body_crc` (mirror the `flags2` / `deliver_encoding` pattern, so conformance/Go-SDK vectors stay byte-identical): server ships the **stored** crc (no recompute); client verifies `crc32c(key‖headers‖payload)`. Then arm the skip only for crc-capable consumers (server re-verifies at delivery for old clients — no regression) + fix the DLQ re-encode to preserve the crc. That protocol change spans proto + server + both clients + Go-SDK vectors and is its own scoped change.

## Changes

- **codec**: `decode_with_subject_trusted` skips the body CRC32C + xxh3 while running every structural/framing check (unchanged; reachable only via the armed fast-path, i.e. tests today).
- **storage/segment**: `SegmentReader` gains `verified_resident`, `verify_always`, and the `crc_skip_armed` safety gate (+ builders); `scan_range`'s plaintext loop honors `skip_body_crc()`.
- **storage/log**: `verified_segments` set + lifecycle inserts/clear; `LogConfig::verify_always`.
- **storage/read_plane**: `SealedSegment.verified` + `SealedSnapshot.verify_always` carried on every republish.
- **storage/dlq**: documented the fresh-CRC re-encode invariant.
- **server/engine**: DLQ/txn sub-log configs inherit `verify_always` (mechanical).

## Tests (all green)

- codec: trusted decode skips a corrupt body while full decode + structural checks still catch it.
- segment: an **armed** verified-resident `scan_range` serves an in-memory-corrupted body while an unverified reader and the verify-always opt-out both catch it; a corrupt header is caught even when armed+verified; encrypted reads never skip AEAD/CRC even when armed+verified.
- log: self-written/recovered sealed segments are marked (active is not); eviction clears the mark so a reloaded reader re-verifies.

## Gates (local, native `cargo 1.97.0`)

- `cargo test --workspace --all-features` → **3602 passed, 0 failed**
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` → clean
- `cargo fmt --all --check` → clean
- `sh scripts/check-format-registry.sh` → layout unchanged
- golden-path acceptance → pass

Rebased onto origin/main (#546 merged). Do **not** merge until the coordinator signs off on the safe scoping (and the follow-on plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01McmNfYNWPmohVS8umY9Lkp
