### PR TITLE
feat(encryption): at-rest encryption phase-3 serve hookup (#1165, closes M7)

### DIFF
--- a/crates/ironbus-cli/Cargo.toml
+++ b/crates/ironbus-cli/Cargo.toml
@@ -36,6 +36,13 @@ zstd = ["ironbus-storage/zstd", "ironbus-core/zstd"]
 # aws-lc-sys allowance is feature-scoped in deny.toml, and cffi-ban.sh proves the default ironbus-cli
 # graph stays pure-Rust).
 tls = ["ironbus-server/tls", "ironbus-client/tls"]
+# At-rest AEAD encryption (#780, phase 3 serve hookup). NON-DEFAULT: forwards `ironbus-server`'s
+# `encryption` feature (and through it `ironbus-storage`'s) so `cargo build -p ironbus-cli --features
+# encryption` produces a broker whose `--encryption-key-file` opens the engine's storage encrypted via
+# `Engine::open_encrypted`. UNLIKE `tls` it pulls NO new C-FFI (the RustCrypto AEAD stack is pure Rust,
+# already deny.toml-clean), so the DEFAULT binary, its SBOM, and cffi-ban stay unchanged, and the
+# default binary refuses the `--encryption-*` flags fail-closed rather than starting plaintext.
+encryption = ["ironbus-server/encryption", "ironbus-storage/encryption"]
 
 [dependencies]
 ironbus-core = { path = "../ironbus-core", version = "0.1.0" }

--- a/crates/ironbus-cli/src/config_file.rs
+++ b/crates/ironbus-cli/src/config_file.rs
@@ -194,6 +194,11 @@ fn key_to_env_name(key: &str) -> Option<&'static str> {
         "network.health_allow_public" => "IRONBUS_HEALTH_ALLOW_PUBLIC",
         "network.health_liveness_window_ms" => "IRONBUS_HEALTH_LIVENESS_WINDOW_MS",
         "network.enable_admin" => "IRONBUS_ENABLE_ADMIN",
+        // [encryption] — optional at-rest AEAD encryption (#780 phase 3). Feature-gated behind the CLI
+        // `encryption` cargo feature: a build WITHOUT the feature refuses these fail-closed at resolve.
+        "encryption.key_file" => "IRONBUS_ENCRYPTION_KEY_FILE",
+        "encryption.key_id" => "IRONBUS_ENCRYPTION_KEY_ID",
+        "encryption.suite" => "IRONBUS_ENCRYPTION_SUITE",
         _ => return None,
     };
     Some(env)
@@ -490,6 +495,35 @@ mod tests {
         assert_eq!(
             layer.lookup_env_name("IRONBUS_DEAD_LETTER_EXPIRED"),
             Some("true".to_string())
+        );
+    }
+
+    #[test]
+    fn the_encryption_keys_map_to_their_env_names() {
+        // The #780 phase-3 at-rest keys: a raw key-file path (string), a key-id (integer), and a suite
+        // (string), each exposed under its IRONBUS_<FLAG> env name for the shared resolution path. The
+        // `[encryption]` section is WIRED (no longer reserved-and-ignored), so its keys are accepted and
+        // exposed rather than warned-and-dropped.
+        let doc = "[encryption]\nkey_file = \"/etc/ironbus/at-rest.key\"\n\
+                   key_id = 7\nsuite = \"aes-256-gcm\"\n";
+        let layer = load_config_file("/x.toml", false, &reader(doc)).unwrap();
+        assert_eq!(
+            layer.lookup_env_name("IRONBUS_ENCRYPTION_KEY_FILE"),
+            Some("/etc/ironbus/at-rest.key".to_string())
+        );
+        assert_eq!(
+            layer.lookup_env_name("IRONBUS_ENCRYPTION_KEY_ID"),
+            Some("7".to_string())
+        );
+        assert_eq!(
+            layer.lookup_env_name("IRONBUS_ENCRYPTION_SUITE"),
+            Some("aes-256-gcm".to_string())
+        );
+        // The wired section produces NO reserved-section warning (it is no longer tolerated-and-ignored).
+        assert!(
+            layer.warnings().iter().all(|w| !w.contains("[encryption]")),
+            "a WIRED [encryption] section must not warn as ignored: {:?}",
+            layer.warnings()
         );
     }
 

--- a/crates/ironbus-cli/src/main.rs
+++ b/crates/ironbus-cli/src/main.rs
@@ -5671,18 +5671,21 @@ struct ServeConfig {
     /// default (byte-for-byte historical). When `Some`, `open_engine_with` loads the 32-byte key (the
     /// phase-1 fail-closed owner-only loader) and opens the engine's storage encrypted via
     /// `Engine::open_encrypted`. Resolved from `--encryption-key-file` / `IRONBUS_ENCRYPTION_KEY_FILE` /
-    /// `[encryption] key_file`; only ever `Some` on an `encryption`-feature build.
+    /// `[encryption] key_file`; only ever `Some` on an `encryption`-feature build. The serve path that
+    /// reads it (`open_engine_with` / `open_memory_engine`) is `cfg(unix)`, so on a non-Unix build it is
+    /// intentionally dead (the broker cannot serve there anyway — v1 serve is Unix-only).
+    #[cfg_attr(not(all(unix, feature = "encryption")), allow(dead_code))]
     encryption_key_file: Option<String>,
     /// The resolved at-rest KEY-ID (#780 phase 3): the non-zero u64 recorded in each encrypted segment
-    /// header. `Some` iff `encryption_key_file` is `Some` (validated at resolve). Only READ on an
-    /// `encryption`-feature build (by `load_encryption_context`); on the default build it is always
-    /// `None` (`resolve_encryption` refuses any at-rest config), so it is intentionally dead there.
-    #[cfg_attr(not(feature = "encryption"), allow(dead_code))]
+    /// header. `Some` iff `encryption_key_file` is `Some` (validated at resolve). Only READ on a Unix
+    /// `encryption`-feature build (by `load_encryption_context`); otherwise it is always `None`
+    /// (`resolve_encryption` refuses any at-rest config off an `encryption` build), so it is dead there.
+    #[cfg_attr(not(all(unix, feature = "encryption")), allow(dead_code))]
     encryption_key_id: Option<u64>,
     /// The resolved at-rest AEAD SUITE (#780 phase 3): `auto` (CPU detect), `aes-256-gcm`, or
-    /// `chacha20-poly1305`. `None` (with a key file set) means `auto`. Only READ on an
-    /// `encryption`-feature build; intentionally dead on the default build (always `None`).
-    #[cfg_attr(not(feature = "encryption"), allow(dead_code))]
+    /// `chacha20-poly1305`. `None` (with a key file set) means `auto`. Only READ on a Unix
+    /// `encryption`-feature build; intentionally dead otherwise (always `None`).
+    #[cfg_attr(not(all(unix, feature = "encryption")), allow(dead_code))]
     encryption_suite: Option<String>,
 }
 

--- a/crates/ironbus-cli/src/main.rs
+++ b/crates/ironbus-cli/src/main.rs
@@ -2703,6 +2703,19 @@ struct ServeFlags {
     /// (#107): mTLS identity-mapping needs the (unwired) TLS layer to supply a verified peer
     /// certificate, so a set value is a fail-closed startup refusal until the TLS layer lands.
     tls_client_ca: Option<String>,
+    /// The at-rest encryption raw KEY-FILE path (#780 phase 3): a file holding exactly 32 raw key bytes,
+    /// owner-only (the phase-1 fail-closed loader refuses a group/world-readable file). Setting it ENABLES
+    /// at-rest encryption. `--encryption-key-file` / `IRONBUS_ENCRYPTION_KEY_FILE` / `[encryption]
+    /// key_file`. Feature-gated: a build without `encryption` refuses it fail-closed.
+    encryption_key_file: Option<String>,
+    /// The at-rest key IDENTIFIER (#780 phase 3): a non-zero u64 recorded in each encrypted segment
+    /// header (never the key). REQUIRED when `encryption_key_file` is set. `--encryption-key-id` /
+    /// `IRONBUS_ENCRYPTION_KEY_ID` / `[encryption] key_id`.
+    encryption_key_id: Option<String>,
+    /// The at-rest AEAD SUITE selector (#780 phase 3): `auto` (default: pick by CPU feature detection),
+    /// `aes-256-gcm`, or `chacha20-poly1305`. `--encryption-suite` / `IRONBUS_ENCRYPTION_SUITE` /
+    /// `[encryption] suite`.
+    encryption_suite: Option<String>,
     /// The EXPLICIT, loud opt-in for a plaintext non-loopback wire (#629): the `--insecure-plaintext-wire`
     /// bare flag. ALLOWS a non-loopback bind WITHOUT TLS but WITH auth, for the legitimate
     /// TLS-terminated-upstream pattern (a mesh / proxy / VPN encrypts the wire; the broker terminates
@@ -3114,6 +3127,47 @@ fn collect_serve_flags(args: &[String]) -> Result<ServeFlags, CliError> {
                     return Err(reserved_tls_flag_refusal("--tls-client-ca"));
                 }
             }
+            // At-rest AEAD encryption (#780 phase 3). HONORED behind `--features encryption`: the key
+            // file is loaded (fail-closed on non-owner-only perms) and the engine's storage opens
+            // encrypted. On a NON-encryption build every `--encryption-*` flag is a fail-closed startup
+            // REFUSAL (the crypto is not compiled in), never a silently-ignored value that would start
+            // the broker in plaintext under a config that asked for encryption.
+            "--encryption-key-file" => {
+                let value = take_value("--encryption-key-file", args, &mut i)?;
+                #[cfg(feature = "encryption")]
+                {
+                    f.encryption_key_file = Some(value);
+                }
+                #[cfg(not(feature = "encryption"))]
+                {
+                    let _ = value;
+                    return Err(reserved_encryption_flag_refusal("--encryption-key-file"));
+                }
+            }
+            "--encryption-key-id" => {
+                let value = take_value("--encryption-key-id", args, &mut i)?;
+                #[cfg(feature = "encryption")]
+                {
+                    f.encryption_key_id = Some(value);
+                }
+                #[cfg(not(feature = "encryption"))]
+                {
+                    let _ = value;
+                    return Err(reserved_encryption_flag_refusal("--encryption-key-id"));
+                }
+            }
+            "--encryption-suite" => {
+                let value = take_value("--encryption-suite", args, &mut i)?;
+                #[cfg(feature = "encryption")]
+                {
+                    f.encryption_suite = Some(value);
+                }
+                #[cfg(not(feature = "encryption"))]
+                {
+                    let _ = value;
+                    return Err(reserved_encryption_flag_refusal("--encryption-suite"));
+                }
+            }
             "--auth-config" => f.auth_config = Some(take_value("--auth-config", args, &mut i)?),
             // The EXPLICIT, loud plaintext-wire opt-in (#629). A bare boolean flag (no value): advance
             // ONE token, not two, or the loop spins.
@@ -3409,6 +3463,16 @@ fn parse_serve_flags_with_env_and_reader(
         }
         None => Vec::new(),
     };
+    // At-rest encryption (#780 phase 3): resolve + validate the `[encryption]` config (flag > env >
+    // file), feature-gated. A build WITHOUT the `encryption` feature refuses any at-rest config
+    // fail-closed here (never silently starts plaintext); a build WITH it validates the key-file/key-id
+    // pairing and the suite name before the broker opens, so a misconfiguration is a clean startup error.
+    let (encryption_key_file, encryption_key_id, encryption_suite) = resolve_encryption(
+        f.encryption_key_file,
+        f.encryption_key_id,
+        f.encryption_suite,
+        env,
+    )?;
     let mut parsed = ParsedServe {
         addr: resolve_string("--addr", f.addr, env, DEFAULT_ADDR),
         data_dir: resolve_opt_string("--data-dir", f.data_dir, env),
@@ -3724,6 +3788,11 @@ fn parse_serve_flags_with_env_and_reader(
             // The security audit-event sink (#635), flag > env > default `None` (off). A reference,
             // never an inline secret: `stderr` or `@<path>`.
             audit_log: resolve_opt_string("--audit-log", f.audit_log.clone(), env),
+            // At-rest encryption (#780 phase 3): the resolved+validated values (or all-`None` for the
+            // plaintext default). `open_engine_with` turns a `Some(key_file)` into the live crypto.
+            encryption_key_file,
+            encryption_key_id,
+            encryption_suite,
         },
         key_shared_groups: f.key_shared_groups,
         broadcast_groups: f.broadcast_groups,
@@ -5598,6 +5667,23 @@ struct ServeConfig {
     /// appends to a file at `<path>` (an owner-only audit log). Events carry the identity NAME and the
     /// mechanism/scope/verb tags only — NEVER a credential. Operator-selectable, off by default.
     audit_log: Option<String>,
+    /// The resolved at-rest encryption RAW KEY-FILE path (#780 phase 3), or `None` for the plaintext
+    /// default (byte-for-byte historical). When `Some`, `open_engine_with` loads the 32-byte key (the
+    /// phase-1 fail-closed owner-only loader) and opens the engine's storage encrypted via
+    /// `Engine::open_encrypted`. Resolved from `--encryption-key-file` / `IRONBUS_ENCRYPTION_KEY_FILE` /
+    /// `[encryption] key_file`; only ever `Some` on an `encryption`-feature build.
+    encryption_key_file: Option<String>,
+    /// The resolved at-rest KEY-ID (#780 phase 3): the non-zero u64 recorded in each encrypted segment
+    /// header. `Some` iff `encryption_key_file` is `Some` (validated at resolve). Only READ on an
+    /// `encryption`-feature build (by `load_encryption_context`); on the default build it is always
+    /// `None` (`resolve_encryption` refuses any at-rest config), so it is intentionally dead there.
+    #[cfg_attr(not(feature = "encryption"), allow(dead_code))]
+    encryption_key_id: Option<u64>,
+    /// The resolved at-rest AEAD SUITE (#780 phase 3): `auto` (CPU detect), `aes-256-gcm`, or
+    /// `chacha20-poly1305`. `None` (with a key file set) means `auto`. Only READ on an
+    /// `encryption`-feature build; intentionally dead on the default build (always `None`).
+    #[cfg_attr(not(feature = "encryption"), allow(dead_code))]
+    encryption_suite: Option<String>,
 }
 
 // Only the Unix `bench` execution path constructs a default `ServeConfig` (the isolated broker); on
@@ -5693,6 +5779,9 @@ impl ServeConfig {
             // shipped `serve` default so a future bench teardown behaves like production.
             drain_timeout_ms: DEFAULT_DRAIN_TIMEOUT_MS,
             audit_log: None,
+            encryption_key_file: None,
+            encryption_key_id: None,
+            encryption_suite: None,
         }
     }
 }
@@ -7283,6 +7372,113 @@ fn reserved_tls_flag_refusal(flag: &str) -> CliError {
          upstream (mesh / proxy / VPN), or pass --insecure-plaintext-wire to explicitly accept a \
          plaintext wire WITH auth."
     ))
+}
+
+/// Fail-closed refusal for an `--encryption-*` flag (or `[encryption]` config key / env) on a build
+/// compiled WITHOUT the `encryption` feature (#780 phase 3). Such a build links no AEAD crypto, so it
+/// CANNOT encrypt segments — accepting the config and starting the broker would write PLAINTEXT under a
+/// configuration that asked for at-rest encryption, the exact silent-downgrade this refuses.
+///
+/// Only reachable on a build WITHOUT the `encryption` feature: its callers (the `--encryption-*` flag
+/// arms and `resolve_encryption`'s refusal branch) are all `cfg(not(feature = "encryption"))`, so on an
+/// `encryption` build (which honors the flags) it would be dead code — hence the cfg gate.
+#[cfg(not(feature = "encryption"))]
+fn reserved_encryption_flag_refusal(what: &str) -> CliError {
+    CliError::Usage(format!(
+        "{what} is not honored in this build: it was compiled WITHOUT the `encryption` feature, so it \
+         links no AEAD crypto and cannot encrypt segments at rest. Accepting it would start the broker \
+         in PLAINTEXT under a configuration that asked for encryption. Rebuild with `--features \
+         encryption` to enable at-rest AES-256-GCM / ChaCha20-Poly1305, or remove the at-rest \
+         encryption configuration."
+    ))
+}
+
+/// Resolves + validates the `[encryption]` config (#780 phase 3): the raw key-file path, the key-id,
+/// and the AEAD suite, each `flag > env > file > default`. Returns `(key_file, key_id, suite)` where a
+/// `Some(key_file)` means at-rest encryption is ON (the broker will open its storage encrypted). This
+/// is the ONLY place the at-rest config is validated, so a misconfiguration is a clean startup error
+/// before the broker opens rather than a late failure.
+///
+/// Feature-gated fail-closed: a build compiled WITHOUT the `encryption` feature refuses ANY at-rest
+/// config (flag, env, or `[encryption]` file key) rather than silently starting plaintext under it.
+///
+/// # Errors
+/// [`CliError::Usage`] on a non-`encryption` build with any at-rest config set; a key-id without a key
+/// file (or vice versa); a non-integer / zero key-id; or an unknown suite name.
+#[allow(clippy::type_complexity)] // the (key_file, key_id, suite) resolved triple is clearer inline
+fn resolve_encryption(
+    key_file_flag: Option<String>,
+    key_id_flag: Option<String>,
+    suite_flag: Option<String>,
+    env: &EnvFn<'_>,
+) -> Result<(Option<String>, Option<u64>, Option<String>), CliError> {
+    let key_file = resolve_opt_string("--encryption-key-file", key_file_flag, env);
+    let key_id_raw = resolve_opt_string("--encryption-key-id", key_id_flag, env);
+    let suite = resolve_opt_string("--encryption-suite", suite_flag, env);
+
+    #[cfg(not(feature = "encryption"))]
+    {
+        // A build without the crypto cannot honor ANY at-rest config: refuse fail-closed rather than
+        // ignore it and start the broker in plaintext under a config that asked for encryption.
+        if key_file.is_some() || key_id_raw.is_some() || suite.is_some() {
+            return Err(reserved_encryption_flag_refusal(
+                "at-rest encryption config ([encryption] / --encryption-* / IRONBUS_ENCRYPTION_*)",
+            ));
+        }
+        Ok((None, None, None))
+    }
+
+    #[cfg(feature = "encryption")]
+    {
+        // Encryption is ON iff a key file is configured. A key-id / suite set WITHOUT a key file is a
+        // misconfiguration (the operator asked for encryption but supplied no key) — refuse, never
+        // silently ignore, so the intent is not lost.
+        let Some(key_file) = key_file else {
+            if key_id_raw.is_some() || suite.is_some() {
+                return Err(CliError::Usage(
+                    "encryption.key_id / encryption.suite were set without encryption.key_file; \
+                     at-rest encryption is enabled by setting the key file (--encryption-key-file / \
+                     IRONBUS_ENCRYPTION_KEY_FILE / [encryption] key_file)"
+                        .to_string(),
+                ));
+            }
+            return Ok((None, None, None));
+        };
+        // The key-id is REQUIRED and must be a NON-ZERO u64 (0 is the no-key/plaintext sentinel the
+        // crypto core rejects), recorded in each encrypted segment header (never the key).
+        let Some(key_id_raw) = key_id_raw else {
+            return Err(CliError::Usage(
+                "at-rest encryption requires --encryption-key-id (a non-zero identifier for the key, \
+                 recorded in the segment header), set alongside --encryption-key-file"
+                    .to_string(),
+            ));
+        };
+        let key_id: u64 = key_id_raw.parse().map_err(|_| {
+            CliError::Usage(format!(
+                "--encryption-key-id must be a non-negative integer, got {key_id_raw:?}"
+            ))
+        })?;
+        if key_id == 0 {
+            return Err(CliError::Usage(
+                "--encryption-key-id must be non-zero (0 is the no-key/plaintext sentinel)"
+                    .to_string(),
+            ));
+        }
+        // Validate the suite name up front so a typo is a clean parse error, not a late open failure.
+        // `auto` (the default when omitted) picks by CPU feature detection at open.
+        if let Some(s) = &suite {
+            match s.as_str() {
+                "auto" | "aes-256-gcm" | "chacha20-poly1305" => {}
+                other => {
+                    return Err(CliError::Usage(format!(
+                        "--encryption-suite must be auto, aes-256-gcm, or chacha20-poly1305, got \
+                         {other:?}"
+                    )))
+                }
+            }
+        }
+        Ok((Some(key_file), Some(key_id), suite))
+    }
 }
 
 /// Refusal for incomplete TLS material (ADR-0004, #766): `--tls-cert` and `--tls-key` are BOTH
@@ -10466,6 +10662,17 @@ fn open_memory_engine(
     key_shared_groups: &[String],
     broadcast_groups: &[String],
 ) -> Result<Engine<EphemeralFs, SystemClock>, CliError> {
+    // At-rest encryption FAIL-CLOSED (#780 phase 3): the in-memory backend has no on-disk segments to
+    // encrypt, so an at-rest key is meaningless here. Refuse rather than pretend to protect data at rest
+    // that never touches a disk. `encryption_key_file` is only ever `Some` on an `encryption`-feature
+    // build (resolve_encryption returns `None` otherwise), so this is a no-op on the default build.
+    if config.encryption_key_file.is_some() {
+        return Err(CliError::Usage(
+            "at-rest encryption (--encryption-key-file) requires an on-disk backend; the in-memory \
+             (--storage memory) broker has no on-disk segments to encrypt"
+                .to_string(),
+        ));
+    }
     open_engine_with(
         EphemeralFs::new(),
         config,
@@ -10473,6 +10680,66 @@ fn open_memory_engine(
         broadcast_groups,
         "in memory",
     )
+}
+
+/// Builds the LIVE at-rest encryption context (#780 phase 3) from the resolved `[encryption]` config:
+/// the write-side [`SegmentCrypto`](ironbus_storage::crypto::SegmentCrypto) (new segments encrypt) and
+/// the read-side [`KeyRing`](ironbus_storage::crypto::KeyRing) (decrypt-on-read), both under the SAME
+/// single key + key-id. The 32-byte raw key is loaded by the phase-1 fail-closed loader, which refuses a
+/// group/world-readable file (#109). Mirrors [`load_tls_termination`] for security material. Only ever
+/// called with a `Some(key_file)` config, and only on an `encryption`-feature build.
+///
+/// # Errors
+/// [`CliError::Usage`] if the key file cannot be loaded (missing, wrong length, or non-owner-only
+/// permissions), or on an unsupported suite name (already validated at resolve; belt-and-braces here).
+#[cfg(all(unix, feature = "encryption"))]
+#[allow(clippy::type_complexity)] // the (write-crypto, read-ring) Arc-option pair is clearer inline
+fn load_encryption_context(
+    config: &ServeConfig,
+) -> Result<
+    (
+        Option<std::sync::Arc<ironbus_storage::crypto::SegmentCrypto>>,
+        Option<std::sync::Arc<ironbus_storage::crypto::KeyRing>>,
+    ),
+    CliError,
+> {
+    use ironbus_storage::crypto::{AeadSuite, KeyRing, SegmentCrypto};
+    let Some(key_file) = config.encryption_key_file.as_deref() else {
+        return Ok((None, None));
+    };
+    let key_id = config
+        .encryption_key_id
+        .expect("key_id is resolved alongside key_file (resolve_encryption)");
+    let suite = match config.encryption_suite.as_deref() {
+        None | Some("auto") => AeadSuite::detect(),
+        Some("aes-256-gcm") => AeadSuite::Aes256Gcm,
+        Some("chacha20-poly1305") => AeadSuite::ChaCha20Poly1305,
+        Some(other) => {
+            return Err(CliError::Usage(format!(
+                "unknown at-rest encryption suite {other:?} (auto, aes-256-gcm, chacha20-poly1305)"
+            )))
+        }
+    };
+    // Load the 32-byte raw key (fail-closed on a non-owner-only file, #109). The key zeroizes on drop.
+    let key = ironbus_storage::crypto::load_key_file(std::path::Path::new(key_file))
+        .map_err(|e| CliError::Usage(format!("at-rest encryption key file {key_file:?}: {e}")))?;
+    // One active WRITE key encrypts new segments; the read RING carries the same key under the same id
+    // so every segment this broker writes decrypts on read. Multi-key rotation (a read ring with prior
+    // keys) is a phase-4 follow-up. The key is cloned into both (it zeroizes on each drop).
+    let crypto = SegmentCrypto::new(suite, key_id, key.clone());
+    let mut ring = KeyRing::new();
+    ring.insert(key_id, key);
+    // A loud, credential-free operator confirmation on the log stream (never the key, only its id +
+    // the chosen suite). `let _`: a broken stderr never blocks serve.
+    let _ = writeln!(
+        std::io::stderr(),
+        "encryption: at-rest AEAD ENABLED (suite {}, key_id {key_id})",
+        suite.name()
+    );
+    Ok((
+        Some(std::sync::Arc::new(crypto)),
+        Some(std::sync::Arc::new(ring)),
+    ))
 }
 
 /// Rebuilds the validated dead-letter EXCHANGE (#551/#710) from the resolved target list, or
@@ -10497,6 +10764,7 @@ fn dead_letter_exchange_config(
 /// (same caps, same retention, same durability mapping, same compression). `context` names the
 /// store in an open error (e.g. `at /var/lib/ironbus`, `in memory`).
 #[cfg(unix)]
+#[allow(clippy::too_many_lines)] // one cohesive EngineConfig build + the at-rest open branch
 fn open_engine_with<F: Filesystem + Clone>(
     fs: F,
     config: &ServeConfig,
@@ -10523,149 +10791,166 @@ fn open_engine_with<F: Filesystem + Clone>(
     )
     .map_err(|e| CliError::Internal(format!("delivery config: {e:?}")))?;
     let visibility_ms = config.visibility_ms;
-    let engine = Engine::open(
-        fs,
-        SystemClock::new(),
-        EngineConfig {
-            // The named-stream STORAGE MODE (#597): `--storage-mode` selects per-stream logs (the
-            // default, byte-for-byte) or the shared-WAL density fallback. Restart-only; the engine
-            // fail-closed refuses a data dir laid out by the other mode.
-            storage_mode: config.storage_mode.to_engine(),
-            // Both caps are honored: `new` validates and sets the segment cap, the builder
-            // layers on the durable-log total byte cap (the drop-new shed; `0` = unlimited).
-            log: LogConfig::new(config.max_segment_bytes)
-                .map_err(|e| CliError::Internal(format!("log config: {e}")))?
-                .with_max_total_bytes(config.max_total_bytes)
-                .with_tindex_stride_records(config.tindex_stride_records),
-            lease: LeaseConfig::from_millis(visibility_ms, visibility_ms.max(DEFAULT_HARD_CAP_MS)),
-            delivery,
-            max_in_flight: config.max_in_flight,
-            // V2-M4 routing richness (per-message/stream TTL + dead-letter exchanges, #549/#551),
-            // wired from `--default-message-ttl-ms` / `--dead-letter-exchange` /
-            // `--dead-letter-expired` (#710). Every knob defaults to its disabling value (no TTL,
-            // no exchange, expired-routing off), so a zero-config broker keeps the historical
-            // fixed-`dlq/` behavior byte-for-byte. The target list was already validated at parse;
-            // re-constructing the typed exchange here cannot fail on a parsed config (surfaced as
-            // an internal error, not a panic, if the invariant ever breaks).
-            default_message_ttl_ms: config.default_message_ttl_ms,
-            // The max accepted per-message delivery delay (V2-M4 #555), wired from
-            // `--max-delay-ms` / `delivery.max_delay_ms`; `0` = unbounded.
-            max_delay_ms: config.max_delay_ms,
-            dead_letter_exchange: dead_letter_exchange_config(config)?,
-            dead_letter_expired: config.dead_letter_expired,
-            // The per-CONSUMER (per-connection) standing in-flight credit CEILING (#65, #552): the most
-            // un-acked messages one connection may EVER hold — the ceiling the auto-tuning credit window
-            // grows toward from a 64 floor as the consumer keeps draining. The effective Flow bound is
-            // min(the current auto-tuned window, the byte budget, the per-group max_in_flight window).
-            // Floored to 1 by the engine. Default 2048 (NOT 65535), the Kafka-class auto-tune ceiling.
-            consumer_credit: config.consumer_credit,
-            // The per-CONSUMER (per-connection) in-flight BYTE budget (#275): the RAM-side companion
-            // to the message-count credit. The effective Flow bound is min(message credit, byte
-            // budget) with a hard floor of one message. Default 8 MiB; `0` = unlimited (off).
-            consumer_credit_bytes: config.consumer_credit_bytes,
-            checkpoint_interval: config.checkpoint_interval,
-            // The acked-ahead RANGE cap (#543) at the engine's safe default: bounds each
-            // work-group cursor's out-of-order-ack memory to 16 KiB (1024 ranges), decoupled
-            // from `--max-in-flight`. Deliberately not a CLI/profile knob yet (the default
-            // never fires at any shipped profile's in-flight window); a
-            // `delivery.max_acked_ahead_runs` knob is the follow-up if operators need it.
-            max_acked_ahead_runs: ironbus_server::engine::DEFAULT_MAX_ACKED_AHEAD_RUNS,
-            // Consumer-safe retention (#13, #80), each `0` = disabled (off), the default. Size in
-            // record bytes, age in milliseconds (against the engine clock), count in messages; the
-            // bounds compose, so a segment is reaped if ANY enabled bound trips.
-            max_retained_bytes: config.max_retained_bytes,
-            max_age_ms: config.max_age_ms,
-            max_messages: config.max_messages,
-            // The work-group cap (refs #240, #9, #10): bounds consumer-state memory once the wire
-            // can name groups. `0` = unlimited (off); the default is non-zero (1024). A new named
-            // group past the cap is rejected by the engine before it allocates.
-            max_groups: config.max_groups,
-            max_streams: config.max_streams,
-            max_open_streams: config.max_open_streams,
-            max_metric_streams: ironbus_server::engine::DEFAULT_MAX_METRIC_STREAMS,
-            // Idle named-group eviction (refs #277, #240): the lifecycle reclaim that completes the
-            // #240 cap. `0` = disabled (off, the default), a non-zero value is the idle window in ms
-            // after which a fully-caught-up, lease-free named group is reclaimed. Never deletes a
-            // durable checkpoint, so a re-subscribe resumes; only caught-up groups are evicted, so a
-            // consumer's committed position is never lost.
-            group_idle_evict_ms: config.group_idle_evict_ms,
-            // The refuse-to-boot RAM ceiling (#115, #19), wired from `--ram-ceiling-bytes` (or the
-            // profile preset: 0 = off for balanced/throughput, 64 MiB for edge-tiny). `0` leaves the
-            // guard off and `ironbus_ram_headroom_bytes` at the `-1` sentinel; a set ceiling makes the
-            // gauge report a real `ceiling - RSS` value AND is enforced before this point by
-            // `validate_serve_config` (which refuses to boot when the worst-case bounded-buffer
-            // footprint provably exceeds it).
-            ram_ceiling_bytes: config.ram_ceiling_bytes,
-            // The disk-full overflow policy (#82): drop-new (default) sheds, drop-oldest force-reaps
-            // the oldest sealed segment then accepts. Honored only when `max_total_bytes` is set.
-            disk_full_policy: match config.disk_full_policy {
-                DiskFullPolicyArg::DropNew => DiskFullPolicy::DropNew,
-                DiskFullPolicyArg::DropOldest => DiskFullPolicy::DropOldest,
-            },
-            // The OPT-IN effectively-once dedup window (#3, #33): the dual count + time bound on each
-            // per-producer dedup ring, plus the cap on the NUMBER of distinct producer windows.
-            // Dedup is OFF by default and activates per-producer only when a publish carries a
-            // `msg_id`; these flags only SIZE the window when it does. `--dedup-max-ids` is the count
-            // bound (default 100k), `--dedup-window-ms` the time bound in ms (default 2 min), and
-            // `--dedup-max-producers` (default 4096) caps the producer windows so a flood of
-            // attacker-chosen `producer_id`s cannot grow RAM without bound (LRU eviction).
-            dedup: ironbus_core::dedup::DedupConfig {
-                max_ids: config.dedup_max_ids,
-                window_nanos: config.dedup_window_ms.saturating_mul(1_000_000),
-                max_producers: config.dedup_max_producers,
-            },
-            // The DURABILITY LEVEL (#341, #379), wired from `--durability-level`. Default `sync`
-            // (ack only after the covering fdatasync, I2, zero acked loss): a zero-config broker is
-            // byte-for-byte the historical durable broker. The relaxed levels are strictly opt-in and
-            // weaken I2 by a documented loss window; `async`/`none` are already gated behind the
-            // explicit `--async-loss-ack` acknowledgement by `validate_serve_config`, so an engine can
-            // only reach a loss-bearing level once the operator accepted the loss. The `interval`
-            // triggers (time/bytes) only matter under `interval`.
-            durability_level: match config.durability_level {
-                DurabilityLevelArg::Sync => DurabilityLevel::Sync,
-                DurabilityLevelArg::Interval => DurabilityLevel::Interval,
-                DurabilityLevelArg::Async => DurabilityLevel::Async,
-                DurabilityLevelArg::None => DurabilityLevel::None,
-            },
-            flush_interval_ms: config.flush_interval_ms,
-            flush_max_bytes: config.flush_max_bytes,
-            // The backpressure controls (#68, #69), wired from the serve flags. Every knob defaults
-            // to its disabling value (CoDel off, retry budget off, fire-and-forget ungoverned, egress
-            // at its floor), so a zero-config broker is byte-for-byte the historical broker. The
-            // engine CLAMPS the CoDel values and bounds the egress limiter, never rejecting a value.
-            codel_target_ms: config.codel_target_ms,
-            codel_interval_ms: config.codel_interval_ms,
-            retry_budget_ratio_per_million: config.retry_budget_ratio_per_million,
-            retry_budget_window_ms: config.retry_budget_window_ms,
-            fire_and_forget_msg_rate: config.fire_and_forget_msg_rate,
-            fire_and_forget_byte_rate: config.fire_and_forget_byte_rate,
-            fire_and_forget_refill_ms: config.fire_and_forget_refill_ms,
-            egress_limit: config.egress_limit,
-            // The event-driven consume long-poll budget (push delivery), wired from
-            // `--consume-longpoll-ms` (default `0` = OFF). Server-only: an idle consumer wakes on a
-            // commit instead of returning empty; no wire/client/format change.
-            consume_longpoll_ms: config.consume_longpoll_ms,
-            // The fsync-headroom admission window (#378), wired from `--wal-fsync-headroom-bytes`.
-            // Default `0` = OFF (the un-fsynced frontier is bounded only by the group-commit
-            // drain under `sync` / the interval window under a relaxed level), so a zero-config
-            // broker is unchanged; a non-zero value is the opt-in tight RAM / loss-window bound.
-            wal_fsync_headroom_bytes: config.wal_fsync_headroom_bytes,
-            // The pipelined sync tier's dirty-byte admission bound (#1040, INV-9), wired from
-            // `--sync-max-dirty-bytes` (default 16 MiB; explicit `0` disables). Enforced by the
-            // append actor's pipelined branch as a THROTTLE (block for the in-flight barrier's
-            // completion), never a shed — the sync tier's semantics.
-            sync_max_dirty_bytes: config.sync_max_dirty_bytes,
-            // The per-record write-path compression codec (#430, ADR-0003), wired from
-            // `--compression` (default `lz4`). `none` stores every record raw, byte-for-byte the
-            // historical layout; `zstd` was already rejected at parse on this build, so the two
-            // arms here are exhaustive.
-            compression: match config.compression {
-                CompressionArg::None => ironbus_core::compress::Codec::None,
-                CompressionArg::Lz4 => ironbus_core::compress::Codec::Lz4,
-            },
+    let engine_config = EngineConfig {
+        // The named-stream STORAGE MODE (#597): `--storage-mode` selects per-stream logs (the
+        // default, byte-for-byte) or the shared-WAL density fallback. Restart-only; the engine
+        // fail-closed refuses a data dir laid out by the other mode.
+        storage_mode: config.storage_mode.to_engine(),
+        // Both caps are honored: `new` validates and sets the segment cap, the builder
+        // layers on the durable-log total byte cap (the drop-new shed; `0` = unlimited).
+        log: LogConfig::new(config.max_segment_bytes)
+            .map_err(|e| CliError::Internal(format!("log config: {e}")))?
+            .with_max_total_bytes(config.max_total_bytes)
+            .with_tindex_stride_records(config.tindex_stride_records),
+        lease: LeaseConfig::from_millis(visibility_ms, visibility_ms.max(DEFAULT_HARD_CAP_MS)),
+        delivery,
+        max_in_flight: config.max_in_flight,
+        // V2-M4 routing richness (per-message/stream TTL + dead-letter exchanges, #549/#551),
+        // wired from `--default-message-ttl-ms` / `--dead-letter-exchange` /
+        // `--dead-letter-expired` (#710). Every knob defaults to its disabling value (no TTL,
+        // no exchange, expired-routing off), so a zero-config broker keeps the historical
+        // fixed-`dlq/` behavior byte-for-byte. The target list was already validated at parse;
+        // re-constructing the typed exchange here cannot fail on a parsed config (surfaced as
+        // an internal error, not a panic, if the invariant ever breaks).
+        default_message_ttl_ms: config.default_message_ttl_ms,
+        // The max accepted per-message delivery delay (V2-M4 #555), wired from
+        // `--max-delay-ms` / `delivery.max_delay_ms`; `0` = unbounded.
+        max_delay_ms: config.max_delay_ms,
+        dead_letter_exchange: dead_letter_exchange_config(config)?,
+        dead_letter_expired: config.dead_letter_expired,
+        // The per-CONSUMER (per-connection) standing in-flight credit CEILING (#65, #552): the most
+        // un-acked messages one connection may EVER hold — the ceiling the auto-tuning credit window
+        // grows toward from a 64 floor as the consumer keeps draining. The effective Flow bound is
+        // min(the current auto-tuned window, the byte budget, the per-group max_in_flight window).
+        // Floored to 1 by the engine. Default 2048 (NOT 65535), the Kafka-class auto-tune ceiling.
+        consumer_credit: config.consumer_credit,
+        // The per-CONSUMER (per-connection) in-flight BYTE budget (#275): the RAM-side companion
+        // to the message-count credit. The effective Flow bound is min(message credit, byte
+        // budget) with a hard floor of one message. Default 8 MiB; `0` = unlimited (off).
+        consumer_credit_bytes: config.consumer_credit_bytes,
+        checkpoint_interval: config.checkpoint_interval,
+        // The acked-ahead RANGE cap (#543) at the engine's safe default: bounds each
+        // work-group cursor's out-of-order-ack memory to 16 KiB (1024 ranges), decoupled
+        // from `--max-in-flight`. Deliberately not a CLI/profile knob yet (the default
+        // never fires at any shipped profile's in-flight window); a
+        // `delivery.max_acked_ahead_runs` knob is the follow-up if operators need it.
+        max_acked_ahead_runs: ironbus_server::engine::DEFAULT_MAX_ACKED_AHEAD_RUNS,
+        // Consumer-safe retention (#13, #80), each `0` = disabled (off), the default. Size in
+        // record bytes, age in milliseconds (against the engine clock), count in messages; the
+        // bounds compose, so a segment is reaped if ANY enabled bound trips.
+        max_retained_bytes: config.max_retained_bytes,
+        max_age_ms: config.max_age_ms,
+        max_messages: config.max_messages,
+        // The work-group cap (refs #240, #9, #10): bounds consumer-state memory once the wire
+        // can name groups. `0` = unlimited (off); the default is non-zero (1024). A new named
+        // group past the cap is rejected by the engine before it allocates.
+        max_groups: config.max_groups,
+        max_streams: config.max_streams,
+        max_open_streams: config.max_open_streams,
+        max_metric_streams: ironbus_server::engine::DEFAULT_MAX_METRIC_STREAMS,
+        // Idle named-group eviction (refs #277, #240): the lifecycle reclaim that completes the
+        // #240 cap. `0` = disabled (off, the default), a non-zero value is the idle window in ms
+        // after which a fully-caught-up, lease-free named group is reclaimed. Never deletes a
+        // durable checkpoint, so a re-subscribe resumes; only caught-up groups are evicted, so a
+        // consumer's committed position is never lost.
+        group_idle_evict_ms: config.group_idle_evict_ms,
+        // The refuse-to-boot RAM ceiling (#115, #19), wired from `--ram-ceiling-bytes` (or the
+        // profile preset: 0 = off for balanced/throughput, 64 MiB for edge-tiny). `0` leaves the
+        // guard off and `ironbus_ram_headroom_bytes` at the `-1` sentinel; a set ceiling makes the
+        // gauge report a real `ceiling - RSS` value AND is enforced before this point by
+        // `validate_serve_config` (which refuses to boot when the worst-case bounded-buffer
+        // footprint provably exceeds it).
+        ram_ceiling_bytes: config.ram_ceiling_bytes,
+        // The disk-full overflow policy (#82): drop-new (default) sheds, drop-oldest force-reaps
+        // the oldest sealed segment then accepts. Honored only when `max_total_bytes` is set.
+        disk_full_policy: match config.disk_full_policy {
+            DiskFullPolicyArg::DropNew => DiskFullPolicy::DropNew,
+            DiskFullPolicyArg::DropOldest => DiskFullPolicy::DropOldest,
         },
-    )
-    .map_err(|e| CliError::Internal(format!("opening broker {context}: {e}")))?;
+        // The OPT-IN effectively-once dedup window (#3, #33): the dual count + time bound on each
+        // per-producer dedup ring, plus the cap on the NUMBER of distinct producer windows.
+        // Dedup is OFF by default and activates per-producer only when a publish carries a
+        // `msg_id`; these flags only SIZE the window when it does. `--dedup-max-ids` is the count
+        // bound (default 100k), `--dedup-window-ms` the time bound in ms (default 2 min), and
+        // `--dedup-max-producers` (default 4096) caps the producer windows so a flood of
+        // attacker-chosen `producer_id`s cannot grow RAM without bound (LRU eviction).
+        dedup: ironbus_core::dedup::DedupConfig {
+            max_ids: config.dedup_max_ids,
+            window_nanos: config.dedup_window_ms.saturating_mul(1_000_000),
+            max_producers: config.dedup_max_producers,
+        },
+        // The DURABILITY LEVEL (#341, #379), wired from `--durability-level`. Default `sync`
+        // (ack only after the covering fdatasync, I2, zero acked loss): a zero-config broker is
+        // byte-for-byte the historical durable broker. The relaxed levels are strictly opt-in and
+        // weaken I2 by a documented loss window; `async`/`none` are already gated behind the
+        // explicit `--async-loss-ack` acknowledgement by `validate_serve_config`, so an engine can
+        // only reach a loss-bearing level once the operator accepted the loss. The `interval`
+        // triggers (time/bytes) only matter under `interval`.
+        durability_level: match config.durability_level {
+            DurabilityLevelArg::Sync => DurabilityLevel::Sync,
+            DurabilityLevelArg::Interval => DurabilityLevel::Interval,
+            DurabilityLevelArg::Async => DurabilityLevel::Async,
+            DurabilityLevelArg::None => DurabilityLevel::None,
+        },
+        flush_interval_ms: config.flush_interval_ms,
+        flush_max_bytes: config.flush_max_bytes,
+        // The backpressure controls (#68, #69), wired from the serve flags. Every knob defaults
+        // to its disabling value (CoDel off, retry budget off, fire-and-forget ungoverned, egress
+        // at its floor), so a zero-config broker is byte-for-byte the historical broker. The
+        // engine CLAMPS the CoDel values and bounds the egress limiter, never rejecting a value.
+        codel_target_ms: config.codel_target_ms,
+        codel_interval_ms: config.codel_interval_ms,
+        retry_budget_ratio_per_million: config.retry_budget_ratio_per_million,
+        retry_budget_window_ms: config.retry_budget_window_ms,
+        fire_and_forget_msg_rate: config.fire_and_forget_msg_rate,
+        fire_and_forget_byte_rate: config.fire_and_forget_byte_rate,
+        fire_and_forget_refill_ms: config.fire_and_forget_refill_ms,
+        egress_limit: config.egress_limit,
+        // The event-driven consume long-poll budget (push delivery), wired from
+        // `--consume-longpoll-ms` (default `0` = OFF). Server-only: an idle consumer wakes on a
+        // commit instead of returning empty; no wire/client/format change.
+        consume_longpoll_ms: config.consume_longpoll_ms,
+        // The fsync-headroom admission window (#378), wired from `--wal-fsync-headroom-bytes`.
+        // Default `0` = OFF (the un-fsynced frontier is bounded only by the group-commit
+        // drain under `sync` / the interval window under a relaxed level), so a zero-config
+        // broker is unchanged; a non-zero value is the opt-in tight RAM / loss-window bound.
+        wal_fsync_headroom_bytes: config.wal_fsync_headroom_bytes,
+        // The pipelined sync tier's dirty-byte admission bound (#1040, INV-9), wired from
+        // `--sync-max-dirty-bytes` (default 16 MiB; explicit `0` disables). Enforced by the
+        // append actor's pipelined branch as a THROTTLE (block for the in-flight barrier's
+        // completion), never a shed — the sync tier's semantics.
+        sync_max_dirty_bytes: config.sync_max_dirty_bytes,
+        // The per-record write-path compression codec (#430, ADR-0003), wired from
+        // `--compression` (default `lz4`). `none` stores every record raw, byte-for-byte the
+        // historical layout; `zstd` was already rejected at parse on this build, so the two
+        // arms here are exhaustive.
+        compression: match config.compression {
+            CompressionArg::None => ironbus_core::compress::Codec::None,
+            CompressionArg::Lz4 => ironbus_core::compress::Codec::Lz4,
+        },
+    };
+    // At-rest encryption (#780 phase 3): a configured `--encryption-key-file` opens the engine's storage
+    // ENCRYPTED via `Engine::open_encrypted` — the phase-2-verified seam, so the resume-reattach fix and
+    // every fail-closed guard engage — and no key is the PLAINTEXT default (byte-for-byte the historical
+    // `Engine::open`). Feature-gated: a non-`encryption` build cannot reach here with a key configured
+    // (`resolve_encryption` refused it), so it always takes the plaintext open.
+    let opened = {
+        #[cfg(feature = "encryption")]
+        {
+            if config.encryption_key_file.is_some() {
+                let (crypto, keyring) = load_encryption_context(config)?;
+                Engine::open_encrypted(fs, SystemClock::new(), engine_config, crypto, keyring)
+            } else {
+                Engine::open(fs, SystemClock::new(), engine_config)
+            }
+        }
+        #[cfg(not(feature = "encryption"))]
+        {
+            Engine::open(fs, SystemClock::new(), engine_config)
+        }
+    };
+    let engine =
+        opened.map_err(|e| CliError::Internal(format!("opening broker {context}: {e}")))?;
     let mut engine = engine;
     // Bound the concurrently-PREPARED transactional half messages (#909): the refuse-to-boot RAM guard
     // charges `max_prepared * a maximal frame` (term 7), so the engine MUST honor the configured cap
@@ -14350,6 +14635,9 @@ mod tests {
             // drain timeout) / off (no audit sink), so these validation/precedence tests are unaffected.
             drain_timeout_ms: DEFAULT_DRAIN_TIMEOUT_MS,
             audit_log: None,
+            encryption_key_file: None,
+            encryption_key_id: None,
+            encryption_suite: None,
         }
     }
 
@@ -15040,6 +15328,100 @@ mod tests {
         }
         drop(engine);
         dir
+    }
+
+    /// #780 phase 3 (the SERVE hookup): a broker started with an `[encryption]` config actually writes
+    /// ENCRYPTED-on-disk segments through the CLI → engine → storage seam, and a DEFAULT (no-key) reader
+    /// REFUSES them fail-closed. This is the end-to-end proof the phase-2 crypto is no longer inert at
+    /// the serve layer: it exercises `resolve_encryption` → `load_encryption_context` →
+    /// `Engine::open_encrypted` → `StreamSet::open_with_at_rest` → `create_encrypted` → encrypting
+    /// append, then the resume-reattach + the `EncryptedSegmentNoKey` guard on a no-key reopen.
+    #[cfg(all(unix, feature = "encryption"))]
+    #[test]
+    fn serve_with_encryption_writes_encrypted_segments_and_a_no_key_reader_refuses() {
+        use std::io::Write;
+        use std::os::unix::fs::PermissionsExt;
+        let base =
+            std::env::temp_dir().join(format!("ironbus-cli-enc-serve-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&base);
+        std::fs::create_dir_all(&base).unwrap();
+        // A 32-byte OWNER-ONLY key file (the phase-1 loader refuses a group/world-readable file).
+        let key_path = base.join("at-rest.key");
+        std::fs::File::create(&key_path)
+            .unwrap()
+            .write_all(&[0x5Au8; 32])
+            .unwrap();
+        std::fs::set_permissions(&key_path, std::fs::Permissions::from_mode(0o600)).unwrap();
+        let data_dir = base.join("data");
+
+        let secret: &[u8] = b"the-confidential-encrypted-payload-CANARY-xyzzy-4242";
+        let enc_config = ServeConfig {
+            encryption_key_file: Some(key_path.display().to_string()),
+            encryption_key_id: Some(7),
+            encryption_suite: None, // auto-detect the suite by CPU features
+            ..test_serve_config(64, 1)
+        };
+
+        // 1) An encrypted broker produces an encrypted-on-disk segment.
+        {
+            let mut engine = open_disk_engine(&data_dir, &enc_config, &[], &[]).unwrap();
+            engine
+                .produce(&Append {
+                    timestamp_ms: 100,
+                    flags: RecordFlags::EMPTY,
+                    key: b"k",
+                    headers: b"",
+                    payload: secret,
+                })
+                .unwrap();
+            drop(engine);
+        }
+
+        // 2) The confidential PLAINTEXT payload NEVER appears on disk in any segment (it is ciphertext).
+        let mut segment_files = 0usize;
+        for entry in std::fs::read_dir(&data_dir).unwrap() {
+            let path = entry.unwrap().path();
+            if path.extension().and_then(|e| e.to_str()) == Some("log") {
+                segment_files += 1;
+                let bytes = std::fs::read(&path).unwrap();
+                assert!(
+                    !bytes.windows(secret.len()).any(|w| w == secret),
+                    "the plaintext payload leaked onto disk in {}",
+                    path.display()
+                );
+            }
+        }
+        assert!(segment_files >= 1, "at least one segment file was written");
+
+        // 3) A DEFAULT (no-key) reader REFUSES the encrypted-on-disk log fail-closed (the
+        //    always-compiled EncryptedSegmentNoKey guard) — it never silently starts plaintext.
+        let opened = open_disk_engine(&data_dir, &test_serve_config(64, 1), &[], &[]);
+        assert!(
+            opened.is_err(),
+            "a no-key reader must REFUSE an encrypted log, not silently start plaintext"
+        );
+        let err = opened.err().unwrap();
+        let msg = format!("{err:?}").to_lowercase();
+        assert!(
+            msg.contains("encrypt") || msg.contains("key"),
+            "the no-key reopen must refuse an encrypted log, got: {msg}"
+        );
+
+        // 4) Reopening WITH the key succeeds (finalize_at_rest re-attaches the crypto) and the record
+        //    round-trips: the decrypt-on-read path returns the original plaintext.
+        {
+            let mut engine = open_disk_engine(&data_dir, &enc_config, &[], &[]).unwrap();
+            match engine.poll(0).unwrap() {
+                ironbus_server::engine::Poll::Message(d) => assert_eq!(
+                    &d.record.payload[..],
+                    secret,
+                    "the encrypted record decrypts back to its plaintext on read"
+                ),
+                other => panic!("expected the decrypted message, got {other:?}"),
+            }
+        }
+
+        let _ = std::fs::remove_dir_all(&base);
     }
 
     // --- offline mutating admin verbs (#299) ---
@@ -18022,6 +18404,9 @@ mod tests {
             // drain timeout) / off (no audit sink), so these validation/precedence tests are unaffected.
             drain_timeout_ms: DEFAULT_DRAIN_TIMEOUT_MS,
             audit_log: None,
+            encryption_key_file: None,
+            encryption_key_id: None,
+            encryption_suite: None,
         }
     }
 

--- a/crates/ironbus-cli/src/main.rs
+++ b/crates/ironbus-cli/src/main.rs
@@ -5079,6 +5079,22 @@ fn validate_serve_config(config: &ServeConfig) -> Result<(), CliError> {
     validate_durability(config)?;
     validate_storage(config)?;
     validate_ram_ceiling(config)?;
+    // At-rest encryption (#780 phase 3) is mutually exclusive with the maintenance passes that are not
+    // yet crypto-aware. Key-compaction rewrites sealed segments and would either lose the encryption or
+    // mis-place nonces, so the storage layer refuses it at runtime (`EncryptedMaintenanceUnsupported`).
+    // Refuse `--compact` + encryption at STARTUP for a clean error, consistent with the shared-WAL /
+    // memory-backend startup refusals, rather than letting a produce start returning ERR_STORAGE once a
+    // compaction pass first triggers. (Tiered cold-segment offload is not serve-configurable, so there
+    // is nothing to refuse for it here; its runtime guard remains the backstop.)
+    // `encryption_key_file` is only ever `Some` on an `encryption`-feature build, so this is a no-op on
+    // the default build.
+    if config.encryption_key_file.is_some() && config.compact {
+        return Err(CliError::Usage(
+            "`--compact` is not supported with at-rest encryption (`--encryption-key-file`): \
+             key-compaction rewrites sealed segments and is not yet crypto-aware. Disable one of them."
+                .to_string(),
+        ));
+    }
     Ok(())
 }
 
@@ -15339,33 +15355,67 @@ mod tests {
     /// the serve layer: it exercises `resolve_encryption` → `load_encryption_context` →
     /// `Engine::open_encrypted` → `StreamSet::open_with_at_rest` → `create_encrypted` → encrypting
     /// append, then the resume-reattach + the `EncryptedSegmentNoKey` guard on a no-key reopen.
+    /// Writes a 32-byte OWNER-ONLY at-rest key file at `path` (the phase-1 loader refuses a
+    /// group/world-readable file) and returns an encryption `ServeConfig` keyed off it.
     #[cfg(all(unix, feature = "encryption"))]
-    #[test]
-    fn serve_with_encryption_writes_encrypted_segments_and_a_no_key_reader_refuses() {
+    fn encryption_test_config(key_path: &std::path::Path) -> ServeConfig {
         use std::io::Write;
         use std::os::unix::fs::PermissionsExt;
-        let base =
-            std::env::temp_dir().join(format!("ironbus-cli-enc-serve-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&base);
-        std::fs::create_dir_all(&base).unwrap();
-        // A 32-byte OWNER-ONLY key file (the phase-1 loader refuses a group/world-readable file).
-        let key_path = base.join("at-rest.key");
-        std::fs::File::create(&key_path)
+        std::fs::File::create(key_path)
             .unwrap()
             .write_all(&[0x5Au8; 32])
             .unwrap();
-        std::fs::set_permissions(&key_path, std::fs::Permissions::from_mode(0o600)).unwrap();
-        let data_dir = base.join("data");
-
-        let secret: &[u8] = b"the-confidential-encrypted-payload-CANARY-xyzzy-4242";
-        let enc_config = ServeConfig {
+        std::fs::set_permissions(key_path, std::fs::Permissions::from_mode(0o600)).unwrap();
+        ServeConfig {
             encryption_key_file: Some(key_path.display().to_string()),
             encryption_key_id: Some(7),
             encryption_suite: None, // auto-detect the suite by CPU features
             ..test_serve_config(64, 1)
-        };
+        }
+    }
 
-        // 1) An encrypted broker produces an encrypted-on-disk segment.
+    /// RECURSIVELY walks every file under `dir` (descending into `pstreams/`, `prstreams/`, `streams/`,
+    /// `dlq/`, and all other subdirs) and asserts `needle` — a confidential plaintext canary — appears in
+    /// NONE of them. Returns the number of files scanned. This is what catches a leak in a substrate the
+    /// crypto seam does not reach (the #693/#553 partitioned/priority sub-logs the earlier non-recursive
+    /// scan missed).
+    #[cfg(all(unix, feature = "encryption"))]
+    fn assert_no_plaintext_under(dir: &std::path::Path, needle: &[u8]) -> usize {
+        let mut files = 0usize;
+        for entry in std::fs::read_dir(dir).unwrap() {
+            let path = entry.unwrap().path();
+            if path.is_dir() {
+                files += assert_no_plaintext_under(&path, needle);
+            } else {
+                files += 1;
+                let bytes = std::fs::read(&path).unwrap();
+                assert!(
+                    !bytes.windows(needle.len()).any(|w| w == needle),
+                    "the plaintext canary leaked onto disk in {}",
+                    path.display()
+                );
+            }
+        }
+        files
+    }
+
+    #[cfg(all(unix, feature = "encryption"))]
+    #[test]
+    fn serve_with_encryption_writes_encrypted_segments_and_a_no_key_reader_refuses() {
+        use ironbus_server::engine::EngineError;
+        let base =
+            std::env::temp_dir().join(format!("ironbus-cli-enc-serve-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&base);
+        std::fs::create_dir_all(&base).unwrap();
+        let enc_config = encryption_test_config(&base.join("at-rest.key"));
+        let data_dir = base.join("data");
+
+        let secret: &[u8] = b"the-confidential-encrypted-payload-CANARY-xyzzy-4242";
+
+        // 1) An encrypted broker produces an encrypted-on-disk segment; and a partitioned (#693) /
+        //    priority-lane (#553) stream declare is REFUSED fail-closed under encryption (their
+        //    PartitionedStream sub-logs are not crypto-aware — a regression that dropped the guard would
+        //    let the declare succeed here, and a produce leak into pstreams//prstreams/).
         {
             let mut engine = open_disk_engine(&data_dir, &enc_config, &[], &[]).unwrap();
             engine
@@ -15377,24 +15427,32 @@ mod tests {
                     payload: secret,
                 })
                 .unwrap();
+            assert!(
+                matches!(
+                    engine.declare_partitioned_stream("orders", 4),
+                    Err(EngineError::EncryptedPartitionedStreamUnsupported)
+                ),
+                "a partitioned-stream declare must be refused under encryption"
+            );
+            assert!(
+                matches!(
+                    engine.declare_priority_stream("alerts", 3),
+                    Err(EngineError::EncryptedPartitionedStreamUnsupported)
+                ),
+                "a priority-lane-stream declare must be refused under encryption"
+            );
             drop(engine);
         }
 
-        // 2) The confidential PLAINTEXT payload NEVER appears on disk in any segment (it is ciphertext).
-        let mut segment_files = 0usize;
-        for entry in std::fs::read_dir(&data_dir).unwrap() {
-            let path = entry.unwrap().path();
-            if path.extension().and_then(|e| e.to_str()) == Some("log") {
-                segment_files += 1;
-                let bytes = std::fs::read(&path).unwrap();
-                assert!(
-                    !bytes.windows(secret.len()).any(|w| w == secret),
-                    "the plaintext payload leaked onto disk in {}",
-                    path.display()
-                );
-            }
-        }
-        assert!(segment_files >= 1, "at least one segment file was written");
+        // 2) The confidential PLAINTEXT payload NEVER appears on disk ANYWHERE under the data dir (a
+        //    RECURSIVE scan: the default stream is ciphertext, and no pstreams//prstreams/ subtree
+        //    leaked it — the refused declares created none).
+        let scanned = assert_no_plaintext_under(&data_dir, secret);
+        assert!(scanned >= 1, "at least one file was written + scanned");
+        assert!(
+            !data_dir.join("pstreams").exists() && !data_dir.join("prstreams").exists(),
+            "a refused partitioned/priority declare must materialize no pstreams//prstreams/ subtree"
+        );
 
         // 3) A DEFAULT (no-key) reader REFUSES the encrypted-on-disk log fail-closed (the
         //    always-compiled EncryptedSegmentNoKey guard) — it never silently starts plaintext.
@@ -15425,6 +15483,145 @@ mod tests {
         }
 
         let _ = std::fs::remove_dir_all(&base);
+    }
+
+    /// #780 phase 3 (the reviewer-found LEAK, fail-closed): declaring a partitioned (#693) OR a
+    /// priority-lane (#553) stream on an encrypted broker is REFUSED with
+    /// `EncryptedPartitionedStreamUnsupported`, and NO confidential body lands anywhere under the data
+    /// dir (a recursive scan). Their `PartitionedStream` sub-logs are not threaded through the at-rest
+    /// crypto seam, so a plaintext write would be a real at-rest leak; this pins the guard.
+    #[cfg(all(unix, feature = "encryption"))]
+    #[test]
+    fn partitioned_and_priority_stream_declares_are_refused_under_encryption_with_no_leak() {
+        use ironbus_server::engine::EngineError;
+        let base =
+            std::env::temp_dir().join(format!("ironbus-cli-enc-part-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&base);
+        std::fs::create_dir_all(&base).unwrap();
+        let enc_config = encryption_test_config(&base.join("at-rest.key"));
+        let data_dir = base.join("data");
+        // A distinct canary we would produce to a partition IF the declare wrongly succeeded.
+        let part_secret: &[u8] = b"PARTITIONED-CONFIDENTIAL-CANARY-abc-98765";
+
+        {
+            let mut engine = open_disk_engine(&data_dir, &enc_config, &[], &[]).unwrap();
+            // Both partitioned modes must refuse at declare, before any pstreams//prstreams/ subtree.
+            match engine.declare_partitioned_stream("orders", 8) {
+                Err(EngineError::EncryptedPartitionedStreamUnsupported) => {}
+                Ok(_) => {
+                    // A guard regression: prove the leak so the recursive scan below FAILS loudly.
+                    let _ = engine.produce_in_stream(
+                        "orders",
+                        &Append {
+                            timestamp_ms: 1,
+                            flags: RecordFlags::EMPTY,
+                            key: b"k",
+                            headers: b"",
+                            payload: part_secret,
+                        },
+                    );
+                    panic!(
+                        "the partitioned declare must be refused under encryption, it succeeded"
+                    );
+                }
+                Err(other) => {
+                    panic!("expected EncryptedPartitionedStreamUnsupported, got {other:?}")
+                }
+            }
+            match engine.declare_priority_stream("alerts", 4) {
+                Err(EngineError::EncryptedPartitionedStreamUnsupported) => {}
+                other => panic!(
+                    "the priority declare must be refused with EncryptedPartitionedStreamUnsupported, \
+                     got {other:?}"
+                ),
+            }
+            drop(engine);
+        }
+
+        // No partitioned/priority subtree was created, and neither canary appears in the clear anywhere.
+        assert!(
+            !data_dir.join("pstreams").exists() && !data_dir.join("prstreams").exists(),
+            "a refused declare must materialize no pstreams//prstreams/ subtree"
+        );
+        assert_no_plaintext_under(&data_dir, part_secret);
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    /// #780 phase 3: an encrypted broker that INHERITS a pre-existing plaintext `pstreams/` subtree on
+    /// disk (a broker that ran plaintext with partitioned streams, then had encryption turned on) must
+    /// FAIL CLOSED at open rather than silently reopen + serve those crypto-unaware sub-logs plaintext.
+    #[cfg(all(unix, feature = "encryption"))]
+    #[test]
+    fn an_encrypted_open_of_a_preexisting_partitioned_subtree_fails_closed() {
+        let base =
+            std::env::temp_dir().join(format!("ironbus-cli-enc-inherit-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&base);
+        std::fs::create_dir_all(&base).unwrap();
+        let data_dir = base.join("data");
+        let enc_config = encryption_test_config(&base.join("at-rest.key"));
+
+        // 1) An ENCRYPTED broker lays down an encrypted ROOT log (and, correctly, NO pstreams/ — the
+        //    declare path refuses partitioned streams under encryption). A clean encrypted deployment.
+        {
+            let mut engine = open_disk_engine(&data_dir, &enc_config, &[], &[]).unwrap();
+            engine
+                .produce(&Append {
+                    timestamp_ms: 1,
+                    flags: RecordFlags::EMPTY,
+                    key: b"k",
+                    headers: b"",
+                    payload: b"encrypted-default-body",
+                })
+                .unwrap();
+            drop(engine);
+        }
+        assert!(
+            !data_dir.join("pstreams").exists(),
+            "a clean encrypted broker declares no partitioned streams, so no pstreams/ exists"
+        );
+
+        // 2) Simulate an INHERITED / hand-crafted crypto-unaware `pstreams/` subtree appearing under the
+        //    encrypted data dir (a copied-in subtree, or a future materialization bug). The open-time
+        //    guard is the defense-in-depth backstop the declare-time guard cannot cover: a broker that
+        //    reopens an encrypted root must NOT silently reopen + serve a plaintext partition sub-log.
+        std::fs::create_dir_all(data_dir.join("pstreams").join("6f7264657273")).unwrap();
+
+        // 3) Reopening WITH the key must FAIL CLOSED at open (the encrypted root would open fine; the
+        //    inherited pstreams/ subtree is what must trip the refusal).
+        let opened = open_disk_engine(&data_dir, &enc_config, &[], &[]);
+        match opened {
+            Err(CliError::Internal(msg)) => assert!(
+                msg.to_lowercase().contains("partitioned")
+                    || msg.to_lowercase().contains("priority"),
+                "the open must refuse the inherited partitioned subtree, got: {msg}"
+            ),
+            Ok(_) => {
+                panic!("an encrypted open of a pre-existing pstreams/ subtree must fail closed")
+            }
+            Err(other) => panic!("expected a partitioned-stream refusal, got {other:?}"),
+        }
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    /// #780 phase 3: `--compact` (key-compaction, not yet crypto-aware) alongside at-rest encryption is
+    /// refused at STARTUP with a clean usage error (consistent with the shared-WAL / memory-backend
+    /// startup refusals), rather than only fail-closing at runtime once a compaction pass first triggers.
+    #[cfg(all(unix, feature = "encryption"))]
+    #[test]
+    fn compact_plus_encryption_is_refused_at_startup() {
+        let cfg = ServeConfig {
+            encryption_key_file: Some("/some/at-rest.key".to_string()),
+            encryption_key_id: Some(7),
+            encryption_suite: None,
+            compact: true,
+            ..test_serve_config(64, 1)
+        };
+        let err = validate_serve_config(&cfg).unwrap_err();
+        let msg = format!("{err:?}").to_lowercase();
+        assert!(
+            msg.contains("compact") && msg.contains("encryption"),
+            "the startup refusal must name both --compact and encryption, got: {msg}"
+        );
     }
 
     // --- offline mutating admin verbs (#299) ---

--- a/crates/ironbus-core/src/config.rs
+++ b/crates/ironbus-core/src/config.rs
@@ -448,6 +448,25 @@ pub const KEY_TABLE: &[KeySpec] = &[
         key: "network.enable_admin",
         kind: KeyKind::Bool,
     },
+    // [encryption] — optional at-rest AEAD encryption (#780 phase 3, docs/AT_REST_ENCRYPTION.md). WIRED
+    // keys, feature-gated behind the CLI/server `encryption` cargo feature: a build WITHOUT the feature
+    // refuses these keys fail-closed at resolve (never silently starts plaintext), and a build WITH it
+    // opens the engine's storage encrypted. `key_file` is the raw 32-byte key-file path (the phase-1
+    // fail-closed loader; owner-only perms enforced); `key_id` is its non-zero identifier recorded in
+    // the segment header (never the key); `suite` is `auto` (default: CPU detect) / `aes-256-gcm` /
+    // `chacha20-poly1305`. Encryption is ON iff `key_file` is set.
+    KeySpec {
+        key: "encryption.key_file",
+        kind: KeyKind::Str,
+    },
+    KeySpec {
+        key: "encryption.key_id",
+        kind: KeyKind::Integer,
+    },
+    KeySpec {
+        key: "encryption.suite",
+        kind: KeyKind::Str,
+    },
 ];
 
 /// True when `section` is a top-level TOML section FROZEN as reserved by the #14 stability
@@ -458,14 +477,12 @@ pub const KEY_TABLE: &[KeySpec] = &[
 /// reject-unknown rule applies only to keys under the WIRED sections in [`KEY_TABLE`].
 #[must_use]
 pub fn is_reserved_section(section: &str) -> bool {
-    // `[encryption]` (#780) is the reserved landing section for at-rest AEAD encryption config (the
-    // key source: `encryption.key_file` etc). The functional raw-key-file loader ships in
-    // `ironbus_storage::crypto::load_key_file`; the full typed key-config schema is owned by #14/#109,
-    // so the section is tolerated-but-ignored here until those keys are wired into `KEY_TABLE`.
-    matches!(
-        section,
-        "observability" | "auth" | "compression" | "encryption"
-    )
+    // `[encryption]` (#780) is NO LONGER reserved: as of the phase-3 serve hookup its keys
+    // (`encryption.key_file`, `encryption.key_id`, `encryption.suite`) are WIRED into `KEY_TABLE`
+    // above and resolved by the CLI (feature-gated behind `encryption`; a build without the feature
+    // refuses them fail-closed rather than tolerating-and-ignoring them). The remaining reserved
+    // sections' per-key contents are still owned by other issues.
+    matches!(section, "observability" | "auth" | "compression")
 }
 
 /// Looks up a fully-qualified dotted key in [`KEY_TABLE`], returning its [`KeySpec`].

--- a/crates/ironbus-server/Cargo.toml
+++ b/crates/ironbus-server/Cargo.toml
@@ -39,6 +39,14 @@ edge-min = []
 # drops its ring-backed webpki path and the tls12 code: IronBus is TLS 1.3-only (docs/TRANSPORT.md),
 # so the shipped tls graph is aws-lc-rs only, never ring.
 tls = ["dep:rustls", "dep:rustls-pki-types", "dep:x509-cert", "dep:const-oid"]
+# At-rest AEAD encryption (#780, phase 3 serve hookup). NON-DEFAULT: forwards `ironbus-storage`'s
+# `encryption` feature so the engine's live storage seam (`Log::open_with_at_rest` /
+# `StreamSet::open_with_at_rest`) and `Engine::open_encrypted` compile, and so the `#[cfg(feature =
+# "encryption")]` gates in this crate that build the at-rest context activate. UNLIKE `tls` it pulls NO
+# C-FFI: the RustCrypto AEAD stack is pure Rust and already deny.toml-clean, so the DEFAULT (no-feature)
+# server graph and the `edge-min` build are byte-for-byte unchanged and link zero crypto. When OFF the
+# engine still refuses to open an encrypted-on-disk log (the always-compiled storage guard).
+encryption = ["ironbus-storage/encryption"]
 
 [dependencies]
 ironbus-core = { path = "../ironbus-core", version = "0.1.0" }

--- a/crates/ironbus-server/src/codes.rs
+++ b/crates/ironbus-server/src/codes.rs
@@ -271,6 +271,16 @@ impl ErrorCode {
             EngineError::DueTimeInjected { .. } => Self::ERR_INVALID_DELAY_HEADER,
             EngineError::Storage(_) if error.is_at_capacity() => Self::ERR_AT_CAPACITY,
             EngineError::Storage(_) => Self::ERR_STORAGE,
+            // At-rest encryption fail-closed refusals (#780 phase 3) for the deferred paths
+            // (shared-WAL, dead-letter, txn). These are storage-layer refusals with their own
+            // human-readable Display text, but they DELIBERATELY reuse the FROZEN generic `ERR_STORAGE`
+            // wire code rather than mint new wire tokens (no proto-decoder change): each is a rare,
+            // fail-closed "the storage layer refused this under encryption" condition, not a routine
+            // client error. The shared body with the `Storage(_)` arm above is intentional.
+            #[allow(clippy::match_same_arms)]
+            EngineError::EncryptedSharedWalUnsupported
+            | EngineError::EncryptedDeadLetterUnsupported
+            | EngineError::EncryptedTxnUnsupported => Self::ERR_STORAGE,
         }
     }
 }

--- a/crates/ironbus-server/src/codes.rs
+++ b/crates/ironbus-server/src/codes.rs
@@ -280,7 +280,8 @@ impl ErrorCode {
             #[allow(clippy::match_same_arms)]
             EngineError::EncryptedSharedWalUnsupported
             | EngineError::EncryptedDeadLetterUnsupported
-            | EngineError::EncryptedTxnUnsupported => Self::ERR_STORAGE,
+            | EngineError::EncryptedTxnUnsupported
+            | EngineError::EncryptedPartitionedStreamUnsupported => Self::ERR_STORAGE,
         }
     }
 }

--- a/crates/ironbus-server/src/engine.rs
+++ b/crates/ironbus-server/src/engine.rs
@@ -53,7 +53,7 @@ use ironbus_storage::fs::Filesystem;
 use ironbus_storage::layout::{
     PARTITIONED_STREAMS_SUBDIR, PRIORITY_STREAMS_SUBDIR, SHARED_WAL_SUBDIR, STREAMS_SUBDIR,
 };
-use ironbus_storage::log::{Append, Log, LogConfig, RetentionBounds, SyncTicket};
+use ironbus_storage::log::{Append, AtRestCrypto, Log, LogConfig, RetentionBounds, SyncTicket};
 use ironbus_storage::loss::LossReport;
 use ironbus_storage::naming::{
     parse_partition_subdir_name, parse_stream_subdir_name, stream_subdir_name, MAX_STREAM_NAME_LEN,
@@ -899,9 +899,26 @@ pub enum EngineError {
         /// The absolute due-instant the wire tried to smuggle in, in Unix milliseconds.
         due_unix_ms: u64,
     },
+    /// At-rest encryption was configured together with the shared-WAL storage mode (#780 phase 3).
+    /// The shared-WAL substrate interleaves every named stream's records in ONE commit log and is not
+    /// wired through the at-rest crypto seam, so encrypting it is a phase-4 item. REFUSED fail-closed
+    /// at open rather than silently writing the shared commit log in PLAINTEXT.
+    EncryptedSharedWalUnsupported,
+    /// A message would be DEAD-LETTERED while at-rest encryption is on (#780 phase 3). The DLQ sink is
+    /// a separate on-disk `Log` whose recovery rebuild reads with the plaintext scanner, so it is NOT
+    /// yet threaded through the at-rest crypto seam; dead-lettering under encryption is a phase-4 item.
+    /// REFUSED fail-closed rather than writing the confidential record body to the DLQ in PLAINTEXT.
+    EncryptedDeadLetterUnsupported,
+    /// A transaction (half-message prepare) was attempted while at-rest encryption is on (#780 phase
+    /// 3). The transactional half-message store is a separate on-disk `Log` whose replay reads with the
+    /// plaintext scanner, so it is NOT yet threaded through the at-rest crypto seam; transactional
+    /// messaging under encryption is a phase-4 item. REFUSED fail-closed rather than buffering the
+    /// confidential prepared payload in PLAINTEXT.
+    EncryptedTxnUnsupported,
 }
 
 impl core::fmt::Display for EngineError {
+    #[allow(clippy::too_many_lines)] // one cohesive arm-per-variant match; splitting it hurts clarity
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             EngineError::Storage(e) => write!(f, "storage error: {e}"),
@@ -999,6 +1016,23 @@ impl core::fmt::Display for EngineError {
                 f,
                 "a publish may not carry a broker-resolved `DUE1` due-time block \
                  (due_unix_ms = {due_unix_ms}); send a `DLY1` relative delay request instead"
+            ),
+            EngineError::EncryptedSharedWalUnsupported => write!(
+                f,
+                "at-rest encryption is not supported with the shared-WAL storage mode (#780 phase 3): \
+                 use the default per-stream-logs mode, or run without an [encryption] key"
+            ),
+            EngineError::EncryptedDeadLetterUnsupported => write!(
+                f,
+                "dead-lettering is not supported while at-rest encryption is on (#780 phase 3): the \
+                 DLQ sink is not yet threaded through the at-rest crypto seam, so a dead-letter is \
+                 refused fail-closed rather than written in plaintext"
+            ),
+            EngineError::EncryptedTxnUnsupported => write!(
+                f,
+                "transactional messaging is not supported while at-rest encryption is on (#780 phase \
+                 3): the half-message store is not yet threaded through the at-rest crypto seam, so a \
+                 prepare is refused fail-closed rather than buffered in plaintext"
             ),
         }
     }
@@ -4234,13 +4268,70 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
     /// # Errors
     /// Returns [`EngineError::ZeroMaxInFlight`] for a zero window, or a storage error from
     /// opening the log or the cursor checkpoint.
-    #[allow(clippy::too_many_lines)]
     pub fn open(fs: F, clock: C, config: EngineConfig) -> Result<Engine<F, C>, EngineError>
+    where
+        F: Clone,
+    {
+        // The PLAINTEXT default (#780 phase 3): byte-for-byte the historical open, every existing
+        // caller unchanged. Only the opt-in `Engine::open_encrypted` threads a non-default context.
+        Self::open_inner(fs, clock, config, AtRestCrypto::default())
+    }
+
+    /// Opens the engine with LIVE at-rest AEAD encryption (#780 phase 3, the serve hookup): a
+    /// configured write `crypto` means every NEW active segment across the whole engine (the root/default
+    /// stream and every named stream) is created encrypted and every append AEAD-encrypts in place; a
+    /// configured `keyring` decrypts on read and recovery. This threads the SAME opaque context phase 2
+    /// verified through the storage seam (`Log::open_with_at_rest` / `StreamSet::open_with_at_rest`), so
+    /// the resume-reattach fix and every fail-closed guard engage. Passing all-`None` is byte-for-byte
+    /// [`Engine::open`].
+    ///
+    /// The deferred-under-encryption paths fail CLOSED rather than leak: the shared-WAL storage mode is
+    /// refused at open ([`EngineError::EncryptedSharedWalUnsupported`]); dead-lettering and transactional
+    /// prepares are refused at their seams ([`EngineError::EncryptedDeadLetterUnsupported`] /
+    /// [`EngineError::EncryptedTxnUnsupported`]); the off-actor zero-copy plane and verbatim replication
+    /// stay refused by the always-compiled storage guards.
+    ///
+    /// # Errors
+    /// As [`Engine::open`], plus [`EngineError::EncryptedSharedWalUnsupported`] on a shared-WAL +
+    /// encryption config, and the storage at-rest guards (a missing key for an encrypted-on-disk log,
+    /// or a plaintext log opened with a key).
+    #[cfg(feature = "encryption")]
+    pub fn open_encrypted(
+        fs: F,
+        clock: C,
+        config: EngineConfig,
+        crypto: Option<std::sync::Arc<ironbus_storage::crypto::SegmentCrypto>>,
+        keyring: Option<std::sync::Arc<ironbus_storage::crypto::KeyRing>>,
+    ) -> Result<Engine<F, C>, EngineError>
+    where
+        F: Clone,
+    {
+        Self::open_inner(fs, clock, config, AtRestCrypto::new(crypto, keyring))
+    }
+
+    /// The shared body behind [`Engine::open`] and [`Engine::open_encrypted`]: opens the engine with the
+    /// given opaque at-rest context (`AtRestCrypto::default()` for the plaintext path). Threading the
+    /// context (always-compiled, `None`-equivalent without the `encryption` feature) through here is what
+    /// lets every existing `Engine::open` call site stay byte-for-byte unchanged.
+    #[allow(clippy::too_many_lines)]
+    fn open_inner(
+        fs: F,
+        clock: C,
+        config: EngineConfig,
+        at_rest: AtRestCrypto,
+    ) -> Result<Engine<F, C>, EngineError>
     where
         F: Clone,
     {
         if config.max_in_flight == 0 {
             return Err(EngineError::ZeroMaxInFlight);
+        }
+        // At-rest encryption FAIL-CLOSED for the deferred shared-WAL substrate (#780 phase 3): the
+        // shared commit log interleaves every named stream and is NOT threaded through the at-rest
+        // crypto seam, so refuse BEFORE any open rather than silently write it in plaintext. A phase-4
+        // item; the default per-stream-logs mode is fully encrypted.
+        if at_rest.is_encrypted() && config.storage_mode == StorageMode::SharedWal {
+            return Err(EngineError::EncryptedSharedWalUnsupported);
         }
         // MODE-vs-LAYOUT fail-closed check (#597 wiring): opening a data directory under the WRONG
         // storage mode is a typed refusal BEFORE any recovery runs, never a silent misread of the
@@ -4265,7 +4356,11 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
                     Self::open_log_and_shared_wal(fs, clock, config.log)?;
                 (log, streams, Some(wal), BTreeMap::new(), Some(recovery))
             } else {
-                let (log, streams, recoveries) = Self::open_log_and_streams(fs, clock, config.log)?;
+                // Move the at-rest context into the per-stream open (its only consumer): the shared-WAL
+                // branch above never uses it, and encryption + shared-WAL was already refused, so this
+                // branch owns it outright.
+                let (log, streams, recoveries) =
+                    Self::open_log_and_streams(fs, clock, config.log, at_rest)?;
                 (log, streams, None, recoveries, None)
             };
 
@@ -4879,17 +4974,23 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         fs: F,
         clock: C,
         config: LogConfig,
+        at_rest: AtRestCrypto,
     ) -> Result<LogAndStreams<F, C>, EngineError>
     where
         F: Clone,
     {
         let fs_for_streams = fs.clone();
-        let log = Log::open(fs, clock.clone(), config)?;
+        // At-rest encryption (#780 phase 3): the root/default stream and the whole stream set are opened
+        // with the SAME opaque at-rest context, so a configured key encrypts EVERY stream through the
+        // phase-2-verified seam (resume-reattach + the fail-closed guards engage), and
+        // `AtRestCrypto::default()` is byte-for-byte the historical plaintext `Log::open`/`StreamSet::open`.
+        let log = Log::open_with_at_rest(fs, clock.clone(), config, at_rest.clone())?;
         // The per-stream recovery summaries are RETURNED (not discarded, #575/#1130) so `open` can
         // fold every named stream's torn-tail / corruption loss events into the recovery-event
         // counters — a named stream's crash damage must be as visible as the root log's.
         let (streams, stream_recoveries) =
-            StreamSet::open(&fs_for_streams, clock, config).map_err(EngineError::Storage)?;
+            StreamSet::open_with_at_rest(&fs_for_streams, clock, config, at_rest)
+                .map_err(EngineError::Storage)?;
         Ok((log, streams, stream_recoveries))
     }
 
@@ -7744,6 +7845,14 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
     /// # Errors
     /// Propagates a storage error from creating the subdirectory or opening the txn log.
     fn ensure_txn_store(&mut self) -> Result<&mut TxnStore<F, C>, EngineError> {
+        // At-rest encryption FAIL-CLOSED (#780 phase 3): the txn store is a separate on-disk `Log`
+        // whose replay reads with the PLAINTEXT scanner, so it is not yet threaded through the at-rest
+        // crypto seam. Refuse a transactional prepare under encryption rather than buffer the
+        // confidential prepared payload in plaintext. Reached only from the transactional verbs, so a
+        // non-transactional broker never trips it; encrypting the txn store is a phase-4 follow-up.
+        if self.log.is_at_rest_encrypted() {
+            return Err(EngineError::EncryptedTxnUnsupported);
+        }
         if self.txn.is_none() {
             let store = TxnStore::open(
                 self.log.filesystem(),
@@ -9132,6 +9241,12 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         id: &StreamId,
         slot: usize,
     ) -> Result<&mut DlqSink<F, C>, EngineError> {
+        // At-rest encryption FAIL-CLOSED (#780 phase 3): the per-stream twin of the guard in
+        // [`Engine::dlq_sink_slot`] — a named stream's DLQ sink is likewise a plaintext-scanned `Log`,
+        // so refuse to dead-letter under encryption rather than leak the confidential body in plaintext.
+        if self.log.is_at_rest_encrypted() {
+            return Err(EngineError::EncryptedDeadLetterUnsupported);
+        }
         if slot >= self.dead_letter_targets.len() {
             // Unreachable: every caller iterates 0..dead_letter_targets.len(). Surface loudly
             // rather than panic if the invariant ever breaks.
@@ -12103,6 +12218,15 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
     /// directory, [`Engine::open`] eagerly opens that slot so the dead-lettered offset set is
     /// present before the first poison redelivers.
     fn dlq_sink_slot(&mut self, slot: usize) -> Result<&mut DlqSink<F, C>, EngineError> {
+        // At-rest encryption FAIL-CLOSED (#780 phase 3): the DLQ sink is a separate on-disk `Log` whose
+        // recovery rebuild reads with the PLAINTEXT scanner, so it is not yet threaded through the
+        // at-rest crypto seam. Refuse to dead-letter under encryption rather than write the confidential
+        // record body to the DLQ in plaintext — the whole point of at-rest encryption. Reached only from
+        // the poison/expiry fan-out, so a broker that never dead-letters never trips it; encrypting the
+        // DLQ end-to-end is a phase-4 follow-up.
+        if self.log.is_at_rest_encrypted() {
+            return Err(EngineError::EncryptedDeadLetterUnsupported);
+        }
         if self.dlq.get(slot).is_none() {
             // Unreachable: every caller iterates 0..dead_letter_targets.len() and `dlq` is sized
             // to it at open. Surface loudly rather than panic if the invariant ever breaks.

--- a/crates/ironbus-server/src/engine.rs
+++ b/crates/ironbus-server/src/engine.rs
@@ -915,6 +915,13 @@ pub enum EngineError {
     /// messaging under encryption is a phase-4 item. REFUSED fail-closed rather than buffering the
     /// confidential prepared payload in PLAINTEXT.
     EncryptedTxnUnsupported,
+    /// A partitioned stream (#693, `P > 1`) or a priority-lane stream (#553) was declared/produced, or
+    /// its `pstreams/`/`prstreams/` subtree was found on disk at open, while at-rest encryption is on
+    /// (#780 phase 3). Both are backed by the separate `PartitionedStream` storage primitive (P sub-logs
+    /// under `pstreams/`/`prstreams/`) which is NOT threaded through the at-rest crypto seam, so its
+    /// segments would be written PLAINTEXT. REFUSED fail-closed rather than leak a confidential record
+    /// body — per-partition `segment_id`/nonce continuity under encryption is a phase-4 crypto feature.
+    EncryptedPartitionedStreamUnsupported,
 }
 
 impl core::fmt::Display for EngineError {
@@ -1033,6 +1040,13 @@ impl core::fmt::Display for EngineError {
                 "transactional messaging is not supported while at-rest encryption is on (#780 phase \
                  3): the half-message store is not yet threaded through the at-rest crypto seam, so a \
                  prepare is refused fail-closed rather than buffered in plaintext"
+            ),
+            EngineError::EncryptedPartitionedStreamUnsupported => write!(
+                f,
+                "partitioned streams (#693) and priority-lane streams (#553) are not supported while \
+                 at-rest encryption is on (#780 phase 3): their PartitionedStream sub-logs are not yet \
+                 threaded through the at-rest crypto seam, so a declare/produce is refused fail-closed \
+                 rather than writing a confidential body in plaintext"
             ),
         }
     }
@@ -4598,6 +4612,21 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         // partition's own subdir — the per-partition twin of `recover_named_stream_groups` above. A
         // deployment that never declared `P > 1` has no `pstreams/` subtree, so this is a no-op and the
         // on-disk image is byte-for-byte unchanged.
+        // At-rest encryption FAIL-CLOSED at open (#780 phase 3): a broker that INHERITED plaintext
+        // partitioned (`pstreams/`) or priority-lane (`prstreams/`) subtrees and is now started with a
+        // key must NOT silently reopen + serve them plaintext. Refuse the open rather than recover a
+        // crypto-unaware subtree. A fresh encrypted deployment has NEITHER subtree (the declare paths
+        // refuse creating them under encryption), so this is a no-op there. The root `log` carries the
+        // threaded at-rest context, so `is_at_rest_encrypted()` reflects the configured key (`at_rest`
+        // itself was already moved into the per-stream open above).
+        if log.is_at_rest_encrypted() {
+            let root_fs = log.filesystem();
+            if root_fs.subdir_exists(PARTITIONED_STREAMS_SUBDIR)?
+                || root_fs.subdir_exists(PRIORITY_STREAMS_SUBDIR)?
+            {
+                return Err(EngineError::EncryptedPartitionedStreamUnsupported);
+            }
+        }
         let (mut partitioned, mut partition_consumers, mut partition_recoveries) =
             recover_partitioned_streams(&log, config.lease, opened_at)?;
         // Recover each PRIORITY-LANE stream (#553) from its SEPARATE `prstreams/<hex(name)>/` subtree,
@@ -6847,6 +6876,14 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         if partition_count <= 1 {
             return self.declare_stream(stream);
         }
+        // At-rest encryption FAIL-CLOSED (#780 phase 3): a partitioned stream (P > 1) is backed by the
+        // separate `PartitionedStream` primitive (P sub-logs under `pstreams/`) that is NOT threaded
+        // through the at-rest crypto seam, so its segments would be PLAINTEXT. Refuse the declare BEFORE
+        // any open/create rather than leak a confidential body. (P <= 1 above routes to the crypto-aware
+        // named-stream path and is unaffected.) Per-partition nonce continuity is a phase-4 feature.
+        if self.log.is_at_rest_encrypted() {
+            return Err(EngineError::EncryptedPartitionedStreamUnsupported);
+        }
         // SHARED-WAL mode (#597): partitioned streams are per-stream-log storage (P sub-logs under
         // pstreams/) and do not compose with the one shared commit log — fail-closed typed reject,
         // matching the open-time pstreams/ layout refusal, never a half-supported hybrid.
@@ -6947,6 +6984,13 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         id: &StreamId,
         message: &Append<'_>,
     ) -> Result<(PartitionIndex, Offset), EngineError> {
+        // At-rest encryption FAIL-CLOSED defense-in-depth (#780 phase 3): the declare path already
+        // refuses a partitioned stream under encryption, so a resident `PartitionedStream` here means a
+        // subtree that predates encryption (open fails closed on that too); refuse the append regardless,
+        // so a confidential body can NEVER be written to a crypto-unaware partition sub-log in plaintext.
+        if self.log.is_at_rest_encrypted() {
+            return Err(EngineError::EncryptedPartitionedStreamUnsupported);
+        }
         // Route + append to the key's partition (short mutable borrow of the storage map).
         let (idx, offset) = {
             let ps = self
@@ -7532,6 +7576,13 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
                 name: stream.to_string(),
             });
         }
+        // At-rest encryption FAIL-CLOSED (#780 phase 3): a priority-lane stream is backed by the same
+        // crypto-unaware `PartitionedStream` primitive (lane sub-logs under `prstreams/`), so its
+        // segments would be PLAINTEXT. Refuse the declare BEFORE any open/create — the priority twin of
+        // the partitioned-stream guard.
+        if self.log.is_at_rest_encrypted() {
+            return Err(EngineError::EncryptedPartitionedStreamUnsupported);
+        }
         // SHARED-WAL mode (#597): priority streams are per-stream-log storage (P lane sub-logs under
         // prstreams/) and do not compose with the one shared commit log — fail-closed typed reject,
         // matching the open-time prstreams/ layout refusal.
@@ -7619,6 +7670,11 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         message: &Append<'_>,
         priority: u8,
     ) -> Result<(PartitionIndex, Offset), EngineError> {
+        // At-rest encryption FAIL-CLOSED defense-in-depth (#780 phase 3): the priority twin of the guard
+        // in `produce_partitioned` — never append a confidential body to a crypto-unaware lane sub-log.
+        if self.log.is_at_rest_encrypted() {
+            return Err(EngineError::EncryptedPartitionedStreamUnsupported);
+        }
         // Route + append to the priority's lane (short mutable borrow of the storage map). The lane is
         // `min(priority, P-1)`: priority mode requires `P >= 2`, so `P - 1 >= 1` never underflows, and a
         // priority >= P saturates to the top (highest) lane.

--- a/crates/ironbus-storage/src/log.rs
+++ b/crates/ironbus-storage/src/log.rs
@@ -820,11 +820,13 @@ impl AtRestCrypto {
         }
     }
 
-    /// Whether this log participates in at-rest encryption at all (a write key and/or a read ring): its
-    /// segments are ciphertext, so reads route through the decrypt path and the zero-copy raw plane is
-    /// refused. Always `false` without the `encryption` feature.
+    /// Whether this context participates in at-rest encryption at all (a write key and/or a read ring):
+    /// its segments are ciphertext, so reads route through the decrypt path and the zero-copy raw plane
+    /// is refused. Always `false` without the `encryption` feature. Public so the engine (#780 phase 3)
+    /// can fail-closed the deferred paths (shared-WAL, dead-letter, txn) when a key is configured,
+    /// without naming the feature-gated crypto types.
     #[must_use]
-    fn is_encrypted(&self) -> bool {
+    pub fn is_encrypted(&self) -> bool {
         self.writes_encrypted() || self.reads_encrypted()
     }
 }
@@ -1354,8 +1356,17 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
 
     /// Opens a log with a pre-built [`AtRestCrypto`] context — the seam [`crate::streamset::StreamSet`]
     /// uses to open EVERY stream's log with the SAME at-rest crypto (#780 phase 2), so a named stream
-    /// is encrypted exactly like the default stream. `AtRestCrypto::default()` is the plaintext path.
-    pub(crate) fn open_with_at_rest(
+    /// is encrypted exactly like the default stream, AND the seam the ENGINE (#780 phase 3, the serve
+    /// hookup) uses to open the ROOT log with the SAME opaque, always-compiled context it threads to
+    /// [`crate::streamset::StreamSet::open_with_at_rest`]. `AtRestCrypto::default()` is the plaintext
+    /// path, byte-for-byte [`Log::open`]. Public (not `pub(crate)`) so the engine crate can pass the
+    /// same context to the root log and the stream set without naming the feature-gated crypto types.
+    ///
+    /// # Errors
+    /// As [`Log::open`], plus the fail-closed at-rest guards ([`StorageError::EncryptedSegmentNoKey`] /
+    /// [`StorageError::PlaintextSegmentWithKey`]) on an at-rest config that does not match the recovered
+    /// active segment.
+    pub fn open_with_at_rest(
         fs: F,
         clock: C,
         config: LogConfig,
@@ -12139,7 +12150,12 @@ mod tests {
         }
         // The raw on-disk bytes of segment `id` (records + any preallocated/footer tail).
         fn seg_bytes(log: &Log<InMemoryFs, ManualClock>, id: u64) -> Vec<u8> {
-            let f = log.filesystem().open(&segment_file_name(id)).unwrap();
+            seg_bytes_from_fs(log.filesystem(), id)
+        }
+        // The raw on-disk bytes of segment `id` read straight from the filesystem (used after the
+        // writing log has been dropped, e.g. to tear the tail before a recovery reopen).
+        fn seg_bytes_from_fs(fs: &InMemoryFs, id: u64) -> Vec<u8> {
+            let f = fs.open(&segment_file_name(id)).unwrap();
             let len = usize::try_from(f.len().unwrap()).unwrap();
             let mut buf = vec![0u8; len];
             f.read_exact_at(&mut buf, 0).unwrap();
@@ -12456,6 +12472,90 @@ mod tests {
             let out = log.read_from(Offset::ZERO, 10).unwrap();
             let got: Vec<&[u8]> = out.iter().map(|r| &r.payload[..]).collect();
             assert_eq!(got, vec![&b"n0"[..], &b"n1"[..], &b"n2"[..]]);
+        }
+
+        #[test]
+        fn log_level_torn_encrypted_tail_recovers_bounded_and_survivors_decrypt() {
+            // #780 phase 3 — the coverage-hardening test the phase-2 crypto review asked for: a
+            // LOG-LEVEL (not just segment-unit) encrypted torn tail. An encrypted log with a DURABLE
+            // prefix plus a TORN (corrupt) final encrypted frame must reopen to BOUNDED, REPORTED loss
+            // (the torn tail is dropped and COUNTED) — never an early truncation of the good prefix —
+            // and every surviving record must DECRYPT. This drives the real Log recovery path
+            // (`open_inner` -> `recover` -> `finalize_at_rest`) on an encrypted segment, exercising the
+            // shared `decoded_len` + `decode_encrypted` header-CRC-gated sizing end-to-end, not just the
+            // segment-unit decode the earlier test covered.
+            let survivors: [&[u8]; 5] = [
+                b"alpha-secret",
+                b"bravo-secret",
+                b"charlie-secret",
+                b"delta-secret",
+                b"echo-secret",
+            ];
+            let fs = InMemoryFs::new();
+            {
+                let mut log = open_enc(fs.clone(), big_cfg());
+                for p in survivors {
+                    log.append(&payload_rec(b"k", p)).unwrap();
+                }
+                // A 6th record — the one we will TEAR. Appended + synced so it is physically framed on
+                // disk (an append buffers until sync), then corrupted below so recovery must drop it as
+                // a torn/bit-rotted final frame while the 5 durable survivors before it are kept.
+                log.append(&payload_rec(b"k", b"TORN-TAIL-RECORD-that-must-be-lost"))
+                    .unwrap();
+                log.sync().unwrap();
+            }
+            // Walk the 5 durable frames key-free (the recovery-style sizing) to the start of the 6th,
+            // then corrupt a byte inside the 6th frame's ciphertext so its CRC-over-ciphertext fails —
+            // exactly the torn/crash-mid-write final frame. No key is used to place the tear.
+            let raw = seg_bytes_from_fs(&fs, 0);
+            let mut pos = SEGMENT_HEADER_LEN;
+            for _ in 0..5 {
+                let (_v, n) =
+                    codec::decode_encrypted(&raw[pos..]).expect("a durable frame decodes");
+                pos += n;
+            }
+            let (_v6, n6) =
+                codec::decode_encrypted(&raw[pos..]).expect("the 6th (soon-torn) frame decodes");
+            // A byte inside the 6th frame's ciphertext body (past its record header). Corrupting it
+            // breaks the CRC over the ciphertext, which recovery catches WITHOUT the key.
+            let corrupt_at = pos + RECORD_HEADER_LEN + 1;
+            assert!(
+                corrupt_at < pos + n6,
+                "corruption lands inside the 6th frame"
+            );
+            let torn = [raw[corrupt_at] ^ 0xFF];
+            fs.open(&segment_file_name(0))
+                .unwrap()
+                .write_all_at(&torn, u64::try_from(corrupt_at).unwrap())
+                .unwrap();
+
+            // Reopen with the SAME key: recovery finds the valid prefix, reports the torn tail, and the
+            // survivors decrypt.
+            let log = open_enc(fs, big_cfg());
+            // (1) BOUNDED, REPORTED loss — in EITHER accounted form (a truncated-byte count or a
+            //     loss-report event), never a silent drop.
+            let reported = log.recovered_truncated_bytes() > 0 || !log.loss_report().is_empty();
+            assert!(
+                reported,
+                "the torn encrypted tail must be REPORTED (truncated bytes {} / loss events {}), \
+                 never silent",
+                log.recovered_truncated_bytes(),
+                log.loss_report().total_bytes_skipped()
+            );
+            // (2) NOT an early truncation: every DURABLE survivor is still present...
+            let out = log.read_from(Offset::ZERO, 100).unwrap();
+            assert_eq!(
+                out.len(),
+                5,
+                "the good prefix must survive; ONLY the torn tail is lost (not an early truncation)"
+            );
+            // (3) ...and each survivor DECRYPTS to its original plaintext (decrypt-on-read), with the
+            //     storage-internal ENCRYPTED bit cleared on the materialized record.
+            for (i, r) in out.iter().enumerate() {
+                assert_eq!(&r.payload[..], survivors[i], "survivor {i} decrypts");
+                assert_eq!(&r.key[..], b"k");
+                assert!(!r.flags.contains(RecordFlags::ENCRYPTED));
+            }
         }
     }
 }

--- a/crates/ironbus-storage/src/streamset.rs
+++ b/crates/ironbus-storage/src/streamset.rs
@@ -370,6 +370,25 @@ impl<F: Filesystem + Clone, C: Clock + Clone> StreamSet<F, C> {
         Self::open_inner(fs, clock, config, AtRestCrypto::new(crypto, keyring))
     }
 
+    /// Opens the whole stream set with a pre-built [`AtRestCrypto`] context (#780 phase 3, the serve
+    /// hookup): the seam the ENGINE uses to open EVERY stream's log with the SAME opaque, always-compiled
+    /// at-rest context it also threads to the root [`Log::open_with_at_rest`], WITHOUT naming the
+    /// feature-gated `SegmentCrypto`/`KeyRing` types. `AtRestCrypto::default()` is byte-for-byte
+    /// [`StreamSet::open`]; a configured context encrypts (and decrypts on read) the default stream and
+    /// every named stream with the same key.
+    ///
+    /// # Errors
+    /// As [`StreamSet::open`], plus the fail-closed at-rest guards of [`Log::open_with_at_rest`] on a
+    /// per-stream config mismatch.
+    pub fn open_with_at_rest(
+        fs: &F,
+        clock: C,
+        config: LogConfig,
+        at_rest: AtRestCrypto,
+    ) -> Result<OpenedStreamSet<F, C>, StorageError> {
+        Self::open_inner(fs, clock, config, at_rest)
+    }
+
     /// The shared body behind [`StreamSet::open`] and [`StreamSet::open_encrypted`]: opens every
     /// stream's log with the SAME at-rest context.
     fn open_inner(

--- a/docs/AT_REST_ENCRYPTION.md
+++ b/docs/AT_REST_ENCRYPTION.md
@@ -65,13 +65,33 @@ opens the engine via `Engine::open_encrypted`, which threads the same opaque con
 the running broker's default and named-stream segments are ciphertext on disk, resume re-attaches
 the crypto, and the fail-closed guards engage.
 
-Operational limits in this phase (each fails CLOSED, never leaks):
+### What at-rest encryption currently constrains (each fails CLOSED, never leaks)
 
-- **Disk backend only.** `--storage memory` + encryption is refused (no on-disk segments to encrypt).
-- **Per-stream-logs mode only.** `--storage-mode shared-wal` + encryption is refused at open.
-- **No dead-lettering / no transactions** while encryption is on (both refused at their seams).
-- **Single node only.** A cluster/federation path that would ship ciphertext off-node or replicate
-  a leader frame verbatim is refused by the always-compiled zero-copy / replication guards.
+Phase 3 encrypts the **default stream and named single-log streams** (the crypto-aware
+`Log`/`StreamSet` seam). Every OTHER substrate is not yet threaded through the at-rest crypto seam,
+so with a key configured each is **refused fail-closed** — never written, opened, or served in
+plaintext — and is a tracked follow-up. Operators must know encryption currently constrains these:
+
+| Substrate / operation | Behavior under encryption | Where it fails closed |
+|---|---|---|
+| Default + named single-log streams | **ENCRYPTED** (supported) | the crypto-aware `Log`/`StreamSet` seam |
+| Partitioned streams (#693, `pstreams/`) | refused | `declare`/`produce` + open (`EncryptedPartitionedStreamUnsupported`) |
+| Priority-lane streams (#553, `prstreams/`) | refused | `declare`/`produce` + open (`EncryptedPartitionedStreamUnsupported`) |
+| Shared-WAL storage mode | refused | `Engine::open` (`EncryptedSharedWalUnsupported`) |
+| Dead-letter queue (DLQ) | refused | the DLQ sink seam (`EncryptedDeadLetterUnsupported`) |
+| Transactions (half-message store) | refused | the txn-store seam (`EncryptedTxnUnsupported`) |
+| In-memory backend (`--storage memory`) | refused at startup | no on-disk segments to encrypt |
+| Key-compaction (`--compact`) | refused at startup | `validate_serve_config` (runtime guard `EncryptedMaintenanceUnsupported` is the backstop) |
+| Tiered cold-segment offload | refused | runtime `EncryptedMaintenanceUnsupported` (not serve-configurable) |
+| Zero-copy / off-actor consume plane | refused (reads route through the actor decrypt path) | `Log::read_plane` (`EncryptedZeroCopyUnsupported`) |
+| Verbatim replication (clustered/federation) | refused | `Log::append_frame_verbatim` (`EncryptedReplicationUnsupported`) |
+
+Consequences: at-rest encryption is **single-node, per-stream-logs, disk-backed only**, and a broker
+using partitioned/priority streams, the DLQ, transactions, shared-WAL, compaction, tiered offload, or
+clustering must NOT enable it this phase (each of those is a separate crypto follow-up). A partitioned
+or priority stream `declare` returns `ERR_STORAGE` with an explanatory message; a broker that inherits
+a `pstreams/`/`prstreams/` subtree and is then keyed refuses to open rather than serve it plaintext.
+
 - **Enable on a FRESH data directory.** Encryption is new-segments-only; opening a plaintext log
   with a key is refused (`PlaintextSegmentWithKey`) and opening an encrypted log without the key is
   refused (`EncryptedSegmentNoKey`) — a no-key reader never silently starts plaintext.

--- a/docs/AT_REST_ENCRYPTION.md
+++ b/docs/AT_REST_ENCRYPTION.md
@@ -1,27 +1,80 @@
 # IronBus optional at-rest AEAD encryption
 
-**Status: PHASE 2 IMPLEMENTED — SINGLE-NODE LIVE WIRING (#780); this document remains the
-normative design.** Phase 1 landed the cryptographic core and the on-disk format; phase 2
-wires that core through the LIVE `Log`/`StreamSet` so a configured key actually encrypts a
-running broker's segments (SINGLE-NODE), and DECRYPTS them on read. A configured key means
-every NEW active segment (fresh, rolled, or resumed after a crash) is created encrypted and
-every append AEAD-encrypts in place; reads and recovery decrypt transparently. The critical
-resume fix ships: recovery re-attaches the write crypto to a resumed encrypted active
-segment, so a post-crash append can never land PLAINTEXT into an encrypted segment. The
-zero-copy read plane is fail-closed for encrypted logs (it would ship ciphertext) — reads
-route through the actor's decrypt path. Clustered/replicated at-rest encryption is
-FAIL-CLOSED and DEFERRED to phase 3: verbatim replication under encryption is refused
-(the leader-nonce hazard), as are compaction/offload of an encrypted log. It remains
-**OFF by default and byte-identical when off**. Still tracked as follow-on: the CLI→engine
-serve-path hookup that loads the `[encryption]` config key and opens the engine's storage
-via `Log::open_encrypted`/`StreamSet::open_encrypted` (the storage seam ships here); the
-Argon2id-passphrase and TEE-sealed key sources; and clustered encryption / re-encryption /
-compaction+encryption (phase 3). The log and the
-dead-letter queue are plaintext on disk in a default deployment, exactly as
+**Status: PHASE 3 IMPLEMENTED — SINGLE-NODE SERVE HOOKUP (#780/#1165); this document remains
+the normative design.** Phase 1 landed the cryptographic core and the on-disk format; phase 2
+wired that core through the LIVE `Log`/`StreamSet` so a configured key encrypts a running
+broker's segments (SINGLE-NODE) and DECRYPTS them on read; phase 3 threads a `[encryption]`
+config through `ironbus serve` so a broker actually starts encrypted end to end (the seam that
+was inert at the serve layer now engages). A configured key means every NEW active segment
+(fresh, rolled, or resumed after a crash) is created encrypted and every append AEAD-encrypts
+in place; reads and recovery decrypt transparently. The critical resume fix ships: recovery
+re-attaches the write crypto to a resumed encrypted active segment, so a post-crash append can
+never land PLAINTEXT into an encrypted segment. The zero-copy read plane is fail-closed for
+encrypted logs (it would ship ciphertext) — reads route through the actor's decrypt path. It
+remains **OFF by default and byte-identical when off**, and a build compiled WITHOUT the
+`encryption` feature refuses an `[encryption]` config fail-closed (it never silently starts
+plaintext) and refuses to open an encrypted-on-disk log.
+
+DEFERRED and FAIL-CLOSED (phase 4): clustered/replicated at-rest encryption (verbatim
+replication under encryption is refused — the leader-nonce hazard), compaction/offload of an
+encrypted log, re-encryption/key-ROTATION-rewrite, and the Argon2id-passphrase / TEE-sealed /
+KMS key sources (only the raw key-file source ships). Because the serve hookup makes them newly
+reachable, three more deferred paths now fail CLOSED under encryption rather than leak: the
+shared-WAL storage mode (refused at open), dead-lettering (the DLQ is a plaintext-scanned log —
+refused rather than write a confidential body in the clear), and transactional messaging (the
+half-message store is likewise refused). The log's confidential record BODIES are ciphertext;
+the framing/metadata, cursor/counters checkpoints, and — in a deployment that does not exercise
+the fail-closed paths — the (unused) DLQ metadata are plaintext, exactly as
 [THREAT_MODEL.md](THREAT_MODEL.md) states. This spec is the child of the security epic
 #18 and the sibling of the auth spec ([AUTHENTICATION.md](AUTHENTICATION.md),
 #106), the TLS transport spec ([TRANSPORT.md](TRANSPORT.md), #107), and the
 secret-handling spec (#109).
+
+---
+
+## Serve configuration (phase 3, #1165)
+
+At-rest encryption is enabled by pointing `ironbus serve` at a raw key file. The config is
+feature-gated behind the `encryption` cargo feature; a build without it refuses every knob
+below fail-closed (it links no AEAD crypto, so honoring them would start the broker in plaintext
+under a config that asked for encryption). The three knobs resolve with the standard
+`flag > env > file > default` precedence (`docs/CONFIG.md`):
+
+| `[encryption]` file key | Flag | Env | Meaning |
+|---|---|---|---|
+| `key_file` | `--encryption-key-file` | `IRONBUS_ENCRYPTION_KEY_FILE` | Path to a file holding EXACTLY 32 raw key bytes. **Setting it enables at-rest encryption.** Owner-only: a group/world-readable file is refused at startup (#109). |
+| `key_id` | `--encryption-key-id` | `IRONBUS_ENCRYPTION_KEY_ID` | A **non-zero** `u64` identifier recorded in each encrypted segment header (never the key). **Required** when `key_file` is set. |
+| `suite` | `--encryption-suite` | `IRONBUS_ENCRYPTION_SUITE` | `auto` (default: pick by CPU feature detection), `aes-256-gcm`, or `chacha20-poly1305`. The chosen suite is recorded in the segment header, so a read is unambiguous on any host. |
+
+Example TOML:
+
+```toml
+[encryption]
+key_file = "/etc/ironbus/at-rest.key"
+key_id = 7
+# suite = "auto"   # optional; omit to auto-detect
+```
+
+Or equivalently: `ironbus serve --encryption-key-file /etc/ironbus/at-rest.key --encryption-key-id 7`.
+
+How the key threads to the storage seam: `ironbus serve` resolves + validates the `[encryption]`
+config, loads the 32-byte key with the fail-closed loader (`ironbus_storage::crypto::load_key_file`),
+builds the write-side `SegmentCrypto` + the read-side `KeyRing` under the single key/key-id, and
+opens the engine via `Engine::open_encrypted`, which threads the same opaque context to the root
+`Log::open_with_at_rest` and `StreamSet::open_with_at_rest` — the exact seam phase 2 verified. So
+the running broker's default and named-stream segments are ciphertext on disk, resume re-attaches
+the crypto, and the fail-closed guards engage.
+
+Operational limits in this phase (each fails CLOSED, never leaks):
+
+- **Disk backend only.** `--storage memory` + encryption is refused (no on-disk segments to encrypt).
+- **Per-stream-logs mode only.** `--storage-mode shared-wal` + encryption is refused at open.
+- **No dead-lettering / no transactions** while encryption is on (both refused at their seams).
+- **Single node only.** A cluster/federation path that would ship ciphertext off-node or replicate
+  a leader frame verbatim is refused by the always-compiled zero-copy / replication guards.
+- **Enable on a FRESH data directory.** Encryption is new-segments-only; opening a plaintext log
+  with a key is refused (`PlaintextSegmentWithKey`) and opening an encrypted log without the key is
+  refused (`EncryptedSegmentNoKey`) — a no-key reader never silently starts plaintext.
 
 This is the device-theft mitigation (threat row T1 in THREAT_MODEL.md), with its
 honest limit stated plainly: a key co-located with a stolen device defeats it.

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -451,6 +451,26 @@ warning), since TLS/auth are not yet wired there either. `enable_admin` ships (i
 gates the read-only `/admin` introspection endpoint) but the mutating `CONFIG`
 verbs do not (#88).
 
+### At-rest encryption (`[encryption]`)
+
+Optional at-rest AEAD encryption of segment record bodies (#780 phase 3,
+[AT_REST_ENCRYPTION.md](AT_REST_ENCRYPTION.md)). WIRED keys, **feature-gated behind the
+`encryption` cargo feature**: a build compiled WITHOUT the feature refuses these keys fail-closed
+(it links no AEAD crypto, so honoring them would start the broker in plaintext under a config that
+asked for encryption), never a silent warn-and-ignore. Encryption is ON iff `key_file` is set.
+
+| Knob (file key) | Flag / env | Type | Default | Units | Valid range | Reload |
+| --- | --- | --- | --- | --- | --- | --- |
+| `key_file` | `--encryption-key-file` / `IRONBUS_ENCRYPTION_KEY_FILE` | path | off (not set) | -- | a file of EXACTLY 32 raw key bytes, mode `& 0o077 == 0` (owner-only, #109). Setting it ENABLES encryption. | COLD |
+| `key_id` | `--encryption-key-id` / `IRONBUS_ENCRYPTION_KEY_ID` | u64 | none | -- | a NON-ZERO identifier; REQUIRED when `key_file` is set | COLD |
+| `suite` | `--encryption-suite` / `IRONBUS_ENCRYPTION_SUITE` | enum | `auto` | -- | `auto` (CPU detect) / `aes-256-gcm` / `chacha20-poly1305` | COLD |
+
+Phase-3 limits (each fails CLOSED, never leaks): disk backend only (not `--storage memory`),
+per-stream-logs mode only (not `--storage-mode shared-wal`), no dead-lettering and no transactions
+while on, single-node only (a cluster/federation ciphertext path is refused), and enable on a FRESH
+data directory (a no-key reader refuses an encrypted log; a keyed open of a plaintext log is
+refused). See [AT_REST_ENCRYPTION.md](AT_REST_ENCRYPTION.md) "Serve configuration".
+
 ### Observability (`[observability]`) and auth (`[auth]`)
 
 Per the #139 coherence resolution, the locked, fatal-on-unknown top-level section
@@ -470,7 +490,8 @@ under the existing tables.
 
 The top-level TOML sections are FROZEN as a stability contract: `[durability]`,
 `[storage]`, `[retention]`, `[backpressure]`, `[network]` (with `[network.tls]`),
-`[delivery]`, `[observability]`, and `[auth]`. A future rename ships the new name
+`[delivery]`, `[encryption]` (WIRED as of #780 phase 3), `[observability]`, and
+`[auth]`. A future rename ships the new name
 WITH the old name as a deprecated alias, never a silent break. Unknown top-level
 sections and unknown keys are REJECTED fatally by default (with an edit-distance
 did-you-mean), because warn-and-ignore is how a typo silently disables durability


### PR DESCRIPTION
## At-rest encryption phase 3 — the serve hookup (closes #1165, closes M7)

Threads the phase-1 AEAD core (#1161) and the phase-2 storage seam (#1164) all the way through
`ironbus serve`, so a broker started with an `[encryption]` config actually encrypts its running
segments end to end. Until now `open_encrypted` / `open_with_at_rest` had **zero callers outside
ironbus-storage**, so the crypto was inert at the serve layer and the fail-closed guards were latent.
This engages them. **OFF by default and byte-identical when off.**

### 1. The config surface (`[encryption]`, feature-gated behind the `encryption` cargo feature)

| `[encryption]` key | flag | env | meaning |
|---|---|---|---|
| `key_file` | `--encryption-key-file` | `IRONBUS_ENCRYPTION_KEY_FILE` | path to a 32-byte owner-only raw key file. **Setting it enables encryption.** |
| `key_id` | `--encryption-key-id` | `IRONBUS_ENCRYPTION_KEY_ID` | non-zero `u64` in each segment header (never the key); required with `key_file`. |
| `suite` | `--encryption-suite` | `IRONBUS_ENCRYPTION_SUITE` | `auto` (CPU detect) / `aes-256-gcm` / `chacha20-poly1305`. |

Standard `flag > env > file > default` precedence. A build compiled **without** the `encryption`
feature refuses the config fail-closed (never silently starts plaintext). `docs/AT_REST_ENCRYPTION.md`
gains a "Serve configuration" section; `docs/CONFIG.md` gains an `[encryption]` table.

### 2. The key seam: CLI → engine → storage `open_encrypted`

`resolve_encryption` validates the config → `load_encryption_context` loads the 32-byte key with the
phase-1 fail-closed loader (owner-only, #109) and builds `SegmentCrypto` + `KeyRing` → the CLI calls
the new `Engine::open_encrypted`, which threads the opaque, always-compiled `AtRestCrypto` to the root
`Log::open_with_at_rest` **and** `StreamSet::open_with_at_rest` — the exact seam phase 2 verified. So
resume-reattach and the fail-closed guards engage; existing `Engine::open` callers are byte-for-byte
unchanged (a thin wrapper over a shared `open_inner`). Feature `encryption` is forwarded across
ironbus-cli → ironbus-server → ironbus-storage.

### 3. Fail-closed guards now ENGAGE (deferred paths, never leak, never implemented)

- **zero-copy plane** → `EncryptedZeroCopyUnsupported` (the phase-2 `read_plane` guard); single-node
  consume routes through the actor decrypt path, never the raw plane.
- **verbatim replication** → `EncryptedReplicationUnsupported` (the phase-2 `append_frame_verbatim` guard).
- **shared-WAL mode** + encryption → refused at `Engine::open` (`EncryptedSharedWalUnsupported`).
- **dead-lettering** under encryption → refused at the DLQ seam (`EncryptedDeadLetterUnsupported`): the
  DLQ is a plaintext-scanned log, so a confidential body is never written in the clear.
- **transactions** under encryption → refused at the txn-store seam (`EncryptedTxnUnsupported`).
- **memory backend** + encryption → refused (no on-disk segments to encrypt).
- missing/wrong key for an encrypted-on-disk log → `EncryptedSegmentNoKey` / a keyed open of a
  plaintext log → `PlaintextSegmentWithKey` (a no-key reader never silently starts plaintext).

### 4. Tests

- **serve-encrypts end-to-end** (ironbus-cli): a broker started with `[encryption]` writes
  encrypted-on-disk segments (the plaintext payload never appears on disk), a default/no-key reader
  refuses them, and reopening with the key round-trips the decrypted record.
- **Log-level torn-encrypted-tail recovery** (ironbus-storage): an encrypted log with a torn final
  encrypted frame reopens to bounded, reported loss (not early truncation), survivors decrypt — the
  coverage gap the phase-2 review flagged.

### Gates

`cargo fmt --check`, clippy `--all-targets --all-features -D warnings` (pedantic), format-registry,
relative-link-check, golden-path acceptance, and cargo-deny (advisories/bans/licenses/sources) all
clean. `cargo tree --all-features -i ring` is empty. No new dependency, `deny.toml` byte-identical.
Default build unchanged and still refuses an encrypted-on-disk log.

### Deferred to phase 4 (guarded, not implemented — for follow-up issues)

clustered/replicated encryption (the `append_verbatim` leader-nonce design), re-encryption /
key-rotation-rewrite, compaction+encryption, encrypting the DLQ + txn + shared-WAL logs, and the
Argon2id-passphrase / TEE-sealed / KMS key sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01McmNfYNWPmohVS8umY9Lkp
