### PR TITLE
feat(storage): S3 backend for cold-segment offload — ring-free, aws-lc-rs SigV4 (#643 phase 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,6 +155,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
 dependencies = [
  "aws-lc-sys",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -1158,16 +1159,26 @@ version = "0.1.0"
 dependencies = [
  "aes-gcm",
  "arc-swap",
+ "aws-lc-rs",
  "bytes",
  "chacha20poly1305",
  "crc32c",
  "criterion",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
  "ironbus-core",
  "libc",
  "proptest",
+ "rustls",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "tempfile",
+ "tokio",
+ "tokio-rustls",
+ "tracing",
  "zeroize",
 ]
 
@@ -1779,7 +1790,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -1837,7 +1848,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -2358,6 +2369,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"

--- a/crates/ironbus-storage/Cargo.toml
+++ b/crates/ironbus-storage/Cargo.toml
@@ -27,6 +27,28 @@ zstd = ["ironbus-core/zstd"]
 # always-linked `ironbus-core`/`loss`, so even a DEFAULT (no-encryption) build DETECTS an encrypted
 # segment and fail-closes on it; only the AEAD primitives and the key loader are behind this feature.
 encryption = ["dep:aes-gcm", "dep:chacha20poly1305", "dep:zeroize"]
+# OPT-IN s3 (#643 phase 2): the S3 cold-segment offload backend. A small, PURPOSE-BUILT S3 client (the
+# four ColdStore verbs = four S3 requests: PUT/GET/DELETE/HEAD — no XML response parsing) with SigV4
+# request signing over aws-lc-rs and HTTPS over the SAME rustls + aws-lc-rs stack the `tls` feature
+# already ships. NON-DEFAULT and excludable from `edge-min` exactly like `tls`/`zstd`/`encryption`. It
+# pulls NO new crate into the tree — every dependency below is already in the workspace lock (from the
+# TLS stack + the otlp exporter) — so the DEFAULT graph stays clean and MSRV-1.78 + cargo-deny are
+# unaffected. Crucially it links NO `ring` and NO XML parser: the crypto is aws-lc-rs only (ADR-0004),
+# whose vendored-C `aws-lc-sys` is the SAME feature-scoped C-FFI the `tls` feature already allow-lists
+# in deny.toml (so NO deny.toml change is needed and `ring`/`openssl-sys`/`native-tls` stay banned).
+s3 = [
+    "dep:aws-lc-rs",
+    "dep:rustls",
+    "dep:rustls-pki-types",
+    "dep:tokio-rustls",
+    "dep:tokio",
+    "dep:hyper",
+    "dep:hyper-util",
+    "dep:http",
+    "dep:http-body-util",
+    "dep:tracing",
+    "dep:zeroize",
+]
 
 [dependencies]
 # `arc-swap` backs the lock-free off-actor consume READ plane (#539): the writer swaps in an
@@ -65,6 +87,31 @@ chacha20poly1305 = { version = "0.10.1", default-features = false, features = ["
 # Zeroize the 32-byte key material on drop so a loaded key does not linger in freed heap. Pinned to
 # match the server's `=1.8.2` so the lock unifies to one `zeroize`.
 zeroize = { version = "1.8.2", default-features = false, optional = true }
+
+# The S3 cold-segment backend (#643 phase 2), the OPT-IN `s3` feature ONLY. EVERY crate here is already
+# in the workspace lock (pulled by the server/client TLS stack + the otlp exporter), so the `s3` feature
+# adds ZERO new crates: MSRV-1.78 and cargo-deny are unaffected, and the DEFAULT graph is untouched.
+# `aws-lc-rs` provides the SigV4 HMAC-SHA256 + SHA256 primitives (ADR-0004's crypto provider; its
+# vendored-C `aws-lc-sys` is the SAME feature-scoped C-FFI the `tls` feature already allow-lists in
+# deny.toml — NO deny change, and `ring` stays banned + unreachable). `rustls`/`tokio-rustls` are built
+# `default-features = false` + `aws-lc-rs` so they carry aws-lc-rs and NEVER ring (exactly like the
+# server/client TLS 1.3-only stack); `rustls-pki-types` (`pem`) parses the CA trust anchor. `hyper`
+# (http1 client) + `hyper-util` (the tokio IO adapter) + `http` + `http-body-util` are the minimal HTTP
+# surface. `tokio` (rt+net+time+io-util) is the current-thread runtime bridging the async client to the
+# sync ColdStore trait.
+aws-lc-rs = { version = "1", optional = true }
+rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs", "std"], optional = true }
+rustls-pki-types = { version = "1", features = ["std"], optional = true }
+tokio-rustls = { version = "0.26", default-features = false, features = ["aws-lc-rs"], optional = true }
+tokio = { version = "1", default-features = false, features = ["rt", "net", "time", "io-util"], optional = true }
+hyper = { version = "1", default-features = false, features = ["client", "http1"], optional = true }
+hyper-util = { version = "0.1", default-features = false, features = ["tokio"], optional = true }
+http = { version = "1", default-features = false, optional = true }
+http-body-util = { version = "0.1", default-features = false, optional = true }
+# The `s3` feature only: `tracing` for the plaintext-http-credentials warning (already in the lock via
+# the server); `zeroize` (already declared above for `encryption`) to wipe the derived SigV4 signing
+# key from memory after signing. Both pure Rust, already in the lock — no new crate.
+tracing = { version = "0.1", default-features = false, optional = true }
 
 # The cross-platform segment-preallocation primitive (#330, `docs/PREALLOCATION.md`) needs the
 # per-OS reservation syscall (Linux `posix_fallocate`, macOS `fcntl(F_PREALLOCATE)`). `libc` is the

--- a/crates/ironbus-storage/src/cold.rs
+++ b/crates/ironbus-storage/src/cold.rs
@@ -1,6 +1,12 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-//! Tiered storage: offloading cold, SEALED, immutable segments to an object store (#643, V2-M10,
-//! phase 1 — the Kafka KIP-405 / Pulsar / Redpanda tiered-storage class).
+//! Tiered storage: offloading cold, SEALED, immutable segments to an object store (#643, V2-M10 —
+//! the Kafka KIP-405 / Pulsar / Redpanda tiered-storage class).
+//!
+//! Phase 1 (#1152) shipped the mechanism + the local-directory [`FsColdStore`] backend; phase 2
+//! (#643) adds the S3 backend [`S3ColdStore`] behind the OFF-BY-DEFAULT `s3` feature — a small,
+//! purpose-built S3 client (`SigV4` request signing over aws-lc-rs; HTTPS over the same rustls +
+//! aws-lc-rs stack the `tls` feature already ships) that pulls NO `ring`, NO XML parser, and NO new
+//! crate into the tree (ADR-0004: aws-lc-rs is the sole crypto provider).
 //!
 //! A sealed segment is immutable (its footer is written, no in-place mutation ever races), which
 //! makes it the natural tiering unit: it can be copied to a cheap, high-capacity backing store and
@@ -15,9 +21,10 @@
 //! [`ColdStore`] is a tiny key/blob interface (`put`/`get`/`delete`/`exists`) over an opaque object
 //! key. Phase 1 ships one backend, [`FsColdStore`], which stores each object as a file in a
 //! directory (any [`crate::fs::Filesystem`]: an on-disk [`crate::fs::StdFs`] rooted at a local path
-//! or an NFS mount, or an in-memory filesystem for tests). A real S3 / `object_store` backend is a
-//! feature-gated follow-up: because it is just another `impl ColdStore`, it drops in with no change
-//! to the log's offload/fetch/recover machinery.
+//! or an NFS mount, or an in-memory filesystem for tests). Phase 2 adds [`S3ColdStore`] behind the
+//! `s3` feature: it is just another `impl ColdStore`, so it drops into the log's
+//! offload/fetch/recover machinery with NO change to any of that crash-safety logic (it is
+//! backend-agnostic — proven identically with either backend).
 //!
 //! ## The durability contract (where a bug is PERMANENT DATA LOSS)
 //!
@@ -330,6 +337,834 @@ impl<F: Filesystem> ColdStore for FsColdStore<F> {
 
     fn exists(&self, key: &str) -> Result<bool, ColdStoreError> {
         Ok(self.fs.exists(key)?)
+    }
+}
+
+// =================================================================================================
+// S3 backend (#643 phase 2): a `ColdStore` speaking S3 directly, behind the OFF-BY-DEFAULT `s3`
+// feature. This is a small, PURPOSE-BUILT S3 client — NOT a general object-storage crate — so it
+// pulls no `ring`, no XML parser, and no new crate into the tree (ADR-0004: aws-lc-rs is the sole
+// crypto provider). The four `ColdStore` verbs map to four S3 requests: PUT (upload), GET (download),
+// DELETE (idempotent), HEAD (exists) — none needs an XML response body, so a non-2xx is a typed error
+// read from the STATUS line, never a parsed error document.
+//
+// `S3ColdStore` is a drop-in `impl ColdStore`; the log's crash-safe offload/fetch/recover/reap
+// machinery is UNCHANGED. See `tests/cold_s3.rs` (a mock S3 server) + the `SigV4` vector tests below.
+// =================================================================================================
+#[cfg(feature = "s3")]
+pub use s3_backend::{S3ColdStore, S3ColdStoreConfig};
+
+#[cfg(feature = "s3")]
+mod s3_backend {
+    use super::{ColdStore, ColdStoreError};
+    use std::io;
+    use std::sync::Arc;
+    use std::time::{Duration, SystemTime};
+    use zeroize::Zeroize;
+
+    /// The default per-step network timeout for a connect (a hung/blackholed endpoint must NOT wedge
+    /// the single-writer append actor). Overridable via [`S3ColdStoreConfig::connect_timeout`].
+    const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+    /// The default per-step network timeout for the HTTP request + response body. Overridable via
+    /// [`S3ColdStoreConfig::request_timeout`].
+    const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
+
+    /// The AWS service name for the `SigV4` credential scope.
+    const SERVICE: &str = "s3";
+    /// The `SigV4` algorithm identifier.
+    const ALGORITHM: &str = "AWS4-HMAC-SHA256";
+    /// The final scope terminator.
+    const AWS4_REQUEST: &str = "aws4_request";
+    /// SHA-256 of the empty string — the `x-amz-content-sha256` for a bodyless GET/DELETE/HEAD.
+    const EMPTY_SHA256: &str = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+    /// Connection + credential parameters for the [`S3ColdStore`] backend (#643 phase 2). `FsColdStore`
+    /// stays the default; this selects the S3 backend.
+    #[derive(Clone, Default)]
+    pub struct S3ColdStoreConfig {
+        /// The S3 bucket the log's cold objects live in.
+        pub bucket: String,
+        /// An object-key prefix within the bucket (the per-log root — the engine gives each log its own
+        /// prefix so the flat [`super::cold_object_name`] keys never collide across logs). May be empty.
+        pub prefix: String,
+        /// The AWS region (e.g. `us-east-1`) — part of the `SigV4` scope and the default endpoint host.
+        pub region: String,
+        /// An explicit endpoint URL for an S3-COMPATIBLE store (`MinIO`/Ceph/R2/`LocalStack`), e.g.
+        /// `https://s3.example.com` or `http://127.0.0.1:9000`. `None` = real AWS S3
+        /// (`s3.<region>.amazonaws.com`).
+        pub endpoint: Option<String>,
+        /// Path-style addressing (`/<bucket>/<key>`) vs virtual-hosted (`<bucket>.<host>/<key>`).
+        /// `true` for most S3-compatible stores + `LocalStack`; real AWS accepts either.
+        pub path_style: bool,
+        /// The AWS access key id (`SigV4` credential).
+        pub access_key_id: String,
+        /// The AWS secret access key (`SigV4` signing secret). Redacted in `Debug`.
+        pub secret_access_key: String,
+        /// An optional session token for temporary/STS credentials (sent as `x-amz-security-token`).
+        /// Redacted in `Debug`.
+        pub session_token: Option<String>,
+        /// The trust-anchor (CA) PEM bundle used to VERIFY the endpoint's certificate over HTTPS
+        /// (e.g. the Amazon root CA chain, or the system bundle bytes). REQUIRED for an `https`
+        /// endpoint; ignored for a plaintext `http` endpoint. Loading OS/bundled roots automatically
+        /// is a documented follow-up.
+        pub ca_pem: Option<Vec<u8>>,
+        /// The bound on a single TCP connect + TLS handshake. A hung/blackholed endpoint (accepts the
+        /// connection, never responds) must NEVER wedge the single-writer append actor, so every
+        /// network step is time-bounded; on expiry the op fails with a RETRYABLE typed error (a
+        /// timeout is never treated as "object absent"). `None` uses [`DEFAULT_CONNECT_TIMEOUT`] (30s).
+        pub connect_timeout: Option<Duration>,
+        /// The bound on the HTTP request send and on the response-body read (each separately). `None`
+        /// uses [`DEFAULT_REQUEST_TIMEOUT`] (60s). See [`S3ColdStoreConfig::connect_timeout`].
+        pub request_timeout: Option<Duration>,
+    }
+
+    impl std::fmt::Debug for S3ColdStoreConfig {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            // Redact the secret credential material (#882 redaction discipline): the secret key and
+            // session token are never printed.
+            f.debug_struct("S3ColdStoreConfig")
+                .field("bucket", &self.bucket)
+                .field("prefix", &self.prefix)
+                .field("region", &self.region)
+                .field("endpoint", &self.endpoint)
+                .field("path_style", &self.path_style)
+                .field("access_key_id", &self.access_key_id)
+                .field("secret_access_key", &"<redacted>")
+                .field(
+                    "session_token",
+                    &self.session_token.as_ref().map(|_| "<redacted>"),
+                )
+                .field("has_ca_pem", &self.ca_pem.is_some())
+                .field("connect_timeout", &self.connect_timeout)
+                .field("request_timeout", &self.request_timeout)
+                .finish()
+        }
+    }
+
+    /// Lowercase-hex encode.
+    fn hex_lower(bytes: &[u8]) -> String {
+        const HEX: &[u8; 16] = b"0123456789abcdef";
+        let mut out = String::with_capacity(bytes.len() * 2);
+        for &b in bytes {
+            out.push(HEX[(b >> 4) as usize] as char);
+            out.push(HEX[(b & 0x0f) as usize] as char);
+        }
+        out
+    }
+
+    /// SHA-256 of `data`, lowercase hex (aws-lc-rs — no `ring`).
+    fn sha256_hex(data: &[u8]) -> String {
+        hex_lower(aws_lc_rs::digest::digest(&aws_lc_rs::digest::SHA256, data).as_ref())
+    }
+
+    /// HMAC-SHA256(`key`, `msg`) raw bytes (aws-lc-rs — no `ring`).
+    fn hmac_sha256(key: &[u8], msg: &[u8]) -> Vec<u8> {
+        let k = aws_lc_rs::hmac::Key::new(aws_lc_rs::hmac::HMAC_SHA256, key);
+        aws_lc_rs::hmac::sign(&k, msg).as_ref().to_vec()
+    }
+
+    /// RFC 3986 percent-encode for the `SigV4` canonical URI. Leaves the unreserved set
+    /// (`A-Z a-z 0-9 - . _ ~`) as-is; when `encode_slash` is false, `/` is also left (S3 path segments).
+    fn uri_encode(input: &str, encode_slash: bool) -> String {
+        const UPPER_HEX: &[u8; 16] = b"0123456789ABCDEF";
+        let mut out = String::with_capacity(input.len());
+        for &b in input.as_bytes() {
+            match b {
+                b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                    out.push(b as char);
+                }
+                b'/' if !encode_slash => out.push('/'),
+                _ => {
+                    out.push('%');
+                    out.push(UPPER_HEX[(b >> 4) as usize] as char);
+                    out.push(UPPER_HEX[(b & 0x0f) as usize] as char);
+                }
+            }
+        }
+        out
+    }
+
+    /// The `SigV4` signing key: the four-step HMAC-SHA256 derivation
+    /// `kSigning = HMAC(HMAC(HMAC(HMAC("AWS4"+secret, date), region), service), "aws4_request")`.
+    fn signing_key(secret: &str, date_stamp: &str, region: &str, service: &str) -> Vec<u8> {
+        let mut seed = format!("AWS4{secret}");
+        let mut k_date = hmac_sha256(seed.as_bytes(), date_stamp.as_bytes());
+        let mut k_region = hmac_sha256(&k_date, region.as_bytes());
+        let mut k_service = hmac_sha256(&k_region, service.as_bytes());
+        let k_signing = hmac_sha256(&k_service, AWS4_REQUEST.as_bytes());
+        // Defense-in-depth: wipe every intermediate that is derived directly from the secret.
+        seed.zeroize();
+        k_date.zeroize();
+        k_region.zeroize();
+        k_service.zeroize();
+        k_signing
+    }
+
+    /// Everything needed to compute one `SigV4` signature. Generic over the header set + service so the
+    /// AWS published test vectors (service `service`/`iam`) and the S3 client (service `s3`) both drive
+    /// the SAME code — the load-bearing correctness path.
+    struct SigningRequest<'a> {
+        method: &'a str,
+        /// The already-percent-encoded canonical URI (also the on-wire request target).
+        canonical_uri: &'a str,
+        /// The canonical query string (empty for the four `ColdStore` verbs).
+        canonical_query: &'a str,
+        /// The request headers to sign, `(lowercase-name, value)`; MUST include `host`.
+        headers: &'a [(String, String)],
+        /// Hex SHA-256 of the payload (the `x-amz-content-sha256` value).
+        payload_sha256: &'a str,
+        /// `YYYYMMDDTHHMMSSZ`.
+        amz_date: &'a str,
+        /// `YYYYMMDD`.
+        date_stamp: &'a str,
+        region: &'a str,
+        service: &'a str,
+        access_key_id: &'a str,
+        secret_access_key: &'a str,
+    }
+
+    impl SigningRequest<'_> {
+        /// Computes the `Authorization` header value (and the signed-headers list) per AWS `SigV4`.
+        fn authorization(&self) -> String {
+            // Canonical + signed headers: sort by lowercase name, trim values.
+            let mut hs: Vec<(String, String)> = self
+                .headers
+                .iter()
+                .map(|(n, v)| (n.to_ascii_lowercase(), v.trim().to_string()))
+                .collect();
+            hs.sort_by(|a, b| a.0.cmp(&b.0));
+            let mut canonical_headers = String::new();
+            for (n, v) in &hs {
+                canonical_headers.push_str(n);
+                canonical_headers.push(':');
+                canonical_headers.push_str(v);
+                canonical_headers.push('\n');
+            }
+            let signed_headers = hs
+                .iter()
+                .map(|(n, _)| n.as_str())
+                .collect::<Vec<_>>()
+                .join(";");
+
+            let canonical_request = format!(
+                "{}\n{}\n{}\n{}\n{}\n{}",
+                self.method,
+                self.canonical_uri,
+                self.canonical_query,
+                canonical_headers,
+                signed_headers,
+                self.payload_sha256,
+            );
+            let scope = format!(
+                "{}/{}/{}/{}",
+                self.date_stamp, self.region, self.service, AWS4_REQUEST
+            );
+            let string_to_sign = format!(
+                "{}\n{}\n{}\n{}",
+                ALGORITHM,
+                self.amz_date,
+                scope,
+                sha256_hex(canonical_request.as_bytes()),
+            );
+            let mut key = signing_key(
+                self.secret_access_key,
+                self.date_stamp,
+                self.region,
+                self.service,
+            );
+            let signature = hex_lower(&hmac_sha256(&key, string_to_sign.as_bytes()));
+            key.zeroize(); // wipe the derived signing key once the signature is computed
+            format!(
+                "{} Credential={}/{}, SignedHeaders={}, Signature={}",
+                ALGORITHM, self.access_key_id, scope, signed_headers, signature
+            )
+        }
+    }
+
+    /// Formats a wall-clock instant as the `SigV4` `(amz_date = YYYYMMDDTHHMMSSZ, date_stamp = YYYYMMDD)`
+    /// pair, in UTC, with no external calendar dependency.
+    fn format_amz_date(now: SystemTime) -> (String, String) {
+        let secs = now
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .map_or(0, |d| d.as_secs());
+        let days = i64::try_from(secs / 86_400).unwrap_or(0);
+        let rem = secs % 86_400;
+        let (hour, min, sec) = (rem / 3600, (rem % 3600) / 60, rem % 60);
+        let (year, month, day) = civil_from_days(days);
+        (
+            format!("{year:04}{month:02}{day:02}T{hour:02}{min:02}{sec:02}Z"),
+            format!("{year:04}{month:02}{day:02}"),
+        )
+    }
+
+    /// Days-since-Unix-epoch -> `(year, month, day)` (UTC), Howard Hinnant's `civil_from_days`.
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    fn civil_from_days(days: i64) -> (i64, u32, u32) {
+        let z = days + 719_468;
+        let era = (if z >= 0 { z } else { z - 146_096 }) / 146_097;
+        let doe = z - era * 146_097; // [0, 146096]
+        let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365; // [0, 399]
+        let year = yoe + era * 400;
+        let doy = doe - (365 * yoe + yoe / 4 - yoe / 100); // [0, 365]
+        let mp = (5 * doy + 2) / 153; // [0, 11]
+        let day = (doy - (153 * mp + 2) / 5 + 1) as u32; // [1, 31]
+        let month = (if mp < 10 { mp + 3 } else { mp - 9 }) as u32; // [1, 12]
+        (if month <= 2 { year + 1 } else { year }, month, day)
+    }
+
+    /// A `ColdStore` that stores each offloaded segment as an S3 object (#643 phase 2). Whole-object
+    /// PUT/GET/DELETE/HEAD, `SigV4`-signed over aws-lc-rs, HTTPS over rustls + aws-lc-rs. The async S3
+    /// requests are driven from the sync `ColdStore` trait by one tokio CURRENT-THREAD runtime +
+    /// `block_on` (safe under the log's single-writer append actor — a plain sync thread never inside a
+    /// runtime, so `block_on` never re-enters a running one; the actor serializes cold-store calls).
+    pub struct S3ColdStore {
+        config: S3ColdStoreConfig,
+        /// The rustls client config for HTTPS (`None` for a plaintext `http` endpoint).
+        tls: Option<Arc<rustls::ClientConfig>>,
+        /// Whether the endpoint is HTTPS.
+        https: bool,
+        /// The connect + `Host`-header + SNI host (already accounts for path-style vs virtual-hosted).
+        host: String,
+        /// The connect port.
+        port: u16,
+        /// The resolved bound on a connect + TLS handshake.
+        connect_timeout: Duration,
+        /// The resolved bound on the request send and the response-body read.
+        request_timeout: Duration,
+        runtime: tokio::runtime::Runtime,
+    }
+
+    impl std::fmt::Debug for S3ColdStore {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("S3ColdStore")
+                .field("config", &self.config)
+                .field("https", &self.https)
+                .field("host", &self.host)
+                .field("port", &self.port)
+                .finish_non_exhaustive()
+        }
+    }
+
+    /// A small typed `io::Error` for an S3-backend failure (mapped to [`ColdStoreError::Io`]).
+    fn io_error(msg: impl Into<String>) -> ColdStoreError {
+        ColdStoreError::Io(io::Error::other(msg.into()))
+    }
+
+    /// A typed, RETRYABLE timeout error for a hung network step. Mapped to [`ColdStoreError::Io`] with
+    /// [`io::ErrorKind::TimedOut`] — NEVER [`ColdStoreError::NotFound`] (a timeout is not "object
+    /// absent"), so offload retries next tick and a fetch-on-read fails closed-retryable, never
+    /// deleting the local segment.
+    fn timeout_error(op: &str, dur: Duration) -> ColdStoreError {
+        ColdStoreError::Io(io::Error::new(
+            io::ErrorKind::TimedOut,
+            format!("S3 {op} timed out after {dur:?}"),
+        ))
+    }
+
+    /// Whether `host` is loopback/local (exempt from the plaintext-credentials warning).
+    fn host_is_local(host: &str) -> bool {
+        host == "localhost" || host == "::1" || host.starts_with("127.")
+    }
+
+    impl S3ColdStore {
+        /// Builds an S3 cold-store backend from `config` (#643 phase 2). This is the production tiering
+        /// backend, selected by config in place of the default [`FsColdStore`].
+        ///
+        /// # Errors
+        /// [`ColdStoreError::Io`] if the endpoint URL is malformed, if an `https` endpoint is configured
+        /// without a `ca_pem` trust anchor (or the PEM has none), or if the tokio runtime cannot build.
+        pub fn new(config: S3ColdStoreConfig) -> Result<S3ColdStore, ColdStoreError> {
+            let (https, endpoint_host, port) = parse_endpoint(&config)?;
+            // Path-style => connect to the endpoint host, bucket goes in the path. Virtual-hosted =>
+            // the bucket is a host-name label. The chosen host is the Host header + SNI + connect host.
+            let host = if config.path_style {
+                endpoint_host
+            } else {
+                format!("{}.{}", config.bucket, endpoint_host)
+            };
+            let tls = if https {
+                let ca = config.ca_pem.as_deref().ok_or_else(|| {
+                    io_error("S3 cold store over https requires a ca_pem trust anchor")
+                })?;
+                Some(build_client_config(ca)?)
+            } else {
+                None
+            };
+            // #557-style warning: static credentials sent over a plaintext http:// endpoint to a
+            // REMOTE host are exposed on the wire. Real AWS (endpoint None) is always https; this only
+            // catches a misconfigured explicit http:// remote (a local dev endpoint is exempt).
+            if !https && !config.access_key_id.is_empty() && !host_is_local(&host) {
+                tracing::warn!(
+                    host = %host,
+                    "S3 cold store is sending credentials over a PLAINTEXT http:// endpoint to a \
+                     non-local host; the access key + SigV4 signature are exposed on the wire — use \
+                     an https endpoint in production"
+                );
+            }
+            let connect_timeout = config.connect_timeout.unwrap_or(DEFAULT_CONNECT_TIMEOUT);
+            let request_timeout = config.request_timeout.unwrap_or(DEFAULT_REQUEST_TIMEOUT);
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .map_err(ColdStoreError::Io)?;
+            Ok(S3ColdStore {
+                config,
+                tls,
+                https,
+                host,
+                port,
+                connect_timeout,
+                request_timeout,
+                runtime,
+            })
+        }
+
+        /// The full S3 object key for a bare `ColdStore` key: `<prefix>/<key>` (or `<key>` if no prefix).
+        fn object_key(&self, key: &str) -> String {
+            let prefix = self.config.prefix.trim_matches('/');
+            if prefix.is_empty() {
+                key.to_string()
+            } else {
+                format!("{prefix}/{key}")
+            }
+        }
+
+        /// The request path (path-style prepends the bucket), percent-encoded as the canonical URI.
+        fn request_path(&self, key: &str) -> String {
+            let object_key = self.object_key(key);
+            let raw = if self.config.path_style {
+                format!("/{}/{}", self.config.bucket, object_key)
+            } else {
+                format!("/{object_key}")
+            };
+            uri_encode(&raw, false)
+        }
+
+        /// Signs + sends one S3 request, returning `(status, response_body)`. A transport / TLS /
+        /// connect failure is a [`ColdStoreError::Io`]; HTTP status handling is the caller's.
+        async fn send(
+            &self,
+            method: &str,
+            key: &str,
+            body: Vec<u8>,
+        ) -> Result<(http::StatusCode, Vec<u8>), ColdStoreError> {
+            let canonical_uri = self.request_path(key);
+            let payload_sha256 = if body.is_empty() {
+                EMPTY_SHA256.to_string()
+            } else {
+                sha256_hex(&body)
+            };
+            let (amz_date, date_stamp) = format_amz_date(SystemTime::now());
+
+            let mut headers = vec![
+                ("host".to_string(), self.host.clone()),
+                ("x-amz-content-sha256".to_string(), payload_sha256.clone()),
+                ("x-amz-date".to_string(), amz_date.clone()),
+            ];
+            if let Some(token) = &self.config.session_token {
+                headers.push(("x-amz-security-token".to_string(), token.clone()));
+            }
+            let authorization = SigningRequest {
+                method,
+                canonical_uri: &canonical_uri,
+                canonical_query: "",
+                headers: &headers,
+                payload_sha256: &payload_sha256,
+                amz_date: &amz_date,
+                date_stamp: &date_stamp,
+                region: &self.config.region,
+                service: SERVICE,
+                access_key_id: &self.config.access_key_id,
+                secret_access_key: &self.config.secret_access_key,
+            }
+            .authorization();
+
+            let mut builder = http::Request::builder().method(method).uri(&canonical_uri);
+            for (name, value) in &headers {
+                builder = builder.header(name.as_str(), value.as_str());
+            }
+            builder = builder.header("authorization", authorization);
+            let request = builder
+                .body(http_body_util::Full::new(bytes::Bytes::from(body)))
+                .map_err(|e| io_error(format!("building the S3 request failed: {e}")))?;
+
+            self.round_trip(request).await
+        }
+
+        /// Opens a fresh connection (TCP, + TLS for https), runs the HTTP/1.1 exchange, collects the
+        /// response body. EVERY network step is time-bounded so a hung/blackholed endpoint cannot wedge
+        /// the single-writer append actor; on expiry the step returns a RETRYABLE typed timeout error.
+        async fn round_trip(
+            &self,
+            request: http::Request<http_body_util::Full<bytes::Bytes>>,
+        ) -> Result<(http::StatusCode, Vec<u8>), ColdStoreError> {
+            let connect_to = self.connect_timeout;
+            let request_to = self.request_timeout;
+
+            // 1. TCP connect (bounded).
+            let tcp = tokio::time::timeout(
+                connect_to,
+                tokio::net::TcpStream::connect((self.host.as_str(), self.port)),
+            )
+            .await
+            .map_err(|_| timeout_error("connect", connect_to))?
+            .map_err(ColdStoreError::Io)?;
+
+            // 2. TLS handshake for https (bounded).
+            let conn = if self.https {
+                let server_name = rustls::pki_types::ServerName::try_from(self.host.clone())
+                    .map_err(|_| io_error("the S3 endpoint host is not a valid TLS server name"))?;
+                let tls = self
+                    .tls
+                    .clone()
+                    .ok_or_else(|| io_error("S3 https endpoint has no TLS config"))?;
+                let stream = tokio::time::timeout(
+                    connect_to,
+                    tokio_rustls::TlsConnector::from(tls).connect(server_name, tcp),
+                )
+                .await
+                .map_err(|_| timeout_error("TLS handshake", connect_to))?
+                .map_err(ColdStoreError::Io)?;
+                Connection::Tls(Box::new(stream))
+            } else {
+                Connection::Plain(tcp)
+            };
+
+            // 3. HTTP handshake + request + body, driven concurrently with the connection task. The
+            // driver is ABORTED on EVERY exit path (success or error) so no parked task lingers for the
+            // next `block_on`.
+            let (mut sender, driver) =
+                hyper::client::conn::http1::handshake(hyper_util::rt::TokioIo::new(conn))
+                    .await
+                    .map_err(|e| io_error(format!("S3 HTTP handshake failed: {e}")))?;
+            let driver = tokio::spawn(async move {
+                let _ = driver.await;
+            });
+            let result = self.exchange(&mut sender, request, request_to).await;
+            driver.abort();
+            result
+        }
+
+        /// Sends the request and reads the response body, each bounded by `request_to`.
+        async fn exchange(
+            &self,
+            sender: &mut hyper::client::conn::http1::SendRequest<
+                http_body_util::Full<bytes::Bytes>,
+            >,
+            request: http::Request<http_body_util::Full<bytes::Bytes>>,
+            request_to: Duration,
+        ) -> Result<(http::StatusCode, Vec<u8>), ColdStoreError> {
+            use http_body_util::BodyExt;
+
+            let response = tokio::time::timeout(request_to, sender.send_request(request))
+                .await
+                .map_err(|_| timeout_error("request", request_to))?
+                .map_err(|e| io_error(format!("S3 request failed: {e}")))?;
+            let status = response.status();
+            let body = tokio::time::timeout(request_to, response.into_body().collect())
+                .await
+                .map_err(|_| timeout_error("response body", request_to))?
+                .map_err(|e| io_error(format!("reading the S3 response body failed: {e}")))?
+                .to_bytes()
+                .to_vec();
+            Ok((status, body))
+        }
+
+        /// Blocks the calling (sync append-actor) thread on `fut` via the owned current-thread runtime.
+        fn block_on<F: std::future::Future>(&self, fut: F) -> F::Output {
+            self.runtime.block_on(fut)
+        }
+    }
+
+    /// A non-2xx S3 status turned into a typed transport error (the body may carry an S3 XML error
+    /// document; we surface the STATUS, not a parse of it — no XML dependency).
+    fn status_error(op: &str, key: &str, status: http::StatusCode) -> ColdStoreError {
+        io_error(format!(
+            "S3 {op} of {key} returned HTTP {} ({})",
+            status.as_u16(),
+            status.canonical_reason().unwrap_or("unknown")
+        ))
+    }
+
+    impl ColdStore for S3ColdStore {
+        fn put(&self, key: &str, bytes: &[u8]) -> Result<(), ColdStoreError> {
+            // A 2xx PUT = the object is DURABLE in S3 before Ok (S3 acks a PUT only once the object is
+            // durably stored + cross-AZ replicated) — the ColdStore durability contract the log relies
+            // on before deleting the local segment. Overwrites any existing object (idempotent by key).
+            let (status, body) = self.block_on(self.send("PUT", key, bytes.to_vec()))?;
+            if status.is_success() {
+                Ok(())
+            } else {
+                Err(status_error("PUT", key, status).with_body(&body))
+            }
+        }
+
+        fn get(&self, key: &str) -> Result<Vec<u8>, ColdStoreError> {
+            let (status, body) = self.block_on(self.send("GET", key, Vec::new()))?;
+            if status.is_success() {
+                // The caller re-verifies (segment header/footer/CRC) before trusting these bytes.
+                Ok(body)
+            } else if status == http::StatusCode::NOT_FOUND {
+                Err(ColdStoreError::NotFound {
+                    key: key.to_string(),
+                })
+            } else {
+                Err(status_error("GET", key, status))
+            }
+        }
+
+        fn delete(&self, key: &str) -> Result<(), ColdStoreError> {
+            let (status, _) = self.block_on(self.send("DELETE", key, Vec::new()))?;
+            // Idempotent: 2xx OR a 404 (already gone) is success. A real 403/401/5xx is surfaced, NOT
+            // masked as success — a permission/transport failure must not look like a completed reap.
+            if status.is_success() || status == http::StatusCode::NOT_FOUND {
+                Ok(())
+            } else {
+                Err(status_error("DELETE", key, status))
+            }
+        }
+
+        fn exists(&self, key: &str) -> Result<bool, ColdStoreError> {
+            let (status, _) = self.block_on(self.send("HEAD", key, Vec::new()))?;
+            if status.is_success() {
+                Ok(true)
+            } else if status == http::StatusCode::NOT_FOUND {
+                Ok(false)
+            } else {
+                Err(status_error("HEAD", key, status))
+            }
+        }
+    }
+
+    impl ColdStoreError {
+        /// Appends a short, non-secret snippet of the S3 error body to an IO error, for diagnosis.
+        fn with_body(self, body: &[u8]) -> ColdStoreError {
+            match self {
+                ColdStoreError::Io(e) => {
+                    let snippet: String = String::from_utf8_lossy(body).chars().take(200).collect();
+                    ColdStoreError::Io(io::Error::new(
+                        e.kind(),
+                        format!("{e}; body: {}", snippet.trim()),
+                    ))
+                }
+                other => other,
+            }
+        }
+    }
+
+    /// Parses `(https, host, port)` from the config's endpoint (or the AWS default for `None`).
+    fn parse_endpoint(config: &S3ColdStoreConfig) -> Result<(bool, String, u16), ColdStoreError> {
+        match &config.endpoint {
+            None => Ok((true, format!("s3.{}.amazonaws.com", config.region), 443)),
+            Some(endpoint) => {
+                let (scheme, rest) = endpoint
+                    .split_once("://")
+                    .ok_or_else(|| io_error("the S3 endpoint must be scheme://host[:port]"))?;
+                let https = scheme.eq_ignore_ascii_case("https");
+                // Strip any path; keep host[:port].
+                let authority = rest.split('/').next().unwrap_or(rest);
+                let (host, port) = match authority.split_once(':') {
+                    Some((h, p)) => (
+                        h.to_string(),
+                        p.parse::<u16>()
+                            .map_err(|_| io_error("the S3 endpoint port is not a number"))?,
+                    ),
+                    None => (authority.to_string(), if https { 443 } else { 80 }),
+                };
+                if host.is_empty() {
+                    return Err(io_error("the S3 endpoint host is empty"));
+                }
+                Ok((https, host, port))
+            }
+        }
+    }
+
+    /// Builds the rustls 1.3-only, aws-lc-rs `ClientConfig` verifying the endpoint against `ca_pem`
+    /// (mirrors the client TLS builder; never `ring`, never insecure-skip-verify).
+    fn build_client_config(ca_pem: &[u8]) -> Result<Arc<rustls::ClientConfig>, ColdStoreError> {
+        use rustls::pki_types::pem::PemObject;
+        use rustls::pki_types::CertificateDer;
+
+        let anchors = CertificateDer::pem_slice_iter(ca_pem)
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|_| io_error("the S3 ca_pem could not be parsed as PEM certificates"))?;
+        let mut roots = rustls::RootCertStore::empty();
+        let (added, _ignored) = roots.add_parsable_certificates(anchors);
+        if added == 0 {
+            return Err(io_error("the S3 ca_pem contained no usable trust anchor"));
+        }
+        let provider = Arc::new(rustls::crypto::aws_lc_rs::default_provider());
+        let config = rustls::ClientConfig::builder_with_provider(provider)
+            .with_protocol_versions(&[&rustls::version::TLS13])
+            .map_err(|e| io_error(format!("building the S3 TLS config failed: {e}")))?
+            .with_root_certificates(roots)
+            .with_no_client_auth();
+        Ok(Arc::new(config))
+    }
+
+    /// A plaintext TCP or a rustls TLS stream, unified so hyper can drive either. Both variants are
+    /// `Unpin`, so the pin projection is a simple `get_mut` + `Pin::new` delegation.
+    enum Connection {
+        Plain(tokio::net::TcpStream),
+        Tls(Box<tokio_rustls::client::TlsStream<tokio::net::TcpStream>>),
+    }
+
+    impl tokio::io::AsyncRead for Connection {
+        fn poll_read(
+            self: std::pin::Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+            buf: &mut tokio::io::ReadBuf<'_>,
+        ) -> std::task::Poll<io::Result<()>> {
+            match self.get_mut() {
+                Connection::Plain(s) => std::pin::Pin::new(s).poll_read(cx, buf),
+                Connection::Tls(s) => std::pin::Pin::new(s.as_mut()).poll_read(cx, buf),
+            }
+        }
+    }
+
+    impl tokio::io::AsyncWrite for Connection {
+        fn poll_write(
+            self: std::pin::Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+            buf: &[u8],
+        ) -> std::task::Poll<io::Result<usize>> {
+            match self.get_mut() {
+                Connection::Plain(s) => std::pin::Pin::new(s).poll_write(cx, buf),
+                Connection::Tls(s) => std::pin::Pin::new(s.as_mut()).poll_write(cx, buf),
+            }
+        }
+        fn poll_flush(
+            self: std::pin::Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<io::Result<()>> {
+            match self.get_mut() {
+                Connection::Plain(s) => std::pin::Pin::new(s).poll_flush(cx),
+                Connection::Tls(s) => std::pin::Pin::new(s.as_mut()).poll_flush(cx),
+            }
+        }
+        fn poll_shutdown(
+            self: std::pin::Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<io::Result<()>> {
+            match self.get_mut() {
+                Connection::Plain(s) => std::pin::Pin::new(s).poll_shutdown(cx),
+                Connection::Tls(s) => std::pin::Pin::new(s.as_mut()).poll_shutdown(cx),
+            }
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        // AWS-published "deriving the signing key" example (`SigV4` docs): PROVES the four-step HMAC
+        // key-derivation chain byte-for-byte.
+        #[test]
+        fn signing_key_matches_aws_documented_vector() {
+            let key = signing_key(
+                "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+                "20150830",
+                "us-east-1",
+                "iam",
+            );
+            assert_eq!(
+                hex_lower(&key),
+                "c4afb1cc5771d871763a393e44b703571b55cc28424d1a5e86da6ed3c154a4b9"
+            );
+        }
+
+        // AWS `SigV4` test suite `get-vanilla`: PROVES the full canonical-request -> string-to-sign ->
+        // signature pipeline byte-for-byte against AWS's published expected signature.
+        #[test]
+        fn get_vanilla_signature_matches_aws_test_suite() {
+            let headers = vec![
+                ("host".to_string(), "example.amazonaws.com".to_string()),
+                ("x-amz-date".to_string(), "20150830T123600Z".to_string()),
+            ];
+            let auth = SigningRequest {
+                method: "GET",
+                canonical_uri: "/",
+                canonical_query: "",
+                headers: &headers,
+                payload_sha256: EMPTY_SHA256,
+                amz_date: "20150830T123600Z",
+                date_stamp: "20150830",
+                region: "us-east-1",
+                service: "service",
+                access_key_id: "AKIDEXAMPLE",
+                secret_access_key: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+            }
+            .authorization();
+            assert_eq!(
+                auth,
+                "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, \
+                 SignedHeaders=host;x-amz-date, \
+                 Signature=5fa00fa31553b73ebf1942676e86291e8372ff2a2260956d9b8aae1d763fbf31"
+            );
+        }
+
+        // AWS S3 docs' "Transferring Payload in a Single Chunk" PUT example: PROVES the PUT-with-body
+        // path the client actually uses — method PUT, a NON-EMPTY payload hash (`x-amz-content-sha256`
+        // computed here from the real payload), a key with a percent-encoded special char
+        // (`/test%24file.text`), service `s3`, and the S3 example's `/`-in-secret credential — against
+        // AWS's published Signature byte-for-byte.
+        #[test]
+        fn put_object_signature_matches_aws_s3_single_chunk_example() {
+            // The exact payload from the AWS example; its SHA-256 is the `x-amz-content-sha256`.
+            let content_sha = sha256_hex(b"Welcome to Amazon S3.");
+            let headers = vec![
+                (
+                    "date".to_string(),
+                    "Fri, 24 May 2013 00:00:00 GMT".to_string(),
+                ),
+                (
+                    "host".to_string(),
+                    "examplebucket.s3.amazonaws.com".to_string(),
+                ),
+                ("x-amz-content-sha256".to_string(), content_sha.clone()),
+                ("x-amz-date".to_string(), "20130524T000000Z".to_string()),
+                (
+                    "x-amz-storage-class".to_string(),
+                    "REDUCED_REDUNDANCY".to_string(),
+                ),
+            ];
+            let auth = SigningRequest {
+                method: "PUT",
+                canonical_uri: "/test%24file.text",
+                canonical_query: "",
+                headers: &headers,
+                payload_sha256: &content_sha,
+                amz_date: "20130524T000000Z",
+                date_stamp: "20130524",
+                region: "us-east-1",
+                service: "s3",
+                access_key_id: "AKIAIOSFODNN7EXAMPLE",
+                secret_access_key: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            }
+            .authorization();
+            assert_eq!(
+                auth,
+                "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request, \
+                 SignedHeaders=date;host;x-amz-content-sha256;x-amz-date;x-amz-storage-class, \
+                 Signature=98ad721746da40c64f1a55b78f14c238d841ea1380cd77a1b5971af0ece108bd"
+            );
+        }
+
+        #[test]
+        fn sha256_and_uri_encode_are_correct() {
+            assert_eq!(sha256_hex(b""), EMPTY_SHA256);
+            // Unreserved chars pass through; a space and a colon are percent-encoded; '/' is kept.
+            assert_eq!(uri_encode("/a b/seg-01.obj", false), "/a%20b/seg-01.obj");
+            assert_eq!(uri_encode("a/b", true), "a%2Fb");
+        }
+
+        #[test]
+        fn civil_from_days_matches_known_dates() {
+            assert_eq!(civil_from_days(0), (1970, 1, 1)); // Unix epoch
+            assert_eq!(civil_from_days(10_957), (2000, 1, 1)); // 30y + 7 leap days
+                                                               // The get-vanilla date: 20150830 is 16677 days after the epoch.
+            assert_eq!(civil_from_days(16_677), (2015, 8, 30));
+        }
     }
 }
 

--- a/crates/ironbus-storage/tests/cold_s3.rs
+++ b/crates/ironbus-storage/tests/cold_s3.rs
@@ -1,0 +1,369 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! Tiered storage (#643, V2-M10, phase 2): the S3 backend (`S3ColdStore`) exercised against a MOCK
+//! S3 HTTP server (a tiny in-process `std::net` server — no network, no real S3, no extra dependency).
+//!
+//! Two proofs:
+//!   1. the `ColdStore` CONTRACT over the wire — put/get round-trip byte-exact, idempotent delete,
+//!      `exists`, a 404 GET => typed `NotFound`, a 403 (bad auth) => a typed transport error (NOT
+//!      masked as `NotFound`); and every request my client sends carries a well-formed `SigV4`
+//!      `Authorization` (+ `x-amz-date` + `x-amz-content-sha256`) header (the mock 403s otherwise);
+//!   2. the SAME `Log` offload/fetch/reap machinery drives the S3 backend byte-for-byte identically to
+//!      `FsColdStore` (mirrors the `cold_tiering.rs` suite).
+//!
+//! Gated on the `s3` feature (the backend + its deps only exist there). The full-endpoint `SigV4`
+//! correctness is proven separately, without network, by the AWS test-vector unit tests in `cold.rs`.
+#![cfg(feature = "s3")]
+// The mock filters `seg-*.log` files by suffix; the file-extension lint is not meaningful here.
+#![allow(clippy::case_sensitive_file_extension_comparisons)]
+
+use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use ironbus_core::clock::ManualClock;
+use ironbus_core::types::{Offset, RecordFlags};
+use ironbus_storage::cold::{
+    cold_object_name, ColdStorageConfig, ColdStore, ColdStoreError, S3ColdStore, S3ColdStoreConfig,
+};
+use ironbus_storage::fs::{Filesystem, InMemoryFs};
+use ironbus_storage::log::{Append, Log, LogConfig, RetentionBounds};
+
+type TestLog = Log<InMemoryFs, ManualClock>;
+
+/// A shared object map: request-path (`/bucket/key`) -> object bytes.
+type Store = Arc<Mutex<HashMap<String, Vec<u8>>>>;
+
+/// Starts a mock S3 server on an ephemeral port; returns `(endpoint_url, store)`. The server runs on a
+/// detached thread and lives for the test process. It VALIDATES that every request carries a
+/// well-formed `SigV4` `Authorization` header (else 403), then routes PUT/GET/DELETE/HEAD over the store.
+fn start_mock_s3() -> (String, Store) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+    let addr = listener.local_addr().expect("local addr");
+    let store: Store = Arc::new(Mutex::new(HashMap::new()));
+    let store_for_thread = Arc::clone(&store);
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(stream) = stream else { continue };
+            let store = Arc::clone(&store_for_thread);
+            // One request per connection (the client opens a fresh connection per op).
+            std::thread::spawn(move || handle_conn(stream, &store));
+        }
+    });
+    (format!("http://{addr}"), store)
+}
+
+/// Handles ONE HTTP/1.1 request on `stream`, mutating/serving `store`, and writes the response.
+fn handle_conn(mut stream: TcpStream, store: &Store) {
+    // Read until the header terminator `\r\n\r\n`, then read any Content-Length body.
+    let mut buf = Vec::new();
+    let mut tmp = [0u8; 4096];
+    let header_end = loop {
+        if let Some(pos) = find_subslice(&buf, b"\r\n\r\n") {
+            break pos;
+        }
+        match stream.read(&mut tmp) {
+            Ok(0) | Err(_) => return,
+            Ok(n) => buf.extend_from_slice(&tmp[..n]),
+        }
+    };
+    let head = String::from_utf8_lossy(&buf[..header_end]).to_string();
+    let mut lines = head.split("\r\n");
+    let request_line = lines.next().unwrap_or("");
+    let mut parts = request_line.split(' ');
+    let method = parts.next().unwrap_or("").to_string();
+    let path = parts.next().unwrap_or("").to_string();
+
+    // Parse headers (lowercased names).
+    let mut headers = HashMap::new();
+    for line in lines {
+        if let Some((name, value)) = line.split_once(':') {
+            headers.insert(name.trim().to_ascii_lowercase(), value.trim().to_string());
+        }
+    }
+
+    // SigV4 header validation: every signed request must carry these.
+    let auth_ok = headers
+        .get("authorization")
+        .is_some_and(|a| a.starts_with("AWS4-HMAC-SHA256 ") && a.contains("Signature="))
+        && headers.contains_key("x-amz-date")
+        && headers.contains_key("x-amz-content-sha256");
+    if !auth_ok {
+        write_response(&mut stream, 403, "Forbidden", b"missing/invalid SigV4 auth");
+        return;
+    }
+
+    // Read the body (Content-Length).
+    let content_length: usize = headers
+        .get("content-length")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+    let mut body = buf[header_end + 4..].to_vec();
+    while body.len() < content_length {
+        match stream.read(&mut tmp) {
+            Ok(0) | Err(_) => break,
+            Ok(n) => body.extend_from_slice(&tmp[..n]),
+        }
+    }
+    body.truncate(content_length);
+
+    match method.as_str() {
+        "PUT" => {
+            store.lock().unwrap().insert(path, body);
+            write_response(&mut stream, 200, "OK", b"");
+        }
+        "GET" => match store.lock().unwrap().get(&path).cloned() {
+            Some(bytes) => write_response(&mut stream, 200, "OK", &bytes),
+            None => write_response(&mut stream, 404, "Not Found", b""),
+        },
+        "HEAD" => {
+            let present = store.lock().unwrap().contains_key(&path);
+            let (code, reason) = if present {
+                (200, "OK")
+            } else {
+                (404, "Not Found")
+            };
+            // HEAD: headers only, no body.
+            write_response(&mut stream, code, reason, b"");
+        }
+        "DELETE" => {
+            // Idempotent: 204 whether or not it existed.
+            store.lock().unwrap().remove(&path);
+            write_response(&mut stream, 204, "No Content", b"");
+        }
+        _ => write_response(&mut stream, 405, "Method Not Allowed", b""),
+    }
+}
+
+fn write_response(stream: &mut TcpStream, code: u16, reason: &str, body: &[u8]) {
+    let header = format!(
+        "HTTP/1.1 {code} {reason}\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+        body.len()
+    );
+    let _ = stream.write_all(header.as_bytes());
+    let _ = stream.write_all(body);
+    let _ = stream.flush();
+}
+
+fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack
+        .windows(needle.len())
+        .position(|window| window == needle)
+}
+
+/// An `S3ColdStore` pointed at the mock, path-style, with dummy static credentials.
+fn s3_store(endpoint: &str, bucket: &str, prefix: &str) -> S3ColdStore {
+    S3ColdStore::new(S3ColdStoreConfig {
+        bucket: bucket.to_string(),
+        prefix: prefix.to_string(),
+        region: "us-east-1".to_string(),
+        endpoint: Some(endpoint.to_string()),
+        path_style: true,
+        access_key_id: "AKIDEXAMPLE".to_string(),
+        secret_access_key: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY".to_string(),
+        session_token: None,
+        ca_pem: None,
+        connect_timeout: None,
+        request_timeout: None,
+    })
+    .expect("build S3ColdStore")
+}
+
+#[test]
+fn s3_cold_store_contract_over_the_wire() {
+    let (endpoint, _store) = start_mock_s3();
+    let store = s3_store(&endpoint, "ironbus-cold", "log-0");
+    let key = cold_object_name(7);
+
+    assert!(!store.exists(&key).unwrap());
+    assert!(matches!(
+        store.get(&key).unwrap_err(),
+        ColdStoreError::NotFound { .. }
+    ));
+
+    let bytes = b"a sealed segment's bytes".to_vec();
+    store.put(&key, &bytes).unwrap();
+    assert!(store.exists(&key).unwrap());
+    assert_eq!(store.get(&key).unwrap(), bytes);
+
+    // Idempotent overwrite.
+    let replacement = b"shorter".to_vec();
+    store.put(&key, &replacement).unwrap();
+    assert_eq!(store.get(&key).unwrap(), replacement);
+
+    // Idempotent delete: gone, and a second delete of the absent key is still Ok.
+    store.delete(&key).unwrap();
+    assert!(!store.exists(&key).unwrap());
+    store.delete(&key).unwrap();
+}
+
+#[test]
+fn s3_bad_auth_is_a_typed_error_not_not_found() {
+    // A store whose SECRET differs from what the mock would accept still SENDS an Authorization header,
+    // so the mock accepts the shape — to prove 403 mapping, point at a server that always 403s.
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    std::thread::spawn(move || {
+        for stream in listener.incoming().flatten() {
+            let mut s = stream;
+            // Drain a bit then always 403 (simulate an auth/permission failure).
+            let mut tmp = [0u8; 1024];
+            let _ = s.read(&mut tmp);
+            write_response(&mut s, 403, "Forbidden", b"AccessDenied");
+        }
+    });
+    let store = s3_store(&format!("http://{addr}"), "b", "p");
+    // A 403 must be a typed transport error, NOT NotFound (a permission failure must not look like a
+    // completed reap or an absent object).
+    let err = store.get(&cold_object_name(1)).unwrap_err();
+    assert!(
+        matches!(err, ColdStoreError::Io(_)),
+        "403 must map to Io, not NotFound: {err:?}"
+    );
+    let del = store.delete(&cold_object_name(1));
+    assert!(del.is_err(), "a 403 DELETE must surface, not be masked Ok");
+}
+
+// ---- Log-driven offload/fetch/reap through the S3 backend (mirrors cold_tiering.rs) ----
+
+fn config() -> LogConfig {
+    LogConfig {
+        max_segment_bytes: 256,
+        ..LogConfig::default()
+    }
+}
+
+fn append_n(log: &mut TestLog, n: u64) {
+    for i in 0..n {
+        let payload = i.to_le_bytes();
+        log.append(&Append {
+            timestamp_ms: 1_700_000_000_000 + i,
+            flags: RecordFlags::EMPTY,
+            key: b"",
+            headers: b"",
+            payload: &payload,
+        })
+        .unwrap();
+        log.sync().unwrap();
+    }
+}
+
+fn read_all(log: &TestLog) -> Vec<(u64, Vec<u8>)> {
+    log.read_from(Offset::ZERO, 100_000)
+        .unwrap()
+        .into_iter()
+        .map(|r| (r.offset.get(), r.payload.to_vec()))
+        .collect()
+}
+
+fn local_segment_count(fs: &InMemoryFs) -> usize {
+    fs.list()
+        .unwrap()
+        .into_iter()
+        .filter(|n| n.starts_with("seg-") && n.ends_with(".log"))
+        .count()
+}
+
+#[test]
+fn log_offloads_to_s3_and_reads_back_then_reaps() {
+    let data_fs = InMemoryFs::new();
+    let (endpoint, _store) = start_mock_s3();
+    let cold: Arc<dyn ColdStore> = Arc::new(s3_store(&endpoint, "ironbus-cold", "default"));
+
+    let mut log = Log::open(data_fs.clone(), ManualClock::new(), config()).unwrap();
+    log.set_cold_store(Arc::clone(&cold), ColdStorageConfig::enabled(1));
+    append_n(&mut log, 60);
+
+    let baseline = read_all(&log);
+    let local_before = local_segment_count(&data_fs);
+    assert!(local_before >= 3, "workload should roll several segments");
+
+    let offloaded = log.offload_cold_segments().unwrap();
+    assert!(offloaded > 0, "at least one cold segment offloads");
+
+    // Segment 0: local file gone, manifest REMOTE, and the OBJECT is durable in S3 (probed via HEAD).
+    assert!(log.is_segment_remote(0));
+    assert!(!data_fs.exists(&format!("seg-{:016x}.log", 0u64)).unwrap());
+    assert!(
+        cold.exists(&cold_object_name(0)).unwrap(),
+        "the offloaded object must be durable in S3"
+    );
+    assert!(local_segment_count(&data_fs) < local_before);
+
+    // A read spanning the offloaded prefix transparently GETs from S3 + serves it byte-exact.
+    assert_eq!(
+        read_all(&log),
+        baseline,
+        "offloaded records read back byte-exact"
+    );
+
+    // Retention reap of the offloaded segment DELETEs the S3 object (no orphan).
+    let bounds = RetentionBounds {
+        max_bytes: 128,
+        max_age_ms: 0,
+        max_messages: 0,
+    };
+    let protect = log.next_offset().get();
+    log.reap(bounds, protect).unwrap();
+    assert!(!log.is_segment_remote(0));
+    assert!(
+        !cold.exists(&cold_object_name(0)).unwrap(),
+        "reaping an offloaded segment must DELETE the S3 object (no orphan)"
+    );
+}
+
+#[test]
+fn a_hung_endpoint_times_out_and_never_wedges_the_actor() {
+    // A server that ACCEPTS the TCP connection but NEVER responds — a routine partition /
+    // security-group / throttle blackhole. Without per-step timeouts this would wedge the single-writer
+    // append actor forever (offload/reap/fetch-on-read all run on it). With them, each op must RETURN a
+    // typed TIMEOUT error within ~the bound, never hang, and NEVER a false NotFound.
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    std::thread::spawn(move || {
+        // Accept every connection and hold it open, reading nothing, writing nothing (blackhole).
+        let mut held = Vec::new();
+        for stream in listener.incoming().flatten() {
+            held.push(stream);
+        }
+    });
+
+    let store = S3ColdStore::new(S3ColdStoreConfig {
+        bucket: "b".to_string(),
+        prefix: "p".to_string(),
+        region: "us-east-1".to_string(),
+        endpoint: Some(format!("http://{addr}")),
+        path_style: true,
+        access_key_id: "AKIDEXAMPLE".to_string(),
+        secret_access_key: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY".to_string(),
+        session_token: None,
+        ca_pem: None,
+        connect_timeout: Some(Duration::from_millis(500)),
+        request_timeout: Some(Duration::from_millis(500)),
+    })
+    .unwrap();
+
+    let key = cold_object_name(1);
+    let start = Instant::now();
+    let err = store.get(&key).unwrap_err();
+    let elapsed = start.elapsed();
+    // A timeout is a typed, RETRYABLE Io(TimedOut) — NOT NotFound (a hang is not "object absent").
+    assert!(
+        matches!(err, ColdStoreError::Io(ref e) if e.kind() == std::io::ErrorKind::TimedOut),
+        "a hung endpoint must yield a typed timeout, got {err:?}"
+    );
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "the op must return promptly (it did not hang), took {elapsed:?}"
+    );
+    // put + exists likewise RETURN (do not hang).
+    assert!(
+        store.put(&key, b"x").is_err(),
+        "put must time out, not hang"
+    );
+    assert!(
+        store.exists(&key).is_err(),
+        "exists must time out, not hang"
+    );
+}

--- a/docs/TIERED_STORAGE.md
+++ b/docs/TIERED_STORAGE.md
@@ -1,0 +1,154 @@
+# Tiered storage — offloading cold segments to object storage (#643, V2-M10)
+
+IronBus tiers **cold, sealed, immutable log segments** out to a cheap, high-capacity backing store,
+reclaiming local disk while keeping every record readable. This is the Kafka KIP-405 / Pulsar /
+Redpanda tiered-storage class: an immutable sealed segment (its footer written, no in-place mutation
+ever races) is the natural tiering unit.
+
+Tiered storage is **OFF by default**. A broker that never enables it writes zero new bytes, touches no
+new files, and pulls none of the object-storage dependencies into its build.
+
+## The two backends
+
+Offload/fetch/recover/reap is driven through one tiny `ColdStore` seam (`put`/`get`/`delete`/`exists`
+over an opaque object key). The backing store is chosen by config; the crash-safety, manifest, and
+retention logic is **backend-agnostic and identical** for either:
+
+| Backend | Selector | Feature | Use |
+| --- | --- | --- | --- |
+| `FsColdStore` | default | (always built, pure Rust) | A local directory / NFS mount. Phase 1 (#1152). |
+| `S3ColdStore` | `S3ColdStoreConfig` | `s3` (off by default) | Amazon S3 / S3-compatible (MinIO, Ceph, Cloudflare R2, LocalStack). Phase 2 (#643). |
+
+`S3ColdStore` is a small, **purpose-built** S3 client — not a general object-storage crate. The four
+`ColdStore` verbs are four S3 requests (`PUT` upload, `GET` download, `DELETE`, `HEAD`), none of which
+needs an XML response body, so a non-2xx is a typed error read from the **status line**, never a parsed
+error document. The log's offload/fetch/recover/reap machinery is **unchanged**; only the trait
+implementation differs. See [`crates/ironbus-storage/src/cold.rs`](../crates/ironbus-storage/src/cold.rs).
+
+### Why hand-rolled (ADR-0004)
+
+The S3 backend deliberately does **not** use a general object-storage crate. The mature options
+(`object_store`, the AWS SDK) have a hard dependency on `ring`, which ADR-0004 bans in favour of
+**aws-lc-rs as IronBus's sole crypto provider**. Instead, `S3ColdStore` is built from crates **already
+in the tree** for the TLS stack:
+
+- **AWS Signature Version 4** request signing over **aws-lc-rs** (HMAC-SHA256 + SHA-256) — no `ring`.
+- **HTTPS** over the same **rustls + aws-lc-rs**, TLS 1.3-only stack the `tls` feature ships.
+- **HTTP/1.1** over `hyper` + `hyper-util`; no XML parser.
+
+So the `s3` feature adds **zero new crates**, links **no `ring`** and **no XML parser**, keeps the
+default graph clean, and needs **no `cargo deny` / MSRV exceptions**.
+
+## Building with the S3 backend
+
+```sh
+cargo build -p ironbus-storage --features s3
+```
+
+The default broker graph pulls **none** of the S3/HTTP/TLS deps (`cargo tree -p ironbus-storage -e
+normal` is clean), and `ring` is absent from the whole all-features tree.
+
+## Configuration
+
+`S3ColdStoreConfig` selects and parameterizes the S3 backend:
+
+| Field | Meaning |
+| --- | --- |
+| `bucket` | The S3 bucket the log's cold objects live in. |
+| `prefix` | An object-key prefix within the bucket (the engine gives each log its own prefix so keys never collide across logs). May be empty. |
+| `region` | The AWS region (e.g. `us-east-1`) — part of the SigV4 scope and the default endpoint host. |
+| `endpoint` | An explicit endpoint URL for an S3-**compatible** store (`https://s3.example.com`, `http://127.0.0.1:9000`). Omit for real AWS S3 (`s3.<region>.amazonaws.com`). |
+| `path_style` | Path-style (`/<bucket>/<key>`) vs virtual-hosted (`<bucket>.<host>/<key>`). `true` for most S3-compatible stores + LocalStack; AWS accepts either. |
+| `access_key_id` / `secret_access_key` / `session_token` | Static SigV4 credentials. The secret + session token are redacted in `Debug`. |
+| `ca_pem` | The trust-anchor (CA) PEM used to verify the endpoint's certificate over HTTPS. **Required** for an `https` endpoint; ignored for a plaintext `http` endpoint. |
+
+**Credentials (phase 2):** static keys from config/environment
+(`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / optional `AWS_SESSION_TOKEN`). IAM instance-profile /
+ECS-task-role / STS auto-resolution is a documented follow-up. Automatic loading of bundled/OS trust
+roots (so `ca_pem` is optional for real AWS) is likewise a follow-up.
+
+Constructed with `S3ColdStore::new(config)`, then installed on the log with the same
+`set_cold_storage(store, ColdStorageConfig)` seam the default `FsColdStore` uses. `ColdStorageConfig`
+(the policy — `enabled` and `keep_recent_segments`) is orthogonal to the backend choice.
+
+## The durability contract (where a bug is permanent data loss)
+
+The load-bearing invariant is **upload → fsync-manifest-REMOTE → then delete the local file**: a local
+segment is never unlinked before **both** its remote copy and its durable manifest entry exist. Every
+crash window in between recovers to either fully-local or fully-remote-and-recorded — never a gap. See
+[`RECOVERY.md`](RECOVERY.md) for the full crash-window analysis.
+
+For the S3 backend this rests on one mapping: **a 2xx response to a `PUT` means the object is durable in
+S3 before `Ok` is returned** (S3 acknowledges a PUT only once the object is durably stored and replicated
+across Availability Zones, with read-after-write consistency) — exactly the "durable before the manifest
+records REMOTE" guarantee `FsColdStore`'s `fsync` provides. A `GET` returns the raw object bytes, which
+the caller re-verifies (segment header + footer + CRC32C, pinned in the manifest entry) before trusting
+them, so a corrupt store fails closed. `DELETE` is idempotent (a 404 is treated as success, so a retried
+reap is safe) — but a `403`/`5xx` is surfaced as a typed error, never masked as a completed reap.
+
+## The async/sync bridge
+
+The S3 client is async; the `ColdStore` trait is sync, to match the log's **single-writer append
+actor** (a plain synchronous thread that owns `&mut Log`). Each `ColdStore` method bridges with
+`block_on` over one tokio **current-thread** runtime owned by the backend. The actor is never itself
+inside a tokio runtime, so `block_on` can never re-enter/deadlock a running one; it serializes every
+cold-store call, so the runtime is never contended.
+
+## Testing
+
+SigV4 correctness is proven in CI **without network**: the SigV4 signer is tested against **AWS's
+published test vectors** (the "deriving the signing key" example and the `get-vanilla` request from the
+AWS SigV4 test suite) in `cold.rs`, matching AWS byte-for-byte. The
+`ColdStore` contract + the full log-driven offload/fetch/reap lifecycle are tested against an in-process
+**mock S3 server** (`tests/cold_s3.rs`) that also validates every request carries a well-formed SigV4
+`Authorization` header. No real S3, no network, no extra dependency.
+
+### Testing against a real S3 (manual)
+
+#### Against LocalStack or MinIO (S3-compatible, local)
+
+```sh
+# 1. Start a local S3-compatible endpoint, e.g. MinIO on :9000; create a bucket `ironbus-cold`.
+# 2. Point the backend at it via S3ColdStoreConfig:
+#      bucket:            "ironbus-cold"
+#      endpoint:          Some("http://127.0.0.1:9000")   # plaintext dev endpoint (no ca_pem)
+#      region:            "us-east-1"
+#      path_style:        true
+#      access_key_id:     "minioadmin"
+#      secret_access_key: "minioadmin"
+# 3. Enable tiering, produce enough to roll several sealed segments, trigger the retention tick, then
+#    confirm the cold objects appear under the bucket/prefix and a fetch-on-read serves them byte-exact
+#    after the local files are reclaimed.
+```
+
+#### Against real AWS S3
+
+```sh
+# Provide static credentials + the CA trust anchor for HTTPS:
+export AWS_ACCESS_KEY_ID=...
+export AWS_SECRET_ACCESS_KEY=...
+# S3ColdStoreConfig {
+#   bucket: "your-bucket", region: "us-east-1", prefix: "ironbus/log-0",
+#   endpoint: None,                 # => https://s3.us-east-1.amazonaws.com
+#   path_style: false,              # virtual-hosted (AWS default)
+#   ca_pem: Some(<the Amazon root CA chain, or the system CA bundle bytes>),
+#   .. }
+```
+
+## Observability
+
+Offload runs best-effort on the retention tick and never fails a produce: a cold-store outage or a full
+manifest is surfaced on the `ironbus_cold_offload_errors_total{reason}` counter (plus a `warn!`) and
+retried on the next tick. See [`METRICS.md`](METRICS.md).
+
+## Phase 2 scope vs deferred
+
+**Phase 2 (this change):** the `S3ColdStore` backend (SigV4 over aws-lc-rs; HTTPS over rustls +
+aws-lc-rs; PUT/GET/DELETE/HEAD) + `S3ColdStoreConfig` + the async/sync bridge, behind the `s3` feature;
+the SigV4 test-vector proof + the full `ColdStore` contract + a log-driven offload/fetch/reap test.
+
+**Deferred (backend-agnostic follow-ups):** operator-facing CLI/serve wiring to select+configure the
+backend; IAM/ECS/STS credential auto-resolution; automatic OS/bundled TLS trust roots (so `ca_pem` is
+optional); connection pooling; a local restore cache with eviction; offload of compacted (v2) segments;
+async/background off-actor offload/prefetch; a startup orphan-object sweep. None touch the backend's
+signing or wire format.


### PR DESCRIPTION
## What

Phase 2 of tiered storage (#643, V2-M10): the **S3 backend** for the cold-segment offload `ColdStore`,
turning phase 1's merged foundation (#1152) into a cloud-usable feature. Behind the new **OFF-BY-DEFAULT
`s3` Cargo feature**, `S3ColdStore` is a small, **purpose-built** S3 client — not a general
object-storage crate — a drop-in `impl ColdStore`. The log's crash-safe offload/fetch/recover/reap
machinery is **UNCHANGED** (backend-agnostic, proven identically with either backend).

> **This replaces the earlier `object_store` draft** on this PR. Per the owner's ratified decision, the
> S3 backend is **hand-rolled to honour ADR-0004** (aws-lc-rs is IronBus's sole crypto provider; `ring`
> is banned) instead of adopting `object_store` (which pulls `ring` + `quick-xml` + fragile MSRV pins).

## Ring-free by construction

| Concern | Result |
| --- | --- |
| Crypto | **AWS SigV4** signing over **aws-lc-rs** (HMAC-SHA256 + SHA-256) — **no `ring`** |
| Transport | **HTTPS** over the same **rustls + aws-lc-rs**, TLS 1.3-only stack the `tls` feature ships |
| HTTP | `hyper`/`hyper-util` HTTP/1.1; the 4 verbs (PUT/GET/DELETE/HEAD) need **no XML** → no `quick-xml` |
| New crates | **Zero** — every dep is already in the lock (TLS stack + otlp) |
| `deny.toml` | **Unchanged** — `cargo deny check` passes with **no exception**; the `ring` ban is fully intact and `ring` is **absent** from the whole all-features tree |
| MSRV 1.78 | Holds (no new/edition-2024 crates) |
| Default graph | Clean — `cargo tree -p ironbus-storage -e normal` has no s3/hyper/rustls/ring |

## Implementation

- **`S3ColdStore`** (`cold.rs`): whole-object PUT/GET/DELETE/HEAD. A missing `get` → typed
  `ColdStoreError::NotFound`; `delete` is idempotent on a 404 **but a 403/5xx is surfaced, never masked**
  as a completed reap; a 2xx `PUT` = **durable-before-Ok** (S3 acks a PUT only once durably stored) — the
  ColdStore contract the log relies on before deleting the local segment.
- **SigV4** (`cold.rs`): canonical request → string-to-sign → the 4-step HMAC signing-key derivation →
  `Authorization`, all over aws-lc-rs. A no-`chrono` UTC date formatter for `x-amz-date`.
- **Async/sync bridge**: the async client is driven from the sync `ColdStore` trait by one tokio
  **current-thread** runtime + `block_on` — safe under the log's single-writer append actor (a plain
  sync thread never inside a runtime, so `block_on` never re-enters one; it serializes cold-store calls).
- **`S3ColdStoreConfig`**: bucket / prefix / region / endpoint (S3-compatible: MinIO, Ceph, R2,
  LocalStack) / path_style + static credentials (AWS_* / config) + a `ca_pem` trust anchor for HTTPS.
  Secrets redacted in `Debug`. `FsColdStore` stays the default. IAM/STS credentials + automatic OS/bundled
  TLS roots are documented follow-ups.

## Tests (all in CI, no network)

- **SigV4 vectors** (unit, `cold.rs`): the signer matches **AWS's published test vectors** byte-for-byte
  — the "deriving the signing key" example (`kSigning`) and the `get-vanilla` request from the AWS SigV4
  test suite. This is the load-bearing correctness proof.

  ```
  test cold::s3_backend::tests::signing_key_matches_aws_documented_vector ... ok
  test cold::s3_backend::tests::get_vanilla_signature_matches_aws_test_suite ... ok
  ```
- **ColdStore contract + Log-driven** (`tests/cold_s3.rs`): against an in-process **mock S3 server**
  (`std::net`, no extra dependency) that also validates every request carries a well-formed SigV4
  `Authorization` header — put/get round-trip byte-exact, idempotent delete, `exists`, 404→`NotFound`,
  **403→typed transport error (not `NotFound`)**, and the full Log offload → object-present → read-back →
  reap → object-deleted lifecycle.

## Gates (container, CI-equivalent, all green)

- `cargo test --workspace --all-features --locked`: **3599 passed, 0 failed**
- `cargo clippy --workspace --all-targets --all-features -D warnings`: clean
- `cargo fmt --all --check`: clean · format-registry: ok · acceptance golden-path: passed
- `cargo deny check`: advisories / bans / licenses / sources **ok — no ring, no exceptions, deny.toml unchanged**
- **MSRV 1.78**: the `s3` subtree builds on 1.78.0
- **Default graph** and **`ring` absence**: `cargo tree` confirms both

## Phase 2 vs deferred

**This PR:** the `S3ColdStore` backend (SigV4/aws-lc-rs; rustls/aws-lc-rs HTTPS; PUT/GET/DELETE/HEAD) +
`S3ColdStoreConfig` + the async/sync bridge; the SigV4 vector proof + the contract + Log-driven tests.

**Deferred:** operator CLI/serve wiring to select the backend; IAM/ECS/STS credential auto-resolution;
automatic OS/bundled TLS roots (so `ca_pem` is optional); connection pooling; local restore-cache
eviction; compacted-segment offload; off-actor async offload; startup orphan sweep. None touch the
backend's signing or wire format.

Closes #643

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01McmNfYNWPmohVS8umY9Lkp
