### PR TITLE
feat(security): controlled cross-tenant import/export (#1163, multi-tenant phase-2)

### DIFF
--- a/crates/ironbus-cli/src/main.rs
+++ b/crates/ironbus-cli/src/main.rs
@@ -6479,8 +6479,16 @@ fn load_auth_config(
     // streams / storage bytes / connections). A tenant referenced by an identity but absent here is
     // valid and simply unlimited. Wired onto the auth config so the session picks it up for free.
     if let Some(tenant_tables) = parsed.get("tenant").and_then(toml::Value::as_array) {
-        use ironbus_server::tenant::{TenantId, TenantQuotas, TenantRegistry};
+        use ironbus_server::tenant::{
+            Export, Import, SharingRegistry, TenantId, TenantQuotas, TenantRegistry,
+        };
         let mut quotas = std::collections::HashMap::new();
+        // #1163: the nested `[[tenant.export]]` / `[[tenant.import]]` tables carry each tenant's
+        // cross-tenant sharing grants. Collected per tenant here and wired as a SharingRegistry.
+        let mut exports: std::collections::HashMap<TenantId, Vec<Export>> =
+            std::collections::HashMap::new();
+        let mut imports: std::collections::HashMap<TenantId, Vec<Import>> =
+            std::collections::HashMap::new();
         for (i, t) in tenant_tables.iter().enumerate() {
             let name = t.get("name").and_then(toml::Value::as_str).ok_or_else(|| {
                 CliError::Usage(format!(
@@ -6496,17 +6504,204 @@ fn load_auth_config(
                     .and_then(|v| u64::try_from(v).ok())
             };
             quotas.insert(
-                id,
+                id.clone(),
                 TenantQuotas {
                     max_streams: as_u64("max_streams"),
                     max_storage_bytes: as_u64("max_storage_bytes"),
                     max_connections: as_u64("max_connections"),
                 },
             );
+            // #1163: parse this tenant's EXPORT grants (what it shares, to whom, in which direction).
+            if let Some(export_tables) = t.get("export").and_then(toml::Value::as_array) {
+                let mut list = Vec::with_capacity(export_tables.len());
+                for ex in export_tables {
+                    list.push(parse_tenant_export(name, ex)?);
+                }
+                if !list.is_empty() {
+                    exports.insert(id.clone(), list);
+                }
+            }
+            // #1163: parse this tenant's IMPORTS (which exported resources it maps into its own space).
+            if let Some(import_tables) = t.get("import").and_then(toml::Value::as_array) {
+                let mut list = Vec::with_capacity(import_tables.len());
+                for im in import_tables {
+                    list.push(parse_tenant_import(name, im)?);
+                }
+                if !list.is_empty() {
+                    imports.insert(id.clone(), list);
+                }
+            }
         }
         cfg.set_tenants(std::sync::Arc::new(TenantRegistry::new(quotas)));
+        // Only wire a sharing registry when a grant is actually configured, so a broker with no
+        // import/export is byte-for-byte the phase-1 isolated broker.
+        if !exports.is_empty() || !imports.is_empty() {
+            cfg.set_sharing(std::sync::Arc::new(SharingRegistry::new(exports, imports)));
+        }
     }
     Ok(Some(std::sync::Arc::new(cfg)))
+}
+
+/// Parses one `[[tenant.export]]` table (#1163): exactly one of `stream` / `subject` (the exported
+/// resource, wildcards allowed on a subject), `to` (`"public"` or a list of importing tenant ids),
+/// and `access` (a non-empty subset of `["subscribe","publish"]`). Fail-closed on any malformation.
+#[cfg(unix)]
+fn parse_tenant_export(
+    tenant: &str,
+    ex: &toml::Value,
+) -> Result<ironbus_server::tenant::Export, CliError> {
+    use ironbus_server::tenant::{
+        validate_share_stream, validate_share_subject, Audience, Export, GrantDirection, ShareKind,
+        TenantId,
+    };
+    let (kind, name) = share_kind_and_name(tenant, ex, "export")?;
+    match kind {
+        ShareKind::Stream => validate_share_stream(&name),
+        ShareKind::Subject => validate_share_subject(&name, true),
+    }
+    .map_err(|e| CliError::Usage(format!("--auth-config tenant `{tenant}` export: {e}")))?;
+    // `to`: "public" (a string) or a list of tenant ids.
+    let audience = match ex.get("to") {
+        Some(toml::Value::String(s)) if s == "public" => Audience::Public,
+        Some(toml::Value::String(s)) => {
+            return Err(CliError::Usage(format!(
+            "--auth-config tenant `{tenant}` export `to` must be \"public\" or a list of tenant \
+                 ids (got {s:?})"
+        )))
+        }
+        Some(toml::Value::Array(arr)) => {
+            let mut set = std::collections::BTreeSet::new();
+            for v in arr {
+                let who = v.as_str().ok_or_else(|| {
+                    CliError::Usage(format!(
+                        "--auth-config tenant `{tenant}` export `to` has a non-string tenant id"
+                    ))
+                })?;
+                set.insert(TenantId::parse(who).map_err(|e| {
+                    CliError::Usage(format!(
+                        "--auth-config tenant `{tenant}` export `to` tenant `{who}`: {e}"
+                    ))
+                })?);
+            }
+            if set.is_empty() {
+                return Err(CliError::Usage(format!(
+                    "--auth-config tenant `{tenant}` export `to` list is empty (name a tenant or use \
+                     \"public\")"
+                )));
+            }
+            Audience::Tenants(set)
+        }
+        _ => {
+            return Err(CliError::Usage(format!(
+            "--auth-config tenant `{tenant}` export needs a `to` (\"public\" or a list of tenant \
+                 ids)"
+        )))
+        }
+    };
+    // `access`: a non-empty subset of subscribe/publish. A grant that permits neither is refused —
+    // it could never authorize anything.
+    let access = ex.get("access").and_then(toml::Value::as_array).ok_or_else(|| {
+        CliError::Usage(format!(
+            "--auth-config tenant `{tenant}` export needs an `access` list (any of subscribe, publish)"
+        ))
+    })?;
+    let mut direction = GrantDirection::default();
+    for a in access {
+        match a.as_str() {
+            Some("subscribe") => direction.subscribe = true,
+            Some("publish") => direction.publish = true,
+            other => {
+                return Err(CliError::Usage(format!(
+                    "--auth-config tenant `{tenant}` export has unknown access {other:?} (expected \
+                     subscribe or publish)"
+                )))
+            }
+        }
+    }
+    if !direction.subscribe && !direction.publish {
+        return Err(CliError::Usage(format!(
+            "--auth-config tenant `{tenant}` export `access` is empty (grant subscribe and/or publish)"
+        )));
+    }
+    Ok(Export {
+        kind,
+        name,
+        audience,
+        direction,
+    })
+}
+
+/// Parses one `[[tenant.import]]` table (#1163): `from` (the exporting tenant), exactly one of
+/// `stream` / `subject` (the exporter's resource, a literal — the export's pattern bounds it), and
+/// `as` (the importer's local alias). Fail-closed on any malformation.
+#[cfg(unix)]
+fn parse_tenant_import(
+    tenant: &str,
+    im: &toml::Value,
+) -> Result<ironbus_server::tenant::Import, CliError> {
+    use ironbus_server::tenant::{
+        validate_share_stream, validate_share_subject, Import, ShareKind, TenantId,
+    };
+    let from = im
+        .get("from")
+        .and_then(toml::Value::as_str)
+        .ok_or_else(|| {
+            CliError::Usage(format!(
+                "--auth-config tenant `{tenant}` import needs a `from` (the exporting tenant id)"
+            ))
+        })?;
+    let from = TenantId::parse(from).map_err(|e| {
+        CliError::Usage(format!(
+            "--auth-config tenant `{tenant}` import `from` `{from}`: {e}"
+        ))
+    })?;
+    let (kind, remote) = share_kind_and_name(tenant, im, "import")?;
+    let local = im.get("as").and_then(toml::Value::as_str).ok_or_else(|| {
+        CliError::Usage(format!(
+            "--auth-config tenant `{tenant}` import needs an `as` (the local alias)"
+        ))
+    })?;
+    // Both the remote name and the local alias are LITERAL (no wildcards): an import alias is a plain
+    // prefix; the export's pattern is what bounds the shared set.
+    let validate = |n: &str| match kind {
+        ShareKind::Stream => validate_share_stream(n),
+        ShareKind::Subject => validate_share_subject(n, false),
+    };
+    validate(&remote).map_err(|e| {
+        CliError::Usage(format!(
+            "--auth-config tenant `{tenant}` import remote: {e}"
+        ))
+    })?;
+    validate(local).map_err(|e| {
+        CliError::Usage(format!("--auth-config tenant `{tenant}` import `as`: {e}"))
+    })?;
+    Ok(Import {
+        kind,
+        from,
+        remote,
+        local: local.to_string(),
+    })
+}
+
+/// Extracts the `stream` / `subject` kind + name from an export or import table: EXACTLY one of the
+/// two must be present (never both, never neither), so a grant is unambiguously stream- or
+/// subject-typed. `role` is `"export"` / `"import"` for the error message.
+#[cfg(unix)]
+fn share_kind_and_name(
+    tenant: &str,
+    table: &toml::Value,
+    role: &str,
+) -> Result<(ironbus_server::tenant::ShareKind, String), CliError> {
+    use ironbus_server::tenant::ShareKind;
+    let stream = table.get("stream").and_then(toml::Value::as_str);
+    let subject = table.get("subject").and_then(toml::Value::as_str);
+    match (stream, subject) {
+        (Some(s), None) => Ok((ShareKind::Stream, s.to_string())),
+        (None, Some(s)) => Ok((ShareKind::Subject, s.to_string())),
+        _ => Err(CliError::Usage(format!(
+            "--auth-config tenant `{tenant}` {role} must declare EXACTLY one of `stream` or `subject`"
+        ))),
+    }
 }
 
 /// Loads exactly one identity's additive credential set from its `[[identity]]` TOML table (#631),

--- a/crates/ironbus-proto/src/err.rs
+++ b/crates/ironbus-proto/src/err.rs
@@ -103,6 +103,10 @@ pub enum ServerErrorCode {
     /// its wire headers (#555 injection hardening) — a permanent reject; publish a `DLY1` relative
     /// delay request instead.
     InvalidDelayHeader,
+    /// `ERR_IMPORT_NOT_GRANTED`: a cross-tenant import was refused because no matching export
+    /// authorizes it for the requested direction (#1163, multi-tenant phase-2). A PERMANENT reject
+    /// until BOTH sides allowlist the crossing — never retry-able as-is.
+    ImportNotGranted,
 }
 
 impl ServerErrorCode {
@@ -140,6 +144,7 @@ impl ServerErrorCode {
             "ERR_TXN_CHECK_UNAUTHORIZED" => Self::TxnCheckUnauthorized,
             "ERR_DELAY_TOO_LONG" => Self::DelayTooLong,
             "ERR_INVALID_DELAY_HEADER" => Self::InvalidDelayHeader,
+            "ERR_IMPORT_NOT_GRANTED" => Self::ImportNotGranted,
             _ => return None,
         };
         Some(code)
@@ -177,6 +182,7 @@ impl ServerErrorCode {
             Self::TxnCheckUnauthorized => "ERR_TXN_CHECK_UNAUTHORIZED",
             Self::DelayTooLong => "ERR_DELAY_TOO_LONG",
             Self::InvalidDelayHeader => "ERR_INVALID_DELAY_HEADER",
+            Self::ImportNotGranted => "ERR_IMPORT_NOT_GRANTED",
         }
     }
 }
@@ -322,6 +328,7 @@ mod tests {
             ServerErrorCode::TxnCheckUnauthorized,
             ServerErrorCode::DelayTooLong,
             ServerErrorCode::InvalidDelayHeader,
+            ServerErrorCode::ImportNotGranted,
         ] {
             assert_eq!(ServerErrorCode::from_token(code.as_token()), Some(code));
         }

--- a/crates/ironbus-server/src/auth.rs
+++ b/crates/ironbus-server/src/auth.rs
@@ -320,6 +320,12 @@ pub struct AuthConfig {
     /// the same `Arc<AuthConfig>` it already receives — no new serve-path plumbing. `None` disables
     /// quota enforcement; isolation (name prefixing) is independent and comes from `Identity::tenant`.
     tenants: Option<std::sync::Arc<crate::tenant::TenantRegistry>>,
+    /// The broker's cross-tenant sharing (import/export) registry (#1163, multi-tenant phase-2), if
+    /// any tenant declared an `[[tenant.export]]` / `[[tenant.import]]`. Rides the auth config for the
+    /// same reason as `tenants`. `None` means no sharing is configured and EVERY resource resolution
+    /// stays in the caller's own tenant — byte-for-byte the phase-1 isolated broker. This is the ONLY
+    /// controlled path across the (otherwise absolute) tenant boundary.
+    sharing: Option<std::sync::Arc<crate::tenant::SharingRegistry>>,
 }
 
 impl AuthConfig {
@@ -339,6 +345,19 @@ impl AuthConfig {
     #[must_use]
     pub fn tenants(&self) -> Option<std::sync::Arc<crate::tenant::TenantRegistry>> {
         self.tenants.clone()
+    }
+
+    /// Attaches the broker's cross-tenant sharing (import/export) registry (#1163).
+    pub fn set_sharing(&mut self, sharing: std::sync::Arc<crate::tenant::SharingRegistry>) {
+        self.sharing = Some(sharing);
+    }
+
+    /// The broker's cross-tenant sharing (import/export) registry (#1163), if configured (a cheap
+    /// `Arc` clone). The session consults it at every subscribe/publish resolution seam to (with
+    /// authorization) resolve an import alias to the exporter's resource.
+    #[must_use]
+    pub fn sharing(&self) -> Option<std::sync::Arc<crate::tenant::SharingRegistry>> {
+        self.sharing.clone()
     }
 
     /// Whether ANY auth identity is configured (#631 / #629). This is the "at least one auth identity

--- a/crates/ironbus-server/src/codes.rs
+++ b/crates/ironbus-server/src/codes.rs
@@ -230,6 +230,14 @@ impl ErrorCode {
     /// per-log [`Self::ERR_AT_CAPACITY`].
     pub const ERR_TENANT_MAX_STORAGE_BYTES: ErrorCode = ErrorCode("ERR_TENANT_MAX_STORAGE_BYTES");
 
+    /// A cross-tenant IMPORT was refused because NO matching export authorizes it for the requested
+    /// direction (#1163, multi-tenant phase-2). The client named one of its import aliases, but the
+    /// exporter has no `[[tenant.export]]` that admits this tenant, permits this direction, and covers
+    /// the name — so the alias resolves to a typed reject, never to the exporter's data and never to
+    /// ambient cross-tenant access. Fail-closed: this is the ONE deliberate boundary crossing, and it
+    /// stays shut until BOTH sides allowlist it. Not an `EngineError`.
+    pub const ERR_IMPORT_NOT_GRANTED: ErrorCode = ErrorCode("ERR_IMPORT_NOT_GRANTED");
+
     /// Maps an [`EngineError`] to its stable code. The single source of truth the conformance
     /// vectors and any wire error-code scheme share. A storage error is split into the two named
     /// outcomes ([`Self::ERR_AT_CAPACITY`] for the byte-cap shed) plus the residual
@@ -327,6 +335,7 @@ mod tests {
             ErrorCode::ERR_NOT_ENOUGH_ISR,
             ErrorCode::ERR_PRODUCER_FENCED,
             ErrorCode::ERR_OUT_OF_ORDER_SEQUENCE,
+            ErrorCode::ERR_IMPORT_NOT_GRANTED,
         ];
         for code in wire_codes {
             assert!(
@@ -374,6 +383,11 @@ mod tests {
         assert_eq!(
             ErrorCode::ERR_TENANT_MAX_STORAGE_BYTES.as_str(),
             crate::tenant::QuotaError::MaxStorageBytes.code()
+        );
+        // #1163 cross-tenant import/export reject code.
+        assert_eq!(
+            ErrorCode::ERR_IMPORT_NOT_GRANTED.as_str(),
+            "ERR_IMPORT_NOT_GRANTED"
         );
     }
 

--- a/crates/ironbus-server/src/session.rs
+++ b/crates/ironbus-server/src/session.rs
@@ -564,6 +564,14 @@ pub struct Session {
     /// fleet-wide concurrent-connection count is decremented on drop (connection close). `None` on a
     /// single-tenant / no-registry connection.
     conn_guard: Option<crate::tenant::ConnGuard>,
+    /// The broker's cross-tenant sharing (import/export) registry (#1163, multi-tenant phase-2), if
+    /// configured. `None` (the default, and every single-tenant broker) means EVERY resource name
+    /// resolves in the caller's OWN tenant — byte-for-byte the phase-1 isolated broker. When `Some(_)`,
+    /// each subscribe/publish seam first consults it: a name that matches one of this tenant's import
+    /// aliases resolves (ONLY with a matching export) to the EXPORTER's prefixed resource, and any name
+    /// that is not an alias stays in this tenant's own namespace. This is the ONE controlled path
+    /// across the otherwise-absolute tenant boundary. A cheap `Arc` clone, shared across connections.
+    sharing: Option<std::sync::Arc<crate::tenant::SharingRegistry>>,
     /// The shared connection-signal ("connz") metric (#572), if the server wired one in. `None` for a
     /// session that does not report connz (every test, and a `serve` overload built with the legacy
     /// un-scraped metric). When `Some(_)`, the session records the AUTHED-FLIP (a successful `Connect`
@@ -609,6 +617,26 @@ pub struct Session {
     consume_longpoll_ms: u64,
 }
 
+/// #1163: the outcome of resolving a client resource name (stream or subject) through the cross-tenant
+/// import/export layer at a subscribe/publish seam. The engine-ready name is already computed for the
+/// two proceed-cases; the session applies it (and, for `Cross`, charges the exporter's quotas).
+enum Resolved {
+    /// The name is in the caller's OWN tenant — the own-scoped engine name (phase-1 behavior, and the
+    /// single-tenant identity). The overwhelming common case.
+    Local(String),
+    /// An import alias resolved (with a matching export) to the EXPORTER's resource: the owning
+    /// tenant plus the exporter-scoped engine name.
+    Cross {
+        /// The exporter (owner of the resolved resource) — charged for a cross-tenant produce.
+        owner: crate::tenant::TenantId,
+        /// The exporter-scoped engine name, ready for the engine.
+        name: String,
+    },
+    /// The name matched an import alias but NO export authorizes it in this direction — a typed
+    /// reject. The caller replies `ERR_IMPORT_NOT_GRANTED` and never touches the exporter's data.
+    Denied,
+}
+
 impl Session {
     /// A new, not-yet-handshaked session with the default member identity (member 0). The server
     /// uses [`Session::with_member_id`] to give each connection a distinct `key_shared` identity;
@@ -641,14 +669,17 @@ impl Session {
         auth_config: std::sync::Arc<crate::auth::AuthConfig>,
         peer_san: Option<String>,
     ) -> Session {
-        // Pick up the per-tenant quota registry (#765) from the same auth config, so the whole
-        // existing accept path wires tenancy for free (no serve-signature change).
+        // Pick up the per-tenant quota registry (#765) and the cross-tenant sharing registry (#1163)
+        // from the same auth config, so the whole existing accept path wires tenancy for free (no
+        // serve-signature change).
         let tenants = auth_config.tenants();
+        let sharing = auth_config.sharing();
         Session {
             member_id,
             auth_config: Some(auth_config),
             peer_san,
             tenants,
+            sharing,
             ..Session::default()
         }
     }
@@ -760,6 +791,87 @@ impl Session {
     fn reserve_tenant_bytes(&self, n: u64) -> Result<(), crate::tenant::QuotaError> {
         match (&self.tenant, &self.tenants) {
             (Some(tenant), Some(reg)) => reg.reserve_bytes(tenant, n),
+            _ => Ok(()),
+        }
+    }
+
+    /// #1163: resolves a client-supplied STREAM id through the cross-tenant import/export layer for
+    /// the given access direction. Returns the engine-ready name (own-scoped OR the exporter's) plus,
+    /// for a cross-tenant hit, the OWNING (exporter) tenant so the caller can charge the right quotas.
+    /// When no sharing is configured (or the name is not an import alias) it is exactly
+    /// [`Session::tenant_stream`] — byte-for-byte the phase-1 path.
+    fn resolve_stream_for(&self, client_name: &str, access: crate::tenant::Access) -> Resolved {
+        match (&self.tenant, &self.sharing) {
+            (Some(t), Some(reg)) => match reg.resolve_stream(t, client_name, access) {
+                crate::tenant::Resolution::Own => Resolved::Local(t.scope_stream(client_name)),
+                crate::tenant::Resolution::Crossed { owner, scoped } => Resolved::Cross {
+                    owner,
+                    name: scoped,
+                },
+                crate::tenant::Resolution::Denied => Resolved::Denied,
+            },
+            _ => Resolved::Local(self.tenant_stream(client_name).into_owned()),
+        }
+    }
+
+    /// #1163: resolves a client-supplied SUBJECT (a concrete subject for a publish, or a pattern for
+    /// a subscribe) through the cross-tenant import/export layer. Own-namespace by default (exactly
+    /// [`Session::tenant_subject`]); a cross-tenant hit yields the exporter-scoped subject + owner.
+    fn resolve_subject_for(&self, client_subject: &str, access: crate::tenant::Access) -> Resolved {
+        match (&self.tenant, &self.sharing) {
+            (Some(t), Some(reg)) => match reg.resolve_subject(t, client_subject, access) {
+                crate::tenant::Resolution::Own => Resolved::Local(t.scope_subject(client_subject)),
+                crate::tenant::Resolution::Crossed { owner, scoped } => Resolved::Cross {
+                    owner,
+                    name: scoped,
+                },
+                crate::tenant::Resolution::Denied => Resolved::Denied,
+            },
+            _ => Resolved::Local(self.tenant_subject(client_subject).into_owned()),
+        }
+    }
+
+    /// #1163: scopes a consumer-GROUP name under THIS connection's own tenant. Used ONLY on a
+    /// cross-tenant SUBSCRIBE, so the importer's cursor on the exporter's shared stream is keyed by
+    /// `(<exporter>/stream, <importer>/group)` and can NEVER collide with — or advance — the
+    /// exporter's own consumer-group cursors on that stream. A single-tenant connection returns the
+    /// group unchanged (it is never reached on the cross path).
+    fn scope_group_under_self(&self, group: &str) -> String {
+        match &self.tenant {
+            Some(t) => t.scope_group(group),
+            None => group.to_string(),
+        }
+    }
+
+    /// #1163: charges a SCOPED stream against a SPECIFIC tenant's stream ceiling — the exporter on a
+    /// cross-tenant produce (the resource is theirs), or this connection's own tenant otherwise.
+    /// A no-op when no quota registry is wired or `tenant` is `None` (single-tenant).
+    ///
+    /// # Errors
+    /// [`crate::tenant::QuotaError::MaxStreams`] at the ceiling.
+    fn charge_stream(
+        &self,
+        tenant: Option<&crate::tenant::TenantId>,
+        scoped: &str,
+    ) -> Result<(), crate::tenant::QuotaError> {
+        match (tenant, &self.tenants) {
+            (Some(t), Some(reg)) => reg.reserve_stream(t, scoped),
+            _ => Ok(()),
+        }
+    }
+
+    /// #1163: charges `n` produced bytes against a SPECIFIC tenant's byte ceiling (the exporter on a
+    /// cross-tenant produce, else this connection's own tenant). A no-op when no registry is wired.
+    ///
+    /// # Errors
+    /// [`crate::tenant::QuotaError::MaxStorageBytes`] at the ceiling.
+    fn charge_bytes(
+        &self,
+        tenant: Option<&crate::tenant::TenantId>,
+        n: u64,
+    ) -> Result<(), crate::tenant::QuotaError> {
+        match (tenant, &self.tenants) {
+            (Some(t), Some(reg)) => reg.reserve_bytes(t, n),
             _ => Ok(()),
         }
     }
@@ -4569,9 +4681,18 @@ impl Session {
             reply_err(out, "stream id must be valid UTF-8");
             return Ok(());
         };
-        // #765: a StreamInfo existence/head probe is answered ONLY within the caller's tenant — the
-        // client name is prefixed so a client can never probe for another tenant's stream.
-        let stream = self.tenant_stream(stream).into_owned();
+        // #765/#1163: a StreamInfo existence/head probe is answered ONLY within the caller's tenant —
+        // the client name is prefixed so a client can never probe for another tenant's stream. An
+        // imported stream (SUBSCRIBE — a read probe) is answered against the EXPORTER's stream when a
+        // matching subscribe-granting export exists; an alias with no such export is a typed reject, so
+        // the probe can never be a cross-tenant existence oracle for a stream the caller may not read.
+        let stream = match self.resolve_stream_for(stream, crate::tenant::Access::Subscribe) {
+            Resolved::Denied => {
+                reply_import_not_granted(out);
+                return Ok(());
+            }
+            Resolved::Cross { name, .. } | Resolved::Local(name) => name,
+        };
         // One round-trip reads both the existence bit and the durable head: the head is meaningful only
         // when the stream exists, and `stream_head` reports `0` for an unknown/malformed stream (which
         // the response folds with `exists = false`), so the two reads are consistent.
@@ -4713,17 +4834,32 @@ impl Session {
             // counters; this named-stream produce path counts it explicitly in the engine job below.
             ack_level: ironbus_proto::message::pub_ack_level(msg.flags),
         };
-        // #765: SERVER-APPLY the tenant prefix (the engine only ever sees `<tenant>/<name>`), then
-        // charge the per-tenant STREAM ceiling (a named produce declares-on-first-produce) and BYTE
+        // #765/#1163: resolve the stream name through the cross-tenant import/export layer (PUBLISH
+        // direction). Own case: SERVER-APPLY the caller's tenant prefix and charge the caller's
+        // ceilings. CROSS case (a matching export granted the write): route to the EXPORTER's stream
+        // and charge the EXPORTER's ceilings — the bytes land in the exporter's log, so the exporter's
+        // storage accounting stays honest and the importer can never use an import to dodge the
+        // exporter's byte cap. No matching export (or a subscribe-only export) → `ERR_IMPORT_NOT_GRANTED`.
+        let (stream, charge_tenant) =
+            match self.resolve_stream_for(stream, crate::tenant::Access::Publish) {
+                Resolved::Denied => {
+                    reply_import_not_granted(out);
+                    return Ok(());
+                }
+                Resolved::Cross { owner, name } => (name, Some(owner)),
+                Resolved::Local(name) => (name, self.tenant.clone()),
+            };
+        let charge = charge_tenant.as_ref();
+        // Charge the per-tenant STREAM ceiling (a named produce declares-on-first-produce) and BYTE
         // ceiling fail-closed BEFORE the produce reaches the log.
-        let stream = self.tenant_stream(stream).into_owned();
-        if let Err(e) = self.reserve_tenant_stream(&stream) {
+        if let Err(e) = self.charge_stream(charge, &stream) {
             reply_err_coded(out, e.code(), e.message());
             return Ok(());
         }
-        if let Err(e) = self
-            .reserve_tenant_bytes((msg.payload.len() + msg.key.len() + msg.headers.len()) as u64)
-        {
+        if let Err(e) = self.charge_bytes(
+            charge,
+            (msg.payload.len() + msg.key.len() + msg.headers.len()) as u64,
+        ) {
             reply_err_coded(out, e.code(), e.message());
             return Ok(());
         }
@@ -5165,17 +5301,29 @@ impl Session {
             reply_err(out, "stream id must be valid UTF-8");
             return Ok(());
         };
-        // #765: SERVER-APPLY the tenant prefix. Every downstream use — the existence check, the
-        // (stream, group) binding pinned into `self.stream`, key_shared join, tier — then resolves
-        // strictly within the caller's tenant, so a SubTo can never bind another tenant's stream (an
-        // unknown-to-the-tenant name is the standard "does not exist" reject). The group is isolated
-        // by the scoped stream (group state is keyed by (stream, group)), so it needs no own prefix.
-        let scoped_stream = self.tenant_stream(stream).into_owned();
-        let stream = scoped_stream.as_str();
-        let Ok(group) = core::str::from_utf8(decoded.group) else {
+        let Ok(group_name) = core::str::from_utf8(decoded.group) else {
             reply_err(out, "group name must be valid UTF-8");
             return Ok(());
         };
+        // #765/#1163: resolve the stream name through the cross-tenant import/export layer (SUBSCRIBE
+        // direction). Common case (no import alias): SERVER-APPLY the caller's own tenant prefix so a
+        // SubTo can never bind another tenant's stream (an unknown-to-the-tenant name is the standard
+        // "does not exist" reject) and the group is isolated by the scoped stream. A CROSS-tenant hit
+        // (a matching export granted the read) binds the EXPORTER's stream — and here the group is
+        // scoped under the IMPORTER, so the importer's cursor on the shared stream is keyed by
+        // `(<exporter>/stream, <importer>/group)` and can never collide with or advance the exporter's
+        // own consumer-group cursors. No matching export → a typed `ERR_IMPORT_NOT_GRANTED` reject.
+        let (scoped_stream, scoped_group) =
+            match self.resolve_stream_for(stream, crate::tenant::Access::Subscribe) {
+                Resolved::Denied => {
+                    reply_import_not_granted(out);
+                    return Ok(());
+                }
+                Resolved::Cross { name, .. } => (name, self.scope_group_under_self(group_name)),
+                Resolved::Local(name) => (name, group_name.to_string()),
+            };
+        let stream = scoped_stream.as_str();
+        let group = scoped_group.as_str();
         // The named stream must already exist: a SubTo binds a consume cursor, and consuming an
         // unknown (never-declared) stream is a typed rejection, never a silent empty subscription.
         let stream_owned = stream.to_string();
@@ -5589,16 +5737,30 @@ impl Session {
             // counters; this subject-routed produce path counts it explicitly in the engine job below.
             ack_level: ironbus_proto::message::pub_ack_level(msg.flags),
         };
-        // #765: SERVER-APPLY the tenant prefix — the subject becomes `<tenant>.<subject>`, so it
-        // resolves ONLY against this tenant's bindings and the record is stored under the tenant's
-        // subject subtree. Charge the per-tenant byte ceiling fail-closed before the produce.
-        if let Err(e) = self
-            .reserve_tenant_bytes((msg.payload.len() + msg.key.len() + msg.headers.len()) as u64)
-        {
+        // #765/#1163: resolve the subject through the cross-tenant import/export layer (PUBLISH
+        // direction). Own case: the subject becomes `<tenant>.<subject>` and resolves ONLY against
+        // this tenant's bindings, charged to this tenant. CROSS case (a matching publish-granting
+        // export): the subject becomes `<exporter>.<subject>` and the record lands in the exporter's
+        // subject subtree, charged to the EXPORTER (their storage). A publish concrete subject must
+        // MATCH the export pattern — a sibling/deeper subject the grant does not cover is a typed
+        // reject. No matching export (or subscribe-only) → `ERR_IMPORT_NOT_GRANTED`.
+        let (subject, charge_tenant) =
+            match self.resolve_subject_for(subject, crate::tenant::Access::Publish) {
+                Resolved::Denied => {
+                    reply_import_not_granted(out);
+                    return Ok(());
+                }
+                Resolved::Cross { owner, name } => (name, Some(owner)),
+                Resolved::Local(name) => (name, self.tenant.clone()),
+            };
+        // Charge the per-tenant byte ceiling fail-closed before the produce.
+        if let Err(e) = self.charge_bytes(
+            charge_tenant.as_ref(),
+            (msg.payload.len() + msg.key.len() + msg.headers.len()) as u64,
+        ) {
             reply_err_coded(out, e.code(), e.message());
             return Ok(());
         }
-        let subject = self.tenant_subject(subject).into_owned();
         // Move the per-connection resolve cache into the job; the job returns it (and the produce
         // outcome) so the cache's freshly-cached entry + adopted generation persist across publishes.
         let cache = std::mem::take(&mut self.subject_cache);
@@ -5712,19 +5874,35 @@ impl Session {
             // DEFAULT stream (`""`), keeping the #594-A default-stream path BYTE-FOR-BYTE. The filter is
             // a per-GROUP property (D3: shared by every consumer in the group, so the durable cursor
             // stays coherent). Resolve + bind run in ONE actor job.
-            let group_owned = group.to_string();
-            // #765: SERVER-APPLY the tenant prefix to the filter PATTERN (`<tenant>.<pattern>`), so it
-            // covers ONLY this tenant's subjects. When no named stream covers it, the filtered consume
-            // falls back to the tenant's OWN default stream (`default_stream()`), NOT the shared root
-            // ("") — so a multi-tenant filtered subscribe can never bind the global default log.
-            let pattern_owned = self.tenant_subject(subject).into_owned();
-            let default_stream = self.default_stream();
+            // #765/#1163: resolve the filter PATTERN through the cross-tenant import/export layer
+            // (SUBSCRIBE direction). Own case: `<tenant>.<pattern>`, covering ONLY this tenant's
+            // subjects, falling back to the tenant's OWN default stream — NEVER the shared root ("").
+            // CROSS case (a matching subscribe-granting export): the pattern is EXPORTER-scoped
+            // (`<exporter>.<pattern>`), the fallback stream is the EXPORTER's default stream, and the
+            // group is scoped under the IMPORTER — so the importer reads the exporter's covering stream
+            // through an isolated cursor `(<exporter> stream, <importer>/group)` and can never advance
+            // the exporter's own group cursors. A requested pattern that widens past the grant (or with
+            // no export) → a typed `ERR_IMPORT_NOT_GRANTED` reject.
+            let (pattern_owned, default_stream, group_owned) =
+                match self.resolve_subject_for(subject, crate::tenant::Access::Subscribe) {
+                    Resolved::Denied => {
+                        reply_import_not_granted(out);
+                        return Ok(());
+                    }
+                    Resolved::Cross { owner, name } => (
+                        name,
+                        owner.scope_stream(""),
+                        self.scope_group_under_self(group),
+                    ),
+                    Resolved::Local(name) => (name, self.default_stream(), group.to_string()),
+                };
+            let group_bind = group_owned.clone();
             let (resolved_stream, set) = engine.with(move |e| {
                 let stream = e
                     .covering_named_stream_for_filter(&pattern_owned)
                     .map_or(default_stream, |id| id.name().to_string());
                 let set =
-                    e.set_subject_filter_in_stream(&stream, &group_owned, Some(&pattern_owned));
+                    e.set_subject_filter_in_stream(&stream, &group_bind, Some(&pattern_owned));
                 (stream, set)
             })?;
             if let Err(e) = set {
@@ -5735,9 +5913,10 @@ impl Session {
             // away from an EPHEMERAL subscription must release its engine-side membership (and
             // reap the group if this was the last member) rather than orphan it until disconnect.
             self.leave_current_subscription(engine)?;
-            // Bind this connection's consume path to the resolved stream (`""` = default) + the group.
+            // Bind this connection's consume path to the resolved stream (`""` = default) + the group
+            // (scoped under the importer on the cross-tenant path).
             self.stream = GroupName::from(resolved_stream.as_str());
-            self.subscription = GroupName::from(group);
+            self.subscription = GroupName::from(group_owned.as_str());
             // A subject subscribe binds the stream as a whole (#693): clear any partition binding.
             self.partition = None;
             // #553: a subject subscribe is never priority-mode (priority streams have no subjects).
@@ -5762,9 +5941,21 @@ impl Session {
         // client sends is resolved through the engine's pattern-aware path below instead. To keep the
         // bind simple and single-home, resolve via `resolve_subject` (literal) and fall back to a typed
         // reject for a non-literal/unbound/ambiguous subject.
-        // #765: SERVER-APPLY the tenant prefix so the single-home resolve reads only this tenant's
-        // bindings; an unbound-within-tenant subject is the standard NoStreamForSubject reject.
-        let subject_owned = self.tenant_subject(subject).into_owned();
+        // #765/#1163: resolve the (single-home LITERAL) subject through the cross-tenant import/export
+        // layer (SUBSCRIBE direction). Own case: `<tenant>.<subject>`, reading only this tenant's
+        // bindings. CROSS case (a matching subscribe-granting export covers this concrete subject): the
+        // subject is EXPORTER-scoped so the single-home resolve binds the EXPORTER's covering stream,
+        // with the group scoped under the IMPORTER for cursor isolation. An unbound-within-tenant
+        // subject is the standard NoStreamForSubject reject; an alias with no export → typed reject.
+        let (subject_owned, group_owned) =
+            match self.resolve_subject_for(subject, crate::tenant::Access::Subscribe) {
+                Resolved::Denied => {
+                    reply_import_not_granted(out);
+                    return Ok(());
+                }
+                Resolved::Cross { name, .. } => (name, self.scope_group_under_self(group)),
+                Resolved::Local(name) => (name, group.to_string()),
+            };
         let cache = std::mem::take(&mut self.subject_cache);
         let (cache, resolved) = engine.with(move |e| {
             let mut cache = cache;
@@ -5785,7 +5976,7 @@ impl Session {
         // Bind this connection's consume path to the resolved stream + the requested work-group, exactly
         // as a `SubTo` binds an explicit stream id (the resolved stream is already declared by its bind).
         self.stream = GroupName::from(stream.name());
-        self.subscription = GroupName::from(group);
+        self.subscription = GroupName::from(group_owned.as_str());
         // A subject subscribe binds the stream as a whole (#693): clear any partition binding.
         self.partition = None;
         // #553: a subject subscribe is never priority-mode (priority streams have no subjects).
@@ -6117,6 +6308,18 @@ fn reply_err_coded(out: &mut Vec<u8>, code_token: &str, message: &str) {
     let mut body = Vec::with_capacity(2 + code_token.len() + message.len());
     ironbus_proto::err::encode_err_body(Some(code_token), message, &mut body);
     reply(out, FrameType::Err, &body);
+}
+
+/// #1163: the single typed reject for a cross-tenant import that no export authorizes for the
+/// requested direction. Emitted at EVERY resolution seam a [`Resolved::Denied`] can arise, so the
+/// wire signal is uniform: the client named an import alias, but the crossing is not (or no longer)
+/// allowlisted on both sides. It reveals NOTHING about the exporter's namespace beyond "not granted".
+fn reply_import_not_granted(out: &mut Vec<u8>) {
+    reply_err_coded(
+        out,
+        crate::codes::ErrorCode::ERR_IMPORT_NOT_GRANTED.as_str(),
+        "no export grant authorizes this import for the requested access",
+    );
 }
 
 /// Writes the single UNIFORM "Authorization Violation" `Err` frame (#631, V2-M7,
@@ -18565,6 +18768,605 @@ mod tests {
             got.iter().map(|r| r.0).collect::<Vec<_>>(),
             (0..10).collect::<Vec<u64>>(),
             "the batched run is bounded by max_in_flight (10), in order"
+        );
+    }
+
+    // ================================================================================================
+    // #1163 — CONTROLLED cross-tenant IMPORT / EXPORT (multi-tenant phase-2). The AUTHZ suite driven
+    // through REAL sessions over a REAL engine: an import crosses the (otherwise absolute) tenant
+    // boundary ONLY with a matching export; without one it is a typed reject and NO data crosses;
+    // an importer reaches EXACTLY the grant and nothing beyond it; the export's direction is
+    // respected; revoking the export cuts the import off; a non-imported name stays isolated
+    // (phase-1); two importers of one export are independent. A leak here is a cross-tenant BREACH.
+    // ================================================================================================
+
+    /// An audience over an explicit tenant allowlist.
+    fn aud(names: &[&str]) -> crate::tenant::Audience {
+        crate::tenant::Audience::Tenants(
+            names
+                .iter()
+                .map(|n| crate::tenant::TenantId::parse(n).unwrap())
+                .collect(),
+        )
+    }
+
+    fn export_stream(
+        name: &str,
+        audience: crate::tenant::Audience,
+        subscribe: bool,
+        publish: bool,
+    ) -> crate::tenant::Export {
+        crate::tenant::Export {
+            kind: crate::tenant::ShareKind::Stream,
+            name: name.to_string(),
+            audience,
+            direction: crate::tenant::GrantDirection { subscribe, publish },
+        }
+    }
+
+    fn export_subject(
+        name: &str,
+        audience: crate::tenant::Audience,
+        subscribe: bool,
+        publish: bool,
+    ) -> crate::tenant::Export {
+        crate::tenant::Export {
+            kind: crate::tenant::ShareKind::Subject,
+            name: name.to_string(),
+            audience,
+            direction: crate::tenant::GrantDirection { subscribe, publish },
+        }
+    }
+
+    fn import_stream(from: &str, remote: &str, local: &str) -> crate::tenant::Import {
+        crate::tenant::Import {
+            kind: crate::tenant::ShareKind::Stream,
+            from: crate::tenant::TenantId::parse(from).unwrap(),
+            remote: remote.to_string(),
+            local: local.to_string(),
+        }
+    }
+
+    fn import_subject(from: &str, remote: &str, local: &str) -> crate::tenant::Import {
+        crate::tenant::Import {
+            kind: crate::tenant::ShareKind::Subject,
+            from: crate::tenant::TenantId::parse(from).unwrap(),
+            remote: remote.to_string(),
+            local: local.to_string(),
+        }
+    }
+
+    /// Builds an auth config: identities each bound to a tenant, PLUS a cross-tenant sharing registry
+    /// built from the given per-tenant exports and imports. The tenant + the grants are properties of
+    /// the credential/config — the client never supplies them.
+    fn share_auth(
+        specs: &[(&[u8], &[Scope], &str)],
+        exports: &[(&str, crate::tenant::Export)],
+        imports: &[(&str, crate::tenant::Import)],
+    ) -> Arc<AuthConfig> {
+        use crate::tenant::{Export, Import, SharingRegistry, TenantId};
+        let mut cfg = AuthConfig::new();
+        for (i, (token, scopes, tenant)) in specs.iter().enumerate() {
+            cfg.add_identity(Identity {
+                name: format!("id{i}"),
+                scopes: ScopeSet::from_scopes(scopes),
+                credential: CredentialSet::Bearer {
+                    digests: vec![
+                        crate::auth::parse_token_digest_hex(&sha256_hex_token(token)).unwrap(),
+                    ],
+                },
+                tenant: Some(TenantId::parse(tenant).unwrap()),
+            });
+        }
+        let mut ex_map: std::collections::HashMap<TenantId, Vec<Export>> =
+            std::collections::HashMap::new();
+        for (who, ex) in exports {
+            ex_map
+                .entry(TenantId::parse(who).unwrap())
+                .or_default()
+                .push(ex.clone());
+        }
+        let mut im_map: std::collections::HashMap<TenantId, Vec<Import>> =
+            std::collections::HashMap::new();
+        for (who, im) in imports {
+            im_map
+                .entry(TenantId::parse(who).unwrap())
+                .or_default()
+                .push(im.clone());
+        }
+        cfg.set_sharing(Arc::new(SharingRegistry::new(ex_map, im_map)));
+        Arc::new(cfg)
+    }
+
+    /// The typed code carried on an `Err` reply (asserting the reply IS an `Err`).
+    fn err_code(out: &[u8]) -> Option<ironbus_proto::err::ServerErrorCode> {
+        let (ty, body) = one_response(out);
+        assert_eq!(ty, FrameType::Err, "expected an Err frame");
+        ironbus_proto::err::decode_err_body(&body).code
+    }
+
+    fn subsub_frame(subject: &[u8], group: &[u8], mode: u8) -> Vec<u8> {
+        let mut s = Vec::new();
+        ironbus_proto::message::encode_sub_subject(
+            &ironbus_proto::message::SubSubjectBody {
+                subject,
+                group,
+                filter_mode: mode,
+            },
+            &mut s,
+        )
+        .unwrap();
+        frame(FrameType::SubSubject, &s)
+    }
+
+    fn bind_frame(stream: &[u8], pattern: &[u8]) -> Vec<u8> {
+        let mut b = Vec::new();
+        ironbus_proto::message::encode_bind_subject(
+            &ironbus_proto::message::BindSubjectBody {
+                stream_id: stream,
+                pattern,
+            },
+            &mut b,
+        )
+        .unwrap();
+        frame(FrameType::BindSubject, &b)
+    }
+
+    fn pubsub_frame(subject: &[u8], payload: &[u8]) -> Vec<u8> {
+        let mut p = Vec::new();
+        ironbus_proto::message::encode_pub_subject(
+            &ironbus_proto::message::PubSubjectBody {
+                subject,
+                pub_body: &pub_body(payload),
+            },
+            &mut p,
+        )
+        .unwrap();
+        frame(FrameType::PubSubject, &p)
+    }
+
+    #[test]
+    fn stream_import_reads_the_exporters_stream_only_with_a_matching_export() {
+        // acme exports its stream "orders" (subscribe) to globex; globex imports it as "partner".
+        // globex naming its alias reads acme's stream — the ONE controlled crossing.
+        let e = DirectEngine::new(engine());
+        let auth = share_auth(
+            &[
+                (
+                    b"tok-a-1aaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    &[Scope::Publish, Scope::Subscribe],
+                    "acme",
+                ),
+                (
+                    b"tok-b-1bbbbbbbbbbbbbbbbbbbbbbbbbb",
+                    &[Scope::Publish, Scope::Subscribe],
+                    "globex",
+                ),
+            ],
+            &[(
+                "acme",
+                export_stream("orders", aud(&["globex"]), true, false),
+            )],
+            &[("globex", import_stream("acme", "orders", "partner"))],
+        );
+        let mut a = mt_session(&e, &auth, 1, b"tok-a-1aaaaaaaaaaaaaaaaaaaaaaaaaa", true);
+        let mut b = mt_session(&e, &auth, 2, b"tok-b-1bbbbbbbbbbbbbbbbbbbbbbbbbb", true);
+        let mut out = Vec::new();
+        a.process(&e, &pubto_frame(b"orders", b"A-shared"), &mut out)
+            .unwrap();
+        assert_eq!(one_response(&out).0, FrameType::PubAck, "acme produced");
+        // globex subscribes to its LOCAL alias — resolves to acme/orders.
+        out.clear();
+        b.process(&e, &sub_to_frame(b"partner", b"g"), &mut out)
+            .unwrap();
+        assert_eq!(
+            one_response(&out).0,
+            FrameType::Ok,
+            "the import bound the exporter's stream"
+        );
+        assert_eq!(
+            delivered_payloads(&flow(&mut b, &e, 8)),
+            vec![b"A-shared".to_vec()],
+            "globex reads acme's exported record through the alias"
+        );
+        // The record physically lives in ACME's stream (globex read it cross-tenant), and globex's
+        // cursor is keyed under globex — the exporter's namespace is untouched.
+        assert_eq!(e.engine_mut().stream_head("acme/orders").get(), 1);
+        assert!(
+            !e.engine_mut().stream_exists("globex/partner"),
+            "the alias never minted a stream in the importer's namespace"
+        );
+    }
+
+    #[test]
+    fn a_stream_import_without_a_matching_export_is_denied_and_no_data_crosses() {
+        // globex imports acme's "orders" as "partner", but acme exports NOTHING → a typed reject and
+        // globex never reaches acme's data. This is the core invariant: no export, no crossing.
+        let e = DirectEngine::new(engine());
+        let auth = share_auth(
+            &[
+                (
+                    b"tok-a-2aaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    &[Scope::Publish, Scope::Subscribe],
+                    "acme",
+                ),
+                (
+                    b"tok-b-2bbbbbbbbbbbbbbbbbbbbbbbbbb",
+                    &[Scope::Publish, Scope::Subscribe],
+                    "globex",
+                ),
+            ],
+            &[], // acme exports nothing
+            &[("globex", import_stream("acme", "orders", "partner"))],
+        );
+        let mut a = mt_session(&e, &auth, 1, b"tok-a-2aaaaaaaaaaaaaaaaaaaaaaaaaa", true);
+        let mut b = mt_session(&e, &auth, 2, b"tok-b-2bbbbbbbbbbbbbbbbbbbbbbbbbb", true);
+        a.process(&e, &pubto_frame(b"orders", b"A-secret"), &mut Vec::new())
+            .unwrap();
+        let mut out = Vec::new();
+        b.process(&e, &sub_to_frame(b"partner", b"g"), &mut out)
+            .unwrap();
+        assert_eq!(
+            err_code(&out),
+            Some(ironbus_proto::err::ServerErrorCode::ImportNotGranted),
+            "import without an export is a typed ERR_IMPORT_NOT_GRANTED reject"
+        );
+        // The rejected subscribe bound nothing — globex is still on its own (empty) default stream and
+        // a Flow yields nothing of acme's.
+        assert!(
+            delivered_payloads(&flow(&mut b, &e, 8)).is_empty(),
+            "no cross-tenant data leaked past the reject"
+        );
+    }
+
+    #[test]
+    fn a_subject_import_cannot_reach_beyond_the_export_grant() {
+        // acme exports subject `orders.*` (subscribe) to globex, imported as `partner.orders`.
+        // A subscribe WITHIN `orders.*` is granted; one that widens past it (a deeper `>`) is denied —
+        // no wildcard escalation, no sibling subtree.
+        let e = DirectEngine::new(engine());
+        let auth = share_auth(
+            &[
+                (
+                    b"tok-a-3aaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    &[Scope::Publish, Scope::Subscribe, Scope::Admin],
+                    "acme",
+                ),
+                (
+                    b"tok-b-3bbbbbbbbbbbbbbbbbbbbbbbbbb",
+                    &[Scope::Publish, Scope::Subscribe, Scope::Admin],
+                    "globex",
+                ),
+            ],
+            &[(
+                "acme",
+                export_subject("orders.*", aud(&["globex"]), true, false),
+            )],
+            &[("globex", import_subject("acme", "orders", "partner.orders"))],
+        );
+        // acme connects (establishing its default stream) and binds `orders.>` to a covering stream so
+        // the importer's filter has a real exporter stream to bind on.
+        let mut a = mt_session(&e, &auth, 1, b"tok-a-3aaaaaaaaaaaaaaaaaaaaaaaaaa", true);
+        a.process(&e, &bind_frame(b"ord", b"orders.>"), &mut Vec::new())
+            .unwrap();
+        let mut b = mt_session(&e, &auth, 2, b"tok-b-3bbbbbbbbbbbbbbbbbbbbbbbbbb", true);
+        // WITHIN the grant: `partner.orders.*` -> `orders.*` ⊑ `orders.*` -> OK.
+        let mut out = Vec::new();
+        b.process(&e, &subsub_frame(b"partner.orders.*", b"w", 1), &mut out)
+            .unwrap();
+        assert_eq!(
+            one_response(&out).0,
+            FrameType::Ok,
+            "a subscribe within the grant is allowed"
+        );
+        // BEYOND the grant: `partner.orders.>` -> `orders.>`, which is BROADER than `orders.*` -> denied.
+        out.clear();
+        b.process(&e, &subsub_frame(b"partner.orders.>", b"w2", 1), &mut out)
+            .unwrap();
+        assert_eq!(
+            err_code(&out),
+            Some(ironbus_proto::err::ServerErrorCode::ImportNotGranted),
+            "widening past the export grant is denied"
+        );
+    }
+
+    #[test]
+    fn export_direction_is_respected_subscribe_only_denies_publish() {
+        // acme exports stream "inbox" SUBSCRIBE-only to globex; globex imports it as "ai".
+        // globex may READ it but a PUBLISH into it is denied — direction is enforced.
+        let e = DirectEngine::new(engine());
+        let auth = share_auth(
+            &[
+                (
+                    b"tok-a-4aaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    &[Scope::Publish, Scope::Subscribe],
+                    "acme",
+                ),
+                (
+                    b"tok-b-4bbbbbbbbbbbbbbbbbbbbbbbbbb",
+                    &[Scope::Publish, Scope::Subscribe],
+                    "globex",
+                ),
+            ],
+            &[(
+                "acme",
+                export_stream("inbox", aud(&["globex"]), true, false),
+            )],
+            &[("globex", import_stream("acme", "inbox", "ai"))],
+        );
+        // acme creates its inbox so the SubTo existence check passes.
+        let mut a = mt_session(&e, &auth, 1, b"tok-a-4aaaaaaaaaaaaaaaaaaaaaaaaaa", true);
+        a.process(&e, &pubto_frame(b"inbox", b"seed"), &mut Vec::new())
+            .unwrap();
+        let mut b = mt_session(&e, &auth, 2, b"tok-b-4bbbbbbbbbbbbbbbbbbbbbbbbbb", true);
+        // A cross-tenant PUBLISH into a subscribe-only export is denied.
+        let mut out = Vec::new();
+        b.process(&e, &pubto_frame(b"ai", b"B-write"), &mut out)
+            .unwrap();
+        assert_eq!(
+            err_code(&out),
+            Some(ironbus_proto::err::ServerErrorCode::ImportNotGranted),
+            "publish into a subscribe-only export is denied"
+        );
+        // But a READ is granted.
+        out.clear();
+        b.process(&e, &sub_to_frame(b"ai", b"g"), &mut out).unwrap();
+        assert_eq!(
+            one_response(&out).0,
+            FrameType::Ok,
+            "the subscribe direction is allowed"
+        );
+    }
+
+    #[test]
+    fn a_publish_grant_lets_the_importer_write_into_the_exporters_stream() {
+        // acme exports stream "drop" PUBLISH to globex, imported as "acme-drop". globex writes into it;
+        // acme reads its own stream and sees globex's record — a controlled cross-tenant WRITE.
+        let e = DirectEngine::new(engine());
+        let auth = share_auth(
+            &[
+                (
+                    b"tok-a-5aaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    &[Scope::Publish, Scope::Subscribe],
+                    "acme",
+                ),
+                (
+                    b"tok-b-5bbbbbbbbbbbbbbbbbbbbbbbbbb",
+                    &[Scope::Publish, Scope::Subscribe],
+                    "globex",
+                ),
+            ],
+            &[("acme", export_stream("drop", aud(&["globex"]), false, true))],
+            &[("globex", import_stream("acme", "drop", "acme-drop"))],
+        );
+        let mut a = mt_session(&e, &auth, 1, b"tok-a-5aaaaaaaaaaaaaaaaaaaaaaaaaa", true);
+        let mut b = mt_session(&e, &auth, 2, b"tok-b-5bbbbbbbbbbbbbbbbbbbbbbbbbb", true);
+        let mut out = Vec::new();
+        b.process(&e, &pubto_frame(b"acme-drop", b"from-globex"), &mut out)
+            .unwrap();
+        assert_eq!(
+            one_response(&out).0,
+            FrameType::PubAck,
+            "the publish-granted cross-tenant write is acked"
+        );
+        // The record landed in ACME's stream, not globex's namespace.
+        assert_eq!(e.engine_mut().stream_head("acme/drop").get(), 1);
+        assert!(!e.engine_mut().stream_exists("globex/acme-drop"));
+        // acme reads its own "drop" stream and sees globex's write.
+        out.clear();
+        a.process(&e, &sub_to_frame(b"drop", b"g"), &mut out)
+            .unwrap();
+        assert_eq!(one_response(&out).0, FrameType::Ok);
+        assert_eq!(
+            delivered_payloads(&flow(&mut a, &e, 8)),
+            vec![b"from-globex".to_vec()],
+            "acme consumes the record globex wrote through the export"
+        );
+    }
+
+    #[test]
+    fn revoking_the_export_stops_the_import() {
+        // With the export present, globex reads acme's stream. Rebuild the auth config WITHOUT the
+        // export (a config reload) and the very same import alias now resolves to a typed reject.
+        let e = DirectEngine::new(engine());
+        let specs: &[(&[u8], &[Scope], &str)] = &[
+            (
+                b"tok-a-6aaaaaaaaaaaaaaaaaaaaaaaaaa",
+                &[Scope::Publish, Scope::Subscribe],
+                "acme",
+            ),
+            (
+                b"tok-b-6bbbbbbbbbbbbbbbbbbbbbbbbbb",
+                &[Scope::Publish, Scope::Subscribe],
+                "globex",
+            ),
+        ];
+        let imports = &[("globex", import_stream("acme", "orders", "partner"))];
+        // Phase A: export present.
+        let granted = share_auth(
+            specs,
+            &[(
+                "acme",
+                export_stream("orders", aud(&["globex"]), true, false),
+            )],
+            imports,
+        );
+        let mut a = mt_session(&e, &granted, 1, b"tok-a-6aaaaaaaaaaaaaaaaaaaaaaaaaa", true);
+        a.process(&e, &pubto_frame(b"orders", b"A-shared"), &mut Vec::new())
+            .unwrap();
+        let mut b = mt_session(&e, &granted, 2, b"tok-b-6bbbbbbbbbbbbbbbbbbbbbbbbbb", true);
+        let mut out = Vec::new();
+        b.process(&e, &sub_to_frame(b"partner", b"g"), &mut out)
+            .unwrap();
+        assert_eq!(one_response(&out).0, FrameType::Ok, "granted read binds");
+
+        // Phase B: REVOKE — the same import, but no export. New sessions on the reloaded config.
+        let revoked = share_auth(specs, &[], imports);
+        let mut b2 = mt_session(&e, &revoked, 3, b"tok-b-6bbbbbbbbbbbbbbbbbbbbbbbbbb", true);
+        out.clear();
+        b2.process(&e, &sub_to_frame(b"partner", b"g2"), &mut out)
+            .unwrap();
+        assert_eq!(
+            err_code(&out),
+            Some(ironbus_proto::err::ServerErrorCode::ImportNotGranted),
+            "revoking the export stops the import on the next resolution"
+        );
+    }
+
+    #[test]
+    fn a_non_imported_name_stays_in_the_importers_own_tenant() {
+        // Even with a sharing registry configured, a name that is NOT an import alias resolves in the
+        // importer's OWN tenant (phase-1 unchanged): globex's "myown" is globex/myown, never acme's.
+        let e = DirectEngine::new(engine());
+        let auth = share_auth(
+            &[
+                (
+                    b"tok-a-7aaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    &[Scope::Publish, Scope::Subscribe],
+                    "acme",
+                ),
+                (
+                    b"tok-b-7bbbbbbbbbbbbbbbbbbbbbbbbbb",
+                    &[Scope::Publish, Scope::Subscribe],
+                    "globex",
+                ),
+            ],
+            &[(
+                "acme",
+                export_stream("orders", aud(&["globex"]), true, false),
+            )],
+            &[("globex", import_stream("acme", "orders", "partner"))],
+        );
+        // acme has a stream literally named "myown"; globex names "myown" (NOT its alias "partner").
+        let mut a = mt_session(&e, &auth, 1, b"tok-a-7aaaaaaaaaaaaaaaaaaaaaaaaaa", true);
+        a.process(&e, &pubto_frame(b"myown", b"A-private"), &mut Vec::new())
+            .unwrap();
+        let mut b = mt_session(&e, &auth, 2, b"tok-b-7bbbbbbbbbbbbbbbbbbbbbbbbbb", true);
+        b.process(&e, &pubto_frame(b"myown", b"B-private"), &mut Vec::new())
+            .unwrap();
+        let mut out = Vec::new();
+        b.process(&e, &sub_to_frame(b"myown", b"g"), &mut out)
+            .unwrap();
+        assert_eq!(one_response(&out).0, FrameType::Ok);
+        assert_eq!(
+            delivered_payloads(&flow(&mut b, &e, 8)),
+            vec![b"B-private".to_vec()],
+            "a non-imported name stays isolated in the importer's own tenant"
+        );
+        // Two distinct isolated logs.
+        assert_eq!(e.engine_mut().stream_head("acme/myown").get(), 1);
+        assert_eq!(e.engine_mut().stream_head("globex/myown").get(), 1);
+    }
+
+    #[test]
+    fn two_importers_of_the_same_export_are_independent() {
+        // acme exports stream "feed" PUBLIC; globex and initech each import it under their own alias.
+        // Both read acme's stream through INDEPENDENT (importer-scoped) cursors.
+        let e = DirectEngine::new(engine());
+        let auth = share_auth(
+            &[
+                (
+                    b"tok-a-8aaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    &[Scope::Publish, Scope::Subscribe],
+                    "acme",
+                ),
+                (
+                    b"tok-b-8bbbbbbbbbbbbbbbbbbbbbbbbbb",
+                    &[Scope::Publish, Scope::Subscribe],
+                    "globex",
+                ),
+                (
+                    b"tok-c-8cccccccccccccccccccccccccc",
+                    &[Scope::Publish, Scope::Subscribe],
+                    "initech",
+                ),
+            ],
+            &[(
+                "acme",
+                export_stream("feed", crate::tenant::Audience::Public, true, false),
+            )],
+            &[
+                ("globex", import_stream("acme", "feed", "gfeed")),
+                ("initech", import_stream("acme", "feed", "ifeed")),
+            ],
+        );
+        let mut a = mt_session(&e, &auth, 1, b"tok-a-8aaaaaaaaaaaaaaaaaaaaaaaaaa", true);
+        a.process(&e, &pubto_frame(b"feed", b"broadcast"), &mut Vec::new())
+            .unwrap();
+        let mut g = mt_session(&e, &auth, 2, b"tok-b-8bbbbbbbbbbbbbbbbbbbbbbbbbb", true);
+        let mut it = mt_session(&e, &auth, 3, b"tok-c-8cccccccccccccccccccccccccc", true);
+        let mut out = Vec::new();
+        g.process(&e, &sub_to_frame(b"gfeed", b"w"), &mut out)
+            .unwrap();
+        assert_eq!(one_response(&out).0, FrameType::Ok);
+        out.clear();
+        it.process(&e, &sub_to_frame(b"ifeed", b"w"), &mut out)
+            .unwrap();
+        assert_eq!(one_response(&out).0, FrameType::Ok);
+        // Each independently reads the one shared record — neither steals it from the other (their
+        // cursors are keyed by (acme/feed, <importer>/w)).
+        assert_eq!(
+            delivered_payloads(&flow(&mut g, &e, 8)),
+            vec![b"broadcast".to_vec()],
+            "globex reads the shared record"
+        );
+        assert_eq!(
+            delivered_payloads(&flow(&mut it, &e, 8)),
+            vec![b"broadcast".to_vec()],
+            "initech independently reads the same shared record"
+        );
+    }
+
+    #[test]
+    fn subject_import_reads_the_exporters_subjects_filtered_and_isolated() {
+        // The headline read use-case: acme binds `orders.>` to a stream and publishes `orders.us`;
+        // acme exports subject `orders.>` (subscribe) to globex; globex imports it as `partner.orders`
+        // and filtered-subscribes `partner.orders.>` — reading acme's subject records through an
+        // importer-scoped cursor. A sibling acme subject globex did not import stays invisible.
+        let e = DirectEngine::new(engine());
+        let auth = share_auth(
+            &[
+                (
+                    b"tok-a-9aaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    &[Scope::Publish, Scope::Subscribe, Scope::Admin],
+                    "acme",
+                ),
+                (
+                    b"tok-b-9bbbbbbbbbbbbbbbbbbbbbbbbbb",
+                    &[Scope::Publish, Scope::Subscribe, Scope::Admin],
+                    "globex",
+                ),
+            ],
+            &[(
+                "acme",
+                export_subject("orders.>", aud(&["globex"]), true, false),
+            )],
+            &[("globex", import_subject("acme", "orders", "partner.orders"))],
+        );
+        let mut a = mt_session(&e, &auth, 1, b"tok-a-9aaaaaaaaaaaaaaaaaaaaaaaaaa", true);
+        let mut out = Vec::new();
+        for f in [
+            bind_frame(b"ord", b"orders.>"),
+            pubsub_frame(b"orders.us", b"A-order"),
+            bind_frame(b"sec", b"secret.>"),
+            pubsub_frame(b"secret.k", b"A-secret"),
+        ] {
+            a.process(&e, &f, &mut out).unwrap();
+        }
+        // globex filtered-subscribes to its imported alias and reads acme's orders subject.
+        let mut b = mt_session(&e, &auth, 2, b"tok-b-9bbbbbbbbbbbbbbbbbbbbbbbbbb", true);
+        out.clear();
+        b.process(&e, &subsub_frame(b"partner.orders.>", b"w", 1), &mut out)
+            .unwrap();
+        assert_eq!(
+            one_response(&out).0,
+            FrameType::Ok,
+            "the subject import bound the exporter's covering stream"
+        );
+        assert_eq!(
+            delivered_payloads(&flow(&mut b, &e, 8)),
+            vec![b"A-order".to_vec()],
+            "globex reads acme's exported orders subject — and NOT acme's un-exported secret subject"
         );
     }
 }

--- a/crates/ironbus-server/src/tenant.rs
+++ b/crates/ironbus-server/src/tenant.rs
@@ -390,6 +390,424 @@ impl Drop for ConnGuard {
     }
 }
 
+// ================================================================================================
+// #1163 — CONTROLLED cross-tenant IMPORT / EXPORT (multi-tenant phase-2).
+//
+// Phase-1 (#1162) made the tenant boundary ABSOLUTE by server-applied prefixing (above). Phase-2
+// adds the ONE deliberate, allowlisted, revocable way to cross it — NATS-accounts-style. It is a
+// controlled ALIAS, never a new namespace: an import resolves (WITH authorization) a local alias to
+// the EXPORTER's already-prefixed resource. Nothing crosses without a matching export on the other
+// side, so the default (no import/export config) is byte-for-byte the phase-1 broker.
+//
+// The whole authorization decision is this one pure, side-effect-free module — [`SharingRegistry`]
+// plus the token matchers below — so the security argument is auditable in one place and unit-tested
+// exhaustively. The session layer merely applies the [`Resolution`] it returns.
+// ================================================================================================
+
+/// The direction of a single resource access at a resolution seam. An export grants a subset of
+/// these; a cross-tenant access is authorized only for a direction the export actually permits.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Access {
+    /// A READ (a `SubTo` / `SubSubject` / `StreamInfo` — the importer consumes the exporter's data).
+    Subscribe,
+    /// A WRITE (a `PubTo` / `PubSubject` — the importer produces INTO the exporter's resource).
+    Publish,
+}
+
+/// The kind of resource a sharing grant covers. A grant is kind-typed so a stream export can never be
+/// satisfied by a subject import (or vice-versa), even if the names collide.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ShareKind {
+    /// A named stream (exact name; streams are not patterns).
+    Stream,
+    /// A subject or subject pattern (may carry `*` / `>` wildcards in an EXPORT; an IMPORT alias is
+    /// always a literal token prefix).
+    Subject,
+}
+
+/// The direction(s) an export permits its importers. At least one is always set (a grant that
+/// permits neither is refused at config load — it could never authorize anything).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub struct GrantDirection {
+    /// The importer may READ (consume) the exported resource.
+    pub subscribe: bool,
+    /// The importer may WRITE (produce into) the exported resource.
+    pub publish: bool,
+}
+
+impl GrantDirection {
+    /// Whether this grant permits `access`.
+    #[must_use]
+    pub fn allows(self, access: Access) -> bool {
+        match access {
+            Access::Subscribe => self.subscribe,
+            Access::Publish => self.publish,
+        }
+    }
+}
+
+/// Who an export is offered to. `Public` admits every tenant; `Tenants` is an explicit allowlist.
+/// Default-deny is structural: an importer not named (and no `Public`) simply finds no matching
+/// export, so the alias resolves to a typed reject — never to ambient cross-tenant access.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Audience {
+    /// Any tenant may import this export.
+    Public,
+    /// Only the named tenants may import this export.
+    Tenants(std::collections::BTreeSet<TenantId>),
+}
+
+impl Audience {
+    /// Whether `importer` is admitted by this audience.
+    #[must_use]
+    pub fn admits(&self, importer: &TenantId) -> bool {
+        match self {
+            Audience::Public => true,
+            Audience::Tenants(set) => set.contains(importer),
+        }
+    }
+}
+
+/// An EXPORT grant declared by an exporting tenant: the exporter's OWN resource name/pattern, who it
+/// is offered to, and in which direction(s). The export defines EXACTLY what is shared — an importer
+/// can reach nothing beyond a name this grant's `name` pattern covers.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Export {
+    /// Whether this exports a stream or a subject.
+    pub kind: ShareKind,
+    /// The exporter's LOCAL resource name (a `Stream` exact name, or a `Subject` pattern that may
+    /// carry `*` / `>`). This is in the exporter's own namespace, BEFORE the exporter's prefix.
+    pub name: String,
+    /// Which importing tenant(s) may use this export.
+    pub audience: Audience,
+    /// The direction(s) the importer is permitted.
+    pub direction: GrantDirection,
+}
+
+/// An IMPORT declared by an importing tenant: a LOCAL alias, in the importer's own namespace, for a
+/// resource EXPORTED by another tenant. `local` (the importer's alias) rewrites to `remote` (the
+/// exporter's name) at resolution, and the resolution succeeds ONLY IF a matching [`Export`] exists.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Import {
+    /// Whether this imports a stream or a subject.
+    pub kind: ShareKind,
+    /// The EXPORTING tenant this import references.
+    pub from: TenantId,
+    /// The exporter's resource name this import points at (a `Stream` exact name, or a `Subject`
+    /// LITERAL prefix — an import alias never carries wildcards; the export's pattern bounds it).
+    pub remote: String,
+    /// The importer's LOCAL alias, in its own namespace (a `Stream` exact name, or a `Subject`
+    /// LITERAL prefix). A client naming this alias reaches the exporter's `remote` resource.
+    pub local: String,
+}
+
+/// The outcome of resolving a client-supplied resource name for an importing tenant through the
+/// import/export layer. It is the ONE decision that can (with authorization) cross the tenant
+/// boundary; the session layer simply applies it.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Resolution {
+    /// The name is NOT an import alias — the caller scopes it in its OWN tenant, exactly as phase-1.
+    Own,
+    /// An import alias matched a valid export grant: the fully EXPORTER-scoped engine name plus the
+    /// owning (exporter) tenant, so the caller can charge the owner's quotas and route to its log.
+    Crossed {
+        /// The exporter (the tenant that owns the resolved resource).
+        owner: TenantId,
+        /// The exporter-scoped engine name (`<exporter>/…` for a stream, `<exporter>.…` for a
+        /// subject) — already prefixed, ready for the engine.
+        scoped: String,
+    },
+    /// The name matched an import alias, but NO export authorizes it for the requested direction —
+    /// a typed reject. The caller must NOT fall back to its own namespace (that would silently hide
+    /// a mis-configuration) and MUST never reach the exporter's data.
+    Denied,
+}
+
+/// The broker's cross-tenant sharing registry (#1163): the configured exports (per exporter) and
+/// imports (per importer), shared immutably across every connection via `Arc`. Absent (`None` on a
+/// session) means no sharing is configured and every resolution is [`Resolution::Own`] — byte-for-
+/// byte the phase-1 isolated broker.
+#[derive(Debug, Default)]
+pub struct SharingRegistry {
+    /// Exports keyed by the EXPORTING tenant.
+    exports: HashMap<TenantId, Vec<Export>>,
+    /// Imports keyed by the IMPORTING tenant.
+    imports: HashMap<TenantId, Vec<Import>>,
+}
+
+impl SharingRegistry {
+    /// Builds a registry from the per-tenant export and import tables.
+    #[must_use]
+    pub fn new(
+        exports: HashMap<TenantId, Vec<Export>>,
+        imports: HashMap<TenantId, Vec<Import>>,
+    ) -> SharingRegistry {
+        SharingRegistry { exports, imports }
+    }
+
+    /// Whether no sharing is configured at all (a purely informational helper; a `true` registry is
+    /// equivalent to `None`).
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.exports.is_empty() && self.imports.is_empty()
+    }
+
+    /// Resolves a client-supplied STREAM name for `importer` in the given direction.
+    #[must_use]
+    pub fn resolve_stream(
+        &self,
+        importer: &TenantId,
+        client_name: &str,
+        access: Access,
+    ) -> Resolution {
+        self.resolve(importer, ShareKind::Stream, client_name, access)
+    }
+
+    /// Resolves a client-supplied SUBJECT (a concrete subject for a publish, or a pattern for a
+    /// subscribe) for `importer` in the given direction.
+    #[must_use]
+    pub fn resolve_subject(
+        &self,
+        importer: &TenantId,
+        client_subject: &str,
+        access: Access,
+    ) -> Resolution {
+        self.resolve(importer, ShareKind::Subject, client_subject, access)
+    }
+
+    /// The single resolution decision, shared by both kinds. Fail-closed at every step: it returns
+    /// [`Resolution::Own`] only when the name is NOT an import alias, [`Resolution::Crossed`] only
+    /// when a matching export authorizes the exact name for the exact direction, and
+    /// [`Resolution::Denied`] whenever an alias matched but no grant backs it.
+    fn resolve(
+        &self,
+        importer: &TenantId,
+        kind: ShareKind,
+        client_name: &str,
+        access: Access,
+    ) -> Resolution {
+        // 1. Is this name one of the importer's import aliases? If not, it is the importer's OWN
+        //    resource — phase-1 behavior, untouched. (A tenant with no imports takes this fast path.)
+        let Some(imports) = self.imports.get(importer) else {
+            return Resolution::Own;
+        };
+        let Some((imp, remote)) = best_import_match(imports, kind, client_name) else {
+            return Resolution::Own;
+        };
+        // 2. An alias matched. It crosses the boundary ONLY IF the referenced exporter has a matching
+        //    export: same kind, admits THIS importer, permits THIS direction, and whose pattern
+        //    covers the resolved remote name. No such export → a typed reject (NEVER own-namespace,
+        //    NEVER the exporter's other resources).
+        let granted = self.exports.get(&imp.from).is_some_and(|exports| {
+            exports.iter().any(|ex| {
+                ex.kind == kind
+                    && ex.direction.allows(access)
+                    && ex.audience.admits(importer)
+                    && export_covers(ex, &remote, access)
+            })
+        });
+        if !granted {
+            return Resolution::Denied;
+        }
+        // 3. Authorized. Resolve to the EXPORTER's prefixed resource — the alias is a controlled
+        //    pointer into the exporter's namespace, bounded to exactly what the export covers.
+        let scoped = match kind {
+            ShareKind::Stream => imp.from.scope_stream(&remote),
+            ShareKind::Subject => imp.from.scope_subject(&remote),
+        };
+        Resolution::Crossed {
+            owner: imp.from.clone(),
+            scoped,
+        }
+    }
+}
+
+/// Finds the import alias (of `kind`) that matches `client_name`, returning the import plus the
+/// exporter-side `remote` name the alias rewrites to. For a stream the alias is an EXACT name; for a
+/// subject the alias is a literal token PREFIX and the client's suffix (which may carry the client's
+/// own wildcards on a subscribe) is preserved. When several aliases match, the MOST SPECIFIC (longest
+/// local prefix) wins, so a general and a specific import never resolve ambiguously.
+fn best_import_match<'a>(
+    imports: &'a [Import],
+    kind: ShareKind,
+    client_name: &str,
+) -> Option<(&'a Import, String)> {
+    let mut best: Option<(&Import, String)> = None;
+    for imp in imports.iter().filter(|i| i.kind == kind) {
+        let remote = match kind {
+            ShareKind::Stream => (imp.local == client_name).then(|| imp.remote.clone()),
+            ShareKind::Subject => rewrite_subject_prefix(&imp.local, &imp.remote, client_name),
+        };
+        if let Some(remote) = remote {
+            if best
+                .as_ref()
+                .map_or(true, |(b, _)| imp.local.len() > b.local.len())
+            {
+                best = Some((imp, remote));
+            }
+        }
+    }
+    best
+}
+
+/// Rewrites `client_name`'s `local` alias prefix to the exporter's `remote` prefix, on a TOKEN
+/// boundary. Returns `None` when `client_name` is not the alias itself and does not descend under it
+/// (so `partnerX` never matches alias `partner`). The preserved suffix keeps its leading `.`.
+fn rewrite_subject_prefix(local: &str, remote: &str, client_name: &str) -> Option<String> {
+    if client_name == local {
+        return Some(remote.to_string());
+    }
+    let rest = client_name.strip_prefix(local)?;
+    // A real descent requires the delimiter immediately after the alias, so `partner` matches
+    // `partner.orders` but NOT `partnerize`.
+    if rest.starts_with(SUBJECT_DELIM) {
+        Some(format!("{remote}{rest}"))
+    } else {
+        None
+    }
+}
+
+/// Whether `export` covers the resolved `remote` name for `access`. Streams are exact; a subject
+/// PUBLISH resolves a concrete subject (must MATCH the export pattern) and a subject SUBSCRIBE
+/// resolves a pattern (must be WITHIN the export pattern — no broadening past the grant).
+fn export_covers(export: &Export, remote: &str, access: Access) -> bool {
+    match export.kind {
+        ShareKind::Stream => export.name == remote,
+        ShareKind::Subject => match access {
+            Access::Publish => subject_matches(&export.name, remote),
+            Access::Subscribe => pattern_within(&export.name, remote),
+        },
+    }
+}
+
+/// Standard subject matching: a `pattern` token `*` matches exactly one subject token, `>` matches
+/// one-or-more trailing tokens (and is only meaningful last), and a concrete token matches itself.
+/// Used to check a concrete PUBLISH subject against an export pattern.
+fn subject_matches(pattern: &str, subject: &str) -> bool {
+    let p: Vec<&str> = pattern.split(SUBJECT_DELIM).collect();
+    let s: Vec<&str> = subject.split(SUBJECT_DELIM).collect();
+    let mut i = 0;
+    while i < p.len() {
+        if p[i] == ">" {
+            // `>` matches one-or-more remaining tokens: the subject must have at least one left.
+            return i < s.len();
+        }
+        if i >= s.len() {
+            return false;
+        }
+        if p[i] != "*" && p[i] != s[i] {
+            return false;
+        }
+        i += 1;
+    }
+    i == s.len()
+}
+
+/// Whether SUBSCRIBING to `req` stays WITHIN what the export pattern `grant` permits — i.e. every
+/// subject `req` could match is also covered by `grant`, so a subscribe can never widen past the
+/// grant (a sibling subject, or a `>` reaching deeper than the grant allows, is refused). This is
+/// the subscribe-direction bound that stops a wildcard import from over-reading.
+fn pattern_within(grant: &str, req: &str) -> bool {
+    let g: Vec<&str> = grant.split(SUBJECT_DELIM).collect();
+    let r: Vec<&str> = req.split(SUBJECT_DELIM).collect();
+    let (mut i, mut j) = (0usize, 0usize);
+    while i < g.len() && j < r.len() {
+        if g[i] == ">" {
+            // The grant covers one-or-more tokens from here; `req` has at least one (j < r.len()),
+            // and everything it can match from here is under the grant's `>`.
+            return true;
+        }
+        if r[j] == ">" {
+            // `req` wants one-or-more tokens where the grant permits only a single token (`*` or a
+            // concrete token): `req` is BROADER than the grant — refuse.
+            return false;
+        }
+        if g[i] != "*" && g[i] != r[j] {
+            // A concrete grant token must be met by the same concrete `req` token; a `*` in `req`
+            // here would be broader than the concrete grant, and `g[i] != r[j]` catches it.
+            return false;
+        }
+        i += 1;
+        j += 1;
+    }
+    // Within iff both ran out together: a leftover grant token (`a.*` vs `a`) means the grant covers
+    // a deeper subject space than `req`, and a leftover `req` token (`a` vs `a.b`) the reverse — both
+    // are disjoint-or-broader, not "within".
+    i == g.len() && j == r.len()
+}
+
+/// Validates a subject name for a sharing grant. `allow_wildcards` is `true` for an EXPORT pattern
+/// (`*` / `>` permitted, `>` only as the final token) and `false` for an IMPORT literal alias/prefix.
+/// Rejects the tenant delimiters and empty tokens fail-closed, so a resolved name can never escape a
+/// prefix or resolve ambiguously.
+///
+/// # Errors
+/// A human-readable reason when the subject is empty, has an empty token, carries `/`, or (when
+/// `!allow_wildcards`) carries a wildcard, or places `>` anywhere but last.
+pub fn validate_share_subject(name: &str, allow_wildcards: bool) -> Result<(), String> {
+    if name.is_empty() {
+        return Err("subject is empty".to_string());
+    }
+    let tokens: Vec<&str> = name.split(SUBJECT_DELIM).collect();
+    for (idx, tok) in tokens.iter().enumerate() {
+        if tok.is_empty() {
+            return Err(format!("subject {name:?} has an empty token"));
+        }
+        if *tok == ">" {
+            if !allow_wildcards {
+                return Err(format!(
+                    "import alias {name:?} must be a literal prefix (no `>` wildcard)"
+                ));
+            }
+            if idx != tokens.len() - 1 {
+                return Err(format!(
+                    "subject {name:?}: `>` is only valid as the final token"
+                ));
+            }
+            continue;
+        }
+        if *tok == "*" {
+            if !allow_wildcards {
+                return Err(format!(
+                    "import alias {name:?} must be a literal prefix (no `*` wildcard)"
+                ));
+            }
+            continue;
+        }
+        for ch in tok.chars() {
+            if ch == STREAM_DELIM {
+                return Err(format!("subject {name:?} may not contain '/'"));
+            }
+            if !(ch.is_ascii_alphanumeric() || ch == '_' || ch == '-') {
+                return Err(format!(
+                    "subject {name:?} token {tok:?} has an illegal character {ch:?}"
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Validates a stream name for a sharing grant: non-empty and free of the stream delimiter `/` and
+/// the subject wildcards, so a resolved `<exporter>/<name>` names EXACTLY one stream within the
+/// exporter and can never fan out or escape the exporter's prefix.
+///
+/// # Errors
+/// A human-readable reason when the stream name is empty or carries `/`, `*`, or `>`.
+pub fn validate_share_stream(name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err("stream name is empty".to_string());
+    }
+    for ch in name.chars() {
+        if ch == STREAM_DELIM || ch == '*' || ch == '>' {
+            return Err(format!(
+                "stream name {name:?} may not contain '/', '*', or '>'"
+            ));
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -507,5 +925,337 @@ mod tests {
         }
         assert!(reg.reserve_stream(&t, "t/x").is_ok());
         assert!(reg.reserve_bytes(&t, u64::MAX).is_ok());
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // #1163 — the import/export authorization core (the pure decision, exhaustively tested).
+    // -------------------------------------------------------------------------------------------
+
+    fn tid(s: &str) -> TenantId {
+        TenantId::parse(s).unwrap()
+    }
+
+    /// A registry: `a` exports `orders.*` (subscribe-only) to `b`; `b` imports it as `partner.orders`.
+    fn subject_sub_registry() -> SharingRegistry {
+        let mut exports = HashMap::new();
+        exports.insert(
+            tid("a"),
+            vec![Export {
+                kind: ShareKind::Subject,
+                name: "orders.*".to_string(),
+                audience: Audience::Tenants([tid("b")].into_iter().collect()),
+                direction: GrantDirection {
+                    subscribe: true,
+                    publish: false,
+                },
+            }],
+        );
+        let mut imports = HashMap::new();
+        imports.insert(
+            tid("b"),
+            vec![Import {
+                kind: ShareKind::Subject,
+                from: tid("a"),
+                remote: "orders".to_string(),
+                local: "partner.orders".to_string(),
+            }],
+        );
+        SharingRegistry::new(exports, imports)
+    }
+
+    #[test]
+    fn subject_matcher_and_pattern_within_are_correct() {
+        assert!(subject_matches("orders.*", "orders.us"));
+        assert!(!subject_matches("orders.*", "orders.us.west")); // `*` is one token
+        assert!(subject_matches("orders.>", "orders.us.west"));
+        assert!(!subject_matches("orders.>", "orders")); // `>` needs >=1 trailing token
+        assert!(subject_matches("orders.us", "orders.us"));
+
+        assert!(pattern_within("orders.*", "orders.us")); // literal within `*`
+        assert!(pattern_within("orders.*", "orders.*")); // same pattern
+        assert!(!pattern_within("orders.*", "orders.>")); // `>` broader than `*`
+        assert!(!pattern_within("orders.*", "orders")); // shorter — disjoint
+        assert!(pattern_within("orders.>", "orders.us.west"));
+        assert!(pattern_within("orders.>", "orders.*"));
+        assert!(!pattern_within("orders.us", "orders.*")); // `*` broader than a concrete token
+        assert!(!pattern_within("orders.us", "billing.us")); // sibling subject
+    }
+
+    #[test]
+    fn import_resolves_only_with_a_matching_export() {
+        let reg = subject_sub_registry();
+        // b's alias `partner.orders.us` resolves cross-tenant to a's `a.orders.us`.
+        assert_eq!(
+            reg.resolve_subject(&tid("b"), "partner.orders.us", Access::Subscribe),
+            Resolution::Crossed {
+                owner: tid("a"),
+                scoped: "a.orders.us".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn import_without_a_matching_export_is_denied_not_own() {
+        // b imports from `a`, but `a` exports NOTHING → the alias is a typed reject, never own-space
+        // and never the exporter's data.
+        let mut imports = HashMap::new();
+        imports.insert(
+            tid("b"),
+            vec![Import {
+                kind: ShareKind::Subject,
+                from: tid("a"),
+                remote: "orders".to_string(),
+                local: "partner.orders".to_string(),
+            }],
+        );
+        let reg = SharingRegistry::new(HashMap::new(), imports);
+        assert_eq!(
+            reg.resolve_subject(&tid("b"), "partner.orders.us", Access::Subscribe),
+            Resolution::Denied
+        );
+    }
+
+    #[test]
+    fn beyond_the_grant_is_denied_no_wildcard_escalation() {
+        let reg = subject_sub_registry(); // grant is `orders.*` (exactly two tokens)
+                                          // A sibling subtree the grant never named.
+        assert_eq!(
+            reg.resolve_subject(&tid("b"), "partner.billing.us", Access::Subscribe),
+            Resolution::Own, // `partner.billing` is not even an alias → own namespace, not the export
+        );
+        // A subscribe that widens past `orders.*` (a deeper `>`): the alias matches but the export
+        // does not cover it → denied.
+        assert_eq!(
+            reg.resolve_subject(&tid("b"), "partner.orders.>", Access::Subscribe),
+            Resolution::Denied
+        );
+        // A deeper concrete subject than `orders.*` allows (three tokens under a two-token grant).
+        assert_eq!(
+            reg.resolve_subject(&tid("b"), "partner.orders.us.west", Access::Subscribe),
+            Resolution::Denied
+        );
+    }
+
+    #[test]
+    fn direction_is_respected_subscribe_only_export_denies_publish() {
+        let reg = subject_sub_registry(); // subscribe-only
+        assert!(matches!(
+            reg.resolve_subject(&tid("b"), "partner.orders.us", Access::Subscribe),
+            Resolution::Crossed { .. }
+        ));
+        // The same alias for a PUBLISH is denied — the export granted subscribe only.
+        assert_eq!(
+            reg.resolve_subject(&tid("b"), "partner.orders.us", Access::Publish),
+            Resolution::Denied
+        );
+    }
+
+    #[test]
+    fn revoking_the_export_stops_the_import() {
+        let granted = subject_sub_registry();
+        assert!(matches!(
+            granted.resolve_subject(&tid("b"), "partner.orders.us", Access::Subscribe),
+            Resolution::Crossed { .. }
+        ));
+        // Reload with the export REMOVED (imports unchanged): the very same alias now resolves to a
+        // typed reject — the grant, not the import, is what authorizes the crossing.
+        let mut imports = HashMap::new();
+        imports.insert(
+            tid("b"),
+            vec![Import {
+                kind: ShareKind::Subject,
+                from: tid("a"),
+                remote: "orders".to_string(),
+                local: "partner.orders".to_string(),
+            }],
+        );
+        let revoked = SharingRegistry::new(HashMap::new(), imports);
+        assert_eq!(
+            revoked.resolve_subject(&tid("b"), "partner.orders.us", Access::Subscribe),
+            Resolution::Denied
+        );
+    }
+
+    #[test]
+    fn audience_default_deny_and_public() {
+        let mk = |audience: Audience| {
+            let mut exports = HashMap::new();
+            exports.insert(
+                tid("a"),
+                vec![Export {
+                    kind: ShareKind::Stream,
+                    name: "orders".to_string(),
+                    audience,
+                    direction: GrantDirection {
+                        subscribe: true,
+                        publish: false,
+                    },
+                }],
+            );
+            let mut imports = HashMap::new();
+            for who in ["b", "c"] {
+                imports.insert(
+                    tid(who),
+                    vec![Import {
+                        kind: ShareKind::Stream,
+                        from: tid("a"),
+                        remote: "orders".to_string(),
+                        local: "partner".to_string(),
+                    }],
+                );
+            }
+            SharingRegistry::new(exports, imports)
+        };
+        // Named only `b`: `c` (also importing) is denied — default-deny for the non-listed tenant.
+        let named = mk(Audience::Tenants([tid("b")].into_iter().collect()));
+        assert!(matches!(
+            named.resolve_stream(&tid("b"), "partner", Access::Subscribe),
+            Resolution::Crossed { .. }
+        ));
+        assert_eq!(
+            named.resolve_stream(&tid("c"), "partner", Access::Subscribe),
+            Resolution::Denied
+        );
+        // Public admits both.
+        let public = mk(Audience::Public);
+        assert!(matches!(
+            public.resolve_stream(&tid("c"), "partner", Access::Subscribe),
+            Resolution::Crossed { .. }
+        ));
+    }
+
+    #[test]
+    fn a_non_imported_name_stays_in_the_importers_own_namespace() {
+        let reg = subject_sub_registry();
+        // b names something with no import alias → phase-1 own-namespace resolution.
+        assert_eq!(
+            reg.resolve_subject(&tid("b"), "internal.metrics", Access::Subscribe),
+            Resolution::Own
+        );
+        assert_eq!(
+            reg.resolve_stream(&tid("b"), "my-own-stream", Access::Publish),
+            Resolution::Own
+        );
+        // And a tenant with no imports at all is always Own (the fast path).
+        assert_eq!(
+            reg.resolve_stream(&tid("z"), "anything", Access::Publish),
+            Resolution::Own
+        );
+    }
+
+    #[test]
+    fn stream_import_exact_and_bidirectional_direction() {
+        let mut exports = HashMap::new();
+        exports.insert(
+            tid("a"),
+            vec![Export {
+                kind: ShareKind::Stream,
+                name: "orders".to_string(),
+                audience: Audience::Public,
+                direction: GrantDirection {
+                    subscribe: true,
+                    publish: true,
+                },
+            }],
+        );
+        let mut imports = HashMap::new();
+        imports.insert(
+            tid("b"),
+            vec![Import {
+                kind: ShareKind::Stream,
+                from: tid("a"),
+                remote: "orders".to_string(),
+                local: "partner-orders".to_string(),
+            }],
+        );
+        let reg = SharingRegistry::new(exports, imports);
+        // Exact alias → exporter's exact stream, both directions.
+        for access in [Access::Subscribe, Access::Publish] {
+            assert_eq!(
+                reg.resolve_stream(&tid("b"), "partner-orders", access),
+                Resolution::Crossed {
+                    owner: tid("a"),
+                    scoped: "a/orders".to_string(),
+                }
+            );
+        }
+        // A near-miss on the exact stream alias is NOT an alias → own namespace.
+        assert_eq!(
+            reg.resolve_stream(&tid("b"), "partner-orders-x", Access::Subscribe),
+            Resolution::Own
+        );
+    }
+
+    #[test]
+    fn two_importers_of_the_same_export_are_independent() {
+        let mut exports = HashMap::new();
+        exports.insert(
+            tid("a"),
+            vec![Export {
+                kind: ShareKind::Stream,
+                name: "feed".to_string(),
+                audience: Audience::Public,
+                direction: GrantDirection {
+                    subscribe: true,
+                    publish: false,
+                },
+            }],
+        );
+        let mut imports = HashMap::new();
+        imports.insert(
+            tid("b"),
+            vec![Import {
+                kind: ShareKind::Stream,
+                from: tid("a"),
+                remote: "feed".to_string(),
+                local: "b-feed".to_string(),
+            }],
+        );
+        imports.insert(
+            tid("c"),
+            vec![Import {
+                kind: ShareKind::Stream,
+                from: tid("a"),
+                remote: "feed".to_string(),
+                local: "c-feed".to_string(),
+            }],
+        );
+        let reg = SharingRegistry::new(exports, imports);
+        // Both resolve to the SAME exporter stream under their OWN alias — independent aliases, one
+        // shared source.
+        assert_eq!(
+            reg.resolve_stream(&tid("b"), "b-feed", Access::Subscribe),
+            Resolution::Crossed {
+                owner: tid("a"),
+                scoped: "a/feed".to_string()
+            }
+        );
+        assert_eq!(
+            reg.resolve_stream(&tid("c"), "c-feed", Access::Subscribe),
+            Resolution::Crossed {
+                owner: tid("a"),
+                scoped: "a/feed".to_string()
+            }
+        );
+        // b's alias is meaningless for c and vice-versa.
+        assert_eq!(
+            reg.resolve_stream(&tid("c"), "b-feed", Access::Subscribe),
+            Resolution::Own
+        );
+    }
+
+    #[test]
+    fn validators_are_fail_closed() {
+        assert!(validate_share_subject("orders.*", true).is_ok());
+        assert!(validate_share_subject("orders.>", true).is_ok());
+        assert!(validate_share_subject("orders.>.tail", true).is_err()); // `>` not last
+        assert!(validate_share_subject("orders.*", false).is_err()); // no wildcards in an alias
+        assert!(validate_share_subject("a..b", true).is_err()); // empty token
+        assert!(validate_share_subject("a/b", true).is_err()); // `/` forbidden
+        assert!(validate_share_subject("partner.orders", false).is_ok());
+        assert!(validate_share_stream("orders").is_ok());
+        assert!(validate_share_stream("a/b").is_err());
+        assert!(validate_share_stream("a*").is_err());
+        assert!(validate_share_stream("").is_err());
     }
 }


### PR DESCRIPTION
## Multi-tenant phase-2: controlled cross-tenant import/export

Closes #1163. Phase-1 (#1162) made the tenant boundary **absolute** via server-applied prefixing. This PR adds the **one** deliberate, allowlisted, revocable way to cross it — NATS-accounts-style import/export. It is a controlled **alias**, never a new namespace: an import resolves (with authorization) a local alias to the **exporter's** already-prefixed resource, and nothing crosses without a matching export on the other side. **This is a security boundary — a bug = ambient cross-tenant access = breach.**

### The grant model (the pure authz core lives in `tenant.rs`)

- **EXPORT** (the grant): a tenant declares a `stream` (exact) or `subject` (pattern) it shares, `to` whom (`"public"` or a tenant allowlist), and the `access` direction(s) (`subscribe` / `publish` / both). The export defines *exactly* what is shared.
- **IMPORT** (the use): the importing tenant maps an exported resource into its own namespace under a local alias — a stream rename, or a literal subject token-prefix rewrite (e.g. import A's `orders` as `partner.orders`).
- **RESOLUTION** (`SharingRegistry::resolve`, the one boundary-crossing decision):
  - not an import alias → `Own` (phase-1 scoping, untouched);
  - an alias that a **matching export** authorizes (same kind, audience admits the importer, direction permits the op, and the export pattern covers the resolved name) → `Crossed` to `<exporter>/…` (stream) or `<exporter>.…` (subject);
  - an alias with **no** backing export → `Denied`: a typed `ERR_IMPORT_NOT_GRANTED` reject — **never** own-namespace, **never** the exporter's other resources.

### Config

Nested tables under each `[[tenant]]`:

```toml
[[tenant]]
name = "acme"

[[tenant.export]]
stream = "orders"        # or subject = "orders.*"
to     = ["globex"]      # or "public"
access = ["subscribe"]   # subset of [subscribe, publish]

[[tenant]]
name = "globex"

[[tenant.import]]
from   = "acme"
stream = "orders"        # exporter's resource (literal)
as     = "partner"       # local alias
```

Parsed fail-closed: exactly one of `stream`/`subject`; `to` is `"public"` or a non-empty tenant list; `access` a non-empty subscribe/publish subset; import aliases are literal (no wildcards — the export's pattern is what bounds the shared set).

### Security invariants, each enforced

| Invariant | Enforcement |
|---|---|
| No export ⇒ no crossing | an alias with no matching export is `Denied` → `ERR_IMPORT_NOT_GRANTED`; no data crosses |
| Exactly-the-grant (no escalation) | subject **publish** must MATCH the export pattern, **subscribe** must be WITHIN it (`pattern_within`); no sibling subtree, no `*`/`>` past the grant; streams are exact |
| Direction respected | a subscribe-only export denies a cross-tenant publish |
| Isolation preserved | a non-imported name stays in the importer's own tenant; a cross-tenant **subscribe** scopes the consumer group under the **importer**, so its cursor on the exporter's shared stream can never collide with / advance the exporter's own group cursors |
| Default byte-identity | no import/export config ⇒ no `SharingRegistry` ⇒ every resolution is `Own` ⇒ byte-for-byte the phase-1 broker |
| Revoke is effective | removing the export makes the same alias resolve to a typed reject on the next resolution |

### Wiring (`session.rs`)

The layer is consulted at every subscribe/publish seam — `SubTo`, `PubTo`, `StreamInfo`, `PubSubject`, and both `SubSubject` arms (filtered + single-home). A cross-tenant **produce** charges the **exporter's** byte/stream quotas (the bytes land in the exporter's log, so its accounting stays honest and an importer can't dodge the exporter's cap).

### Tests (the AUTHZ suite is the point)

- **Pure authz unit suite** (`tenant.rs`): subject matcher + `pattern_within`, import-only-with-export, **import-without-export-denied**, **beyond-grant-denied** (no wildcard escalation), direction, **revoke**, audience default-deny/public, two independent importers, fail-closed validators.
- **End-to-end AUTHZ suite** (`session.rs`, real sessions over a real engine): stream read/write via alias, subject filtered cross-tenant read, **import-without-export reject with no data leak**, **beyond-grant reject**, subscribe-only-denies-publish, **revoke stops the import**, non-imported stays isolated (phase-1), two importers independent.

New wire code `ERR_IMPORT_NOT_GRANTED`, registered in the proto decoder and pinned in the frozen-taxonomy tests.

### Gates (all green, run foreground)

- `cargo test --workspace --all-features --locked` → **0 failed, 3613 passed** (59 binaries)
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` → **clean**
- `cargo fmt --all --check` → **clean**
- format-registry gate → **ok** (no on-disk/wire layout change)
- golden-path acceptance → **PASS**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01McmNfYNWPmohVS8umY9Lkp
