### PR TITLE
feat(consume): Linux sendfile(2) zero-copy Tier-S delivery — refs #1034, closes #658

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1130,6 +1130,7 @@ dependencies = [
  "ironbus-core",
  "ironbus-proto",
  "ironbus-storage",
+ "libc",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",

--- a/crates/ironbus-cli/src/main.rs
+++ b/crates/ironbus-cli/src/main.rs
@@ -2536,6 +2536,11 @@ struct ServeFlags {
     /// default. Honored only when the broker is built with the non-default `otlp` feature; on the
     /// default build, setting it logs a clear "built without otlp" diagnostic and export stays off.
     enable_otlp_export: bool,
+    /// The Linux `sendfile(2)` zero-copy Tier-S delivery KILL-SWITCH (#1034 / #658): the
+    /// `--no-zero-copy-sendfile` bare flag. `true` only if it appeared; without it the zero-copy path is
+    /// AUTO-ON where sound (a plaintext, disk-backed, unencrypted window on a Linux build). Setting it
+    /// forces the userspace copy path on every connection, with no behavioral or wire change.
+    disable_zero_copy_sendfile: bool,
     /// The OTLP collector endpoint (#352): `--otlp-endpoint <url>`, e.g. `http://127.0.0.1:4317`
     /// (plaintext gRPC). `None` falls back to the default endpoint when export is on. Read only when
     /// export is on AND the `otlp` feature is built in.
@@ -2952,6 +2957,12 @@ fn collect_serve_flags(args: &[String]) -> Result<ServeFlags, CliError> {
             // explicit EPHEMERAL data-loss consent that gates `--storage memory` (#443).
             "--ephemeral-loss-ack" => {
                 f.ephemeral_loss_ack = true;
+                i += 1;
+            }
+            // A bare boolean flag (advance ONE token): the zero-copy `sendfile(2)` KILL-SWITCH (#1034).
+            // Its presence forces the userspace copy path; absence keeps the AUTO-ON default.
+            "--no-zero-copy-sendfile" => {
+                f.disable_zero_copy_sendfile = true;
                 i += 1;
             }
             "--key-shared-group" => {
@@ -3748,6 +3759,14 @@ fn parse_serve_flags_with_env_and_reader(
                 f.consume_longpoll_ms,
                 env,
                 DEFAULT_CONSUME_LONGPOLL_MS,
+            )?,
+            // Zero-copy `sendfile(2)` delivery (#1034 / #658) is AUTO-ON by default; the
+            // `--no-zero-copy-sendfile` kill-switch (flag > env) flips it off. The resolve is on the
+            // NEGATED flag, so the resolved value is `true` unless the operator opted out.
+            zero_copy_sendfile: !resolve_bool(
+                "--no-zero-copy-sendfile",
+                f.disable_zero_copy_sendfile,
+                env,
             )?,
             // V2-M4 routing richness (#549/#551), the #710 serve surface. Each defaults to its
             // disabling value (no TTL, no exchange, expired-routing off), so a zero-config broker
@@ -5636,6 +5655,13 @@ struct ServeConfig {
     /// `Flow`/`Fetch` block up to this budget on the broker's commit-notify seam and re-poll the
     /// instant a record commits. Threaded into [`EngineConfig::consume_longpoll_ms`]. Server-only.
     consume_longpoll_ms: u64,
+    /// Whether Linux `sendfile(2)` zero-copy Tier-S delivery (#1034 / #658) is ENABLED (default `true` =
+    /// AUTO-ON). `--no-zero-copy-sendfile` flips it `false` (the operator kill-switch that forces the
+    /// userspace copy path). Installed on the base engine handle via
+    /// [`ironbus_server::actor::EngineHandle::with_zero_copy_sendfile`]. Server-only — read ONLY by the
+    /// `#[cfg(unix)]` `run_broker`, so on a non-unix build (which never serves) the field is inert.
+    #[cfg_attr(not(unix), allow(dead_code))]
+    zero_copy_sendfile: bool,
     /// The per-stream DEFAULT message TTL in MILLISECONDS (V2-M4 #549, wired by #710): a record
     /// older than this (its durable producer `timestamp_ms + ttl` against the wall-clock seam) is
     /// EXPIRED — skipped on read, never delivered, reclaimed by the segment reap. `0` = OFF (the
@@ -5717,6 +5743,9 @@ impl ServeConfig {
     fn bench_default() -> ServeConfig {
         ServeConfig {
             consume_longpoll_ms: 0,
+            // Zero-copy `sendfile(2)` delivery (#1034) AUTO-ON, the shipped default (the in-process bench
+            // broker is a memory backend, where the fd path fail-closes to the copy path anyway).
+            zero_copy_sendfile: true,
             // V2-M4 routing richness (#549/#551) at its shipped defaults: no TTL, no dead-letter
             // exchange (the fixed `dlq/`), expired-routing off — the historical broker.
             default_message_ttl_ms: 0,
@@ -9443,6 +9472,10 @@ fn run_broker<F: Filesystem + Clone + 'static>(
         Some(slot) => shared.with_client_ack_slot(slot),
         None => shared,
     };
+    // Install the zero-copy `sendfile(2)` operator toggle (#1034 / #658) onto the base handle BEFORE any
+    // per-connection clone, so every connection reads the resolved setting locally. Default `true`
+    // (AUTO-ON where sound); `--no-zero-copy-sendfile` resolves it `false` (force the copy path).
+    let shared = shared.with_zero_copy_sendfile(config.zero_copy_sendfile);
     // Install the SHARED span-emission sink (#770) onto the base handle BEFORE any per-connection clone,
     // so every connection's produce/deliver/ack sites reach the ONE sink over the exporter's bounded
     // queue. `None` (export off) installs nothing, so `EngineAccess::span_sink` stays `None` and every
@@ -14580,6 +14613,7 @@ mod tests {
     fn test_serve_config(max_in_flight: u32, checkpoint_interval: u64) -> ServeConfig {
         ServeConfig {
             consume_longpoll_ms: 0,
+            zero_copy_sendfile: true,
             // V2-M4 routing (#549/#551) at its inert defaults: no TTL, no exchange, no
             // expired-routing — the historical fixed-`dlq/` broker.
             default_message_ttl_ms: 0,
@@ -18531,6 +18565,7 @@ mod tests {
     fn validation_config() -> ServeConfig {
         ServeConfig {
             consume_longpoll_ms: 0,
+            zero_copy_sendfile: true,
             // V2-M4 routing (#549/#551) at its inert defaults, mirroring production.
             default_message_ttl_ms: 0,
             max_delay_ms: DEFAULT_MAX_DELAY_MS,

--- a/crates/ironbus-client/src/lib.rs
+++ b/crates/ironbus-client/src/lib.rs
@@ -7847,31 +7847,63 @@ toYtkjmdU2eQ2pK/3gM=
         handle.join().unwrap();
     }
 
-    #[test]
-    fn a_scripted_deliver_batch_with_a_corrupt_record_is_a_typed_error_never_a_panic() {
-        // CRC end-to-end: a DeliverBatch body whose on-disk record bytes are corrupted (a flipped byte
-        // breaks the body CRC) is a typed `BadResponse`, never a panic and never a corrupt message handed
-        // to the caller — the client verifies each record's CRC as it decodes the batch.
-        let recs: Vec<BatchRec<'_>> = vec![(0, b"", b"", b"good-record")];
-        let mut record_bytes = on_disk_record_bytes(0, &recs);
-        // Flip a payload byte: the header CRC still passes (the header is untouched), but the body CRC
-        // now mismatches, so `codec::decode` rejects it.
-        let last = record_bytes.len() - ironbus_core::format::RECORD_TRAILER_LEN - 1;
-        record_bytes[last] ^= 0xFF;
+    /// Frames a `DeliverBatch` response script (`Info` handshake, one batch body, a `FlowEnd`) for the CRC
+    /// end-to-end test below, sharing the framing between the CLEAN and CORRUPT cases so the ONLY
+    /// difference under test is the flipped body byte.
+    #[cfg(test)]
+    fn deliver_batch_script(record_bytes: &[u8], record_count: u32) -> Vec<u8> {
         let mut batch_body = Vec::new();
         ironbus_proto::message::encode_deliver_batch(
             &ironbus_proto::message::DeliverBatchHeader {
                 first_offset: 0,
                 generation: 0,
-                record_count: 1,
+                record_count,
             },
-            &record_bytes,
+            record_bytes,
             &mut batch_body,
         );
         let mut script = frame(FrameType::Info, b"");
         script.extend(frame(FrameType::DeliverBatch, &batch_body));
-        script.extend(frame(FrameType::FlowEnd, &1u32.to_le_bytes()));
-        let (addr, handle) = raw_server(script);
+        script.extend(frame(FrameType::FlowEnd, &record_count.to_le_bytes()));
+        script
+    }
+
+    #[test]
+    fn a_scripted_deliver_batch_with_a_corrupt_record_is_a_typed_error_never_a_panic() {
+        // CRC end-to-end (#541, and the #1034 sendfile path): a DeliverBatch body is the STORED on-disk
+        // record bytes VERBATIM — identical whether the broker memcpy'd them (copy path) or spliced them
+        // straight from the page cache (`sendfile(2)`), so this client-side CRC check is the SAME integrity
+        // guarantee for both paths. A flipped body byte breaks the record's body CRC, so the fetch is a
+        // typed `BadResponse` — never a panic and never a corrupt message handed to the caller.
+        let recs: Vec<BatchRec<'_>> = vec![(0, b"", b"", b"good-record")];
+
+        // POSITIVE CONTROL: the untouched batch decodes to exactly the good record (so the rejection below
+        // is provably the flipped byte, not the framing).
+        {
+            let clean = on_disk_record_bytes(0, &recs);
+            let (addr, handle) = raw_server(deliver_batch_script(&clean, 1));
+            let mut c = Client::connect_with(
+                addr,
+                &ClientConfig {
+                    understands_deliver_batch: true,
+                    ..ClientConfig::default()
+                },
+            )
+            .unwrap();
+            let msgs = c.fetch(10).unwrap().messages;
+            assert_eq!(msgs.len(), 1, "the clean batch yields the one record");
+            assert_eq!(msgs[0].payload, b"good-record");
+            assert_eq!(msgs[0].offset, 0);
+            drop(c);
+            handle.join().unwrap();
+        }
+
+        // CORRUPT: flip a payload byte — the header CRC still passes (the header is untouched), but the
+        // body CRC now mismatches, so `codec::decode` rejects it.
+        let mut record_bytes = on_disk_record_bytes(0, &recs);
+        let last = record_bytes.len() - ironbus_core::format::RECORD_TRAILER_LEN - 1;
+        record_bytes[last] ^= 0xFF;
+        let (addr, handle) = raw_server(deliver_batch_script(&record_bytes, 1));
         let mut c = Client::connect_with(
             addr,
             &ClientConfig {

--- a/crates/ironbus-proto/src/message.rs
+++ b/crates/ironbus-proto/src/message.rs
@@ -793,6 +793,43 @@ pub fn encode_deliver_batch_frame(
     Ok(())
 }
 
+/// Encodes ONLY the `[len:u32][type][header]` PREFIX of a `DeliverBatch` frame onto `out` (#658, the
+/// Linux `sendfile(2)` zero-copy path) — everything `encode_deliver_batch_frame` writes EXCEPT the
+/// `record_bytes` body, whose `body_len` bytes the caller SPLICES straight from the segment's page cache
+/// into the socket right after this prefix. The framed length is computed from `body_len` (the eventual
+/// spliced length) EXACTLY as `encode_deliver_batch_frame` computes it from `record_bytes.len()`, so the
+/// bytes on the wire are byte-for-byte identical to the copy path's — the client is oblivious to whether
+/// the body was memcpy'd or spliced, and each stored record's CRC still ships end-to-end.
+///
+/// The caller writes this prefix, records where `out` ends (the splice injection point), then delivers
+/// `body_len` bytes via `sendfile(2)` before appending any further frames to `out`.
+///
+/// # Errors
+/// [`FrameError::FrameTooLarge`](crate::frame::FrameError::FrameTooLarge) if the framed length would
+/// exceed [`MAX_FRAME_LEN`](crate::frame::MAX_FRAME_LEN), exactly as [`encode_deliver_batch_frame`].
+pub fn encode_deliver_batch_frame_header(
+    header: &DeliverBatchHeader,
+    body_len: usize,
+    out: &mut Vec<u8>,
+) -> Result<(), crate::frame::FrameError> {
+    // Identical length arithmetic to `encode_deliver_batch_frame`, only sourcing the body length from
+    // `body_len` (the spliced range) rather than a materialized `record_bytes` slice, so the framed
+    // length — and thus every wire byte of the prefix — matches the copy path exactly.
+    let frame_body_len = DELIVER_BATCH_HEADER_LEN as u64 + body_len as u64;
+    let frame_len = 1u64 + frame_body_len;
+    if frame_len > u64::from(crate::frame::MAX_FRAME_LEN) {
+        return Err(crate::frame::FrameError::FrameTooLarge { len: frame_len });
+    }
+    let Ok(frame_len) = u32::try_from(frame_len) else {
+        return Err(crate::frame::FrameError::FrameTooLarge { len: frame_len });
+    };
+    out.reserve(4 + 1 + DELIVER_BATCH_HEADER_LEN);
+    out.extend_from_slice(&frame_len.to_le_bytes());
+    out.push(crate::frame::FrameType::DeliverBatch.as_u8());
+    write_deliver_batch_header(header, out);
+    Ok(())
+}
+
 /// Decodes a `DeliverBatch` frame body (#541) into its fixed [`DeliverBatchHeader`] and a BORROWED slice
 /// of the contiguous on-disk record-frame bytes that follow it, cap-before-alloc and panic-free.
 ///

--- a/crates/ironbus-server/Cargo.toml
+++ b/crates/ironbus-server/Cargo.toml
@@ -234,6 +234,17 @@ rustls-pki-types = { version = "1", optional = true, features = ["std"] }
 x509-cert = { version = "0.2", optional = true }
 const-oid = { version = "0.9", optional = true, features = ["db"] }
 
+# The Linux `sendfile(2)` zero-copy Tier-S consume path (#1034 / #658) makes the raw `sendfile` syscall
+# on the blocking connection-handler thread. `libc` is the raw binding only (no vendored C, no `links`
+# key, no build script), is ALREADY in the workspace tree (declared directly by `ironbus-storage`'s
+# per-OS preallocation and used by `ironbus-bench`), is MIT/permissive and on the deny.toml pure-Rust-
+# syscall allow-list, so it adds NO new crate to `Cargo.lock` and keeps the #139 pure-Rust posture (this
+# is NOT `nix`). Gated on `target_os = "linux"` — the only target the splice path compiles on; every
+# other target takes the userspace copy path and never links it, so the DEFAULT non-Linux build is
+# byte-for-byte unchanged.
+[target.'cfg(target_os = "linux")'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 tempfile = "3"
 # The semantics conformance vector suite (#35) is a checked-in JSON data file driven by a Rust

--- a/crates/ironbus-server/src/actor.rs
+++ b/crates/ironbus-server/src/actor.rs
@@ -716,6 +716,15 @@ pub struct EngineHandle<F: Filesystem, C: Clock> {
     /// `None`/empty on a non-tracing broker, so [`EngineAccess::span_sink`] returns `None` and emission
     /// is a zero-cost no-op — the byte-for-byte default hot path.
     span_sink: Arc<OnceLock<crate::obs::SpanSink>>,
+    /// Whether the Linux `sendfile(2)` zero-copy Tier-S delivery path (#1034 / #658) is ENABLED for this
+    /// broker — the operator tunable (default `true` = AUTO-ON). A connection actually splices only when
+    /// ALSO on a plaintext wire, a Linux build, and a disk-backed/unencrypted window (all enforced
+    /// downstream); this flag is the operator KILL-SWITCH that forces the userspace copy path everywhere
+    /// when `false`, with no behavioral or wire change. Read LOCALLY by the connection setup (no actor
+    /// round-trip) to seed `Session::with_splice_enabled`, exactly like [`Self::consume_longpoll_ms`]. A
+    /// plain `bool` copied on clone (like `reply_spin`), set on the base handle before any per-connection
+    /// clone via [`Self::with_zero_copy_sendfile`].
+    zero_copy_sendfile: bool,
 }
 
 /// The shared, set-once slot holding the clustered [`ClientAckGate`] (#719). Created empty at serve
@@ -755,6 +764,9 @@ impl<F: Filesystem, C: Clock + Clone> Clone for EngineHandle<F, C> {
             // The SAME shared span-emission sink (#770): the ONE sink the serve path installed reaches
             // every connection, so the `Arc<OnceLock>` is shared on clone (like `client_ack`).
             span_sink: Arc::clone(&self.span_sink),
+            // The fixed-for-life zero-copy `sendfile(2)` toggle (#1034): a plain copy, like `reply_spin`,
+            // so every connection clone inherits the base handle's operator setting.
+            zero_copy_sendfile: self.zero_copy_sendfile,
         }
     }
 }
@@ -769,6 +781,18 @@ impl<F: Filesystem + 'static, C: Clock + 'static> EngineHandle<F, C> {
     #[must_use]
     pub fn with_client_ack_slot(mut self, slot: ClientAckSlot<F, C>) -> Self {
         self.client_ack = Some(slot);
+        self
+    }
+
+    /// Set the Linux `sendfile(2)` zero-copy delivery toggle (#1034 / #658) on this base handle: `true`
+    /// (the default) AUTO-ONs the zero-copy path wherever it is sound; `false` is the operator KILL-SWITCH
+    /// that forces the userspace copy path on every connection. Called ONCE at serve start, RIGHT AFTER
+    /// [`spawn_actor_with_gather`] and BEFORE any per-connection clone, so every connection's handle
+    /// captures the setting (the `bool` is copied on clone). A consuming builder like
+    /// [`Self::with_client_ack_slot`]; a serve that never calls it keeps the AUTO-ON default.
+    #[must_use]
+    pub fn with_zero_copy_sendfile(mut self, on: bool) -> Self {
+        self.zero_copy_sendfile = on;
         self
     }
 
@@ -826,6 +850,16 @@ impl<F: Filesystem + 'static, C: Clock + 'static> EngineHandle<F, C> {
     #[must_use]
     pub fn consume_longpoll_ms(&self) -> u64 {
         self.consume_longpoll_ms
+    }
+
+    /// Whether Linux `sendfile(2)` zero-copy Tier-S delivery (#1034 / #658) is enabled for this broker
+    /// (the operator tunable; default `true`). Read by the connection setup to seed
+    /// `Session::with_splice_enabled` WITHOUT an actor round-trip (like [`Self::consume_longpoll_ms`]); a
+    /// connection still splices only on a plaintext wire, a Linux build, and a spliceable window. `false`
+    /// is the operator kill-switch forcing the copy path.
+    #[must_use]
+    pub fn zero_copy_sendfile(&self) -> bool {
+        self.zero_copy_sendfile
     }
 
     /// The engine-wide commit-notify wakeup seam (push delivery): the shared `Arc` an idle
@@ -1901,6 +1935,12 @@ where
             // shared sink via [`EngineHandle::set_span_sink`] right after this returns, BEFORE any
             // connection's handle is cloned, so every connection sees it.
             span_sink: Arc::new(OnceLock::new()),
+            // Zero-copy `sendfile(2)` delivery (#1034) AUTO-ON by default (the tunability-safe default: it
+            // is enabled precisely where it is sound — a plaintext, disk-backed, unencrypted window on a
+            // Linux build — and inert everywhere else). A serve started with the operator kill-switch flips
+            // it off via [`EngineHandle::with_zero_copy_sendfile`] right after this returns, BEFORE any
+            // connection's handle is cloned.
+            zero_copy_sendfile: true,
         },
         join,
     )

--- a/crates/ironbus-server/src/engine.rs
+++ b/crates/ironbus-server/src/engine.rs
@@ -1288,6 +1288,78 @@ pub struct StreamRawBatch {
     pub next_offset: Offset,
 }
 
+/// A live, spliceable file descriptor source for the Linux `sendfile(2)` zero-copy Tier-S consume path
+/// (#1034 / #658): a type-ERASED holder that keeps the segment reader (and thus its fd) OPEN for the
+/// whole splice, exposing only the raw descriptor the `sendfile` loop reads from. Erasing the concrete
+/// [`ironbus_storage::log::FdRun`] behind this trait keeps the filesystem type parameter out of the
+/// session/server writer types — a `Box<dyn SpliceSource>` crosses the sans-IO boundary carrying just the
+/// fd plus the byte range (in the [`StreamFdBatch::Fd`] fields). The `Send` supertrait lets the holder
+/// return from the append actor ([`crate::actor::EngineAccess::with`]) back to the connection thread that
+/// performs the splice.
+///
+/// Linux-only: the whole zero-copy WIRING is gated on `target_os = "linux"` (the `sendfile` syscall);
+/// every other target takes the copy path and never constructs one of these. The underlying storage fd
+/// primitives are `cfg(unix)`, so they still compile (and are unit-tested) on macOS — only the wiring is
+/// Linux-gated.
+#[cfg(target_os = "linux")]
+pub trait SpliceSource: Send {
+    /// The raw descriptor to `sendfile(2)` from. Valid for as long as `self` is alive (the holder owns
+    /// the segment reader that owns the fd), so the caller MUST keep the `Box<dyn SpliceSource>` alive
+    /// across the ENTIRE splice — the kernel reads the fd for the whole `sendfile` loop.
+    fn splice_raw_fd(&self) -> std::os::fd::RawFd;
+}
+
+#[cfg(target_os = "linux")]
+impl<Fl> SpliceSource for ironbus_storage::log::FdRun<Fl>
+where
+    Fl: ironbus_storage::io::RandomAccessFile + 'static,
+{
+    fn splice_raw_fd(&self) -> std::os::fd::RawFd {
+        use std::os::fd::AsRawFd;
+        // `run()` re-borrows the (still-open) splice fd from the reader this `FdRun` OWNS; the returned
+        // `RawFd` is valid exactly while `self` lives, which the `SpliceDirective` holding this box
+        // guarantees across the whole `sendfile` loop (the retire-race fd-lifetime guarantee: a fresh
+        // owned reader, so a concurrent compaction retire cannot close it — the fd stays open until the
+        // box drops, after the splice completes).
+        self.run().fd.as_raw_fd()
+    }
+}
+
+/// The result of [`Engine::stream_fetch_fd_in_stream`] (#1034 / #658): EITHER an fd run to `sendfile(2)`
+/// splice, OR a materialized copy-path batch when the zero-copy path was not available for the window
+/// (at-rest encryption, a compacted/remote slot, a no-fd backend, or a not-yet-indexed active tail — the
+/// SAME fail-closed reroutes [`ironbus_storage::log::Log::read_range_fd_range`] applies). The `Fd` variant
+/// is type-ERASED (its holder is a `Box<dyn SpliceSource>`), so the filesystem type never enters the
+/// session/server writer types; the `Copy` variant carries the ordinary [`StreamRawBatch`] so the caller
+/// serves it byte-for-byte as [`Engine::stream_fetch_raw_in_stream`] would.
+#[cfg(target_os = "linux")]
+pub enum StreamFdBatch {
+    /// The zero-copy path: splice `[file_offset, file_offset + len)` from `holder`'s fd as the
+    /// `DeliverBatch` body (`record_count` whole frames from `first_offset`), THEN deliver `tail`
+    /// per-record. `next_offset` is the consumer's resume point across both.
+    Fd {
+        /// Keeps the segment fd open for the whole splice; exposes the raw descriptor via
+        /// [`SpliceSource::splice_raw_fd`].
+        holder: Box<dyn SpliceSource>,
+        /// The absolute byte offset in the segment file where the spliced run's first frame begins.
+        file_offset: u64,
+        /// The spliced run's on-disk byte length: exactly `record_count` whole frames, verbatim.
+        len: usize,
+        /// The log offset of the FIRST frame in the spliced range.
+        first_offset: Offset,
+        /// How many complete frames the spliced range carries.
+        record_count: u64,
+        /// The ACTIVE-tail remainder past the sealed prefix, delivered as ordinary per-record `Deliver`s
+        /// (the raw fd read serves only the sealed, flushed prefix), contiguous with the splice.
+        tail: Vec<OwnedRecord>,
+        /// The consumer's resume offset: one past the last record across BOTH the splice and the tail.
+        next_offset: Offset,
+    },
+    /// The copy path: the zero-copy path was unavailable for this window; serve this materialized batch
+    /// exactly as [`Engine::stream_fetch_raw_in_stream`] does (byte-identical wire).
+    Copy(StreamRawBatch),
+}
+
 /// The outcome of [`Engine::progress`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ProgressResult {
@@ -14856,6 +14928,229 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
             tail,
             next_offset,
         })
+    }
+
+    /// The Linux `sendfile(2)` zero-copy sibling of [`Engine::stream_fetch_raw_in`] (#1034 / #658):
+    /// serves the contiguous SEALED prefix as an FD RUN — a borrowed segment descriptor plus the on-disk
+    /// byte range to splice — instead of the run's bytes in userspace, so the broker never reads the
+    /// record bodies into RAM (the kernel splices them straight from the page cache to the socket). The
+    /// group-mode guard, activity refresh, PAUSE gate, ACTIVE-tail materialization, and `delivered`
+    /// counter accounting are IDENTICAL to `stream_fetch_raw_in`, so the two are interchangeable on the
+    /// wire from the engine's view.
+    ///
+    /// FAIL-CLOSES to the copy path (a materialized [`StreamRawBatch`] in [`StreamFdBatch::Copy`]) whenever
+    /// the fd path is not available for the window — at-rest encryption, a compacted (v2 sparse) or remote
+    /// (offloaded) slot, a no-fd backend (memory / `O_DIRECT`), or a not-yet-indexed active tail — reusing
+    /// the exact fail-closed reroutes [`ironbus_storage::log::Log::read_range_fd_range`] already applies. On
+    /// the fd path the returned [`StreamFdBatch::Fd`] holds the segment reader ALIVE (via its
+    /// `Box<dyn SpliceSource>` holder) so a concurrent compaction retire cannot close the fd mid-splice.
+    ///
+    /// # Errors
+    /// [`EngineError::CumulativeAckOnWorkGroup`] if `group` is not a streaming group (the same wrong-mode
+    /// guard as `stream_fetch_raw_in`), or a storage error reading the durable prefix.
+    #[cfg(target_os = "linux")]
+    pub fn stream_fetch_fd_in(
+        &mut self,
+        group: &str,
+        _member: MemberId,
+        start_offset: Offset,
+        max_records: usize,
+        max_bytes: Option<usize>,
+    ) -> Result<StreamFdBatch, EngineError>
+    where
+        <F as Filesystem>::File: 'static,
+    {
+        // The wrong-mode guard, activity refresh, and PAUSE gate are IDENTICAL to `stream_fetch_raw_in`.
+        if !self.is_streaming_in(group) {
+            return Err(EngineError::CumulativeAckOnWorkGroup);
+        }
+        let now = self.log.now_monotonic();
+        if let Some(g) = self.groups.get_mut(group) {
+            g.last_activity = now;
+            g.touched = true;
+            if g.pause_active(now) {
+                return Ok(StreamFdBatch::Copy(StreamRawBatch {
+                    raw: RawByteRun {
+                        bytes: bytes::Bytes::new(),
+                        first_offset: start_offset,
+                        record_count: 0,
+                        next_offset: start_offset,
+                    },
+                    tail: Vec::new(),
+                    next_offset: start_offset,
+                }));
+            }
+        }
+        // Try the zero-copy fd path first. `read_range_fd_range` fail-closes (returns `None`) for every
+        // case the copy path must handle, so a `Some` here is a genuine spliceable sealed run.
+        let (fd_run, tail_from) =
+            self.log
+                .read_range_fd_range(start_offset, max_records, max_bytes)?;
+        if let Some(fd_run) = fd_run {
+            // ACTIVE-tail remainder, bounded exactly as `stream_fetch_raw_in` bounds it.
+            let fd_count = usize::try_from(fd_run.record_count()).unwrap_or(usize::MAX);
+            let tail = match tail_from {
+                Some(from) if fd_count < max_records => {
+                    self.log
+                        .read_range(from, max_records - fd_count, max_bytes)?
+                }
+                _ => Vec::new(),
+            };
+            let next_offset = tail.last().map_or(fd_run.next_offset(), |r| {
+                r.offset.checked_next().unwrap_or(r.offset)
+            });
+            let total = fd_run.record_count().saturating_add(tail.len() as u64);
+            let file_offset = fd_run.file_offset();
+            let len = fd_run.len();
+            let first_offset = fd_run.first_offset();
+            let record_count = fd_run.record_count();
+            // `self.log` borrow ended above (the tail read was its last use); bump the counter now.
+            self.counters.delivered = self.counters.delivered.saturating_add(total);
+            return Ok(StreamFdBatch::Fd {
+                holder: Box::new(fd_run),
+                file_offset,
+                len,
+                first_offset,
+                record_count,
+                tail,
+                next_offset,
+            });
+        }
+        // Copy fallback: byte-for-byte the body of `stream_fetch_raw_in` post-guard.
+        let (raw, tail_from) = self
+            .log
+            .read_range_raw(start_offset, max_records, max_bytes)?;
+        let raw_count = usize::try_from(raw.record_count).unwrap_or(usize::MAX);
+        let tail = match tail_from {
+            Some(from) if raw_count < max_records => {
+                self.log
+                    .read_range(from, max_records - raw_count, max_bytes)?
+            }
+            _ => Vec::new(),
+        };
+        let next_offset = tail.last().map_or(raw.next_offset, |r| {
+            r.offset.checked_next().unwrap_or(r.offset)
+        });
+        let total = raw.record_count.saturating_add(tail.len() as u64);
+        self.counters.delivered = self.counters.delivered.saturating_add(total);
+        Ok(StreamFdBatch::Copy(StreamRawBatch {
+            raw,
+            tail,
+            next_offset,
+        }))
+    }
+
+    /// The NAMED-stream twin of [`Engine::stream_fetch_fd_in`] (#1034 / #658): the `sendfile(2)` zero-copy
+    /// sibling of [`Engine::stream_fetch_raw_in_stream`]. Routes a named stream to its OWN per-stream log's
+    /// [`ironbus_storage::log::Log::read_range_fd_range`], with the IDENTICAL existence + wrong-mode guard,
+    /// activity refresh, PAUSE gate, and `delivered` accounting as `stream_fetch_raw_in_stream`. The default
+    /// stream (`""`) routes to [`Engine::stream_fetch_fd_in`] BYTE-FOR-BYTE. FAIL-CLOSES to
+    /// [`StreamFdBatch::Copy`] for every non-spliceable window, exactly as `stream_fetch_fd_in`.
+    ///
+    /// # Errors
+    /// [`EngineError::InvalidStreamName`] for a malformed name, [`EngineError::UnknownStream`] for a
+    /// never-declared stream, [`EngineError::CumulativeAckOnWorkGroup`] if `group` is not a streaming group
+    /// of `stream`, or a storage error reading the durable prefix.
+    #[cfg(target_os = "linux")]
+    pub fn stream_fetch_fd_in_stream(
+        &mut self,
+        stream: &str,
+        group: &str,
+        member: MemberId,
+        start_offset: Offset,
+        max_records: usize,
+        max_bytes: Option<usize>,
+    ) -> Result<StreamFdBatch, EngineError>
+    where
+        <F as Filesystem>::File: 'static,
+    {
+        if stream.is_empty() {
+            return self.stream_fetch_fd_in(group, member, start_offset, max_records, max_bytes);
+        }
+        let id = StreamId::named(stream)?;
+        // Mode-aware existence (#597), identical to `stream_fetch_raw_in_stream`.
+        let resident = if self.shared_wal.is_some() {
+            self.known_named_streams.contains(&id)
+        } else {
+            self.streams.get(&id).is_some()
+        };
+        if !resident {
+            return Err(EngineError::UnknownStream {
+                name: stream.to_string(),
+            });
+        }
+        if !self.is_streaming_in_stream(stream, group) {
+            return Err(EngineError::CumulativeAckOnWorkGroup);
+        }
+        let now = self.streams.get(&id).map_or(0, Log::now_monotonic);
+        if let Some(g) = self.named_group_mut(&id, group) {
+            g.last_activity = now;
+            g.touched = true;
+            if g.pause_active(now) {
+                return Ok(StreamFdBatch::Copy(StreamRawBatch {
+                    raw: RawByteRun {
+                        bytes: bytes::Bytes::new(),
+                        first_offset: start_offset,
+                        record_count: 0,
+                        next_offset: start_offset,
+                    },
+                    tail: Vec::new(),
+                    next_offset: start_offset,
+                }));
+            }
+        }
+        let Some(log) = self.streams.get(&id) else {
+            return Err(EngineError::UnknownStream {
+                name: stream.to_string(),
+            });
+        };
+        let (fd_run, tail_from) = log.read_range_fd_range(start_offset, max_records, max_bytes)?;
+        if let Some(fd_run) = fd_run {
+            let fd_count = usize::try_from(fd_run.record_count()).unwrap_or(usize::MAX);
+            let tail = match tail_from {
+                Some(from) if fd_count < max_records => {
+                    log.read_range(from, max_records - fd_count, max_bytes)?
+                }
+                _ => Vec::new(),
+            };
+            let next_offset = tail.last().map_or(fd_run.next_offset(), |r| {
+                r.offset.checked_next().unwrap_or(r.offset)
+            });
+            let total = fd_run.record_count().saturating_add(tail.len() as u64);
+            let file_offset = fd_run.file_offset();
+            let len = fd_run.len();
+            let first_offset = fd_run.first_offset();
+            let record_count = fd_run.record_count();
+            // `log` borrow (of `self.streams`) ended above; bump the counter now.
+            self.counters.delivered = self.counters.delivered.saturating_add(total);
+            return Ok(StreamFdBatch::Fd {
+                holder: Box::new(fd_run),
+                file_offset,
+                len,
+                first_offset,
+                record_count,
+                tail,
+                next_offset,
+            });
+        }
+        let (raw, tail_from) = log.read_range_raw(start_offset, max_records, max_bytes)?;
+        let raw_count = usize::try_from(raw.record_count).unwrap_or(usize::MAX);
+        let tail = match tail_from {
+            Some(from) if raw_count < max_records => {
+                log.read_range(from, max_records - raw_count, max_bytes)?
+            }
+            _ => Vec::new(),
+        };
+        let next_offset = tail.last().map_or(raw.next_offset, |r| {
+            r.offset.checked_next().unwrap_or(r.offset)
+        });
+        let total = raw.record_count.saturating_add(tail.len() as u64);
+        self.counters.delivered = self.counters.delivered.saturating_add(total);
+        Ok(StreamFdBatch::Copy(StreamRawBatch {
+            raw,
+            tail,
+            next_offset,
+        }))
     }
 
     /// Commits a Tier-S STREAMING group's cursor up to the EXCLUSIVE offset `up_to` (#544, M1-I7): the

--- a/crates/ironbus-server/src/server.rs
+++ b/crates/ironbus-server/src/server.rs
@@ -864,7 +864,13 @@ where
                 if session.has_parked() {
                     out.clear();
                     let _ = session.flush_all_parked_blocking(engine, &mut out);
-                    let _ = stream.write_all(&out);
+                    // Route the EOF drain through `write_response` so the invariant "a `DeliverBatch`
+                    // header queued in `out` ALWAYS gets its spliced body" (#1034) holds STRUCTURALLY on
+                    // EVERY write path, not just the two `process`-pass sites above. This drain only ever
+                    // emits produce-ack frames (never a batch), so `take_splices` is empty here and this
+                    // is byte-for-byte today's `write_all(&out)`; routing keeps it correct-by-construction
+                    // if a future refactor ever enqueues a splice directive on the parked/EOF path.
+                    let _ = write_response(stream, &out, session);
                 }
                 return Ok(());
             }
@@ -931,12 +937,17 @@ where
             // this and instead closes the connection via the arm below.
             Err(ref e) if want_nonblocking && e.kind() == std::io::ErrorKind::WouldBlock => {
                 out.clear();
+                // Both drain-write sites route through `write_response` for the same structural
+                // splice-safety invariant as the EOF path above (#1034): `drain_one_parked_blocking` only
+                // emits produce-ack frames, so `take_splices` is empty and the wire bytes are identical to
+                // `write_all(&out)` today, but a queued `DeliverBatch` header could never silently ship
+                // without its spliced body on this path either.
                 if session.drain_one_parked_blocking(engine, &mut out).is_err() {
-                    let _ = stream.write_all(&out);
+                    let _ = write_response(stream, &out, session);
                     return Ok(());
                 }
                 if !out.is_empty() {
-                    stream.write_all(&out)?;
+                    write_response(stream, &out, session)?;
                 }
             }
             // A real IO error, or a BLOCKING-mode read timeout (the slowloris defense with nothing

--- a/crates/ironbus-server/src/server.rs
+++ b/crates/ironbus-server/src/server.rs
@@ -685,6 +685,16 @@ where
     // into the session as `peer_san` so an `Mtls`-mechanism `Connect` authenticates on the certificate
     // alone; a non-mTLS connection carries `None` and an mTLS-mechanism connect fails closed.
     let peer_san = wire.peer_san();
+    // Zero-copy `sendfile(2)` eligibility for THIS connection (#1034 / #658): a plaintext wire, a Linux
+    // build (the whole splice path is `cfg(target_os = "linux")`), and the operator toggle on. A TLS wire,
+    // a non-Linux target, or the kill-switch leaves it `false`, so the session emits NO splice directives
+    // and every `DeliverBatch` takes the unchanged userspace copy path. Computed ONCE here (the wire type
+    // is fixed for the connection's life), read off the handle with no actor round-trip like the long-poll
+    // budget. Split by target so a non-Linux build never even references the eligibility inputs.
+    #[cfg(target_os = "linux")]
+    let splice_enabled = matches!(wire, Wire::Plain(_)) && engine.zero_copy_sendfile();
+    #[cfg(not(target_os = "linux"))]
+    let splice_enabled = false;
     // Pin the auth requirement onto the session: with a configured table the `Connect` handshake must
     // authenticate and verbs are scope-gated; with `None` the gate is bypassed (loopback-dev).
     // The connz handle (#572) is attached so a successful `Connect` records the authed-flip.
@@ -696,7 +706,9 @@ where
     // Seed the event-driven consume long-poll budget (push delivery) from the engine config via a
     // LOCAL handle read (no actor round-trip), exactly like the credit-cap negotiation. `0` (the
     // default) keeps the byte-identical empty-and-return consume path.
-    .with_consume_longpoll_ms(engine.consume_longpoll_ms());
+    .with_consume_longpoll_ms(engine.consume_longpoll_ms())
+    // Seed the zero-copy `sendfile(2)` eligibility (#1034): a no-op on a non-Linux build.
+    .with_splice_enabled(splice_enabled);
     // Attach the pre-auth `DoS` guard (#633) so the `Connect` handshake reports its auth outcome to the
     // per-IP failed-auth lockout (a failure feeds the lockout + bumps `rejected_total{auth_failed}`; a
     // success clears the IP's window). A no-op when no `DoS` defense is configured.
@@ -867,8 +879,10 @@ where
                 let Ok(progress) = session.process(engine, &inbuf, &mut out) else {
                     // A malformed frame, a fatal engine error, or a gone actor: flush any queued response
                     // (which, on the closing path, already carries the block-drained window) and close (a
-                    // length-prefixed stream cannot resync).
-                    let _ = stream.write_all(&out);
+                    // length-prefixed stream cannot resync). Route through `write_response` so a
+                    // `DeliverBatch` whose header was queued before the error still gets its spliced body
+                    // (#1034) rather than shipping a torn frame on the way out.
+                    let _ = write_response(stream, &out, session);
                     return Ok(());
                 };
                 inbuf.drain(..progress.consumed);
@@ -882,7 +896,10 @@ where
                 // round-trip from directly in front of the client-visible response, shaving it off the
                 // delivery/ack median (the hop still runs every committing pass, just AFTER the write).
                 if !out.is_empty() {
-                    stream.write_all(&out)?;
+                    // Write the response, splicing any zero-copy `DeliverBatch` bodies (#1034) in order
+                    // between the buffered frames; with no directives this is exactly today's
+                    // `write_all(&out)`.
+                    write_response(stream, &out, session)?;
                 }
                 // Persist the session's work-group cursor on the configured interval so a crash
                 // redelivers a bounded tail. ONLY when this pass actually advanced a committed cursor (an
@@ -927,6 +944,120 @@ where
             Err(e) => return Err(e),
         }
     }
+}
+
+/// Writes a `process` pass's response `out` to the wire, splicing any zero-copy `DeliverBatch` bodies
+/// (#1034 / #658) in order between the buffered frames. With NO splice directives — a TLS wire, a
+/// non-Linux build, the operator kill-switch, or a pass that emitted no batch — this is EXACTLY today's
+/// `stream.write_all(out)`. With directives (only ever a PLAINTEXT Linux connection), it delegates to
+/// [`write_response_spliced`], which walks them front-to-back: write the buffered prefix up to each
+/// directive's `out_pos`, then `sendfile(2)` its segment byte range straight from the page cache to the
+/// socket — so the batch body never entered userspace, yet the wire bytes are byte-identical to the copy
+/// path (the client is oblivious).
+fn write_response(stream: &mut Wire, out: &[u8], session: &mut Session) -> std::io::Result<()> {
+    #[cfg(target_os = "linux")]
+    {
+        let splices = session.take_splices();
+        if !splices.is_empty() {
+            match stream {
+                Wire::Plain(sock) => return write_response_spliced(sock, out, &splices),
+                // Unreachable: the session only emits directives when `splice_enabled`, which requires a
+                // plaintext wire. Fail CLOSED (close the connection) rather than risk a torn frame — the
+                // header is in `out` but the body is not — if that invariant is ever violated.
+                #[cfg(feature = "tls")]
+                Wire::Tls(_) => {
+                    return Err(std::io::Error::other(
+                        "zero-copy splice directive on a non-plaintext wire",
+                    ))
+                }
+            }
+        }
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = session;
+    }
+    stream.write_all(out)
+}
+
+/// Writes `out` to a PLAINTEXT socket, interleaving each ordered `sendfile(2)` splice (#1034) at its
+/// `out_pos`: the buffered prefix (the `DeliverBatch` frame header, plus any earlier frames) is written,
+/// then the directive's segment byte range is spliced from the page cache to the socket, then the walk
+/// continues. Each directive's `holder` keeps its segment fd OPEN until `splices` drops at the end of the
+/// call — AFTER every splice — so a concurrent compaction retire cannot close an fd mid-`sendfile`.
+#[cfg(target_os = "linux")]
+fn write_response_spliced(
+    sock: &mut TcpStream,
+    out: &[u8],
+    splices: &[crate::session::SpliceDirective],
+) -> std::io::Result<()> {
+    use std::os::fd::AsRawFd;
+    let sock_fd = sock.as_raw_fd();
+    let mut cursor = 0usize;
+    for directive in splices {
+        // The buffered prefix up to this splice's injection point (the batch header + any earlier frames).
+        if directive.out_pos > cursor {
+            sock.write_all(&out[cursor..directive.out_pos])?;
+        }
+        cursor = directive.out_pos;
+        // Splice the batch body straight from the segment's page cache into the socket.
+        sendfile_all(
+            sock_fd,
+            directive.holder.splice_raw_fd(),
+            directive.file_offset,
+            directive.len,
+        )?;
+    }
+    // The trailing frames after the last splice (tail `Deliver`s, the `FlowEnd`, any following batch).
+    if cursor < out.len() {
+        sock.write_all(&out[cursor..])?;
+    }
+    Ok(())
+}
+
+/// Splices exactly `len` bytes at `file_offset` from the segment descriptor `in_fd` to the socket
+/// `out_fd` via a BLOCKING `libc::sendfile(2)` loop (#1034 / #658), advancing a PRIVATE offset (NOT the
+/// fd cursor) so a concurrent reader of the same segment is unaffected and a partial write resumes from
+/// exactly where the kernel stopped. `EINTR` retries; `EAGAIN`/`EWOULDBLOCK` (the blocking-socket write
+/// TIMEOUT under `SO_SNDTIMEO`) and any other errno close the connection exactly as `write_all` does on a
+/// stalled write; a `0` return before the range is complete is an unexpected short segment, surfaced as
+/// `UnexpectedEof` rather than a silently truncated body.
+#[cfg(target_os = "linux")]
+fn sendfile_all(
+    out_fd: std::os::fd::RawFd,
+    in_fd: std::os::fd::RawFd,
+    file_offset: u64,
+    len: usize,
+) -> std::io::Result<()> {
+    // A PRIVATE offset the kernel advances (NOT the fd cursor), so a concurrent reader of the same
+    // segment is unaffected and a partial write resumes from exactly where the kernel stopped.
+    let mut off: libc::off_t = libc::off_t::try_from(file_offset).unwrap_or(libc::off_t::MAX);
+    let mut remaining = len;
+    while remaining > 0 {
+        // SAFETY: `out_fd` (the socket) and `in_fd` (the segment, kept open by the caller's `holder`) are
+        // valid open descriptors for this call; `&mut off` points to a live local. `sendfile` only READS
+        // `in_fd` and WRITES `out_fd`, advancing `off` by the byte count it returns (at most `remaining`).
+        // The one justified FFI call for the #1034 zero-copy path.
+        #[allow(unsafe_code)]
+        let n = unsafe { libc::sendfile(out_fd, in_fd, &mut off, remaining) };
+        if n < 0 {
+            let err = std::io::Error::last_os_error();
+            if err.kind() == std::io::ErrorKind::Interrupted {
+                // EINTR: the kernel did not advance `off`; retry the same range.
+                continue;
+            }
+            return Err(err);
+        }
+        if n == 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "sendfile returned 0 before the full range was sent",
+            ));
+        }
+        // Partial write: the kernel advanced `off` by `n` (> 0, and <= `remaining`); shrink the remainder.
+        remaining = remaining.saturating_sub(usize::try_from(n).unwrap_or(0));
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -2215,5 +2346,130 @@ zxTKkkRkG34kW+An4JfM0v3R6HpyUKFFNJP37W1f1Ari7Abj6pI3Df40
         let _ = handle.shutdown();
         drop(handle);
         let _ = actor.join();
+    }
+
+    // ===== Linux sendfile(2) zero-copy writer: real syscall over a real socket (#1034 / #658) ======
+    // These exercise the ACTUAL `write_response_spliced` / `sendfile_all` against a live loopback socket
+    // and a real file, so the partial-write loop and the fd-lifetime guarantee are proven end to end (the
+    // buffer-level byte-identity + zero-copy + ordering + fallback tests live in `session.rs`).
+
+    /// A minimal [`crate::engine::SpliceSource`] over an owned file handle, so a test can build a
+    /// `SpliceDirective` and drive the real splice writer without standing up a whole engine.
+    #[cfg(target_os = "linux")]
+    struct FileSplice(std::fs::File);
+
+    #[cfg(target_os = "linux")]
+    impl crate::engine::SpliceSource for FileSplice {
+        fn splice_raw_fd(&self) -> std::os::fd::RawFd {
+            use std::os::fd::AsRawFd;
+            self.0.as_raw_fd()
+        }
+    }
+
+    /// A connected loopback `TcpStream` pair `(sender, reader)` with DEFAULT socket buffers.
+    #[cfg(target_os = "linux")]
+    fn socket_pair() -> (TcpStream, TcpStream) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let sender = TcpStream::connect(addr).unwrap();
+        let (reader, _) = listener.accept().unwrap();
+        (sender, reader)
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn sendfile_partial_write_loop_delivers_the_whole_body_byte_identical() {
+        // (6) PARTIAL-WRITE: a body far larger than the socket send buffer forces `sendfile` to return
+        // SHORT counts, so the loop must iterate on a PRIVATE offset until the whole range is sent. A
+        // concurrent reader drains the socket so the blocking sender never wedges (default buffers). The
+        // reader must receive `prefix ++ body ++ suffix` byte-for-byte.
+        let prefix = b"PREFIX-DELIVERBATCH-HEADER".to_vec();
+        let suffix = b"SUFFIX-TAIL-DELIVER-FLOWEND".to_vec();
+        // 4 MiB body with a recognizable pattern (detects any misorder / partial-loop bug).
+        let body: Vec<u8> = (0..4 * 1024 * 1024u32)
+            .map(|i| u8::try_from(i % 251).expect("< 256"))
+            .collect();
+
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        std::io::Write::write_all(&mut file, &body).unwrap();
+        let reopened = file.reopen().unwrap();
+
+        // `out` = prefix, then a splice at out_pos = prefix.len() (the body is NOT in `out`), then suffix.
+        let mut out = prefix.clone();
+        let out_pos = out.len();
+        out.extend_from_slice(&suffix);
+        let directive = crate::session::SpliceDirective {
+            out_pos,
+            holder: Box::new(FileSplice(reopened)),
+            file_offset: 0,
+            len: body.len(),
+        };
+
+        let (mut sender, mut reader) = socket_pair();
+        let expected_len = prefix.len() + body.len() + suffix.len();
+        let reader_thread = std::thread::spawn(move || {
+            let mut got = vec![0u8; expected_len];
+            reader.read_exact(&mut got).unwrap();
+            got
+        });
+
+        write_response_spliced(&mut sender, &out, &[directive]).unwrap();
+        drop(sender);
+
+        let got = reader_thread.join().unwrap();
+        let mut want = prefix.clone();
+        want.extend_from_slice(&body);
+        want.extend_from_slice(&suffix);
+        assert_eq!(got.len(), want.len(), "full length delivered");
+        assert_eq!(got, want, "prefix ++ spliced body ++ suffix, byte-for-byte");
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn sendfile_survives_the_segment_file_being_retired_mid_hold() {
+        // (7) fd LIFETIME / RETIRE RACE: the splice holder owns an OPEN fd, so UNLINKING the segment file
+        // (what a concurrent compaction retire does) does NOT close it — the kernel keeps the inode alive
+        // for the open fd, and `sendfile` still delivers the original bytes. This is the guarantee the
+        // `FdRun` holder provides across the whole splice.
+        let body: Vec<u8> = (0..64 * 1024u32)
+            .map(|i| u8::try_from(i % 97).expect("< 256"))
+            .collect();
+        let file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(file.path(), &body).unwrap();
+        let open = std::fs::File::open(file.path()).unwrap();
+        // RETIRE the segment: remove the file while our fd stays open (simulating a compaction retire).
+        std::fs::remove_file(file.path()).unwrap();
+        assert!(
+            !file.path().exists(),
+            "the segment file is unlinked (retired)"
+        );
+
+        let out = b"HDR".to_vec();
+        let out_pos = out.len();
+        let directive = crate::session::SpliceDirective {
+            out_pos,
+            holder: Box::new(FileSplice(open)),
+            file_offset: 0,
+            len: body.len(),
+        };
+
+        let (mut sender, mut reader) = socket_pair();
+        let expected_len = out.len() + body.len();
+        let reader_thread = std::thread::spawn(move || {
+            let mut got = vec![0u8; expected_len];
+            reader.read_exact(&mut got).unwrap();
+            got
+        });
+
+        write_response_spliced(&mut sender, &out, &[directive]).unwrap();
+        drop(sender);
+
+        let got = reader_thread.join().unwrap();
+        let mut want = out.clone();
+        want.extend_from_slice(&body);
+        assert_eq!(
+            got, want,
+            "sendfile from the still-open fd delivered the original bytes despite the unlink"
+        );
     }
 }

--- a/crates/ironbus-server/src/session.rs
+++ b/crates/ironbus-server/src/session.rs
@@ -24,6 +24,11 @@ use crate::cluster::read_consistency::ReadTier;
 use crate::engine::{
     AckResult, Engine, EngineError, NackResult, Poll, ProgressResult, StreamBatch, StreamRawBatch,
 };
+// The Linux `sendfile(2)` zero-copy Tier-S types (#1034 / #658). Gated on `target_os = "linux"` — the
+// only target the splice path compiles on; every other target takes the userspace copy path and never
+// references these (so the import would be unused there under `-D warnings`).
+#[cfg(target_os = "linux")]
+use crate::engine::{SpliceSource, StreamFdBatch};
 use bytes::Bytes;
 use ironbus_core::binding::{single_home, Resolution};
 use ironbus_core::clock::Clock;
@@ -54,7 +59,7 @@ use ironbus_proto::message::{
 };
 use ironbus_storage::fs::Filesystem;
 use ironbus_storage::log::Append;
-use ironbus_storage::segment::OwnedRecord;
+use ironbus_storage::segment::{OwnedRecord, RawByteRun};
 use ironbus_storage::streamset::StreamId;
 use std::borrow::Cow;
 use std::collections::{HashMap, VecDeque};
@@ -133,6 +138,42 @@ pub struct Progress {
     /// checkpoint path entirely: a ping never triggers a `maybe_checkpoint` command, so a stalled
     /// produce fsync on another connection cannot head-of-line-block it (invariant 4, #177).
     pub committed_progress: bool,
+}
+
+/// One ordered `sendfile(2)` splice to interleave into a `process` pass's response bytes (#1034 / #658):
+/// a `DeliverBatch` frame whose fixed header was written into `out` up to `out_pos`, but whose BODY
+/// (`len` bytes at `file_offset` in a sealed segment) is NOT in `out` — the server writer splices it from
+/// the page cache straight to the socket at `out_pos`, then resumes writing `out`. The `holder` keeps the
+/// segment fd OPEN for the whole splice (a fresh owned reader, so a concurrent compaction retire cannot
+/// close it), and is dropped only after the `sendfile` completes. Ordered by `out_pos` (a Flow can drain
+/// several batches per pass), so the writer walks them front-to-back. Linux-only (carries a raw fd).
+#[cfg(target_os = "linux")]
+pub(crate) struct SpliceDirective {
+    /// The position in `out` up to which the writer must `write_all` before this splice: the byte just
+    /// PAST this `DeliverBatch` frame's fixed header (and any frames before it), where the spliced body
+    /// belongs.
+    pub(crate) out_pos: usize,
+    /// Keeps the segment reader (and thus its fd) alive across the whole splice; exposes the raw fd via
+    /// [`SpliceSource::splice_raw_fd`]. Type-erased so the filesystem type does not enter this struct.
+    pub(crate) holder: Box<dyn SpliceSource>,
+    /// The absolute byte offset in the segment file where the spliced run's first frame begins.
+    pub(crate) file_offset: u64,
+    /// The run's on-disk byte length: exactly the `DeliverBatch` body, spliced verbatim.
+    pub(crate) len: usize,
+}
+
+#[cfg(target_os = "linux")]
+impl std::fmt::Debug for SpliceDirective {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // The `Box<dyn SpliceSource>` holder is not `Debug`; surface its raw fd instead, which is all a
+        // reader of a `Session` dump needs (the derived `Session` `Debug` requires this field be `Debug`).
+        f.debug_struct("SpliceDirective")
+            .field("out_pos", &self.out_pos)
+            .field("fd", &self.holder.splice_raw_fd())
+            .field("file_offset", &self.file_offset)
+            .field("len", &self.len)
+            .finish()
+    }
 }
 
 /// One entry in a session's connection-scoped in-flight set (#175, #275): the generation the lease
@@ -615,6 +656,21 @@ pub struct Session {
     /// turning the client's poll-interval latency floor into a commit-driven wakeup. Purely opt-in — the
     /// wire, the client, and the response framing are unchanged.
     consume_longpoll_ms: u64,
+    /// Whether this connection may use the Linux `sendfile(2)` zero-copy Tier-S delivery path (#1034 /
+    /// #658): set once at connection setup to a plaintext wire on a Linux build with the operator's
+    /// zero-copy toggle on. When `false` (a TLS wire, a non-Linux build, or the operator kill-switch) the
+    /// session emits NO splice directives and every `DeliverBatch` is framed body-and-all into `out`, so
+    /// the server writes it with today's exact `write_all(&out)`. Linux-only: the whole zero-copy wiring
+    /// is gated on `target_os = "linux"`.
+    #[cfg(target_os = "linux")]
+    splice_enabled: bool,
+    /// The ORDERED `sendfile(2)` splice directives this pass's `DeliverBatch` frames produced (#1034):
+    /// each names where a batch header ends in `out` and the segment byte range whose body the server
+    /// SPLICES there (the body is NOT in `out`). Appended to during `process` and DRAINED by the server
+    /// writer immediately after (`take_splices`), so a directive never spans passes. Only ever non-empty
+    /// when `splice_enabled`. Linux-only (a directive holds a raw fd).
+    #[cfg(target_os = "linux")]
+    pending_splices: Vec<SpliceDirective>,
 }
 
 /// #1163: the outcome of resolving a client resource name (stream or subject) through the cross-tenant
@@ -951,6 +1007,34 @@ impl Session {
         self
     }
 
+    /// Enables (or disables) the Linux `sendfile(2)` zero-copy Tier-S delivery path for THIS connection
+    /// (#1034 / #658). The server sets it once at connection setup — a plaintext wire on a Linux build with
+    /// the operator's zero-copy toggle on — so a TLS wire, a non-Linux build, or the operator kill-switch
+    /// leaves it `false` and the connection serves every `DeliverBatch` through the unchanged userspace
+    /// copy path. A builder-style setter (like [`with_connz`](Session::with_connz)) so
+    /// every existing call site is unchanged. On a non-Linux build the zero-copy wiring does not exist, so
+    /// this is a no-op that keeps the serve signature identical across targets.
+    #[must_use]
+    // On a non-Linux build the zero-copy field does not exist, so `self` is returned unmutated and the
+    // `enabled` argument is inert — the receiver's `mut` and the parameter are then genuinely unused.
+    #[cfg_attr(not(target_os = "linux"), allow(unused_mut, unused_variables))]
+    pub fn with_splice_enabled(mut self, enabled: bool) -> Session {
+        #[cfg(target_os = "linux")]
+        {
+            self.splice_enabled = enabled;
+        }
+        self
+    }
+
+    /// Drains this pass's ORDERED `sendfile(2)` splice directives (#1034) for the server writer to
+    /// interleave the spliced bodies between the buffered `out` frames. Called ONCE by the server
+    /// immediately after `process`, so a directive never spans passes; on a pass with no `DeliverBatch`
+    /// splice it returns empty (the writer then does a plain `write_all`). Linux-only.
+    #[cfg(target_os = "linux")]
+    pub(crate) fn take_splices(&mut self) -> Vec<SpliceDirective> {
+        std::mem::take(&mut self.pending_splices)
+    }
+
     /// Attaches the pre-auth `DoS` guard (#633) and this connection's source IP so the `Connect`
     /// handshake reports its auth outcome to the guard's per-IP failed-auth lockout. A builder-style
     /// setter (like [`with_connz`](Session::with_connz)) so every existing call site is unchanged and
@@ -1082,6 +1166,12 @@ impl Session {
         // the connection loop overlaps the NEXT batch through — the pass no longer block-awaits the
         // window at its end, so batch N's fdatasync no longer starves batch N+1 on one connection.
         let mut parked = std::mem::take(&mut self.parked);
+        // Start this pass with an empty splice-directive list (#1034): the server drains it right after
+        // every pass, so it is normally already empty; clearing defensively drops any stale fd holder
+        // (closing its fd) that a prior pass's writer somehow did not take, so a directive never leaks
+        // across passes.
+        #[cfg(target_os = "linux")]
+        self.pending_splices.clear();
         let result = loop {
             match decode_frame(&input[consumed..]).map_err(SessionError::BadFrame) {
                 Err(e) => break Err(e),
@@ -3846,7 +3936,7 @@ impl Session {
             // batch means decoding the on-disk record layout, so a DeliverBatch-capable consumer is
             // compression-capable by construction. The ACTIVE-tail per-record remainder is still gated
             // via `capable` inside the fn. (#1066)
-            Self::serve_stream_fetch_batch(
+            self.serve_stream_fetch_batch(
                 engine, &stream, &group, member, start, want, max_bytes, capable, out,
             )?
         } else {
@@ -4066,27 +4156,97 @@ impl Session {
         }
     }
 
+    /// Emits the ACTIVE-tail remainder of a Tier-S batch as ordinary per-record `Deliver` frames (#541),
+    /// returning how many were delivered. Extracted so the copy path and the `sendfile(2)` zero-copy path
+    /// (#1034) frame the tail through ONE source of truth. Each record is `capable`-gated for compressed
+    /// delivery (#1066) exactly as the inline loop it replaced; a frame that fails to encode ENDS the tail
+    /// (the same `break`). One reusable scratch buffer for the per-record frame bodies (#826).
+    fn emit_tail_records(tail: &[OwnedRecord], capable: bool, out: &mut Vec<u8>) -> u32 {
+        let mut delivered: u32 = 0;
+        let mut frame_body = Vec::with_capacity(DELIVER_FRAME_SCRATCH_CAP);
+        for record in tail {
+            let Some((wire_flags, wire_payload)) =
+                Self::deliver_encoding_for(capable, record.flags.bits(), &record.payload)
+            else {
+                break;
+            };
+            let msg = DeliverBody {
+                offset: record.offset.get(),
+                generation: 0,
+                flags: wire_flags,
+                timestamp_ms: record.timestamp_ms,
+                key: &record.key,
+                headers: &record.headers,
+                payload: wire_payload.as_ref(),
+            };
+            frame_body.clear();
+            if encode_deliver(&msg, &mut frame_body).is_err() {
+                break;
+            }
+            reply(out, FrameType::Deliver, &frame_body);
+            delivered = delivered.saturating_add(1);
+        }
+        delivered
+    }
+
+    /// Emits a materialized [`StreamRawBatch`] (the COPY path): the contiguous SEALED prefix as ONE
+    /// `DeliverBatch` frame whose body is the on-disk frame bytes VERBATIM, then the ACTIVE-tail remainder
+    /// as per-record `Deliver`s. Returns the TOTAL records delivered. Shared by the non-splice
+    /// `serve_stream_fetch_batch` and the `sendfile(2)` path's copy-fallback (#1034), so the framing has
+    /// one source of truth.
+    fn emit_stream_raw_batch(
+        raw: &RawByteRun,
+        tail: &[OwnedRecord],
+        capable: bool,
+        out: &mut Vec<u8>,
+    ) -> u32 {
+        let mut delivered: u32 = 0;
+        // A zero-record run is NOT framed (no empty batch on the wire); the tail and the FlowEnd still
+        // terminate the response.
+        if raw.record_count > 0 {
+            let header = DeliverBatchHeader {
+                first_offset: raw.first_offset.get(),
+                // No lease, no fence: a streaming batch carries generation 0, exactly as the per-record
+                // streaming `Deliver`. The consumer commits by offset (StreamCommit).
+                generation: 0,
+                // The record_count is bounded by `want` (a u32 on the wire), so this conversion never
+                // truncates a real batch; saturate defensively rather than wrap.
+                record_count: u32::try_from(raw.record_count).unwrap_or(u32::MAX),
+            };
+            // Frame the batch DIRECTLY into `out` in one pass (#812): the zero-copy `raw.bytes` segment
+            // slice is copied exactly once. Matches `reply`'s cap handling (checked before any write, so
+            // `out` is unchanged on the unreachable over-cap case).
+            let result = encode_deliver_batch_frame(&header, &raw.bytes, out);
+            debug_assert!(result.is_ok(), "DeliverBatch frame exceeded the frame cap");
+            delivered = delivered.saturating_add(header.record_count);
+        }
+        delivered.saturating_add(Self::emit_tail_records(tail, capable, out))
+    }
+
     /// Serves a Tier-S streaming fetch as a RAW-FRAMED `DeliverBatch` (#541, M1-I5), the batch-capable
     /// half of [`Session::handle_stream_fetch`]. The contiguous SEALED prefix of the run ships as ONE
-    /// `DeliverBatch` frame whose body is the records' on-disk frame bytes VERBATIM (never re-encoded, so
-    /// #658's disk `sendfile(2)` can splice them); any ACTIVE-tail remainder follows as ordinary
-    /// per-record `Deliver` frames, so the consumer always receives one continuous contiguous run.
+    /// `DeliverBatch` frame whose body is the records' on-disk frame bytes VERBATIM (never re-encoded); any
+    /// ACTIVE-tail remainder follows as ordinary per-record `Deliver` frames, so the consumer always
+    /// receives one continuous contiguous run.
+    ///
+    /// When this connection is `splice_enabled` (#1034 / #658 — a plaintext wire on a Linux build with the
+    /// operator's zero-copy toggle on), the SEALED prefix is delivered by `sendfile(2)`: only the batch
+    /// frame HEADER enters `out` and the server splices the body straight from the segment's page cache
+    /// (see [`Session::serve_stream_fetch_batch_spliced`]). Otherwise the whole batch is framed into `out`
+    /// (the byte-identical copy path). Either way the wire bytes are identical and the client is oblivious.
     ///
     /// Returns the TOTAL records delivered (`Some(n)`), or `None` when a recoverable engine reject was
     /// surfaced as an `Err` terminator. It does NOT write the `FlowEnd`; the caller writes it after the
-    /// shared #552 keep-up check, so the batch and per-record halves terminate identically (one `FlowEnd`
-    /// carrying the total delivered count), and the client frames the response the same way either way.
-    ///
-    /// CRC integrity end-to-end: the broker copies the stored bytes UNTOUCHED into the batch body, so
-    /// each record's header/body CRC ships verbatim for the client to verify exactly as it does a
-    /// per-record `Deliver`. NO lease, NO generation fence, NO cursor write — the same lease-free Tier-S
-    /// contract; the batch header's `generation` is `0`, matching the per-record streaming delivery.
+    /// shared #552 keep-up check. CRC integrity is end-to-end either way: the stored bytes ship UNTOUCHED,
+    /// so each record's header/body CRC is verified by the client exactly as for a per-record `Deliver`.
+    /// NO lease, NO generation fence, NO cursor write — the batch header's `generation` is `0`.
     #[allow(clippy::too_many_arguments)]
     fn serve_stream_fetch_batch<
         F: Filesystem + 'static,
         C: Clock + Clone + 'static,
         E: EngineAccess<F, C>,
     >(
+        &mut self,
         engine: &E,
         stream: &GroupName,
         group: &GroupName,
@@ -4097,6 +4257,14 @@ impl Session {
         capable: bool,
         out: &mut Vec<u8>,
     ) -> Result<Option<u32>, SessionError> {
+        // The zero-copy `sendfile(2)` path (#1034): a plaintext Linux connection with the operator toggle
+        // on. Every other case (TLS, non-Linux, kill-switch) falls through to the unchanged copy path.
+        #[cfg(target_os = "linux")]
+        if self.splice_enabled {
+            return self.serve_stream_fetch_batch_spliced(
+                engine, stream, group, member, start, want, max_bytes, capable, out,
+            );
+        }
         let group = group.clone();
         // Route by stream (#681 follow-up): a NAMED stream reads its OWN per-stream log via
         // `stream_fetch_raw_in_stream`; the DEFAULT stream (`stream` empty) routes to `stream_fetch_raw_in`
@@ -4106,61 +4274,101 @@ impl Session {
             e.stream_fetch_raw_in_stream(&stream, &group, member, start, want, max_bytes)
         })? {
             Ok(StreamRawBatch { raw, tail, .. }) => {
+                Ok(Some(Self::emit_stream_raw_batch(&raw, &tail, capable, out)))
+            }
+            Err(e) if e.is_fatal() => {
+                reply_err(out, "fatal storage error");
+                Err(SessionError::EngineFatal(e))
+            }
+            Err(e) => {
+                reply_err_coded(out, e.code().as_str(), &e.to_string());
+                Ok(None)
+            }
+        }
+    }
+
+    /// The Linux `sendfile(2)` zero-copy sibling of [`Session::serve_stream_fetch_batch`] (#1034 / #658):
+    /// fetches the contiguous SEALED prefix as an FD RUN via [`crate::engine::Engine::stream_fetch_fd_in_stream`]
+    /// and, when one is available, writes ONLY the `DeliverBatch` frame HEADER into `out` and records a
+    /// [`SpliceDirective`] (the segment byte range whose body the server splices at `out.len()`) — the
+    /// batch body never enters userspace. The ACTIVE-tail remainder frames per-record exactly as the copy
+    /// path. When the fd path is not available for the window (encryption / compacted / remote / no-fd /
+    /// unindexed tail), the engine returns [`StreamFdBatch::Copy`] and this serves the materialized batch
+    /// byte-for-byte as the copy path. The two are byte-identical on the wire; the client is oblivious.
+    #[cfg(target_os = "linux")]
+    #[allow(clippy::too_many_arguments)]
+    fn serve_stream_fetch_batch_spliced<
+        F: Filesystem + 'static,
+        C: Clock + Clone + 'static,
+        E: EngineAccess<F, C>,
+    >(
+        &mut self,
+        engine: &E,
+        stream: &GroupName,
+        group: &GroupName,
+        member: MemberId,
+        start: Offset,
+        want: usize,
+        max_bytes: Option<usize>,
+        capable: bool,
+        out: &mut Vec<u8>,
+    ) -> Result<Option<u32>, SessionError>
+    where
+        <F as Filesystem>::File: 'static,
+    {
+        let group = group.clone();
+        let stream = stream.clone();
+        match engine.with(move |e| {
+            e.stream_fetch_fd_in_stream(&stream, &group, member, start, want, max_bytes)
+        })? {
+            Ok(StreamFdBatch::Fd {
+                holder,
+                file_offset,
+                len,
+                first_offset,
+                record_count,
+                tail,
+                next_offset: _,
+            }) => {
                 let mut delivered: u32 = 0;
-                // The contiguous SEALED prefix as ONE DeliverBatch: the on-disk frame bytes verbatim. A
-                // zero-record run is NOT framed (no empty batch on the wire); the per-record tail and the
-                // FlowEnd still terminate the response.
-                if raw.record_count > 0 {
+                // The SEALED prefix as ONE DeliverBatch delivered by `sendfile(2)`: write only the fixed
+                // frame HEADER into `out`, then record the splice so the server writes the body straight
+                // from the page cache at `out.len()`. A zero-record run is never an `Fd` variant (the
+                // engine reports an empty run as `Copy`), but the guard mirrors the copy path exactly.
+                if record_count > 0 {
                     let header = DeliverBatchHeader {
-                        first_offset: raw.first_offset.get(),
-                        // No lease, no fence: a streaming batch carries generation 0, exactly as the
-                        // per-record streaming `Deliver`. The consumer commits by offset (StreamCommit).
+                        first_offset: first_offset.get(),
                         generation: 0,
-                        // The record_count is bounded by `want` (a u32 on the wire), so this conversion
-                        // never truncates a real batch; saturate defensively rather than wrap.
-                        record_count: u32::try_from(raw.record_count).unwrap_or(u32::MAX),
+                        record_count: u32::try_from(record_count).unwrap_or(u32::MAX),
                     };
-                    // Frame the batch DIRECTLY into `out` in one pass (#812): the zero-copy `raw.bytes`
-                    // segment slice is copied exactly once, dropping the redundant full-batch memcpy into a
-                    // temporary `frame_body` Vec and that per-batch allocation. Byte-identical to the old
-                    // `encode_deliver_batch` + `reply` path; matches `reply`'s cap handling (the cap is
-                    // checked before any write, so `out` is unchanged on the unreachable over-cap case).
-                    let result = encode_deliver_batch_frame(&header, &raw.bytes, out);
-                    debug_assert!(result.is_ok(), "DeliverBatch frame exceeded the frame cap");
-                    delivered = delivered.saturating_add(header.record_count);
-                }
-                // The ACTIVE-tail remainder (which the raw read does not serve) as ordinary per-record
-                // `Deliver` frames, immediately following the batch — so the run stays contiguous.
-                // One reusable scratch buffer for the tail's per-record frame bodies (#826): cleared
-                // and reused each iteration instead of a fresh `Vec` per delivered record.
-                let mut frame_body = Vec::with_capacity(DELIVER_FRAME_SCRATCH_CAP);
-                for record in &tail {
-                    // Compressed-delivery gate (#1066) on the ACTIVE-tail per-record remainder: a
-                    // non-capable consumer gets a stored-COMPRESSED record decompressed (COMPRESSED bit
-                    // cleared); a capable consumer and every uncompressed record pass through verbatim.
-                    // (The raw SEALED prefix above ships verbatim — sound, see the call site.)
-                    let Some((wire_flags, wire_payload)) =
-                        Self::deliver_encoding_for(capable, record.flags.bits(), &record.payload)
-                    else {
-                        break;
-                    };
-                    let msg = DeliverBody {
-                        offset: record.offset.get(),
-                        generation: 0,
-                        flags: wire_flags,
-                        timestamp_ms: record.timestamp_ms,
-                        key: &record.key,
-                        headers: &record.headers,
-                        payload: wire_payload.as_ref(),
-                    };
-                    frame_body.clear();
-                    if encode_deliver(&msg, &mut frame_body).is_err() {
-                        break;
+                    // The framed length accounts for the spliced `len` body, so the wire frame is
+                    // byte-identical to the copy path's `encode_deliver_batch_frame`. A cap error is
+                    // unreachable for a bounded batch; on it, drop the holder and skip the batch, leaving
+                    // `out` unchanged exactly as the copy path's `debug_assert` path does.
+                    match ironbus_proto::message::encode_deliver_batch_frame_header(
+                        &header, len, out,
+                    ) {
+                        Ok(()) => {
+                            self.pending_splices.push(SpliceDirective {
+                                out_pos: out.len(),
+                                holder,
+                                file_offset,
+                                len,
+                            });
+                            delivered = delivered.saturating_add(header.record_count);
+                        }
+                        Err(_) => {
+                            debug_assert!(false, "DeliverBatch frame exceeded the frame cap");
+                        }
                     }
-                    reply(out, FrameType::Deliver, &frame_body);
-                    delivered = delivered.saturating_add(1);
                 }
+                delivered = delivered.saturating_add(Self::emit_tail_records(&tail, capable, out));
                 Ok(Some(delivered))
+            }
+            // The fd path was unavailable for this window: serve the materialized batch byte-for-byte as
+            // the copy path (the engine already fail-closed to a plain `StreamRawBatch`).
+            Ok(StreamFdBatch::Copy(StreamRawBatch { raw, tail, .. })) => {
+                Ok(Some(Self::emit_stream_raw_batch(&raw, &tail, capable, out)))
             }
             Err(e) if e.is_fatal() => {
                 reply_err(out, "fatal storage error");
@@ -9776,8 +9984,346 @@ mod tests {
         );
     }
 
+    // ===== Linux sendfile(2) zero-copy Tier-S delivery (#1034 / #658) =============================
+    // These prove the WIRING at the session buffer level over a REAL disk (`StdFs`) backend whose sealed
+    // segments have spliceable fds: the header-only `out` plus the recorded splice directives reconstruct
+    // BYTE-FOR-BYTE the wire the materialize+encode copy path produces, the batch body never enters `out`,
+    // and the fallback (a memory backend / the kill-switch) emits no directives and ships the full-frame
+    // copy path. The REAL `sendfile` syscall + partial-write loop + fd-lifetime tests live in `server.rs`;
+    // the storage byte-range differential (incl. the encryption / compacted / remote fail-closes) lives in
+    // `ironbus-storage`'s `read_range_fd_range_byte_range_is_identical_to_read_range_raw`.
+    #[cfg(target_os = "linux")]
+    mod sendfile_zerocopy {
+        use super::*;
+        use ironbus_storage::fs::StdFs;
+
+        /// A disk-backed engine with a SMALL segment cap so a run SEALS several segments (the raw fd path
+        /// serves only the SEALED/indexed prefix) plus an active tail. `StdFs` gives each sealed segment a
+        /// real spliceable fd (unlike `InMemoryFs`, whose `splice_fd` is `None`).
+        fn disk_engine(dir: &std::path::Path) -> Engine<StdFs, ManualClock> {
+            Engine::open(
+                StdFs::new(dir.to_path_buf()),
+                ManualClock::new(),
+                EngineConfig {
+                    log: LogConfig {
+                        max_segment_bytes: 160,
+                        ..LogConfig::default()
+                    },
+                    ..test_config()
+                },
+            )
+            .unwrap()
+        }
+
+        fn produce_disk(
+            e: &DirectEngine<StdFs, ManualClock>,
+            key: &[u8],
+            headers: &[u8],
+            payload: &[u8],
+        ) {
+            e.engine_mut()
+                .produce(&Append {
+                    timestamp_ms: 42,
+                    flags: RecordFlags::EMPTY,
+                    key,
+                    headers,
+                    payload,
+                })
+                .unwrap();
+        }
+
+        /// A batch-capable Tier-S session over a disk engine, with `sendfile(2)` splicing on or off.
+        fn disk_batch_session(
+            e: &DirectEngine<StdFs, ManualClock>,
+            group: &[u8],
+            splice: bool,
+        ) -> Session {
+            e.with({
+                let g = String::from_utf8(group.to_vec()).unwrap();
+                move |eng| eng.set_streaming_in(&g, true).unwrap()
+            })
+            .unwrap();
+            let mut s = Session::new().with_splice_enabled(splice);
+            let mut out = Vec::new();
+            s.process(
+                e,
+                &frame(FrameType::Connect, &batch_connect_body(true, true)),
+                &mut out,
+            )
+            .unwrap();
+            out.clear();
+            s.process(e, &frame(FrameType::Sub, group), &mut out)
+                .unwrap();
+            s
+        }
+
+        fn stream_fetch_req() -> Vec<u8> {
+            let mut req = Vec::new();
+            ironbus_proto::message::encode_stream_fetch(
+                &ironbus_proto::message::StreamFetchBody {
+                    start_offset: 0,
+                    max_records: 100,
+                    max_bytes: 0,
+                    ..Default::default()
+                },
+                &mut req,
+            );
+            req
+        }
+
+        /// Reads exactly `len` bytes at `offset` from a raw fd (a positioned `pread`), the userspace twin
+        /// of what `sendfile(2)` splices — used to RECONSTRUCT the full wire from the header-only `out`
+        /// plus the splice directives, so the test compares it to the copy path byte-for-byte.
+        fn pread_exact(fd: std::os::fd::RawFd, offset: u64, len: usize) -> Vec<u8> {
+            let mut buf = vec![0u8; len];
+            let mut done = 0usize;
+            while done < len {
+                let at = libc::off_t::try_from(offset + done as u64).unwrap_or(libc::off_t::MAX);
+                // SAFETY: `fd` is a valid open segment descriptor kept alive by the directive's holder;
+                // `buf[done..]` has `len - done` bytes; `pread` reads at an explicit offset without moving
+                // the fd cursor. Test-only reconstruction of the spliced bytes.
+                #[allow(unsafe_code)]
+                let n = unsafe { libc::pread(fd, buf[done..].as_mut_ptr().cast(), len - done, at) };
+                assert!(n > 0, "pread short read reconstructing the spliced body");
+                done += usize::try_from(n).unwrap_or(0);
+            }
+            buf
+        }
+
+        /// Rebuilds the FULL wire bytes the server would put on the socket: `out` (header-only where a
+        /// splice was recorded) with each directive's spliced body `pread` back in at its `out_pos`.
+        fn reconstruct_wire(out: &[u8], splices: &[super::SpliceDirective]) -> Vec<u8> {
+            let mut wire = Vec::new();
+            let mut cursor = 0usize;
+            for d in splices {
+                wire.extend_from_slice(&out[cursor..d.out_pos]);
+                wire.extend_from_slice(&pread_exact(
+                    d.holder.splice_raw_fd(),
+                    d.file_offset,
+                    d.len,
+                ));
+                cursor = d.out_pos;
+            }
+            wire.extend_from_slice(&out[cursor..]);
+            wire
+        }
+
+        #[test]
+        fn socket_bytes_are_byte_identical_to_the_copy_path() {
+            // (1) HEADLINE DIFFERENTIAL: the wire the sendfile path produces (header-only `out` + spliced
+            // bodies) is BYTE-FOR-BYTE the wire the materialize+encode copy path produces for the SAME
+            // window. Two disk engines with identical records; one splices, one copies.
+            let dir_s = tempfile::tempdir().unwrap();
+            let dir_c = tempfile::tempdir().unwrap();
+            let es = DirectEngine::new(disk_engine(dir_s.path()));
+            let ec = DirectEngine::new(disk_engine(dir_c.path()));
+            for i in 0..16u8 {
+                produce_disk(&es, &[i], &[i, 1], &[i; 6]);
+                produce_disk(&ec, &[i], &[i, 1], &[i; 6]);
+            }
+            assert!(
+                es.engine_mut().segment_count() >= 2,
+                "the small cap must have sealed several segments"
+            );
+            let mut ss = disk_batch_session(&es, b"s", true);
+            let mut sc = disk_batch_session(&ec, b"s", false);
+
+            let mut out_splice = Vec::new();
+            ss.process(
+                &es,
+                &frame(FrameType::StreamFetch, &stream_fetch_req()),
+                &mut out_splice,
+            )
+            .unwrap();
+            let splices = ss.take_splices();
+            assert!(
+                !splices.is_empty(),
+                "the disk sealed prefix was delivered via sendfile (directives emitted)"
+            );
+
+            let mut out_copy = Vec::new();
+            sc.process(
+                &ec,
+                &frame(FrameType::StreamFetch, &stream_fetch_req()),
+                &mut out_copy,
+            )
+            .unwrap();
+            assert!(
+                sc.take_splices().is_empty(),
+                "the copy session emits no directives"
+            );
+
+            assert_eq!(
+                reconstruct_wire(&out_splice, &splices),
+                out_copy,
+                "the spliced wire == the copy-path wire, byte for byte"
+            );
+        }
+
+        #[test]
+        fn body_bytes_are_absent_from_out_when_spliced() {
+            // (2) ZERO-COPY HAPPENS: when a splice directive is emitted, the batch BODY (the sealed record
+            // bytes) is NOT present in `out` — the body never entered userspace; only the frame header did.
+            let dir = tempfile::tempdir().unwrap();
+            let e = DirectEngine::new(disk_engine(dir.path()));
+            for i in 0..16u8 {
+                produce_disk(&e, &[i], &[i, 1], &[i; 6]);
+            }
+            let mut s = disk_batch_session(&e, b"s", true);
+            let mut out = Vec::new();
+            s.process(
+                &e,
+                &frame(FrameType::StreamFetch, &stream_fetch_req()),
+                &mut out,
+            )
+            .unwrap();
+            let splices = s.take_splices();
+            assert!(!splices.is_empty());
+            for d in &splices {
+                let body = pread_exact(d.holder.splice_raw_fd(), d.file_offset, d.len);
+                assert!(d.len > 0, "a splice carries a non-empty body");
+                assert!(
+                    !out.windows(body.len()).any(|w| w == body.as_slice()),
+                    "the spliced body must NOT appear in `out` (zero user-space copy)"
+                );
+                assert!(d.out_pos <= out.len(), "the splice injects within `out`");
+            }
+        }
+
+        #[test]
+        fn splice_sits_between_the_batch_header_and_the_tail_no_torn_frames() {
+            // (5) NO TORN FRAMES / ORDERING: with several sealed segments + an active tail, the response is
+            // a sequence of DeliverBatch (spliced) + tail Deliver frames. The directives are ordered by
+            // `out_pos`, and reconstructing + decoding the wire in order yields EXACTLY the records the
+            // copy path does — the splice sits precisely between each batch header and the following frames.
+            let dir = tempfile::tempdir().unwrap();
+            let e = DirectEngine::new(disk_engine(dir.path()));
+            for i in 0..16u8 {
+                produce_disk(&e, &[i], &[i, 1], &[i; 6]);
+            }
+            let mut s = disk_batch_session(&e, b"s", true);
+            let mut out = Vec::new();
+            s.process(
+                &e,
+                &frame(FrameType::StreamFetch, &stream_fetch_req()),
+                &mut out,
+            )
+            .unwrap();
+            let splices = s.take_splices();
+            assert!(!splices.is_empty());
+            for w in splices.windows(2) {
+                assert!(
+                    w[0].out_pos < w[1].out_pos,
+                    "directives are strictly ordered by out_pos (no interleave)"
+                );
+            }
+            let wire = reconstruct_wire(&out, &splices);
+            let frames = decode_all(&wire);
+            assert!(frames.iter().any(|(t, _)| *t == FrameType::DeliverBatch));
+            let mut got: Vec<u64> = Vec::new();
+            for (ty, body) in &frames {
+                match ty {
+                    FrameType::DeliverBatch => {
+                        for r in decode_batch_records(body) {
+                            got.push(r.0);
+                        }
+                    }
+                    FrameType::Deliver => got.push(decode_deliver(body).unwrap().offset),
+                    _ => {}
+                }
+            }
+            assert_eq!(
+                got,
+                (0..16).collect::<Vec<_>>(),
+                "every offset in order across the sealed/active boundary — no torn or duplicated frame"
+            );
+        }
+
+        #[test]
+        fn memory_backend_fails_closed_to_the_copy_path() {
+            // (3a) FALLBACK — a MEMORY backend has no spliceable fd, so even with splicing ENABLED the
+            // engine fail-closes to the copy path: NO directives, and the wire carries full DeliverBatch
+            // frames byte-identical to the splice-off run.
+            let e = DirectEngine::new(small_segment_engine()); // InMemoryFs
+            for i in 0..16u8 {
+                produce_kh(&e, &[i], &[i, 1], &[i; 6]);
+            }
+            e.with(|eng| eng.set_streaming_in("s", true).unwrap())
+                .unwrap();
+            let mut s = Session::new().with_splice_enabled(true);
+            let mut scratch = Vec::new();
+            s.process(
+                &e,
+                &frame(FrameType::Connect, &batch_connect_body(true, true)),
+                &mut scratch,
+            )
+            .unwrap();
+            scratch.clear();
+            s.process(&e, &frame(FrameType::Sub, b"s"), &mut scratch)
+                .unwrap();
+
+            let mut out = Vec::new();
+            s.process(
+                &e,
+                &frame(FrameType::StreamFetch, &stream_fetch_req()),
+                &mut out,
+            )
+            .unwrap();
+            assert!(
+                s.take_splices().is_empty(),
+                "a memory backend never splices (no spliceable fd)"
+            );
+            assert!(
+                decode_all(&out)
+                    .iter()
+                    .any(|(t, _)| *t == FrameType::DeliverBatch),
+                "the sealed run still ships as a DeliverBatch via the copy path"
+            );
+        }
+
+        #[test]
+        fn kill_switch_forces_the_full_frame_copy_path() {
+            // (3b) FALLBACK — with splicing DISABLED (a TLS wire, a non-Linux build, or the operator
+            // kill-switch) the session emits NO directives and the batch BODY is present in `out` (the
+            // full-frame copy path), byte-identical to what the splice-off wire always was.
+            let dir = tempfile::tempdir().unwrap();
+            let e = DirectEngine::new(disk_engine(dir.path()));
+            for i in 0..16u8 {
+                produce_disk(&e, &[i], &[i, 1], &[i; 6]);
+            }
+            let mut s = disk_batch_session(&e, b"s", false);
+            let mut out = Vec::new();
+            s.process(
+                &e,
+                &frame(FrameType::StreamFetch, &stream_fetch_req()),
+                &mut out,
+            )
+            .unwrap();
+            assert!(
+                s.take_splices().is_empty(),
+                "a disabled connection never emits a splice directive"
+            );
+            // The whole run decodes straight out of `out` (bodies present) — the copy path.
+            let mut got: Vec<u64> = Vec::new();
+            for (ty, body) in decode_all(&out) {
+                match ty {
+                    FrameType::DeliverBatch => {
+                        for r in decode_batch_records(&body) {
+                            got.push(r.0);
+                        }
+                    }
+                    FrameType::Deliver => got.push(decode_deliver(&body).unwrap().offset),
+                    _ => {}
+                }
+            }
+            assert_eq!(got, (0..16).collect::<Vec<_>>());
+        }
+    }
+
     #[test]
     fn an_old_client_never_gets_a_deliver_batch_and_the_wire_is_byte_identical() {
+        // BACK-COMPAT: a batch-INCAPABLE consumer (an old client, or one that did not advertise) is
+        // served the per-record `Deliver` run byte-for-byte the pre-#541 wire, and NEVER the new tag.
         // BACK-COMPAT: a batch-INCAPABLE consumer (an old client, or one that did not advertise) is
         // served the per-record `Deliver` run byte-for-byte the pre-#541 wire, and NEVER the new tag.
         let e = DirectEngine::new(engine());

--- a/crates/ironbus-storage/src/io.rs
+++ b/crates/ironbus-storage/src/io.rs
@@ -156,6 +156,26 @@ pub trait RandomAccessFile: Send + Sync {
         let _ = len;
         Ok(())
     }
+
+    /// A borrowed OS file descriptor to splice a STORED byte range straight from the page cache to a
+    /// socket with Linux `sendfile(2)` — the zero-copy Tier-S consume path (#1034 / #658) — or `None`
+    /// when this backend has no descriptor safe to splice from. `None` is the always-available signal
+    /// to take the ordinary copy path; it is never a correctness compromise, so a backend that cannot
+    /// (or should not) be spliced simply keeps the default.
+    ///
+    /// The default is `None`; a backend opts IN by returning its descriptor. The in-memory and
+    /// ephemeral backends keep the default (no OS fd), and the `O_DIRECT` [`DirectFile`] returns `None`
+    /// on purpose (its page-cache coherence model makes a `sendfile` splice unsafe to assume — see its
+    /// override). Only the buffered production file ([`StdFile`], and the buffered arm of
+    /// [`MaybeDirectFile`]) returns `Some`.
+    ///
+    /// The returned descriptor BORROWS `self`: the caller MUST keep this file (or the reader owning it)
+    /// alive for the whole splice, because the fd must stay open while the kernel reads it. The method
+    /// exists only on unix (a `BorrowedFd` is unix-only; the disk backend is a v1 non-goal off unix).
+    #[cfg(unix)]
+    fn splice_fd(&self) -> Option<std::os::fd::BorrowedFd<'_>> {
+        None
+    }
 }
 
 /// Returns one past the LAST non-zero byte of `file` in `[start, end)`, or `start` when the
@@ -1189,6 +1209,15 @@ impl RandomAccessFile for StdFile {
     fn preallocate(&self, len: u64) -> io::Result<()> {
         preallocate_file(&self.file, len)
     }
+
+    // The buffered production file IS spliceable: `sendfile(2)` reads it straight from the page cache
+    // to the socket with no userspace copy of the record bodies (#1034 / #658). The borrow is tied to
+    // `self`, so the caller keeps this `StdFile` (or the `SegmentReader` owning it) alive across the
+    // whole splice.
+    fn splice_fd(&self) -> Option<std::os::fd::BorrowedFd<'_>> {
+        use std::os::fd::AsFd;
+        Some(self.file.as_fd())
+    }
 }
 
 /// Reserves `len` backing blocks for `file` AND advances its LOGICAL length up to `len`, with the
@@ -1342,6 +1371,34 @@ pub fn sync_dir(path: &std::path::Path) -> io::Result<()> {
 #[cfg(all(test, unix))]
 mod std_file_tests {
     use super::*;
+
+    #[test]
+    fn splice_fd_some_for_buffered_none_for_memory_backends() {
+        // The zero-copy Tier-S consume path (#1034 / #658) gates on `splice_fd()`: `Some` means the
+        // stored bytes can `sendfile(2)` straight from the page cache, `None` means take the copy path.
+        // Pin the contract so a backend that forgets to opt in fails SAFE (the default `None` = copy).
+        assert!(
+            InMemoryFile::new().splice_fd().is_none(),
+            "the in-memory backend has no OS fd"
+        );
+        assert!(
+            EphemeralFile::new().splice_fd().is_none(),
+            "the ephemeral backend has no OS fd"
+        );
+        let dir = tempfile::tempdir().unwrap();
+        let f = StdFile::create(&dir.path().join("splice.log")).unwrap();
+        assert!(
+            f.splice_fd().is_some(),
+            "the buffered production file is spliceable"
+        );
+        // `StdFs::File` IS `MaybeDirectFile`, so the delegating override is what actually engages on
+        // the disk read path: the buffered arm stays spliceable.
+        let mdf = MaybeDirectFile::Buffered(StdFile::create(&dir.path().join("mdf.log")).unwrap());
+        assert!(
+            mdf.splice_fd().is_some(),
+            "the buffered MaybeDirectFile delegates to Some"
+        );
+    }
 
     #[test]
     fn stdfile_roundtrip_and_persists() {
@@ -2039,6 +2096,18 @@ impl RandomAccessFile for DirectFile {
         // was (0 for a fresh create), which is what keeps the following appends read-free.
         Ok(())
     }
+
+    // NOT spliceable — return `None` so the splice caller takes the copy path (#1034 / #658). A
+    // `DirectFile` writes O_DIRECT (cache-bypassing) and reads through a SEPARATE buffered fd, relying
+    // on the write-invalidates-page-cache coherence rule that holds for `pread`; a `sendfile(2)` on the
+    // read fd would read through the very page cache the direct writes deliberately bypass, so whether
+    // it observes the freshest bytes for a still-active segment is exactly the kind of coherence
+    // question the design says to sidestep. A SEALED segment can be opened as a `DirectFile` when the
+    // io-mode is `direct`, so this case is reachable; the task's rule is to return `None` on any
+    // uncertainty, which keeps direct-mode consumes on the always-correct copy path.
+    fn splice_fd(&self) -> Option<std::os::fd::BorrowedFd<'_>> {
+        None
+    }
 }
 
 /// The [`Filesystem`](crate::fs::Filesystem)-selected production file: either the buffered
@@ -2099,6 +2168,16 @@ impl RandomAccessFile for MaybeDirectFile {
             MaybeDirectFile::Direct(f) => f.preallocate(len),
         }
     }
+    // Delegate so the filesystem-selected file reports its true spliceability: the buffered arm hands
+    // out its fd (splice-eligible), the O_DIRECT arm returns `None` (copy path). This delegation is
+    // load-bearing — `StdFs::File` IS `MaybeDirectFile`, so without it every disk read would report no
+    // fd and the zero-copy path would never engage.
+    fn splice_fd(&self) -> Option<std::os::fd::BorrowedFd<'_>> {
+        match self {
+            MaybeDirectFile::Buffered(f) => f.splice_fd(),
+            MaybeDirectFile::Direct(f) => f.splice_fd(),
+        }
+    }
 }
 
 /// Sharing a file behind a reference forwards to the inner implementation, so the
@@ -2125,6 +2204,10 @@ impl<F: RandomAccessFile + ?Sized> RandomAccessFile for &F {
     fn preallocate(&self, len: u64) -> io::Result<()> {
         (**self).preallocate(len)
     }
+    #[cfg(unix)]
+    fn splice_fd(&self) -> Option<std::os::fd::BorrowedFd<'_>> {
+        (**self).splice_fd()
+    }
 }
 
 /// Sharing a file behind an [`std::sync::Arc`] forwards to the inner implementation.
@@ -2150,6 +2233,10 @@ impl<F: RandomAccessFile + ?Sized> RandomAccessFile for std::sync::Arc<F> {
     fn preallocate(&self, len: u64) -> io::Result<()> {
         (**self).preallocate(len)
     }
+    #[cfg(unix)]
+    fn splice_fd(&self) -> Option<std::os::fd::BorrowedFd<'_>> {
+        (**self).splice_fd()
+    }
 }
 
 // The direct-write backend's byte-level correctness (alignment, the partial-tail read-modify-write,
@@ -2166,6 +2253,25 @@ mod direct_file_tests {
 
     fn dir() -> tempfile::TempDir {
         tempfile::tempdir().unwrap()
+    }
+
+    #[test]
+    fn splice_fd_none_for_o_direct() {
+        // A `DirectFile` (O_DIRECT, page-cache-bypassing writes with a SEPARATE buffered read fd) is
+        // NOT spliceable: a `sendfile(2)` on the read fd would read through the very page cache the
+        // direct writes bypass, so it returns `None` and direct-mode consumes take the copy path
+        // (#1034 / #658). A SEALED segment can be opened as a DirectFile, so this case is reachable.
+        let d = dir();
+        let df = DirectFile::create_new(&d.path().join("seg")).unwrap();
+        assert!(
+            df.splice_fd().is_none(),
+            "an O_DIRECT DirectFile is not spliceable"
+        );
+        let mdf = MaybeDirectFile::Direct(df);
+        assert!(
+            mdf.splice_fd().is_none(),
+            "the direct MaybeDirectFile delegates to None"
+        );
     }
 
     /// Reads the whole file (through the buffered read fd) into a `Vec` for oracle comparison.

--- a/crates/ironbus-storage/src/log.rs
+++ b/crates/ironbus-storage/src/log.rs
@@ -9057,6 +9057,188 @@ mod tests {
         differential(&log);
     }
 
+    #[cfg(unix)]
+    #[test]
+    #[allow(clippy::too_many_lines)]
+    fn fd_range_byte_range_is_identical_for_compressed_subject_and_stream_tag_frames() {
+        // #1034 / #658 — the headline gate above
+        // (`read_range_fd_range_byte_range_is_identical_to_read_range_raw`) exercises only plain
+        // EMPTY-flag records. This pins the SAME fd (`sendfile`) range == copy-path raw byte-range
+        // equality for the FLAGGED frame types that actually SHIP in production and drive the
+        // header-only walk down its flag-dependent branches:
+        //   (a) a stored-COMPRESSED frame — an extra content flag in the header; framing is unchanged
+        //       (the body is stored verbatim, the storage read path never decompresses), so
+        //       `decoded_len` must size it exactly like a plain record;
+        //   (b) a HAS_SUBJECT (#594) frame and (c) a HAS_STREAM_TAG (#597) frame — each carries a `u16`
+        //       length prefix immediately after the record header, so the header-only `frame_len_at`
+        //       reads `RECORD_HEADER_LEN + RECORD_SUBJECT_LEN_PREFIX` (HDR_MAX) and `decoded_len` sizes
+        //       the frame from that prefix.
+        // Proving the header-only fd walk names byte-for-byte the same range the in-buffer `decoded_len`
+        // walk does for these frames means a `DeliverBatch` that splices their bodies ships bytes
+        // identical to the copy path — which is exactly what the session-level
+        // `socket_bytes_are_byte_identical_to_the_copy_path` wire differential rests on. Safe by
+        // construction today; this pins it. (HAS_STREAM_TAG is a storage-internal demux key cleared
+        // before a record materializes to the wire, so the fd/copy byte-range identity is the natural
+        // place to pin it.)
+        use crate::fs::StdFs;
+        let dir = tempfile::tempdir().unwrap();
+        let mut log = Log::open(
+            StdFs::new(dir.path().to_path_buf()),
+            ManualClock::new(),
+            small_config(),
+        )
+        .unwrap();
+
+        // Interleave the three flagged frame types with plain records so the header-only walk crosses
+        // each flag branch mid-run and at a segment boundary (the tiny `small_config` cap rolls often).
+        // A subject and a stream tag share the fixed post-header slot (mutually exclusive), so they go on
+        // separate records.
+        let subject: &[u8] = b"orders.eu.payments";
+        let stream_tag: &[u8] = b"orders";
+        for i in 0..24u64 {
+            let body = [u8::try_from(i % 256).unwrap(); 16];
+            match i % 4 {
+                0 => {
+                    log.append(&rec(&body)).unwrap();
+                }
+                1 => {
+                    // The COMPRESSED content flag is preserved in the header; the body is stored verbatim
+                    // (the read path never decompresses), so the frame is sized like a plain record.
+                    let mut r = rec(&body);
+                    r.flags = RecordFlags::COMPRESSED;
+                    log.append(&r).unwrap();
+                }
+                2 => {
+                    log.append_with_subject(&rec(&body), subject).unwrap();
+                }
+                _ => {
+                    log.append_with_stream_tag(&rec(&body), stream_tag).unwrap();
+                }
+            }
+        }
+        log.sync().unwrap();
+        // A short un-synced active tail, exactly as the plain fixture leaves it (the fd path serves only
+        // the sealed, spliceable prefix below `flushed`).
+        for i in 24..27u64 {
+            log.append(&rec(&[u8::try_from(i % 256).unwrap(); 16]))
+                .unwrap();
+        }
+        let flushed = log.flushed_offset().get();
+        assert!(
+            log.active_segment_id() >= 2,
+            "the small cap must have sealed several segments"
+        );
+
+        // Guard against a vacuous test: confirm each flagged frame type actually reached the header-only
+        // fd walk in the sealed prefix. `codec::decode` derives HAS_SUBJECT/HAS_STREAM_TAG from the
+        // stored field's presence and preserves COMPRESSED, so seeing a flag on a decoded fd byte proves
+        // `frame_len_at`/`decoded_len` sized that frame from its header correctly. Reading a run at every
+        // start makes each sealed frame the head of some run, so every flag is observed.
+        let mut seen = RecordFlags::EMPTY;
+        for start in 0..flushed {
+            if let (Some(run), _) = log
+                .read_range_fd_range(Offset::new(start), 1_000, None)
+                .unwrap()
+            {
+                if run.record_count() > 0 {
+                    let synthetic = RawByteRun {
+                        bytes: run.read_bytes().unwrap(),
+                        first_offset: run.first_offset(),
+                        record_count: run.record_count(),
+                        next_offset: run.next_offset(),
+                    };
+                    for (view, _) in decode_raw_run(&synthetic) {
+                        seen = seen.with(view.flags);
+                    }
+                }
+            }
+        }
+        assert!(
+            seen.contains(RecordFlags::COMPRESSED),
+            "a stored-COMPRESSED frame reached the sealed fd walk"
+        );
+        assert!(
+            seen.contains(RecordFlags::HAS_SUBJECT),
+            "a HAS_SUBJECT (#594) frame reached the sealed fd walk"
+        );
+        assert!(
+            seen.contains(RecordFlags::HAS_STREAM_TAG),
+            "a HAS_STREAM_TAG (#597) frame reached the sealed fd walk"
+        );
+
+        // The differential: for every window and cap, the fd (`sendfile`) byte range EQUALS the copy-path
+        // raw bytes byte-for-byte, with the same run metadata, and the fd bytes decode (each frame
+        // CRC-checked) to whole frames — for the flagged frames as much as the plain ones.
+        let differential = |log: &Log<StdFs, ManualClock>| {
+            for start in 0..flushed {
+                for max in [1usize, 2, 3, 7, 1000] {
+                    for cap in [None, Some(1usize), Some(64), Some(4096)] {
+                        let (raw, raw_tail) =
+                            log.read_range_raw(Offset::new(start), max, cap).unwrap();
+                        let (fd, fd_tail) = log
+                            .read_range_fd_range(Offset::new(start), max, cap)
+                            .unwrap();
+                        let ctx = format!("start={start} max={max} cap={cap:?}");
+                        assert_eq!(fd_tail, raw_tail, "tail_from matches at {ctx}");
+                        match fd {
+                            Some(run) => {
+                                let fd_bytes = run.read_bytes().unwrap();
+                                assert_eq!(
+                                    &fd_bytes[..],
+                                    &raw.bytes[..],
+                                    "fd byte range == raw bytes at {ctx}"
+                                );
+                                assert_eq!(run.len(), raw.bytes.len(), "len matches at {ctx}");
+                                assert_eq!(
+                                    run.first_offset(),
+                                    raw.first_offset,
+                                    "first_offset at {ctx}"
+                                );
+                                assert_eq!(
+                                    run.record_count(),
+                                    raw.record_count,
+                                    "record_count at {ctx}"
+                                );
+                                assert_eq!(
+                                    run.next_offset(),
+                                    raw.next_offset,
+                                    "next_offset at {ctx}"
+                                );
+                                // The fd bytes are whole, CRC-valid frames tiling the run exactly
+                                // (`decode_raw_run` asserts the tiling and the count).
+                                let synthetic = RawByteRun {
+                                    bytes: fd_bytes,
+                                    first_offset: run.first_offset(),
+                                    record_count: run.record_count(),
+                                    next_offset: run.next_offset(),
+                                };
+                                let decoded = decode_raw_run(&synthetic);
+                                if let Some((_, off)) = decoded.first() {
+                                    assert_eq!(
+                                        *off, start,
+                                        "fd run starts at the requested offset {ctx}"
+                                    );
+                                }
+                            }
+                            None => {
+                                assert_eq!(
+                                    raw.record_count, 0,
+                                    "fd fallback (None) implies an empty raw run at {ctx}"
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        // With the append-seeded indexes, then after dropping them so the freshly REBUILT seek path is
+        // proven byte-identical for the flagged frames too.
+        differential(&log);
+        log.clear_segment_indexes();
+        differential(&log);
+    }
+
     #[test]
     fn read_range_raw_honors_max_records_and_max_bytes_like_read_range() {
         // The raw read applies the SAME record-count and byte caps (first-frame-always rule) as

--- a/crates/ironbus-storage/src/log.rs
+++ b/crates/ironbus-storage/src/log.rs
@@ -4409,6 +4409,139 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
         Ok((trimmed, tail_from))
     }
 
+    /// The fd (Linux `sendfile(2)`) sibling of [`Log::read_range_raw`] (#1034 / #658): instead of the
+    /// run's bytes in userspace, it names the exact on-disk byte range of the SAME contiguous run and
+    /// hands back a [`FdRun`] holding the opened segment reader (so the splice fd outlives the syscall)
+    /// plus that range. The SEEK / gap-trim / `max_records` / `max_bytes` / flushed-frontier logic is
+    /// IDENTICAL to `read_range_raw`, so the named range `[file_offset, file_offset + len)` is
+    /// byte-for-byte the [`RawByteRun::bytes`] the copy path returns for the same window (the
+    /// differential test pins this) — the wire body is unchanged and the client is oblivious.
+    ///
+    /// The boundary walk touches only frame HEADERS: no record body is ever read into userspace, which
+    /// is the whole point of the zero-copy path (the kernel splices the bodies straight from the page
+    /// cache to the socket).
+    ///
+    /// Returns `(Some(fd_run), tail_from)` when a spliceable run was found, or `(None, tail_from)` when
+    /// there is nothing to splice here and the caller must serve the window through the COPY path
+    /// ([`Log::read_range_raw`] / [`Log::read_range`]): the same fail-closed reroutes `read_range_raw`
+    /// uses — at-rest encryption, a compacted (v2 sparse) or offloaded (remote) slot, a not-yet-indexed
+    /// active tail — PLUS the no-splice-fd backends (an `O_DIRECT` segment), all of which take the copy
+    /// path for free. `(None, None)` means nothing remains to serve. `tail_from` matches
+    /// `read_range_raw`'s exactly, so a caller can chain the two paths interchangeably.
+    ///
+    /// # Errors
+    /// Returns [`StorageError::OffsetOutOfRange`] if `start` is older than the oldest retained record,
+    /// or an IO error reading a segment header.
+    #[cfg(unix)]
+    pub fn read_range_fd_range(
+        &self,
+        start: Offset,
+        max_records: usize,
+        max_bytes: Option<usize>,
+    ) -> Result<FdRangeRead<F::File>, StorageError> {
+        let start_v = start.get();
+        let flushed = self.flushed_offset.get();
+        if max_records == 0 || start_v >= flushed {
+            return Ok((None, None));
+        }
+        // At-rest encryption FAIL-CLOSED: the on-disk bytes are CIPHERTEXT, never spliceable to a
+        // plaintext consumer. Reroute the whole window to the materialize path (which decrypts on
+        // read), exactly as `read_range_raw` does.
+        if self.at_rest.is_encrypted() {
+            return Ok((None, Some(start)));
+        }
+        let oldest = self
+            .segments
+            .first()
+            .map_or(0, SegmentSlot::covered_base_offset);
+        if start_v < oldest {
+            return Err(StorageError::OffsetOutOfRange {
+                requested: start_v,
+                oldest,
+            });
+        }
+        // #643 tiered storage: restore an offloaded slot to local disk before opening it.
+        let slot_id = self.segments[self.segment_index_for(start_v)].id;
+        if self.is_segment_remote(slot_id) {
+            self.ensure_segment_local(slot_id)?;
+        }
+        let slot = &self.segments[self.segment_index_for(start_v)];
+        // A COMPACTED (sparse, v2) slot's byte run is non-contiguous: serve it via the materialize
+        // path from this segment's covered base (clamped to start), exactly as `read_range_raw`.
+        if slot.compacted_covered.is_some() {
+            let tail = start_v.max(slot.covered_base_offset());
+            return Ok((None, Some(Offset::new(tail))));
+        }
+        let seg_start = start_v.max(slot.base_offset);
+        let Some((anchor_offset, byte_pos, read_end)) =
+            self.seek_in_segment(slot, seg_start, max_records)?
+        else {
+            // The dense index does not cover `seg_start` (a not-yet-indexed active tail): copy path.
+            return Ok((None, Some(start)));
+        };
+        // Identical gap / want / byte-cap setup to `read_range_raw` (see its comments): read
+        // `gap + max_records` frames so the wanted count survives the leading-gap trim, and bind the
+        // byte cap to the anchor read only when there is no gap.
+        let gap = usize::try_from(seg_start.saturating_sub(anchor_offset)).unwrap_or(0);
+        let below_flushed =
+            usize::try_from(flushed.saturating_sub(anchor_offset)).unwrap_or(usize::MAX);
+        let want = max_records.saturating_add(gap).min(below_flushed);
+        let reader = SegmentReader::open(self.fs.open(&segment_file_name(slot.id))?)?;
+        let raw_max_bytes = if gap == 0 { max_bytes } else { None };
+        // The anchor run over this single segment, header-only. `None` = no splice fd for this segment
+        // (an `O_DIRECT` sealed segment): the caller serves the whole window through the copy path.
+        let Some(anchor) = reader.raw_fd_range(
+            byte_pos,
+            Offset::new(anchor_offset),
+            read_end,
+            want,
+            raw_max_bytes,
+        )?
+        else {
+            return Ok((None, Some(start)));
+        };
+        // Copy the anchor run's plain byte plan out before the borrowed `fd` (which borrows `reader`)
+        // has to be dropped so `reader` can move into `FdRun`. `RawFdRun` is `Copy`, so its last field
+        // read below ends the borrow (NLL) — no explicit `drop` (which clippy would reject on a Copy).
+        let anchor_start = anchor.file_offset;
+        let anchor_len = anchor.len;
+        let anchor_first = anchor.first_offset.get();
+        // Trim the leading `gap` frames and re-bound to `max_records` / `max_bytes` — the fd twin of
+        // `trim_and_bound_raw_run`, header-only, producing byte-identical boundaries.
+        let (file_offset, len, first_offset, record_count, next) = reader.trim_fd_run(
+            anchor_start,
+            anchor_len,
+            anchor_first,
+            seg_start,
+            max_records,
+            max_bytes,
+        )?;
+        // Resume reporting: byte-for-byte the same computation `read_range_raw` performs.
+        let tail_from = if next < flushed && record_count >= max_records as u64 {
+            None
+        } else if next < flushed {
+            Some(Offset::new(next))
+        } else {
+            None
+        };
+        if record_count == 0 {
+            // Nothing survived the trim as a spliceable run (mirrors an empty `read_range_raw` run):
+            // hand back only the resume point so the caller serves it via the copy path.
+            return Ok((None, tail_from));
+        }
+        Ok((
+            Some(FdRun {
+                reader,
+                file_offset,
+                len,
+                first_offset: Offset::new(first_offset),
+                record_count,
+                next_offset: Offset::new(next),
+            }),
+            tail_from,
+        ))
+    }
+
     // -----------------------------------------------------------------------------------------
     // Tiered storage: offload cold sealed segments to an object store (#643, V2-M10, phase 1).
     // All of these run on the single append actor (the `&mut Log` owner), so they are serialized
@@ -6108,6 +6241,101 @@ impl<F: Filesystem + Clone, C: Clock> Log<F, C> {
         );
         *self.read_plane.borrow_mut() = Some(plane.clone());
         Ok(plane)
+    }
+}
+
+/// The result of [`Log::read_range_fd_range`]: `Some(fd_run)` to splice plus the resume offset, or
+/// `None` plus the resume offset when the window must be served through the copy path.
+#[cfg(unix)]
+pub type FdRangeRead<F> = (Option<FdRun<F>>, Option<Offset>);
+
+/// The owned result of [`Log::read_range_fd_range`]: the opened [`SegmentReader`] whose descriptor the
+/// `sendfile(2)` splice reads — held here so the fd outlives the syscall — plus the bounded run's
+/// on-disk byte range and offsets. Keep this alive across the whole splice; the [`FdRun::run`] and
+/// [`FdRun::read_bytes`] accessors borrow it. Unix-only (a `BorrowedFd` is unix-only; the disk backend
+/// is a v1 non-goal off unix).
+#[cfg(unix)]
+#[derive(Debug)]
+pub struct FdRun<F: RandomAccessFile> {
+    reader: SegmentReader<F>,
+    file_offset: u64,
+    len: usize,
+    first_offset: Offset,
+    record_count: u64,
+    next_offset: Offset,
+}
+
+#[cfg(unix)]
+impl<F: RandomAccessFile> FdRun<F> {
+    /// The absolute byte offset in the segment file where the run's first frame begins.
+    #[must_use]
+    pub fn file_offset(&self) -> u64 {
+        self.file_offset
+    }
+
+    /// The run's total on-disk byte length: exactly `record_count` whole frames, verbatim.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Whether the run carries no bytes. A `read_range_fd_range` `FdRun` is never empty (an empty run
+    /// is reported as `None`), but the accessor exists for completeness and clippy's `len`/`is_empty`
+    /// pairing.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// The log offset of the FIRST frame in the range.
+    #[must_use]
+    pub fn first_offset(&self) -> Offset {
+        self.first_offset
+    }
+
+    /// How many complete frames the range carries.
+    #[must_use]
+    pub fn record_count(&self) -> u64 {
+        self.record_count
+    }
+
+    /// The next offset AFTER the run: where a follow-on read resumes.
+    #[must_use]
+    pub fn next_offset(&self) -> Offset {
+        self.next_offset
+    }
+
+    /// The borrowed splice descriptor plus this run's byte range as a [`RawFdRun`], the value the
+    /// `sendfile(2)` writer consumes. Borrows `self`, so the caller must hold the `FdRun` across the
+    /// whole splice (the fd must stay open while the kernel reads it).
+    ///
+    /// # Panics
+    /// Never in practice: an `FdRun` is only constructed after `raw_fd_range` returned a splice fd for
+    /// its (immutable) reader, so the reader still exposes one. The `expect` documents that invariant.
+    #[must_use]
+    pub fn run(&self) -> crate::segment::RawFdRun<'_> {
+        crate::segment::RawFdRun {
+            // Guaranteed `Some`: an `FdRun` is only built after `raw_fd_range` returned a splice fd for
+            // this reader, and the reader is immutable, so the fd is still present.
+            fd: self
+                .reader
+                .splice_fd()
+                .expect("an FdRun is only built when the reader has a splice fd"),
+            file_offset: self.file_offset,
+            len: self.len,
+            first_offset: self.first_offset,
+            record_count: self.record_count,
+            next_offset: self.next_offset,
+        }
+    }
+
+    /// Materializes this run's bytes into an owned [`Bytes`] via a userspace copy — the byte-identity
+    /// oracle and the copy fallback, NEVER the zero-copy hot path (which splices the fd instead).
+    ///
+    /// # Errors
+    /// Returns an IO error from the positioned read.
+    pub fn read_bytes(&self) -> Result<Bytes, StorageError> {
+        self.reader.read_fd_run_bytes(self.file_offset, self.len)
     }
 }
 
@@ -8542,6 +8770,38 @@ mod tests {
         log
     }
 
+    /// The disk-backed twin of [`rolled_log_unsynced_tail`]: same shape (a synced multi-segment prefix
+    /// plus a 3-record unsynced active tail) but over a REAL [`StdFs`] so the sealed segments are
+    /// buffered `StdFile`s with an OS descriptor — the only backend the fd (`sendfile`) path serves.
+    /// The `TempDir` is returned so the caller keeps the data directory alive for the log's lifetime.
+    #[cfg(unix)]
+    fn rolled_disk_log_unsynced_tail(
+        n: u64,
+    ) -> (tempfile::TempDir, Log<crate::fs::StdFs, ManualClock>) {
+        use crate::fs::StdFs;
+        let dir = tempfile::tempdir().unwrap();
+        let mut log = Log::open(
+            StdFs::new(dir.path().to_path_buf()),
+            ManualClock::new(),
+            small_config(),
+        )
+        .unwrap();
+        for i in 0..n {
+            log.append(&rec(&[u8::try_from(i % 256).unwrap(); 16]))
+                .unwrap();
+        }
+        log.sync().unwrap();
+        for i in n..n + 3 {
+            log.append(&rec(&[u8::try_from(i % 256).unwrap(); 16]))
+                .unwrap();
+        }
+        assert!(
+            log.active_segment_id() >= 2,
+            "should have rolled several times"
+        );
+        (dir, log)
+    }
+
     #[test]
     fn read_range_equals_n_single_record_reads_over_every_window() {
         // The core differential: a single-pass `read_range(start, max, None)` must return the EXACT
@@ -8673,6 +8933,125 @@ mod tests {
             );
         };
 
+        differential(&log);
+        log.clear_segment_indexes();
+        differential(&log);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn read_range_fd_range_byte_range_is_identical_to_read_range_raw() {
+        // #1034 / #658 HEADLINE GATE: the fd (`sendfile`) run for a window names the EXACT same bytes
+        // the copy-path raw read returns — proven over a REAL on-disk (spliceable) segment. For every
+        // window and every record/byte cap, `read_range_fd_range`'s `[file_offset, file_offset + len)`
+        // byte range EQUALS `read_range_raw`'s `bytes` byte-for-byte, with the same first_offset /
+        // record_count / next_offset / tail_from. Those bytes then decode (each frame CRC-validated) to
+        // the SAME records the materialize path returns, so the body a later DeliverBatch splices is
+        // identical to today's — and the header-only walk produced the range without ever reading a body.
+        let n: u64 = 25;
+        let (_dir, log) = rolled_disk_log_unsynced_tail(n);
+        let flushed = log.flushed_offset().get();
+        assert!(log.active_segment_id() >= 2, "must span several segments");
+
+        let differential = |log: &Log<crate::fs::StdFs, ManualClock>| {
+            for start in 0..flushed {
+                for max in [1usize, 2, 3, 7, 1000] {
+                    for cap in [None, Some(1usize), Some(64), Some(4096)] {
+                        let (raw, raw_tail) =
+                            log.read_range_raw(Offset::new(start), max, cap).unwrap();
+                        let (fd, fd_tail) = log
+                            .read_range_fd_range(Offset::new(start), max, cap)
+                            .unwrap();
+                        let ctx = format!("start={start} max={max} cap={cap:?}");
+                        // The resume point matches, so a caller can chain fd and copy paths freely.
+                        assert_eq!(fd_tail, raw_tail, "tail_from matches at {ctx}");
+                        match fd {
+                            Some(run) => {
+                                // The named byte range EQUALS the copy path's bytes, byte for byte.
+                                let fd_bytes = run.read_bytes().unwrap();
+                                assert_eq!(
+                                    &fd_bytes[..],
+                                    &raw.bytes[..],
+                                    "fd byte range == raw bytes at {ctx}"
+                                );
+                                assert_eq!(run.len(), raw.bytes.len(), "len matches at {ctx}");
+                                assert_eq!(
+                                    run.first_offset(),
+                                    raw.first_offset,
+                                    "first_offset at {ctx}"
+                                );
+                                assert_eq!(
+                                    run.record_count(),
+                                    raw.record_count,
+                                    "record_count at {ctx}"
+                                );
+                                assert_eq!(
+                                    run.next_offset(),
+                                    raw.next_offset,
+                                    "next_offset at {ctx}"
+                                );
+                                assert!(
+                                    run.record_count() >= 1,
+                                    "a Some run is non-empty at {ctx}"
+                                );
+                                // The `RawFdRun` splice view names the same range and a live fd.
+                                let view = run.run();
+                                assert_eq!(
+                                    view.file_offset,
+                                    run.file_offset(),
+                                    "view offset {ctx}"
+                                );
+                                assert_eq!(view.len, run.len(), "view len at {ctx}");
+                                assert_eq!(view.record_count, run.record_count());
+                                // The fd bytes decode (each frame CRC-checked) to the SAME records the
+                                // materialize path returns — the spliced body is valid and identical.
+                                let synthetic = RawByteRun {
+                                    bytes: fd_bytes,
+                                    first_offset: run.first_offset(),
+                                    record_count: run.record_count(),
+                                    next_offset: run.next_offset(),
+                                };
+                                let decoded = decode_raw_run(&synthetic);
+                                let materialized =
+                                    log.read_range(Offset::new(start), max, cap).unwrap();
+                                // A raw/fd run is bounded to ONE segment, so it is a PREFIX of what the
+                                // (possibly segment-crossing) materialize path returns — never more.
+                                assert!(
+                                    decoded.len() <= materialized.len(),
+                                    "fd run is a prefix of materialize at {ctx}"
+                                );
+                                for ((view, off), owned) in decoded.iter().zip(materialized.iter())
+                                {
+                                    assert_eq!(*off, owned.offset.get(), "offset at {ctx}");
+                                    assert_eq!(
+                                        view.payload,
+                                        &owned.payload[..],
+                                        "payload at {ctx}"
+                                    );
+                                }
+                                if let Some((_, off)) = decoded.first() {
+                                    assert_eq!(
+                                        *off, start,
+                                        "fd run starts at the requested offset {ctx}"
+                                    );
+                                }
+                            }
+                            None => {
+                                // No spliceable run here: the copy-path read must also be empty, so the
+                                // caller loses nothing by taking the copy path from `tail_from`.
+                                assert_eq!(
+                                    raw.record_count, 0,
+                                    "fd fallback (None) implies an empty raw run at {ctx}"
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        // With the append-seeded / lazily-built indexes, then after dropping them so the freshly
+        // REBUILT seek path is proven byte-identical too.
         differential(&log);
         log.clear_segment_indexes();
         differential(&log);

--- a/crates/ironbus-storage/src/segment.rs
+++ b/crates/ironbus-storage/src/segment.rs
@@ -578,6 +578,41 @@ pub struct RawByteRun {
     pub next_offset: Offset,
 }
 
+/// The fd sibling of [`RawByteRun`] for the Linux `sendfile(2)` zero-copy Tier-S consume path
+/// (#1034 / #658): instead of the run's bytes IN userspace, it names the exact on-disk BYTE RANGE
+/// `[file_offset, file_offset + len)` — a contiguous run of `record_count` whole, header-validated
+/// frames in one segment file — plus a BORROWED descriptor to splice that range straight from the
+/// page cache to the socket. The bodies are never read into userspace: the boundary walk that
+/// produced this touched only the frame HEADERS (see [`SegmentReader::raw_fd_range`]).
+///
+/// Byte-for-byte, `[file_offset, file_offset + len)` equals the [`RawByteRun::bytes`] the copy path
+/// returns for the SAME window (the differential test in `log.rs` pins this), so the wire body a
+/// later `DeliverBatch` splices is identical to today's — the client is oblivious. Each frame's
+/// header CRC was validated while walking; each frame's body CRC ships VERBATIM inside the range for
+/// the consumer to verify end to end, exactly as [`RawByteRun`] documents.
+///
+/// The `fd` BORROWS the [`SegmentReader`] it came from: the caller MUST keep that reader alive for
+/// the whole splice (the fd must stay open while the kernel reads it). Unix-only (a `BorrowedFd` is
+/// unix-only; the disk backend is a v1 non-goal off unix).
+#[cfg(unix)]
+#[derive(Clone, Copy, Debug)]
+pub struct RawFdRun<'a> {
+    /// The borrowed segment descriptor to `sendfile(2)` from. Borrows the reader; keep it alive.
+    pub fd: std::os::fd::BorrowedFd<'a>,
+    /// The absolute byte offset in the segment file where the run's first frame begins.
+    pub file_offset: u64,
+    /// The run's total on-disk byte length: exactly `record_count` whole frames, verbatim. Zero iff
+    /// `record_count == 0`.
+    pub len: usize,
+    /// The log offset of the FIRST frame in the range.
+    pub first_offset: Offset,
+    /// How many complete frames the range carries. `next_offset == first_offset + record_count`.
+    pub record_count: u64,
+    /// The next offset AFTER the run (the first offset NOT included): where a follow-on read resumes.
+    /// Equals `first_offset` when the run is empty.
+    pub next_offset: Offset,
+}
+
 impl OwnedRecord {
     /// Materializes a record from a CRC-VALIDATED [`RecordView`] by taking refcounted slices of the
     /// shared read `buf` the view borrows (#480). `buf` MUST be the exact buffer the `view` was
@@ -2684,6 +2719,197 @@ impl<F: RandomAccessFile> SegmentReader<F> {
         })
     }
 
+    /// A borrowed descriptor to `sendfile(2)` this segment's bytes from, or `None` when the backend
+    /// has no spliceable fd (memory, ephemeral, or `O_DIRECT`). The fd BORROWS `self`; keep the reader
+    /// alive across the splice. The unix-only gate on the [`RandomAccessFile::splice_fd`] seam.
+    #[cfg(unix)]
+    #[must_use]
+    pub fn splice_fd(&self) -> Option<std::os::fd::BorrowedFd<'_>> {
+        self.file.splice_fd()
+    }
+
+    /// Reads ONLY the frame header at absolute file offset `abs` (never the body) and returns the whole
+    /// frame's on-disk length via [`codec::decoded_len`], or `None` when the header is torn, corrupt,
+    /// or too short — which ENDS a run exactly as [`SegmentReader::raw_byte_range`]'s in-buffer walk
+    /// does when `decoded_len` errors. `region_end` bounds the read so it never reads past the admitted
+    /// region; at most `RECORD_HEADER_LEN` + the fixed post-header `u16` prefix (the width the subject
+    /// (#594) and stream-tag (#597) fields share) enter userspace — never a record body. This is the
+    /// header-only atom that keeps the fd walk zero-copy.
+    #[cfg(unix)]
+    fn frame_len_at(&self, abs: u64, region_end: u64) -> Result<Option<usize>, StorageError> {
+        const HDR_MAX: usize = RECORD_HEADER_LEN + RECORD_SUBJECT_LEN_PREFIX;
+        let want = usize::try_from(region_end.saturating_sub(abs))
+            .unwrap_or(HDR_MAX)
+            .min(HDR_MAX);
+        if want < RECORD_HEADER_LEN {
+            // Fewer bytes than a header remain: a torn tail. `decoded_len` would report `Truncated`, so
+            // end the run — mirroring `raw_byte_range` where `decoded_len(&body[cursor..])` breaks.
+            return Ok(None);
+        }
+        let mut hdr = [0u8; HDR_MAX];
+        self.file.read_exact_at(&mut hdr[..want], abs)?;
+        // `decoded_len` reads only the header fields (and, for a tagged/subject frame, the `u16` at the
+        // fixed post-header offset), so `want` bytes always suffice: it returns the SAME length the
+        // in-buffer walk computes for the identical on-disk header. A header-CRC/magic/version failure
+        // (or a short tagged frame) errors, which we map to `None` = end of run.
+        Ok(codec::decoded_len(&hdr[..want]).ok())
+    }
+
+    /// The fd sibling of [`SegmentReader::raw_byte_range`]: walks the SAME contiguous run of whole,
+    /// header-validated frames from `start_byte`, under the IDENTICAL bounds (`max`, `read_end`,
+    /// `max_bytes` with the first-frame-always rule), but reads ONLY the frame headers — never a body —
+    /// and returns the run's on-disk BYTE RANGE plus a borrowed splice fd as a [`RawFdRun`], for the
+    /// Linux `sendfile(2)` zero-copy path (#1034 / #658).
+    ///
+    /// Returns `Ok(None)` when this backend has no spliceable descriptor (memory / ephemeral /
+    /// `O_DIRECT`): the caller then takes the copy path via [`SegmentReader::raw_byte_range`]. Otherwise
+    /// the returned range `[file_offset, file_offset + len)` is byte-for-byte the [`RawByteRun::bytes`]
+    /// `raw_byte_range` would return for the same arguments (the differential test pins this), with the
+    /// same `first_offset` / `record_count` / `next_offset`. `start_byte` MUST be a real frame boundary;
+    /// a header that fails its CRC ENDS the run, so the range is always a clean whole-frame prefix.
+    ///
+    /// # Errors
+    /// Returns an IO error from reading a header, or [`StorageError::SegmentFull`] if the region length
+    /// does not fit `usize`. A torn or corrupt header is NOT an error: it ends the run.
+    #[cfg(unix)]
+    pub fn raw_fd_range(
+        &self,
+        start_byte: u64,
+        start_offset: Offset,
+        read_end: u64,
+        max: usize,
+        max_bytes: Option<usize>,
+    ) -> Result<Option<RawFdRun<'_>>, StorageError> {
+        // Only a backend with a spliceable descriptor can serve the zero-copy path; otherwise the
+        // caller copies. Take the fd first so `None` short-circuits before any IO.
+        let Some(fd) = self.file.splice_fd() else {
+            return Ok(None);
+        };
+        let mut run = RawFdRun {
+            fd,
+            file_offset: start_byte,
+            len: 0,
+            first_offset: start_offset,
+            record_count: 0,
+            next_offset: start_offset,
+        };
+        if max == 0 || start_byte >= read_end {
+            return Ok(Some(run));
+        }
+        // The region is `[start_byte, read_end)` — the exact window `raw_byte_range` reads into `body`,
+        // so `region_len` plays the role of `body.len()` and every bound below matches it one-for-one.
+        let region_len = usize::try_from(read_end.saturating_sub(start_byte))
+            .map_err(|_| StorageError::SegmentFull)?;
+        let mut rel = 0usize;
+        let mut byte_total = 0usize;
+        let mut count = 0usize;
+        let mut next_offset = start_offset.get();
+        while rel < region_len && count < max {
+            // HEADER-ONLY boundary walk (`decoded_len`, header-CRC-validated); a torn/corrupt header
+            // ends the run exactly as `raw_byte_range`'s `decoded_len(&body[cursor..])` does.
+            let Some(consumed) = self.frame_len_at(start_byte + rel as u64, read_end)? else {
+                break;
+            };
+            // A frame that would run past the region is a torn tail: end the run (mirrors
+            // `cursor + consumed > body.len()`).
+            if rel.saturating_add(consumed) > region_len {
+                break;
+            }
+            // Byte cap: stop before a frame that would exceed `max_bytes`, but ALWAYS admit the first
+            // (the "at least one" rule) — the identical check `raw_byte_range` applies.
+            if let Some(cap) = max_bytes {
+                if count != 0 && byte_total.saturating_add(consumed) > cap {
+                    break;
+                }
+            }
+            byte_total = byte_total.saturating_add(consumed);
+            count += 1;
+            next_offset = next_offset.saturating_add(1);
+            rel += consumed;
+        }
+        run.len = byte_total;
+        run.record_count = count as u64;
+        run.next_offset = Offset::new(next_offset);
+        Ok(Some(run))
+    }
+
+    /// The fd sibling of `trim_and_bound_raw_run` (in `log.rs`): given an anchor run's byte range
+    /// `[anchor_start, anchor_start + anchor_len)`, drops the leading frames below `seg_start` and
+    /// re-bounds the remainder to `max_records` / `max_bytes` (first-frame-always), returning the
+    /// trimmed `(file_offset, len, first_offset, record_count, next_offset)`. A header-only re-walk of
+    /// the SAME frames the anchor run admitted, so it produces byte-identical boundaries without ever
+    /// reading a body. `anchor_first_offset` is the log offset of the anchor run's first frame.
+    ///
+    /// # Errors
+    /// Propagates an IO error from reading a header.
+    #[cfg(unix)]
+    pub(crate) fn trim_fd_run(
+        &self,
+        anchor_start: u64,
+        anchor_len: usize,
+        anchor_first_offset: u64,
+        seg_start: u64,
+        max_records: usize,
+        max_bytes: Option<usize>,
+    ) -> Result<(u64, usize, u64, u64, u64), StorageError> {
+        let region_end = anchor_start + anchor_len as u64;
+        let mut rel = 0usize;
+        let mut offset = anchor_first_offset;
+        // Drop the leading frames below `seg_start` by walking their header lengths (mirrors the first
+        // loop of `trim_and_bound_raw_run`, bounded by `anchor_len` == the run's `bytes.len()`).
+        while offset < seg_start && rel < anchor_len {
+            let Some(consumed) = self.frame_len_at(anchor_start + rel as u64, region_end)? else {
+                break;
+            };
+            if rel.saturating_add(consumed) > anchor_len {
+                break;
+            }
+            rel += consumed;
+            offset = offset.saturating_add(1);
+        }
+        let run_start_rel = rel;
+        let first_offset = offset;
+        // Admit up to `max_records` / `max_bytes` frames from `seg_start`, "at least one" honored.
+        let mut count = 0usize;
+        let mut byte_total = 0usize;
+        while rel < anchor_len && count < max_records {
+            let Some(consumed) = self.frame_len_at(anchor_start + rel as u64, region_end)? else {
+                break;
+            };
+            if rel.saturating_add(consumed) > anchor_len {
+                break;
+            }
+            if let Some(cap) = max_bytes {
+                if count != 0 && byte_total.saturating_add(consumed) > cap {
+                    break;
+                }
+            }
+            byte_total = byte_total.saturating_add(consumed);
+            count += 1;
+            offset = offset.saturating_add(1);
+            rel += consumed;
+        }
+        Ok((
+            anchor_start + run_start_rel as u64,
+            byte_total,
+            first_offset,
+            count as u64,
+            offset,
+        ))
+    }
+
+    /// Materializes the bytes of `[file_offset, file_offset + len)` into an owned [`Bytes`] — the
+    /// copy-path twin of a [`RawFdRun`]'s byte range, for the byte-identity oracle and any caller that
+    /// must fall back to a userspace copy. This DOES read the bytes into userspace (unlike the sendfile
+    /// splice), so it is the verification/fallback path, never the zero-copy hot path.
+    ///
+    /// # Errors
+    /// Returns an IO error from the positioned read.
+    #[cfg(unix)]
+    pub fn read_fd_run_bytes(&self, file_offset: u64, len: usize) -> Result<Bytes, StorageError> {
+        self.read_into_fresh(len, file_offset)
+    }
+
     /// Scans a COMPACTED (`version` = 2) segment (#337): validates the v2 header (the caller's
     /// [`SegmentReader::open`] already accepted it), reads its SPARSE survivor records, the v2
     /// footer, and the trailing 44-byte compaction-metadata block, and returns them as a
@@ -4047,6 +4273,113 @@ mod tests {
         let (view, consumed) = codec::decode(&raw.bytes).expect("the one good frame decodes");
         assert_eq!(view.payload, b"good1");
         assert_eq!(consumed, raw.bytes.len());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn raw_fd_range_names_the_same_bytes_as_raw_byte_range() {
+        // #1034 / #658: `raw_fd_range` (the fd/sendfile sibling) names EXACTLY the byte range
+        // `raw_byte_range` returns, over a REAL StdFile (the only backend with a splice fd). Same
+        // record_count / first_offset / next_offset, and `[file_offset, file_offset + len)` reads back
+        // byte-for-byte equal — under the unbounded, record-capped, byte-capped (first-frame-always),
+        // and TORN-TAIL cases — all via a HEADER-ONLY walk that never reads a body.
+        use crate::io::StdFile;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("seg.log");
+        let file = Arc::new(StdFile::create(&path).unwrap());
+        let mut w = SegmentWriter::create(Arc::clone(&file), header()).unwrap();
+        for i in 0..6u64 {
+            w.append(&rec(i, &[u8::try_from(i).unwrap(); 7])).unwrap();
+        }
+        w.sync().unwrap();
+        let reader = SegmentReader::open(Arc::clone(&file)).unwrap();
+        let (positions, valid_end) = reader.record_byte_positions().unwrap();
+        let one_frame = reader
+            .raw_byte_range(positions[0], Offset::new(0), valid_end, 1, None)
+            .unwrap()
+            .bytes
+            .len();
+
+        // Every (max, byte-cap) combination the copy path handles, the fd path must NAME identically.
+        let caps = [
+            None,
+            Some(1usize),
+            Some(one_frame),
+            Some(one_frame * 3 + 1),
+            Some(usize::MAX),
+        ];
+        for max in [0usize, 1, 2, 3, 6, usize::MAX] {
+            for cap in caps {
+                let raw = reader
+                    .raw_byte_range(positions[0], Offset::new(0), valid_end, max, cap)
+                    .unwrap();
+                let fd = reader
+                    .raw_fd_range(positions[0], Offset::new(0), valid_end, max, cap)
+                    .unwrap()
+                    .expect("a StdFile-backed reader has a splice fd");
+                let ctx = format!("max={max} cap={cap:?}");
+                assert_eq!(fd.file_offset, positions[0], "file_offset at {ctx}");
+                assert_eq!(fd.len, raw.bytes.len(), "len at {ctx}");
+                assert_eq!(fd.record_count, raw.record_count, "record_count at {ctx}");
+                assert_eq!(fd.first_offset, raw.first_offset, "first_offset at {ctx}");
+                assert_eq!(fd.next_offset, raw.next_offset, "next_offset at {ctx}");
+                let fd_bytes = reader.read_fd_run_bytes(fd.file_offset, fd.len).unwrap();
+                assert_eq!(&fd_bytes[..], &raw.bytes[..], "byte range at {ctx}");
+            }
+        }
+
+        // An in-memory reader has NO splice fd: the fd path declines (copy path), never mis-serves.
+        let mem_file = Arc::new(InMemoryFile::new());
+        let mut mw = SegmentWriter::create(Arc::clone(&mem_file), header()).unwrap();
+        mw.append(&rec(0, b"m")).unwrap();
+        mw.sync().unwrap();
+        let mem_reader = SegmentReader::open(Arc::clone(&mem_file)).unwrap();
+        let (mpos, mend) = mem_reader.record_byte_positions().unwrap();
+        assert!(
+            mem_reader
+                .raw_fd_range(mpos[0], Offset::new(0), mend, 10, None)
+                .unwrap()
+                .is_none(),
+            "the in-memory backend has no splice fd — the fd path declines to the copy path"
+        );
+
+        // TORN TAIL: corrupt the last frame's header magic on disk; the header-only walk ends the run
+        // at the last good frame, naming the same bytes the copy path does.
+        let last_pos = *positions.last().unwrap();
+        let mut b = [0u8; 1];
+        file.read_at(&mut b, last_pos).unwrap();
+        b[0] ^= 0xFF;
+        file.write_all_at(&b, last_pos).unwrap();
+        let file_len = file.len().unwrap();
+        let torn_reader = SegmentReader::open(Arc::clone(&file)).unwrap();
+        let raw_torn = torn_reader
+            .raw_byte_range(positions[0], Offset::new(0), file_len, 10, None)
+            .unwrap();
+        let fd_torn = torn_reader
+            .raw_fd_range(positions[0], Offset::new(0), file_len, 10, None)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            fd_torn.record_count, 5,
+            "the torn last header ends the run at 5 frames"
+        );
+        assert_eq!(
+            fd_torn.record_count, raw_torn.record_count,
+            "torn count matches copy path"
+        );
+        assert_eq!(
+            fd_torn.len,
+            raw_torn.bytes.len(),
+            "torn len matches copy path"
+        );
+        let fd_torn_bytes = torn_reader
+            .read_fd_run_bytes(fd_torn.file_offset, fd_torn.len)
+            .unwrap();
+        assert_eq!(
+            &fd_torn_bytes[..],
+            &raw_torn.bytes[..],
+            "torn byte range matches copy path"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Linux `sendfile(2)` zero-copy Tier-S consume path (#1034 epic, closes #658)

Deliver a contiguous Tier-S `DeliverBatch`'s SEALED-prefix body by splicing the
segment's page-cache bytes straight to the socket with `sendfile(2)`, instead of
reading them into userspace and memcpy'ing them into the response buffer. The
DeliverBatch wire body is already the on-disk record frame bytes **verbatim**
(`encode_deliver_batch_frame` writes a fixed header then the stored bytes unchanged),
so the broker writes the header and splices the stored byte range for the body.

**The wire format is UNCHANGED — the client is oblivious to whether a batch body was
memcpy'd (copy path) or spliced (`sendfile`).** This PR proves CORRECTNESS +
byte-identity + that the zero copy actually happens.

> **Throughput is a separate t4g follow-up — no number is claimed here.**

### How it works
- **Engine** (`stream_fetch_fd_in{,_stream}`): source the sealed prefix as an `FdRun`
  (a borrowed segment fd + on-disk byte range), reusing the exact seek / gap-trim /
  `max_records` / `max_bytes` / flushed-frontier logic as the copy path. FAIL-CLOSES to
  a materialized `StreamRawBatch` for every non-spliceable window.
- **Session** (sans-IO): write only the `[len][type][DeliverBatchHeader]` into `out` and
  record an ordered `SpliceDirective { out_pos, holder, file_offset, len }`; the body
  never enters `out`. The copy path (`encode_deliver_batch_frame`) is kept for every
  non-splice case.
- **Server**: `write_all(out[..out_pos])` → blocking `libc::sendfile` loop → continue.
  Gated on `Wire::Plain(_)` **and** `cfg(target_os = "linux")`.

### Fallback matrix (all take the byte-identical copy path, no splice)
| Case | Where it fail-closes |
|---|---|
| TLS wire | server gate `matches!(wire, Wire::Plain(_))` |
| non-Linux / CI-windows | `cfg(target_os = "linux")` on the whole wiring |
| operator kill-switch | `--no-zero-copy-sendfile` → `zero_copy_sendfile = false` |
| at-rest encryption | `Log::read_range_fd_range` (ciphertext never spliced to a plaintext consumer) |
| compacted (v2 sparse) / remote (offloaded) | `Log::read_range_fd_range` reroute |
| memory / `O_DIRECT` backend | `splice_fd()` is `None` → engine returns `Copy` |
| non-capable consumer / active tail | per-record `Deliver`, never a batch |

### Tunability
`zero_copy_sendfile` is **AUTO-ON by default** where sound (Linux + plaintext +
disk-backed + unencrypted, all enforced downstream) with `--no-zero-copy-sendfile` as
the operator KILL-SWITCH forcing the copy path — never a baked-in one-way choice.

### Tests (all Linux; correctness is fully verifiable without a perf rig)
1. **Byte-identical differential** — the reconstructed spliced wire == the
   materialize+encode wire, byte-for-byte, over a real disk backend.
2. **Zero-copy happens** — the batch body bytes are absent from `out` when a splice is
   emitted.
3. **Fallback exercised** — a memory backend and the kill-switch fail-close to the
   full-frame copy path (encryption / compacted / remote fail-close in
   `read_range_fd_range`, covered by the storage byte-range differential).
4. **CRC e2e** — a flipped stored body byte → the client rejects (typed `BadResponse`);
   the spliced body carries the same CRC-bearing bytes as the copy path.
5. **No torn frames / no interleave** — directives are strictly ordered and sit exactly
   between each batch header and the tail.
6. **Partial-write loop** — a 4 MiB body over a real loopback socket forces short
   `sendfile` returns; the private-offset loop delivers the whole body byte-for-byte.
7. **fd lifetime / retire race** — `sendfile` from a still-open fd survives the segment
   file being unlinked (the holder keeps the fd open across the whole splice).

### Constraints honored
- No new dependency (`libc` was already in the workspace tree; **not** `nix`).
- `deny.toml` byte-identical; `cargo tree --all-features -i ring` empty.
- Default + all non-Linux builds compile & pass the copy path under `-D warnings`
  (verified `cargo check --target x86_64-pc-windows-gnu`).
- No proto / format-registry change.

### Deferred (follow-up)
- **Tier-W `flush_run` parity** (`session.rs`) via the same splice mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
