### PR TITLE
perf(storage): append-actor sharding phase-1 — inert K=1 routing/recovery plumbing (#811)

### DIFF
--- a/crates/ironbus-cli/src/main.rs
+++ b/crates/ironbus-cli/src/main.rs
@@ -143,7 +143,9 @@ use ironbus_core::lease::LeaseConfig;
 #[cfg(unix)]
 use ironbus_core::types::RecordFlags;
 #[cfg(unix)]
-use ironbus_server::actor::{spawn_actor_with_gather, DEFAULT_CHANNEL_BOUND};
+use ironbus_server::actor::{
+    resolve_append_shards, spawn_actor_with_gather, AppendShards, DEFAULT_CHANNEL_BOUND,
+};
 #[cfg(unix)]
 use ironbus_server::engine::{DiskFullPolicy, DurabilityLevel, Engine, EngineConfig};
 #[cfg(unix)]
@@ -292,6 +294,14 @@ const DEFAULT_DISK_FULL_POLICY: &str = "drop-new";
 /// MANY named streams share ONE tagged commit log. The mode is RESTART-ONLY and layout-bound: the
 /// engine fail-closed refuses to open a data directory laid out by the other mode.
 const DEFAULT_STORAGE_MODE: &str = "per-stream";
+
+/// The default APPEND-SHARD count for `serve` (`1` = a single append shard, #811): today's
+/// byte-for-byte single-actor write plane. `auto` resolves to the machine's core count (capped at
+/// [`MAX_APPEND_SHARDS`]); an explicit positive integer pins the count. RESTART-ONLY, and in this
+/// release INERT — the broker runs one append shard regardless of a resolved `> 1` until append-actor
+/// sharding is enabled, so the knob is a validated, reported setting (it never changes runtime
+/// behavior yet). Shared-WAL forces `1` and rejects an explicit `> 1`.
+const DEFAULT_APPEND_SHARDS: &str = "1";
 
 /// The default durability LEVEL for `serve` (`sync`, matching the engine default, #341, #379): an ack
 /// is emitted only after the covering `fdatasync`, so I2 holds and an acknowledged record is never
@@ -998,7 +1008,7 @@ USAGE:
                   [--max-groups <n>] [--max-streams <n>] [--max-open-streams <n>]
                   [--group-idle-evict-ms <ms>]
                   [--disk-full-policy <drop-new|drop-oldest>]
-                  [--storage-mode <per-stream|shared-wal>]
+                  [--storage-mode <per-stream|shared-wal>] [--append-shards <auto|N>]
                   [--key-shared-group <name>]... [--broadcast-group <name>]...
                   [--visibility-timeout-ms <n>] [--health-addr <host:port>] [--enable-admin]
     ironbus passwd --auth-config <path> --user <name> [--scopes <publish,subscribe,admin>]
@@ -1169,6 +1179,13 @@ Notes:
     subjects/filtered subscriptions, Tier-S streaming, and partitioned streams (all typed rejects
     in shared-wal mode). RESTART-ONLY and layout-bound: opening a data dir laid out by the other
     mode is refused fail-closed, never silently misread.
+    --append-shards (default 1) sets how many append shards the write plane runs (#811): 1 is the
+    single-actor write plane (today's behavior byte-for-byte); auto resolves to the machine's core
+    count (capped at a safe maximum); an explicit positive integer pins the count. RESTART-ONLY, and
+    INERT in this release: a resolved value greater than 1 does NOT yet spawn multiple append actors
+    (the broker still runs a single append shard), so the knob is a validated, reported setting only.
+    shared-wal cannot shard (all named streams share one physical commit log), so it forces 1 and
+    rejects an explicit value greater than 1.
     --key-shared-group <name> (repeatable, default none) runs the named competing group in
     key_shared ordering: a record's key routes to one live member, so same-key records keep their
     order while the group drains in parallel across keys. A group not named here stays plain
@@ -2530,6 +2547,10 @@ struct ServeFlags {
     /// The named-stream STORAGE MODE (#597): `--storage-mode <per-stream|shared-wal>`; `None`
     /// falls back to the `per-stream` default. Restart-only (layout-bound), never reloadable.
     storage_mode: Option<String>,
+    /// The APPEND-SHARD count (#811): `--append-shards <auto|N>`; `None` falls back to `1` (a single
+    /// append shard, today's byte-for-byte single-actor write plane). Restart-only, and inert in this
+    /// release (a resolved `> 1` does not yet spawn K actors — that is the C8 flip).
+    append_shards: Option<String>,
     visibility_ms: Option<u64>,
     enable_admin: bool,
     /// Turn ON the OTLP span export (#99, #352): the `--enable-otlp-export` bare flag. OFF by
@@ -2856,6 +2877,9 @@ fn collect_serve_flags(args: &[String]) -> Result<ServeFlags, CliError> {
             }
             "--storage-mode" => {
                 f.storage_mode = Some(take_value("--storage-mode", args, &mut i)?);
+            }
+            "--append-shards" => {
+                f.append_shards = Some(take_value("--append-shards", args, &mut i)?);
             }
             "--durability-level" => {
                 f.durability_level = Some(take_value("--durability-level", args, &mut i)?);
@@ -3372,6 +3396,45 @@ fn parse_serve_flags_with_env_and_reader(
             "`{source}` must be `per-stream` or `shared-wal`, got `{storage_mode_arg}`"
         ))
     })?;
+    // The APPEND-SHARD count (#811): flag > env > default (`1`), parsed like the other enum-ish flags,
+    // then RESOLVED against the storage mode in the one shared policy (`resolve_append_shards`): `auto`
+    // -> core count (capped at `MAX_APPEND_SHARDS`); an explicit count is honored (clamped to the cap);
+    // shared-WAL forces `1` and fail-closed REJECTS an explicit `> 1` (it shares one physical commit
+    // log across all named streams and cannot shard the append plane). RESTART-ONLY and, in this
+    // release, INERT: a resolved `> 1` does NOT yet spawn K actors (that is the owner-gated C8 flip), so
+    // the broker runs a single append shard (K=1) regardless — the resolved count is a validated,
+    // reported setting only.
+    let shards_from_flag = f.append_shards.is_some();
+    let append_shards_arg = resolve_string(
+        "--append-shards",
+        f.append_shards,
+        env,
+        DEFAULT_APPEND_SHARDS,
+    );
+    let append_shards_request = AppendShards::parse(&append_shards_arg).ok_or_else(|| {
+        let source = if shards_from_flag {
+            "--append-shards".to_string()
+        } else {
+            env_var_name("--append-shards")
+        };
+        CliError::Usage(format!(
+            "`{source}` must be `auto` or a positive integer, got `{append_shards_arg}`"
+        ))
+    })?;
+    let append_shards = resolve_append_shards(append_shards_request, storage_mode.to_engine())
+        .map_err(|_shared_wal_cannot_shard| {
+            let source = if shards_from_flag {
+                "--append-shards".to_string()
+            } else {
+                env_var_name("--append-shards")
+            };
+            CliError::Usage(format!(
+                "`{source} = {append_shards_arg}` cannot be combined with `--storage-mode shared-wal`: \
+                 a shared-WAL broker shares one physical commit log across all named streams and cannot \
+                 shard the append plane (use `auto`, which resolves to 1 under shared-WAL, or select \
+                 `--storage-mode per-stream`)"
+            ))
+        })?;
     // The durability LEVEL (#341, #379) resolves like the disk-full policy: an enum string with
     // flag > env > default (`sync`) precedence, parsed after resolution so a bad value names its
     // source (the flag if explicit, else the env var). The default `sync` keeps the historical
@@ -3589,6 +3652,7 @@ fn parse_serve_flags_with_env_and_reader(
             )?,
             disk_full_policy,
             storage_mode,
+            append_shards,
             visibility_ms: resolve_number(
                 "--visibility-timeout-ms",
                 f.visibility_ms,
@@ -5473,6 +5537,12 @@ struct ServeConfig {
     /// and layout-bound: deliberately absent from the SIGHUP-reloadable subset, and the engine
     /// fail-closed refuses a data dir laid out by the other mode.
     storage_mode: StorageModeArg,
+    /// The resolved APPEND-SHARD count (#811), `>= 1`: `1` (the default) is today's single-actor write
+    /// plane; a `> 1` value is the RESOLVED `--append-shards` request (auto core-count or an explicit
+    /// count, capped at [`ironbus_server::actor::MAX_APPEND_SHARDS`]; shared-WAL is forced to 1). Carried here only so the
+    /// materialized-config startup log can report it — in this release it is INERT (the broker runs one
+    /// append shard regardless; the C8 flip spawns K actors off this value). RESTART-ONLY.
+    append_shards: usize,
     visibility_ms: u64,
     /// Enable the OPT-IN read-only `/admin` introspection endpoint on the health server (#99). OFF
     /// by default: only with `--enable-admin` (and only when `--health-addr` is set) does `/admin`
@@ -5778,6 +5848,8 @@ impl ServeConfig {
             ram_ceiling_bytes: DEFAULT_RAM_CEILING_BYTES,
             disk_full_policy: DiskFullPolicyArg::DropNew,
             storage_mode: StorageModeArg::PerStream,
+            // A single append shard = today's single-actor write plane (#811, the inert K=1 default).
+            append_shards: 1,
             visibility_ms: DEFAULT_VISIBILITY_MS,
             enable_admin: false,
             enable_otlp_export: false,
@@ -7644,7 +7716,8 @@ fn materialized_config_line(config: &ServeConfig, addr: &str, data_dir: Option<&
          power_loss_safe={power_loss_safe} compression={compression} io_mode={io_mode} \
          flush_interval_ms={} \
          flush_max_bytes={} async_loss_ack={} wal_fsync_headroom_bytes={} storage={storage} \
-         commit_gather_us={} sync_max_dirty_bytes={} storage_mode={storage_mode}",
+         commit_gather_us={} sync_max_dirty_bytes={} storage_mode={storage_mode} \
+         append_shards={append_shards}",
         config.profile.name(),
         config.profile_schema_version,
         config.max_connections,
@@ -7680,6 +7753,7 @@ fn materialized_config_line(config: &ServeConfig, addr: &str, data_dir: Option<&
         config.sync_max_dirty_bytes,
         data_dir = data_dir.map_or_else(|| "none".to_string(), |d| d.display().to_string()),
         storage_mode = config.storage_mode.as_str(),
+        append_shards = config.append_shards,
     )
 }
 
@@ -14645,6 +14719,8 @@ mod tests {
             ram_ceiling_bytes: DEFAULT_RAM_CEILING_BYTES,
             disk_full_policy: DiskFullPolicyArg::DropNew,
             storage_mode: StorageModeArg::PerStream,
+            // A single append shard = today's single-actor write plane (#811, the inert K=1 default).
+            append_shards: 1,
             visibility_ms: DEFAULT_VISIBILITY_MS,
             enable_admin: false,
             enable_otlp_export: false,
@@ -18596,6 +18672,8 @@ mod tests {
             ram_ceiling_bytes: DEFAULT_RAM_CEILING_BYTES,
             disk_full_policy: DiskFullPolicyArg::DropNew,
             storage_mode: StorageModeArg::PerStream,
+            // A single append shard = today's single-actor write plane (#811, the inert K=1 default).
+            append_shards: 1,
             visibility_ms: DEFAULT_VISIBILITY_MS,
             enable_admin: false,
             enable_otlp_export: false,

--- a/crates/ironbus-cli/src/main.rs
+++ b/crates/ironbus-cli/src/main.rs
@@ -142,10 +142,13 @@ use ironbus_core::delivery::DeliveryConfig;
 use ironbus_core::lease::LeaseConfig;
 #[cfg(unix)]
 use ironbus_core::types::RecordFlags;
+// `AppendShards` + `resolve_append_shards` (#811) are platform-neutral PURE logic (no Unix
+// dependency): the `--append-shards` flag is parsed and validated on EVERY platform inside the
+// cross-platform serve-flags parser, exactly like `DurabilityLevelArg`/`StorageModeArg`. Only the
+// actual actor SPAWN (`spawn_actor_with_gather`, `DEFAULT_CHANNEL_BOUND`) is Unix-only.
+use ironbus_server::actor::{resolve_append_shards, AppendShards};
 #[cfg(unix)]
-use ironbus_server::actor::{
-    resolve_append_shards, spawn_actor_with_gather, AppendShards, DEFAULT_CHANNEL_BOUND,
-};
+use ironbus_server::actor::{spawn_actor_with_gather, DEFAULT_CHANNEL_BOUND};
 #[cfg(unix)]
 use ironbus_server::engine::{DiskFullPolicy, DurabilityLevel, Engine, EngineConfig};
 #[cfg(unix)]
@@ -530,10 +533,10 @@ impl StorageModeArg {
         }
     }
 
-    /// The engine-side [`ironbus_storage::shared_wal::StorageMode`] this flag selects. Unix-gated
-    /// like its only caller (`open_engine_with`, the broker's engine-open path): on non-Unix the
-    /// serve path does not build, so this mapping would be dead code there.
-    #[cfg(unix)]
+    /// The engine-side [`ironbus_storage::shared_wal::StorageMode`] this flag selects. Platform-neutral
+    /// (like `as_str`): the cross-platform serve-flags parser calls it to resolve the append-shard
+    /// count against the storage mode (#811, the shared-WAL-cannot-shard guard), and the Unix
+    /// engine-open path (`open_engine_with`) calls it too — so it is used on every platform.
     fn to_engine(self) -> ironbus_storage::shared_wal::StorageMode {
         match self {
             StorageModeArg::PerStream => ironbus_storage::shared_wal::StorageMode::PerStreamLogs,

--- a/crates/ironbus-server/src/actor.rs
+++ b/crates/ironbus-server/src/actor.rs
@@ -56,9 +56,11 @@ use crate::liveness::ActorWatchdog;
 use crate::produce_gate::ProduceCapGate;
 use bytes::Bytes;
 use ironbus_core::clock::Clock;
+use ironbus_core::sublist::SublistSnapshot;
 use ironbus_core::types::Offset;
 use ironbus_storage::fs::Filesystem;
 use ironbus_storage::log::Append;
+use ironbus_storage::streamset::StreamId;
 use std::collections::HashMap;
 use std::collections::VecDeque;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -725,6 +727,15 @@ pub struct EngineHandle<F: Filesystem, C: Clock> {
     /// plain `bool` copied on clone (like `reply_spin`), set on the base handle before any per-connection
     /// clone via [`Self::with_zero_copy_sendfile`].
     zero_copy_sendfile: bool,
+    /// The SHARED wait-free subject routing snapshot (#585 / #811 C3): the SAME `Arc<SublistSnapshot>`
+    /// the engine's [`crate::engine::Engine::bind_subject`] publishes to, cloned into the handle at
+    /// `spawn_actor` time BEFORE the engine moves into the actor thread. A connection thread resolves a
+    /// subject WAIT-FREE off the actor against it (no round-trip through the append actor), then routes
+    /// the produce to the resolved stream's shard via [`EngineAccess::with_on_shard`] — parity with the
+    /// `PubTo` path. SHARED across every per-connection clone (one per actor, like `cap_gate`):
+    /// `bind_subject` stores a rebuilt trie through the `ArcSwap` this `Arc` wraps, so every reader sees
+    /// the latest committed bindings without the `Arc` itself ever being replaced.
+    binding_snapshot: Arc<SublistSnapshot<StreamId>>,
 }
 
 /// The shared, set-once slot holding the clustered [`ClientAckGate`] (#719). Created empty at serve
@@ -767,6 +778,10 @@ impl<F: Filesystem, C: Clock + Clone> Clone for EngineHandle<F, C> {
             // The fixed-for-life zero-copy `sendfile(2)` toggle (#1034): a plain copy, like `reply_spin`,
             // so every connection clone inherits the base handle's operator setting.
             zero_copy_sendfile: self.zero_copy_sendfile,
+            // The SAME shared subject-routing snapshot (#811 C3): one per actor, published to by
+            // `bind_subject` and resolved off the actor by every connection, so the `Arc` is shared on
+            // clone (like `cap_gate`), never freshened.
+            binding_snapshot: Arc::clone(&self.binding_snapshot),
         }
     }
 }
@@ -1317,6 +1332,21 @@ pub trait EngineAccess<F: Filesystem, C: Clock> {
         self.with(job)
     }
 
+    /// The wait-free SUBJECT ROUTING snapshot (#585 / #811 C3), read LOCALLY off the actor (no
+    /// round-trip) so a connection thread resolves a subject to its single bound stream BEFORE routing
+    /// the produce to that stream's shard — parity with the `PubTo` path, which hashes the stream name
+    /// on the connection thread. Returns a cheap `Arc` clone of the SAME snapshot the engine's
+    /// [`crate::engine::Engine::bind_subject`] publishes to, so a resolve always observes the latest
+    /// committed bindings, exactly as an in-actor resolve would.
+    ///
+    /// The DEFAULT returns an EMPTY snapshot (every subject resolves `NoStream`); that is correct ONLY
+    /// for the test fixtures that never drive a subject-addressed verb. Every real handle
+    /// ([`EngineHandle`], [`ShardedEngineHandle`], and the direct test engines that back the session's
+    /// subject tests) OVERRIDES it to return the engine's shared snapshot.
+    fn binding_snapshot(&self) -> Arc<SublistSnapshot<StreamId>> {
+        Arc::new(SublistSnapshot::empty())
+    }
+
     /// The current MONOTONIC time (nanoseconds) from the engine's clock seam, read LOCALLY (no actor
     /// round-trip), so a connection handler can stamp a produce's ENQUEUE instant for the CoDel
     /// admission sojourn (#68). It is the same clock the engine reads at dequeue, so the two readings
@@ -1528,6 +1558,13 @@ impl<F: Filesystem + Clone + 'static, C: Clock + Clone + 'static> EngineAccess<F
     fn now_monotonic_nanos(&self) -> u64 {
         // A LOCAL clock read, no actor round-trip: the handle holds a clone of the engine's clock.
         self.clock.now_monotonic_nanos()
+    }
+
+    fn binding_snapshot(&self) -> Arc<SublistSnapshot<StreamId>> {
+        // A LOCAL clone of the shared snapshot `Arc` (#811 C3), no actor round-trip: the handle holds
+        // the SAME snapshot `bind_subject` publishes to, so a connection resolves a subject off the
+        // actor and routes the produce to the resolved stream's shard.
+        Arc::clone(&self.binding_snapshot)
     }
 
     fn consumer_credit_caps(&self) -> (u32, u64) {
@@ -1760,6 +1797,12 @@ impl<F: Filesystem + Clone + 'static, C: Clock + Clone + 'static> EngineAccess<F
         self.primary().now_monotonic_nanos()
     }
 
+    fn binding_snapshot(&self) -> Arc<SublistSnapshot<StreamId>> {
+        // Every shard shares the ONE subject-routing snapshot (bindings are engine-global, not
+        // per-shard), so the primary's snapshot is authoritative for the whole front (#811 C3).
+        EngineAccess::binding_snapshot(self.primary())
+    }
+
     fn consumer_credit_caps(&self) -> (u32, u64) {
         EngineAccess::consumer_credit_caps(self.primary())
     }
@@ -1882,6 +1925,13 @@ impl<F: Filesystem, C: Clock + Clone> EngineAccess<F, C> for DirectEngine<F, C> 
         self.engine.borrow().now_monotonic()
     }
 
+    fn binding_snapshot(&self) -> Arc<SublistSnapshot<StreamId>> {
+        // The direct (same-thread) test engine resolves against the REAL engine's shared snapshot
+        // `Arc` (#811 C3), so the session's subject unit tests exercise the true off-actor resolve.
+        // A cloned `Arc` (owned), so it outlives the transient `RefCell` borrow.
+        self.engine.borrow().binding_snapshot_arc()
+    }
+
     fn consumer_credit_caps(&self) -> (u32, u64) {
         let e = self.engine.borrow();
         (e.consumer_credit(), e.consumer_credit_bytes())
@@ -1923,6 +1973,14 @@ impl<F: Filesystem, C: Clock + Clone> EngineAccess<F, C> for SharedEngine<F, C> 
         self.lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .now_monotonic()
+    }
+
+    fn binding_snapshot(&self) -> Arc<SublistSnapshot<StreamId>> {
+        // The shared-engine test fixture resolves against the REAL engine's snapshot `Arc` (#811 C3),
+        // read under the lock and cloned out (owned), so it outlives the guard.
+        self.lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .binding_snapshot_arc()
     }
 
     fn consumer_credit_caps(&self) -> (u32, u64) {
@@ -2089,6 +2147,11 @@ where
     // stamp a produce's enqueue instant (the CoDel sojourn measurement, #68) with the SAME clock the
     // actor reads at dequeue.
     let clock = engine.clock_clone();
+    // Clone the SHARED subject-routing snapshot `Arc` (#811 C3) BEFORE the engine moves into the actor,
+    // so every connection thread resolves a subject WAIT-FREE off the actor against the SAME snapshot
+    // `bind_subject` publishes to (then routes the produce to the resolved stream's shard) — exactly the
+    // off-actor read the credit caps and clock above already do.
+    let binding_snapshot = engine.binding_snapshot_arc();
     // Snapshot the static per-consumer credit caps (#292) BEFORE the engine moves into the actor, so
     // the Connect handshake can negotiate them off the actor's hot path (no round-trip, #177).
     let consumer_credit_caps = (engine.consumer_credit(), engine.consumer_credit_bytes());
@@ -2222,6 +2285,9 @@ where
             // it off via [`EngineHandle::with_zero_copy_sendfile`] right after this returns, BEFORE any
             // connection's handle is cloned.
             zero_copy_sendfile: true,
+            // The shared subject-routing snapshot (#811 C3), cloned above before the engine moved: every
+            // connection resolves a subject off the actor against it, then routes to the resolved shard.
+            binding_snapshot,
         },
         join,
     )

--- a/crates/ironbus-server/src/actor.rs
+++ b/crates/ironbus-server/src/actor.rs
@@ -1114,6 +1114,106 @@ pub fn shard_of(stream: &str, shards: usize) -> usize {
     usize::try_from(hasher.finish() % shards as u64).unwrap_or(0)
 }
 
+/// The maximum number of append shards `--append-shards auto` (or an explicit request) resolves to
+/// (#811). `auto` picks the machine's core count, but a shard is a dedicated append actor THREAD, so
+/// an unbounded `auto` on a very-many-core box would spawn a pathological number of threads for no
+/// gain past the number of distinct hot streams; this caps the fan-out at a safe, conservative bound.
+/// A deliberately conservative value the owner can revisit alongside the C8 flip that first spawns
+/// K > 1 actors (until then every resolution is inert — see [`resolve_append_shards`]).
+pub const MAX_APPEND_SHARDS: usize = 64;
+
+/// A requested append-shard count (#811) — the parsed form of the `--append-shards` knob BEFORE
+/// resolution. [`AppendShards::Auto`] defers the count to the machine (its core count, capped at
+/// [`MAX_APPEND_SHARDS`]); [`AppendShards::Fixed`] pins an explicit count. The [`Default`] is
+/// `Fixed(1)` — a single append shard, i.e. today's byte-for-byte single-actor engine.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AppendShards {
+    /// Resolve the count from the machine's available parallelism, capped at [`MAX_APPEND_SHARDS`].
+    Auto,
+    /// An explicit shard count (clamped to `1..=MAX_APPEND_SHARDS` on resolution).
+    Fixed(usize),
+}
+
+impl Default for AppendShards {
+    fn default() -> Self {
+        // One append shard = today's unsharded single-actor engine, byte-for-byte.
+        AppendShards::Fixed(1)
+    }
+}
+
+impl AppendShards {
+    /// Parses an `--append-shards` value: the token `auto` (any case) → [`AppendShards::Auto`]; a
+    /// positive decimal integer → [`AppendShards::Fixed`]. Returns `None` for an empty string, a
+    /// non-numeric token, or `0` (a broker must have at least one append shard), so the caller can
+    /// name the bad source in a usage error (mirroring the other enum-string flags).
+    #[must_use]
+    pub fn parse(value: &str) -> Option<AppendShards> {
+        if value.eq_ignore_ascii_case("auto") {
+            return Some(AppendShards::Auto);
+        }
+        match value.parse::<usize>() {
+            Ok(n) if n >= 1 => Some(AppendShards::Fixed(n)),
+            _ => None,
+        }
+    }
+
+    /// Whether this is an EXPLICIT request for MORE than one shard (`Fixed(n)` with `n > 1`). The
+    /// shared-WAL guard ([`resolve_append_shards`]) rejects exactly this combined with
+    /// [`StorageMode::SharedWal`](ironbus_storage::shared_wal::StorageMode::SharedWal); an `Auto`
+    /// request is NOT explicit (it silently resolves to 1 under shared-WAL), so it is allowed.
+    #[must_use]
+    fn is_explicit_multi(self) -> bool {
+        matches!(self, AppendShards::Fixed(n) if n > 1)
+    }
+}
+
+/// The typed error from [`resolve_append_shards`] (#811, C4): the operator EXPLICITLY asked for more
+/// than one append shard AND selected the shared-WAL storage mode, which cannot shard — every named
+/// stream shares ONE physical commit log, so its records cannot be split across writer threads. Raised
+/// fail-closed rather than silently downgrading to one shard, so the contradiction is a visible boot
+/// error, never a surprise.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SharedWalCannotShard;
+
+/// Resolves a requested [`AppendShards`] count against the selected storage mode (#811, C4) — the ONE
+/// place the `auto` core-count resolution, the [`MAX_APPEND_SHARDS`] cap, and the shared-WAL guard
+/// live, so the CLI, the engine, and the tests agree on one policy.
+///
+/// - [`StorageMode::SharedWal`](ironbus_storage::shared_wal::StorageMode::SharedWal) can NEVER shard,
+///   so an EXPLICIT `Fixed(n > 1)` is REJECTED with [`SharedWalCannotShard`] (fail-closed) and every
+///   non-explicit request (`Auto` or `Fixed(1)`) resolves to `1`.
+/// - [`StorageMode::PerStreamLogs`](ironbus_storage::shared_wal::StorageMode::PerStreamLogs) resolves
+///   `Auto` to the machine's available parallelism capped at [`MAX_APPEND_SHARDS`], and `Fixed(n)` to
+///   `n` clamped to `1..=MAX_APPEND_SHARDS`.
+///
+/// The result is always `>= 1`. NOTE: resolving `> 1` does NOT itself spawn K actors — that is the
+/// owner-gated C8 flip; until then the resolved count is a validated, reported setting and the broker
+/// runs a single append shard (K = 1), byte-for-byte today.
+///
+/// # Errors
+/// Returns [`SharedWalCannotShard`] when an explicit multi-shard request is combined with shared-WAL.
+pub fn resolve_append_shards(
+    request: AppendShards,
+    storage_mode: ironbus_storage::shared_wal::StorageMode,
+) -> Result<usize, SharedWalCannotShard> {
+    use ironbus_storage::shared_wal::StorageMode;
+    if storage_mode == StorageMode::SharedWal {
+        if request.is_explicit_multi() {
+            return Err(SharedWalCannotShard);
+        }
+        // A shared-WAL broker is pinned to ONE append shard: every named stream shares one physical
+        // commit log, so the write plane cannot be split across writer threads.
+        return Ok(1);
+    }
+    let resolved = match request {
+        AppendShards::Auto => std::thread::available_parallelism()
+            .map_or(1, std::num::NonZeroUsize::get)
+            .min(MAX_APPEND_SHARDS),
+        AppendShards::Fixed(n) => n.clamp(1, MAX_APPEND_SHARDS),
+    };
+    Ok(resolved)
+}
+
 /// The engine access a [`Session`](crate::session::Session) needs: a group-committed produce and a
 /// generic "run this on the engine" call. Production wires [`EngineHandle`] (the channel to the
 /// append actor); session UNIT tests wire [`DirectEngine`] (a same-thread `&mut Engine`), so the
@@ -1543,6 +1643,187 @@ impl<F: Filesystem + Clone + 'static, C: Clock + Clone + 'static> EngineAccess<F
             max_records,
             max_bytes,
         )
+    }
+}
+
+/// A #811 append-sharding FRONT over the engine-access surface: it holds K per-shard
+/// [`EngineHandle`]s (each a channel to one shard's append actor) and routes an [`EngineAccess`] call
+/// to the shard the caller selected via [`EngineAccess::with_on_shard`]. Shard 0 is the DEFAULT shard:
+/// the default stream `""` pins to it ([`shard_of`]`("", _) == 0`) and every NON-shard-routed call
+/// (produce, the per-connection cleanups, health) forwards to it.
+///
+/// In THIS phase (C1) it is ALWAYS built with K = 1 via [`Self::single`], so it is a PURE PASS-THROUGH
+/// to today's single [`EngineHandle`] — byte-for-byte identical at runtime: [`EngineAccess::shard_count`]
+/// returns 1, so [`shard_of`] yields 0 for every stream and [`EngineAccess::with_on_shard`]`(0, ..)`
+/// collapses to [`EngineHandle`]'s `with`. Spawning K > 1 shard actors (and building this with K
+/// handles) is the owner-gated C8 flip; the type exists now so that flip is a single small commit —
+/// swap [`Self::single`] for a K-handle constructor over K spawned actors.
+///
+/// Every [`EngineAccess`] method is forwarded EXPLICITLY to the selected shard's handle (rather than
+/// left to the trait default), so the front carries [`EngineHandle`]'s real cluster / watchdog /
+/// span-sink / commit-notify behavior verbatim instead of the inert non-actor defaults — the invariant
+/// that makes K = 1 byte-for-byte the single-handle engine.
+pub struct ShardedEngineHandle<F: Filesystem, C: Clock> {
+    /// The per-shard engine handles, indexed by shard id in `0..shards.len()`. Exactly ONE entry today
+    /// ([`Self::single`]); the C8 flip builds this with K handles over K spawned actors.
+    shards: Vec<EngineHandle<F, C>>,
+}
+
+// Spelled out (not derived) so it does not demand `F: Clone`: [`EngineHandle`]'s own manual `Clone`
+// clones the `SyncSender` + the clock for ANY `F`, so cloning the vec of handles does too. Cloning a
+// front is exactly the per-connection clone the serve loop makes of a single handle today (a FRESH
+// per-connection reply pool, the SAME shared actor channel + gates on each shard), so a future
+// K-shard serve path can clone this per connection with identical semantics.
+impl<F: Filesystem, C: Clock + Clone> Clone for ShardedEngineHandle<F, C> {
+    fn clone(&self) -> Self {
+        ShardedEngineHandle {
+            shards: self.shards.clone(),
+        }
+    }
+}
+
+impl<F: Filesystem, C: Clock + Clone> ShardedEngineHandle<F, C> {
+    /// The single-shard (K = 1) front: wraps ONE [`EngineHandle`] so every call forwards to it,
+    /// byte-for-byte today's unsharded engine. The ONLY constructor in C1 — no second actor is spawned
+    /// (that is the C8 flip).
+    #[must_use]
+    pub fn single(handle: EngineHandle<F, C>) -> Self {
+        ShardedEngineHandle {
+            shards: vec![handle],
+        }
+    }
+
+    /// The DEFAULT shard (shard 0): the target of every non-shard-routed call and of the default
+    /// stream `""`. Present for any K >= 1, so it is always in range.
+    fn primary(&self) -> &EngineHandle<F, C> {
+        &self.shards[0]
+    }
+}
+
+// The same bounds as `EngineAccess for EngineHandle` (the follower-read override needs `F: Clone`);
+// every production `EngineAccess` path already carries them.
+impl<F: Filesystem + Clone + 'static, C: Clock + Clone + 'static> EngineAccess<F, C>
+    for ShardedEngineHandle<F, C>
+{
+    // NOTE: several forwarded methods (`produce*`, `with`, `consumer_credit_caps`, `commit_notify`,
+    // `drop_client_acks`) share a NAME with an inherent [`EngineHandle`] method, and an inherent method
+    // shadows a trait one in `self.primary().m()` resolution (e.g. inherent `commit_notify` returns
+    // `&Arc<..>`, the trait one `Option<&Arc<..>>`). These are called through fully-qualified
+    // [`EngineAccess`] syntax so the front carries the TRAIT behavior verbatim — the invariant that
+    // makes K = 1 byte-for-byte the single handle.
+
+    fn produce(&self, append: OwnedAppend) -> Result<ProduceOutcome, ActorGone> {
+        EngineAccess::produce(self.primary(), append)
+    }
+
+    fn produce_submit(&self, append: OwnedAppend) -> Result<ProduceSubmission, ActorGone> {
+        EngineAccess::produce_submit(self.primary(), append)
+    }
+
+    fn produce_no_reply(&self, append: OwnedAppend) -> Result<(), ActorGone> {
+        EngineAccess::produce_no_reply(self.primary(), append)
+    }
+
+    fn produce_no_reply_batch(&self, appends: Vec<OwnedAppend>) -> Result<(), ActorGone> {
+        EngineAccess::produce_no_reply_batch(self.primary(), appends)
+    }
+
+    fn with<R, J>(&self, job: J) -> Result<R, ActorGone>
+    where
+        R: Send + 'static,
+        J: FnOnce(&mut Engine<F, C>) -> R + Send + 'static,
+    {
+        EngineAccess::with(self.primary(), job)
+    }
+
+    fn shard_count(&self) -> usize {
+        self.shards.len()
+    }
+
+    fn with_on_shard<R, J>(&self, shard: usize, job: J) -> Result<R, ActorGone>
+    where
+        R: Send + 'static,
+        J: FnOnce(&mut Engine<F, C>) -> R + Send + 'static,
+    {
+        debug_assert!(
+            shard < self.shards.len(),
+            "shard index {shard} out of range for {} shards",
+            self.shards.len()
+        );
+        // Route to the chosen shard's OWN engine via `with` (NOT `with_on_shard` — each handle owns
+        // exactly one shard, so re-routing would be wrong). At K = 1 `shard` is always 0, so this is
+        // `primary().with(job)` — byte-for-byte [`EngineHandle`]'s default `with_on_shard`.
+        EngineAccess::with(&self.shards[shard], job)
+    }
+
+    fn now_monotonic_nanos(&self) -> u64 {
+        self.primary().now_monotonic_nanos()
+    }
+
+    fn consumer_credit_caps(&self) -> (u32, u64) {
+        EngineAccess::consumer_credit_caps(self.primary())
+    }
+
+    fn has_client_ack_gate(&self) -> bool {
+        self.primary().has_client_ack_gate()
+    }
+
+    fn span_sink(&self) -> Option<crate::obs::SpanSink> {
+        self.primary().span_sink()
+    }
+
+    fn actor_watchdog_overran(&self, now_monotonic_nanos: u64) -> bool {
+        self.primary().actor_watchdog_overran(now_monotonic_nanos)
+    }
+
+    fn writer_appears_healthy(&self) -> bool {
+        self.primary().writer_appears_healthy()
+    }
+
+    fn actor_alive(&self) -> bool {
+        self.primary().actor_alive()
+    }
+
+    fn commit_notify(&self) -> Option<&Arc<CommitNotify>> {
+        EngineAccess::commit_notify(self.primary())
+    }
+
+    fn consume_wait_spin(&self) -> bool {
+        self.primary().consume_wait_spin()
+    }
+
+    fn client_ack_disposition(
+        &self,
+        member: MemberId,
+        offset: u64,
+        reply_bytes: Vec<u8>,
+    ) -> Option<AckDisposition> {
+        self.primary()
+            .client_ack_disposition(member, offset, reply_bytes)
+    }
+
+    fn drain_client_acks(&self, member: MemberId) -> Vec<Vec<u8>> {
+        self.primary().drain_client_acks(member)
+    }
+
+    fn drop_client_acks(&self, member: MemberId) {
+        EngineAccess::drop_client_acks(self.primary(), member);
+    }
+
+    fn cluster_produce_routing(&self, partition: u64) -> ClusterProduceRouting {
+        self.primary().cluster_produce_routing(partition)
+    }
+
+    fn cluster_follower_consume(
+        &self,
+        partition: u64,
+        tier: ReadTier,
+        from: Offset,
+        max_records: usize,
+        max_bytes: Option<usize>,
+    ) -> Option<FollowerReadOutcome> {
+        self.primary()
+            .cluster_follower_consume(partition, tier, from, max_records, max_bytes)
     }
 }
 
@@ -3465,6 +3746,115 @@ mod tests {
             "200 named streams spread across the shards (got {} of {K})",
             distinct.len()
         );
+    }
+
+    #[test]
+    fn append_shards_parse_accepts_auto_and_positive_ints_only() {
+        assert_eq!(AppendShards::parse("auto"), Some(AppendShards::Auto));
+        assert_eq!(AppendShards::parse("AUTO"), Some(AppendShards::Auto));
+        assert_eq!(AppendShards::parse("Auto"), Some(AppendShards::Auto));
+        assert_eq!(AppendShards::parse("1"), Some(AppendShards::Fixed(1)));
+        assert_eq!(AppendShards::parse("8"), Some(AppendShards::Fixed(8)));
+        // Rejected: zero (a broker needs at least one shard), non-numeric, empty, negative, junk.
+        for bad in ["0", "", "x", "-1", "1.5", "auto2", " 4"] {
+            assert_eq!(AppendShards::parse(bad), None, "`{bad}` must be rejected");
+        }
+        // The DEFAULT request is a single shard — today's byte-for-byte single-actor engine.
+        assert_eq!(AppendShards::default(), AppendShards::Fixed(1));
+    }
+
+    #[test]
+    fn resolve_append_shards_per_stream_resolves_and_caps() {
+        use ironbus_storage::shared_wal::StorageMode::PerStreamLogs;
+        // The default (Fixed(1)) stays 1 — the inert K=1 path.
+        assert_eq!(
+            resolve_append_shards(AppendShards::default(), PerStreamLogs),
+            Ok(1)
+        );
+        // An explicit fixed count is honored, clamped to the safe max.
+        assert_eq!(
+            resolve_append_shards(AppendShards::Fixed(4), PerStreamLogs),
+            Ok(4)
+        );
+        assert_eq!(
+            resolve_append_shards(AppendShards::Fixed(1), PerStreamLogs),
+            Ok(1)
+        );
+        assert_eq!(
+            resolve_append_shards(AppendShards::Fixed(100_000), PerStreamLogs),
+            Ok(MAX_APPEND_SHARDS),
+            "an oversized explicit request clamps to the cap"
+        );
+        // `auto` resolves to the machine's parallelism, always in `1..=MAX`.
+        let auto = resolve_append_shards(AppendShards::Auto, PerStreamLogs).unwrap();
+        assert!(
+            (1..=MAX_APPEND_SHARDS).contains(&auto),
+            "auto resolved {auto} out of 1..={MAX_APPEND_SHARDS}"
+        );
+    }
+
+    #[test]
+    fn resolve_append_shards_shared_wal_forces_one_and_rejects_explicit_multi() {
+        use ironbus_storage::shared_wal::StorageMode::SharedWal;
+        // Non-explicit requests silently resolve to 1 under shared-WAL (it cannot shard).
+        assert_eq!(resolve_append_shards(AppendShards::Auto, SharedWal), Ok(1));
+        assert_eq!(
+            resolve_append_shards(AppendShards::Fixed(1), SharedWal),
+            Ok(1)
+        );
+        assert_eq!(
+            resolve_append_shards(AppendShards::default(), SharedWal),
+            Ok(1)
+        );
+        // But an EXPLICIT request for > 1 shard + shared-WAL is a contradiction — fail closed.
+        for n in [2usize, 4, 64] {
+            assert_eq!(
+                resolve_append_shards(AppendShards::Fixed(n), SharedWal),
+                Err(SharedWalCannotShard),
+                "explicit --append-shards {n} + shared-WAL must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn sharded_engine_handle_single_is_a_byte_for_byte_k1_pass_through() {
+        // C1: `ShardedEngineHandle::single` wraps ONE `EngineHandle`, so it is a pure pass-through — K=1,
+        // every stream routes to shard 0, and `with_on_shard(0, ..)` collapses to `with(..)`.
+        let engine = Engine::open(InMemoryFs::new(), ManualClock::new(), config()).unwrap();
+        let (handle, actor) = spawn_actor(engine, DEFAULT_CHANNEL_BOUND);
+        let sharded = ShardedEngineHandle::single(handle);
+
+        assert_eq!(sharded.shard_count(), 1, "single => one shard");
+        assert_eq!(shard_of("", sharded.shard_count()), 0);
+        for name in ["orders", "clicks", "a/b/c", "payments"] {
+            assert_eq!(
+                shard_of(name, sharded.shard_count()),
+                0,
+                "at K=1 every stream pins to shard 0"
+            );
+        }
+
+        // `with_on_shard(0, ..)` observes the SAME engine state as `with(..)`.
+        let via_with = sharded.with(|e| e.durable_record_bytes()).unwrap();
+        let via_shard = sharded
+            .with_on_shard(0, |e| e.durable_record_bytes())
+            .unwrap();
+        assert_eq!(via_with, via_shard);
+
+        // A produce through the front lands on the one engine, visible identically to both entry points.
+        sharded.produce(append(b"hello-shard")).expect("produce ok");
+        let after_with = sharded.with(|e| e.durable_record_bytes()).unwrap();
+        let after_shard = sharded
+            .with_on_shard(0, |e| e.durable_record_bytes())
+            .unwrap();
+        assert_eq!(after_with, after_shard);
+        assert!(
+            after_with > via_with,
+            "the produce advanced the durable byte total"
+        );
+
+        drop(sharded);
+        let _ = actor.join();
     }
 
     fn config() -> EngineConfig {

--- a/crates/ironbus-server/src/engine.rs
+++ b/crates/ironbus-server/src/engine.rs
@@ -4808,6 +4808,12 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         // existence cap (`max_streams`) and the reopen-vs-reject decision are correct BEFORE any client
         // touches a stream. This survives a hot-set LRU eviction (which drops the open `Log`), so an
         // evicted-then-consumed stream is recognized as KNOWN (reopened), never UNKNOWN (rejected).
+        //
+        // #811 C7: this is seeded from `streams.stream_ids()`, i.e. exactly the named streams THIS
+        // append shard recovered (its `shard_of` subset). At K = 1 that subset is the WHOLE named set,
+        // so this is byte-for-byte today; at K > 1 each shard's set is its own subset and the union
+        // across shards is the full existence set (the cross-shard existence sum the front assembles
+        // is the owner-gated C6 concern, not done here).
         let known_named_streams: std::collections::BTreeSet<StreamId> = match shared_known {
             // Shared mode (#597): existence is the wal-scanned ∪ metadata-dir union recovered above
             // (a shared stream has no per-stream log for `stream_ids` to report).
@@ -5110,9 +5116,24 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         // The per-stream recovery summaries are RETURNED (not discarded, #575/#1130) so `open` can
         // fold every named stream's torn-tail / corruption loss events into the recovery-event
         // counters — a named stream's crash damage must be as visible as the root log's.
-        let (streams, stream_recoveries) =
-            StreamSet::open_with_at_rest(&fs_for_streams, clock, config, at_rest)
-                .map_err(EngineError::Storage)?;
+        //
+        // #811 C7 recovery partition: this engine opens the named-stream substrate through the
+        // SHARD-FILTERED open, recovering only the named streams THIS append shard owns
+        // (`shard_of(name, K) == shard_index`, in parallel, per-stream isolation preserved). At K = 1
+        // — the default and, until the owner-gated C8 flip, the only runtime mode — the sole shard is
+        // the COORDINATOR (shard 0), so its predicate is `|_| true`: it opens the root default log
+        // (above) plus EVERY named stream, byte-for-byte the historical `StreamSet::open_with_at_rest`.
+        // The K > 1 flip that gives each shard a real `shard_of`-derived predicate (and has the LEAN
+        // shards skip the root log + the global producer-seq/counters/bindings/txn checkpoints so the
+        // coordinator opens them ONCE) is C6/C8 and is NOT done here.
+        let (streams, stream_recoveries) = StreamSet::open_with_at_rest_for_shard(
+            &fs_for_streams,
+            clock,
+            config,
+            at_rest,
+            |_name| true,
+        )
+        .map_err(EngineError::Storage)?;
         Ok((log, streams, stream_recoveries))
     }
 
@@ -16748,6 +16769,128 @@ mod tests {
             1,
             "the count is floored to at least one shard",
         );
+    }
+
+    /// #811 C7 (recovery partition): the REAL routing hash [`crate::actor::shard_of`], used as the
+    /// `StreamSet::open_with_at_rest_for_shard` predicate over a real on-disk named set, yields a
+    /// TOTAL, LOSSLESS partition of RECOVERY. For K in {1, 2, 4}: each shard recovers EXACTLY its
+    /// `shard_of` subset (and each stream's OWN records — per-stream isolation), every named stream is
+    /// recovered by exactly ONE shard, and the total recovered record count equals the pre-crash
+    /// total. At K = 1 the sole shard recovers ALL named streams — byte-for-byte the unsharded open —
+    /// which is the inert property this whole phase-1 PR rests on.
+    #[test]
+    #[allow(clippy::too_many_lines)] // one cohesive K in {1,2,4} partition sweep; splitting hurts clarity
+    fn shard_of_partitions_named_stream_recovery_losslessly() {
+        use crate::actor::shard_of;
+        fn mkrec(p: &[u8]) -> Append<'_> {
+            Append {
+                timestamp_ms: 1,
+                flags: RecordFlags::EMPTY,
+                key: b"",
+                headers: b"",
+                payload: p,
+            }
+        }
+        let fs = InMemoryFs::new();
+        let def = StreamId::default_stream();
+        let cfg = LogConfig::default();
+        let names = [
+            "orders",
+            "clicks",
+            "alpha",
+            "beta",
+            "gamma",
+            "payments",
+            "audit",
+            "telemetry",
+            "carts",
+            "users",
+        ];
+        // Lay down the pre-crash image: stream i carries i + 1 records tagged with its own name, so a
+        // wrong-shard or mis-assembled recovery surfaces as a wrong count or wrong bytes.
+        {
+            let (mut set, _) = StreamSet::open(&fs, ManualClock::new(), cfg).unwrap();
+            for name in names {
+                set.declare(&StreamId::named(name).unwrap()).unwrap();
+            }
+            for (i, name) in names.iter().enumerate() {
+                let id = StreamId::named(name).unwrap();
+                for r in 0..=i {
+                    set.append_to(&id, &mkrec(format!("{name}-{r}").as_bytes()))
+                        .unwrap();
+                }
+            }
+            set.sync_all().unwrap();
+        }
+        let full: Vec<StreamId> = names.iter().map(|n| StreamId::named(n).unwrap()).collect();
+        let expected: std::collections::BTreeMap<StreamId, usize> = full
+            .iter()
+            .enumerate()
+            .map(|(i, id)| (id.clone(), i + 1))
+            .collect();
+        let total_records: usize = expected.values().sum();
+
+        for k in [1usize, 2, 4] {
+            let mut seen: std::collections::BTreeSet<StreamId> = std::collections::BTreeSet::new();
+            let mut recovered = 0usize;
+            for idx in 0..k {
+                let (shard, recoveries) = StreamSet::open_with_at_rest_for_shard(
+                    &fs,
+                    ManualClock::new(),
+                    cfg,
+                    AtRestCrypto::default(),
+                    |name| shard_of(name, k) == idx,
+                )
+                .unwrap();
+                // The coordinator-owned default root is opened by every shard (unconditional at K = 1).
+                assert!(
+                    shard.is_open(&def),
+                    "K={k} shard {idx} opens the default root"
+                );
+                for id in shard.stream_ids() {
+                    if id.is_default() {
+                        continue;
+                    }
+                    assert_eq!(
+                        shard_of(id.name(), k),
+                        idx,
+                        "K={k} shard {idx} recovered {} outside its shard_of subset",
+                        id.name()
+                    );
+                    assert!(
+                        recoveries[&id].loss_report.is_empty(),
+                        "{} clean",
+                        id.name()
+                    );
+                    let read = shard.read_range(&id, Offset::ZERO, 1000, None).unwrap();
+                    assert_eq!(read.len(), expected[&id], "{} own record count", id.name());
+                    recovered += read.len();
+                    assert!(
+                        seen.insert(id.clone()),
+                        "K={k}: {} was recovered by more than one shard",
+                        id.name()
+                    );
+                }
+            }
+            assert_eq!(
+                seen,
+                full.iter()
+                    .cloned()
+                    .collect::<std::collections::BTreeSet<_>>(),
+                "K={k}: the union of the shard subsets is the whole named set"
+            );
+            assert_eq!(
+                recovered, total_records,
+                "K={k}: total recovered records equals the pre-crash total"
+            );
+        }
+
+        // K = 1 inert identity: the unfiltered open recovers the identical (default-first) named set.
+        let (all, _) = StreamSet::open(&fs, ManualClock::new(), cfg).unwrap();
+        let mut expected_ids = vec![def.clone()];
+        expected_ids.extend(full.iter().cloned());
+        expected_ids.sort();
+        assert_eq!(all.stream_ids(), expected_ids);
     }
 
     /// Polls stream `stream` in `group` and expects a delivered message.

--- a/crates/ironbus-server/src/engine.rs
+++ b/crates/ironbus-server/src/engine.rs
@@ -663,14 +663,21 @@ pub struct EngineConfig {
     /// many named streams share ONE tagged commit log ([`ironbus_storage::shared_wal::SharedWal`]),
     /// trading per-stream resilience isolation for density (see the type docs for the tradeoff).
     ///
-    /// **Wiring status (surfaced, #597):** the shared-WAL storage PRIMITIVE — tagged interleaved
-    /// append, per-stream demux read, and index-rebuilding recovery — is implemented and tested at the
-    /// storage layer ([`ironbus_storage::shared_wal::SharedWal`]). Threading it through the engine's
-    /// `produce_in_stream`/`poll_in_stream`/`ack_in_stream` and recovery paths in place of the
-    /// per-stream `StreamSet` is the deferred follow-up (like #693's deferred cooperative rebalance);
-    /// until then [`Engine::open`] fail-closed REJECTS a config that selects [`StorageMode::SharedWal`]
-    /// with a typed error rather than silently running per-stream (an honest opt-in, never a silent
-    /// no-op). The default [`StorageMode::PerStreamLogs`] path is completely untouched.
+    /// **Wiring status (#597, WIRED):** the shared-WAL storage substrate — tagged interleaved append,
+    /// per-stream demux read, and index-rebuilding recovery — is implemented in
+    /// [`ironbus_storage::shared_wal::SharedWal`] and now THREADED through the engine's
+    /// `produce_in_stream`/`poll_in_stream`/`ack_in_stream` and recovery paths, so
+    /// [`StorageMode::SharedWal`] is a LIVE mode: [`Engine::open`] opens it when selected (it does NOT
+    /// reject it). The one combination [`Engine::open`] still fail-closed REJECTS is at-rest ENCRYPTION
+    /// with shared-WAL ([`EngineError::EncryptedSharedWalUnsupported`]); a plaintext shared-WAL data dir
+    /// opens and runs. The default [`StorageMode::PerStreamLogs`] path is completely untouched.
+    ///
+    /// **Append sharding (#811, C4):** a shared-WAL broker CANNOT shard the append plane — every named
+    /// stream shares ONE physical commit log, so its records cannot be split across writer threads.
+    /// [`Engine::append_shard_count`] therefore reports 1 for a shared-WAL engine regardless of the
+    /// configured count, and config validation ([`crate::actor::resolve_append_shards`]) fail-closed
+    /// REJECTS an EXPLICIT `--append-shards > 1` combined with this mode
+    /// ([`crate::actor::SharedWalCannotShard`]).
     pub storage_mode: ironbus_storage::shared_wal::StorageMode,
 }
 
@@ -15561,6 +15568,23 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         self.log.durable_record_bytes()
     }
 
+    /// The number of append shards this engine actually runs (#811, C4), given a `configured` count
+    /// (already resolved + capped by [`crate::actor::resolve_append_shards`]). A SHARED-WAL engine is
+    /// PINNED to ONE shard — every named stream shares one physical commit log, so its records cannot
+    /// be split across writer threads — so it clamps any request to 1; a per-stream-logs engine honors
+    /// `configured` (floored to >= 1). The named-stream produce path routes with
+    /// [`crate::actor::shard_of`]`(stream, this)`, so a shared-WAL engine returning 1 pins every stream
+    /// to shard 0. In C1 the effective `configured` is 1 (the C8 flip spawns K > 1), so this returns 1
+    /// on every engine today — byte-for-byte the single-actor path.
+    #[must_use]
+    pub fn append_shard_count(&self, configured: usize) -> usize {
+        if self.shared_wal.is_some() {
+            1
+        } else {
+            configured.max(1)
+        }
+    }
+
     /// The configured durable-log byte cap (`LogConfig::max_total_bytes`, the quantity
     /// [`Engine::durable_record_bytes`] is shed against). `0` means UNLIMITED (the cap is off). Fixed
     /// for the engine's life: the cap is layout/contract-bound and NOT live-reloadable (a change
@@ -16663,6 +16687,43 @@ mod tests {
             storage_mode: ironbus_storage::shared_wal::StorageMode::SharedWal,
             ..config(max_in_flight, max_deliver)
         }
+    }
+
+    #[test]
+    fn shared_wal_engine_reports_one_append_shard_and_named_produces_route_to_shard_zero() {
+        // #811 C4: a shared-WAL engine CANNOT shard the append plane (every named stream shares ONE
+        // physical commit log), so it reports exactly ONE append shard for ANY configured count, and
+        // `shard_of` therefore pins every named stream to shard 0 — its byte-identical single-log path.
+        let shared = open(shared_config(100, 5));
+        for configured in [1usize, 2, 8, 64] {
+            assert_eq!(
+                shared.append_shard_count(configured),
+                1,
+                "shared-WAL forces one append shard for configured={configured}",
+            );
+        }
+        for name in ["orders", "clicks", "alpha", "beta/gamma", "x"] {
+            assert_eq!(
+                crate::actor::shard_of(name, shared.append_shard_count(64)),
+                0,
+                "every named stream routes to shard 0 under shared-WAL",
+            );
+        }
+
+        // A per-stream-logs engine, by contrast, HONORS the configured count (the routing base the C8
+        // flip fans across) — still 1 by default today, so K=1 is byte-for-byte the single-actor path.
+        let per_stream = open(config(100, 5));
+        assert_eq!(per_stream.append_shard_count(1), 1);
+        assert_eq!(
+            per_stream.append_shard_count(8),
+            8,
+            "per-stream honors the configured count",
+        );
+        assert_eq!(
+            per_stream.append_shard_count(0),
+            1,
+            "the count is floored to at least one shard",
+        );
     }
 
     /// Polls stream `stream` in `group` and expects a delivered message.

--- a/crates/ironbus-server/src/engine.rs
+++ b/crates/ironbus-server/src/engine.rs
@@ -3464,7 +3464,14 @@ struct BindingTable {
     /// The compiled, wait-free routing trie: a publish resolves a literal subject against this
     /// snapshot (directly or through a per-connection resolve cache) with no lock and no walk on a
     /// cache hit. Rebuilt and swapped on every successful `bind`, advancing its generation.
-    snapshot: SublistSnapshot<StreamId>,
+    ///
+    /// Held behind an `Arc` (#811 C3) so the SAME wait-free snapshot is SHARED with every
+    /// [`crate::actor::EngineHandle`]: a connection thread resolves a subject OFF the actor against
+    /// this exact object, and `bind_subject` publishes a rebuilt trie through the `ArcSwap` it wraps
+    /// (an interior-mutability `store`, so the shared `Arc` never has to be replaced), visible to
+    /// every reader. The `Arc` wrapper changes no routing behavior — it is the same snapshot, merely
+    /// reachable from the connection threads without a round-trip through the actor.
+    snapshot: Arc<SublistSnapshot<StreamId>>,
 }
 
 impl BindingTable {
@@ -3473,8 +3480,15 @@ impl BindingTable {
     fn new() -> BindingTable {
         BindingTable {
             entries: Vec::new(),
-            snapshot: SublistSnapshot::empty(),
+            snapshot: Arc::new(SublistSnapshot::empty()),
         }
+    }
+
+    /// A clone of the SHARED wait-free snapshot `Arc` (#811 C3), handed to each
+    /// [`crate::actor::EngineHandle`] at `spawn_actor` time so a connection thread resolves a subject
+    /// off the actor against the SAME snapshot `bind_subject` publishes to.
+    fn snapshot_arc(&self) -> Arc<SublistSnapshot<StreamId>> {
+        Arc::clone(&self.snapshot)
     }
 
     /// Builds an immutable routing trie from the current registry (generation `0`; the snapshot restamps
@@ -3502,7 +3516,7 @@ impl BindingTable {
     fn from_entries(entries: Vec<(String, StreamId)>) -> Result<BindingTable, SublistError> {
         let table = BindingTable {
             entries,
-            snapshot: SublistSnapshot::empty(),
+            snapshot: Arc::new(SublistSnapshot::empty()),
         };
         let trie = table.build()?;
         table.snapshot.store(trie);
@@ -10162,7 +10176,17 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
     /// and generation-stamped, so the cache's generation-guard detects a bind change with one compare.
     #[must_use]
     pub fn binding_snapshot(&self) -> &SublistSnapshot<StreamId> {
-        &self.bindings.snapshot
+        self.bindings.snapshot.as_ref()
+    }
+
+    /// A clone of the SHARED subject-routing snapshot `Arc` (#811 C3): the same `ArcSwap`
+    /// [`Engine::bind_subject`] publishes to, taken at `spawn_actor` time and stored in every
+    /// [`crate::actor::EngineHandle`] so a connection thread resolves a subject WAIT-FREE off the
+    /// actor (then routes the produce to the resolved stream's shard). A resolve through this always
+    /// observes the latest committed bindings, exactly as an in-actor resolve does.
+    #[must_use]
+    pub fn binding_snapshot_arc(&self) -> Arc<SublistSnapshot<StreamId>> {
+        self.bindings.snapshot_arc()
     }
 
     /// Appends `message` durably-pending (write, NO fsync) and records the produce statistics that

--- a/crates/ironbus-server/src/server.rs
+++ b/crates/ironbus-server/src/server.rs
@@ -11,7 +11,7 @@
 //! produce fsync never blocks another connection's ping. Concurrency is bounded by a connection cap
 //! so a connection flood cannot spawn unbounded threads.
 
-use crate::actor::EngineHandle;
+use crate::actor::{EngineAccess, EngineHandle};
 use crate::auth::AuthConfig;
 use crate::connz::ConnectionMetrics;
 use crate::session::Session;
@@ -779,7 +779,14 @@ where
     // a named-stream consumer's committed position is made durable to that stream's own checkpoint, the
     // default stream (`""`) stays byte-for-byte the historical `checkpoint_group`.
     let stream = session.stream().to_string();
-    let _ = engine.with(move |e| {
+    // #811 C2: a named-stream consumer's committed cursor is state OWNED by `shard_of(stream)` (it
+    // persists to `streams/<hex(name)>/cursor-<hex(group)>.ckpt`), so this clean-disconnect flush must
+    // land on that stream's shard, exactly like the session.rs named-stream verbs — the default stream
+    // (`""`) pins to shard 0. At K = 1 `with_on_shard(0, …)` is byte-for-byte `with`; this is the inert
+    // routing plumbing the future owner-gated K > 1 flip needs (a miss would persist the cursor on the
+    // wrong shard → nowhere → mass redelivery on restart, #1177).
+    let shard = crate::actor::shard_of(&stream, engine.shard_count());
+    let _ = engine.with_on_shard(shard, move |e| {
         let _ = e.checkpoint_in_stream(&stream, &group);
     });
     outcome
@@ -921,7 +928,12 @@ where
                     // consumer persists its cursor to that stream's own `cursor-<hex(group)>.ckpt`, the
                     // default stream (`""`) stays byte-for-byte the historical `maybe_checkpoint_group`.
                     let stream = session.stream().to_string();
-                    let _ = engine.with(move |e| {
+                    // #811 C2: route the per-pass committed-progress checkpoint to the shard that OWNS
+                    // this (stream, group)'s durable cursor — the same seam the session.rs named-stream
+                    // verbs use, byte-for-byte `with` at K = 1 (default `""` → shard 0), inert plumbing
+                    // for the future K > 1 flip (a miss would persist the cursor nowhere at K > 1, #1177).
+                    let shard = crate::actor::shard_of(&stream, engine.shard_count());
+                    let _ = engine.with_on_shard(shard, move |e| {
                         let _ = e.maybe_checkpoint_in_stream(&stream, &group);
                     });
                 }

--- a/crates/ironbus-server/src/session.rs
+++ b/crates/ironbus-server/src/session.rs
@@ -22,7 +22,7 @@ use crate::actor::{
 use crate::cluster::dataplane::FollowerReadOutcome;
 use crate::cluster::read_consistency::ReadTier;
 use crate::engine::{
-    AckResult, Engine, EngineError, NackResult, Poll, ProgressResult, StreamBatch, StreamRawBatch,
+    AckResult, EngineError, NackResult, Poll, ProgressResult, StreamBatch, StreamRawBatch,
 };
 // The Linux `sendfile(2)` zero-copy Tier-S types (#1034 / #658). Gated on `target_os = "linux"` — the
 // only target the splice path compiles on; every other target takes the userspace copy path and never
@@ -42,6 +42,7 @@ use ironbus_core::keyshared::{KeyOrdering, MemberId};
 use ironbus_core::lease::LeaseToken;
 use ironbus_core::resolve_cache::ResolveCache;
 use ironbus_core::subject::{Subject, SubjectPattern};
+use ironbus_core::sublist::SublistSnapshot;
 use ironbus_core::types::{Offset, RecordFlags};
 use ironbus_proto::frame::{decode_frame, encode_frame, FrameDecode, FrameError, FrameType};
 use ironbus_proto::message::{
@@ -2471,7 +2472,12 @@ impl Session {
         match ack.op {
             AckOp::Ack => {
                 let token = *token;
-                let status = match engine.with(move |e| e.ack_in_stream(&stream, &group, &token))? {
+                // #811 C2: route the named-stream ack to the shard that OWNS the stream. With one shard
+                // (today) `shard_of` is 0 and `with_on_shard` is byte-for-byte `with`.
+                let shard = crate::actor::shard_of(&stream, engine.shard_count());
+                let status = match engine
+                    .with_on_shard(shard, move |e| e.ack_in_stream(&stream, &group, &token))?
+                {
                     AckResult::Acked => 1u8,
                     AckResult::Fenced => 0u8,
                 };
@@ -2516,9 +2522,11 @@ impl Session {
         match ack.op {
             AckOp::Ack => {
                 let token = *token;
-                let status = match engine
-                    .with(move |e| e.ack_partition(&stream, partition, &group, &token))?
-                {
+                // #811 C2: a partition's records live on its stream's shard, so route the ack there.
+                let shard = crate::actor::shard_of(&stream, engine.shard_count());
+                let status = match engine.with_on_shard(shard, move |e| {
+                    e.ack_partition(&stream, partition, &group, &token)
+                })? {
                     AckResult::Acked => 1u8,
                     AckResult::Fenced => 0u8,
                 };
@@ -2557,7 +2565,11 @@ impl Session {
         match ack.op {
             AckOp::Ack => {
                 let token = *token;
-                let status = match engine.with(move |e| e.ack_priority(&stream, &group, &token))? {
+                // #811 C2: a priority stream's lanes live on its shard, so route the ack there.
+                let shard = crate::actor::shard_of(&stream, engine.shard_count());
+                let status = match engine
+                    .with_on_shard(shard, move |e| e.ack_priority(&stream, &group, &token))?
+                {
                     AckResult::Acked => 1u8,
                     AckResult::Fenced => 0u8,
                 };
@@ -2839,8 +2851,11 @@ impl Session {
         if !self.stream.is_empty() {
             let stream = self.stream.clone();
             let group = self.subscription.clone();
-            let committed =
-                engine.with(move |e| e.committed_offset_in_stream(&stream, &group).get())?;
+            // #811 C2: read the named stream's committed cursor on its OWN shard.
+            let shard = crate::actor::shard_of(&stream, engine.shard_count());
+            let committed = engine.with_on_shard(shard, move |e| {
+                e.committed_offset_in_stream(&stream, &group).get()
+            })?;
             self.leased.retain(|&offset, _| offset >= committed);
             return Ok(());
         }
@@ -3173,7 +3188,11 @@ impl Session {
                 // consumer takes the unchanged member-aware paths below.
                 let partition = self.partition;
                 let priority_bound = self.priority_bound;
-                let poll = engine.with(move |e| {
+                // #811 C2: route every per-record poll to the bound stream's shard. The default
+                // (empty) stream hashes to shard 0 (`poll_now_in_member`); a named/partitioned/priority
+                // stream to its own shard. With one shard (today) this is 0 and `with_on_shard` == `with`.
+                let shard = crate::actor::shard_of(&stream, engine.shard_count());
+                let poll = engine.with_on_shard(shard, move |e| {
                     if let Some(partition) = partition {
                         let now = e.now_monotonic();
                         e.poll_partition(&stream, partition, &group, now)
@@ -3409,7 +3428,10 @@ impl Session {
         // cursor byte-for-byte.
         let group = self.subscription.clone();
         let stream = self.stream.clone();
-        let committed = engine.with(move |e| {
+        // #811 C2: route the committed-cursor read to the bound stream's shard. The default (empty)
+        // stream hashes to shard 0 (`committed_offset_in`), a named stream to its own shard.
+        let shard = crate::actor::shard_of(&stream, engine.shard_count());
+        let committed = engine.with_on_shard(shard, move |e| {
             if stream.is_empty() {
                 e.committed_offset_in(&group).get()
             } else {
@@ -3581,7 +3603,9 @@ impl Session {
                 // stream drains its OWN id-routed log via `poll_in_stream_member`. Without this a
                 // multi-tenant Sub+Fetch drained the SHARED root default stream (a cross-tenant leak).
                 let stream = self.stream.clone();
-                match engine.with(move |e| {
+                // #811 C2: route the batch-fetch poll to the bound stream's shard (default → shard 0).
+                let shard = crate::actor::shard_of(&stream, engine.shard_count());
+                match engine.with_on_shard(shard, move |e| {
                     if stream.is_empty() {
                         e.poll_now_in_member(&group, member)
                     } else {
@@ -3755,7 +3779,9 @@ impl Session {
         // named/tenant cursor), mirroring the poll above — not the root-only `committed_offset_in`.
         let group = self.subscription.clone();
         let stream = self.stream.clone();
-        let committed = engine.with(move |e| {
+        // #811 C2: route the committed-cursor read to the bound stream's shard (default → shard 0).
+        let shard = crate::actor::shard_of(&stream, engine.shard_count());
+        let committed = engine.with_on_shard(shard, move |e| {
             if stream.is_empty() {
                 e.committed_offset_in(&group).get()
             } else {
@@ -3854,7 +3880,11 @@ impl Session {
         if has_time {
             let (st, et) = (req.start_time_ms, req.end_time_ms);
             let (s, g) = (stream.clone(), group.clone());
-            match engine.with(move |e| e.stream_resolve_time_in_stream(&s, &g, st, et))? {
+            // #811 C2: resolve the seek-by-time bounds on the target stream's OWN shard.
+            let shard = crate::actor::shard_of(&stream, engine.shard_count());
+            match engine.with_on_shard(shard, move |e| {
+                e.stream_resolve_time_in_stream(&s, &g, st, et)
+            })? {
                 Ok((resolved_start, resolved_end)) => {
                     if let Some(rs) = resolved_start {
                         start = rs;
@@ -4094,7 +4124,9 @@ impl Session {
         // ONE actor round-trip serves the whole contiguous batch — the heart of the Tier-S win versus
         // the N per-record round-trips the Tier-W poll loop makes. The engine reads off the shared
         // durable read path, claims no lease, and writes no cursor.
-        match engine.with(move |e| {
+        // #811 C2: serve the contiguous batch from the target stream's OWN shard (default → shard 0).
+        let shard = crate::actor::shard_of(&stream, engine.shard_count());
+        match engine.with_on_shard(shard, move |e| {
             e.stream_fetch_in_stream(&stream, &group, member, start, want, max_bytes)
         })? {
             Ok(StreamBatch { records, .. }) => {
@@ -4270,7 +4302,9 @@ impl Session {
         // `stream_fetch_raw_in_stream`; the DEFAULT stream (`stream` empty) routes to `stream_fetch_raw_in`
         // BYTE-FOR-BYTE. Same lease-free raw contiguous read — only the log differs.
         let stream = stream.clone();
-        match engine.with(move |e| {
+        // #811 C2: serve the raw contiguous batch from the target stream's OWN shard (default → shard 0).
+        let shard = crate::actor::shard_of(&stream, engine.shard_count());
+        match engine.with_on_shard(shard, move |e| {
             e.stream_fetch_raw_in_stream(&stream, &group, member, start, want, max_bytes)
         })? {
             Ok(StreamRawBatch { raw, tail, .. }) => {
@@ -4318,7 +4352,9 @@ impl Session {
     {
         let group = group.clone();
         let stream = stream.clone();
-        match engine.with(move |e| {
+        // #811 C2: fetch the fd run from the target stream's OWN shard (default → shard 0).
+        let shard = crate::actor::shard_of(&stream, engine.shard_count());
+        match engine.with_on_shard(shard, move |e| {
             e.stream_fetch_fd_in_stream(&stream, &group, member, start, want, max_bytes)
         })? {
             Ok(StreamFdBatch::Fd {
@@ -4419,7 +4455,11 @@ impl Session {
         // cursor via `stream_commit_in_stream`; the DEFAULT stream (`self.stream` empty) routes to
         // `stream_commit_in` BYTE-FOR-BYTE (the engine method dispatches on the empty name).
         let stream = self.stream.clone();
-        match engine.with(move |e| e.stream_commit_in_stream(&stream, &group, up_to))? {
+        // #811 C2: advance the named stream's streaming cursor on its OWN shard (default → shard 0).
+        let shard = crate::actor::shard_of(&stream, engine.shard_count());
+        match engine.with_on_shard(shard, move |e| {
+            e.stream_commit_in_stream(&stream, &group, up_to)
+        })? {
             // A committed (or idempotent no-op) streaming commit: the generic body-less success. There
             // is no per-connection lease to release (Tier-S grants none), so unlike the broadcast
             // cumulative-ack path there is no `self.leased` bookkeeping here.
@@ -4556,7 +4596,11 @@ impl Session {
         // durable subscribe against a live-ephemeral conflict — exactly like `handle_sub_to`.
         if ephemeral {
             let (s, g) = (stream.to_string(), group.to_string());
-            match engine.with(move |e| e.subscribe_ephemeral_in_stream(&s, &g, member))? {
+            // #811 C2: register the ephemeral subscription on the target stream's OWN shard.
+            let shard = crate::actor::shard_of(stream, engine.shard_count());
+            match engine.with_on_shard(shard, move |e| {
+                e.subscribe_ephemeral_in_stream(&s, &g, member)
+            })? {
                 Ok(()) => {}
                 Err(e) => {
                     reply_err_coded(out, e.code().as_str(), &e.to_string());
@@ -4565,7 +4609,9 @@ impl Session {
             }
         } else {
             let (s, g) = (stream.to_string(), group.to_string());
-            if engine.with(move |e| e.is_ephemeral_in_stream(&s, &g))? {
+            // #811 C2: probe the ephemeral conflict on the target stream's OWN shard.
+            let shard = crate::actor::shard_of(stream, engine.shard_count());
+            if engine.with_on_shard(shard, move |e| e.is_ephemeral_in_stream(&s, &g))? {
                 reply_err_coded(
                     out,
                     crate::codes::ErrorCode::ERR_EPHEMERAL_GROUP_CONFLICT.as_str(),
@@ -4589,7 +4635,9 @@ impl Session {
         self.leased.clear();
         let stream_name = self.stream.clone();
         let sub = self.subscription.clone();
-        let joined = engine.with(move |e| {
+        // #811 C2: enable key_shared + join membership on the stream's OWN per-stream work-group shard.
+        let shard = crate::actor::shard_of(&stream_name, engine.shard_count());
+        let joined = engine.with_on_shard(shard, move |e| {
             if e.is_configured_key_shared(&sub)
                 && e.set_key_ordering_in_stream(&stream_name, &sub, KeyOrdering::KeyShared)
                     .is_ok()
@@ -4604,7 +4652,9 @@ impl Session {
         if self.default_tier == ConsumeTier::Streaming {
             let stream_name = self.stream.clone();
             let sub = self.subscription.clone();
-            engine.with(move |e| {
+            // #811 C2: mark THIS stream's group streaming on the stream's OWN shard.
+            let shard = crate::actor::shard_of(&stream_name, engine.shard_count());
+            engine.with_on_shard(shard, move |e| {
                 let _ = e.set_streaming_in_stream(&stream_name, &sub, true);
             })?;
         }
@@ -4711,7 +4761,9 @@ impl Session {
         // the stream: a same-name subscription on a DIFFERENT stream is a different group. The
         // default-stream durable path is byte-for-byte the historical `unsubscribe_in`.
         if self.registered_subscription && (!old_stream.is_empty() || *old_group != *new_group) {
-            engine.with(move |e| {
+            // #811 C2: deregister the old subscription on ITS stream's shard (default → shard 0).
+            let shard = crate::actor::shard_of(&old_stream, engine.shard_count());
+            engine.with_on_shard(shard, move |e| {
                 if old_stream.is_empty() {
                     e.unsubscribe_in(&old_group, member);
                 } else {
@@ -5622,9 +5674,11 @@ impl Session {
             // current subscription fully intact.
             let stream_q = stream.to_string();
             let group_q = group.to_string();
-            match engine
-                .with(move |e| e.subscribe_ephemeral_in_stream(&stream_q, &group_q, member))?
-            {
+            // #811 C2: register the ephemeral named subscription on the target stream's OWN shard.
+            let shard = crate::actor::shard_of(stream, engine.shard_count());
+            match engine.with_on_shard(shard, move |e| {
+                e.subscribe_ephemeral_in_stream(&stream_q, &group_q, member)
+            })? {
                 Ok(()) => {}
                 Err(e) => {
                     reply_err_coded(out, e.code().as_str(), &e.to_string());
@@ -5634,7 +5688,11 @@ impl Session {
         } else {
             let stream_q = stream.to_string();
             let group_q = group.to_string();
-            if engine.with(move |e| e.is_ephemeral_in_stream(&stream_q, &group_q))? {
+            // #811 C2: probe the ephemeral conflict on the target stream's OWN shard.
+            let shard = crate::actor::shard_of(stream, engine.shard_count());
+            if engine.with_on_shard(shard, move |e| {
+                e.is_ephemeral_in_stream(&stream_q, &group_q)
+            })? {
                 reply_err_coded(
                     out,
                     crate::codes::ErrorCode::ERR_EPHEMERAL_GROUP_CONFLICT.as_str(),
@@ -5689,7 +5747,9 @@ impl Session {
         let stream_name = self.stream.clone();
         let sub = self.subscription.clone();
         let member = self.member_id;
-        let joined = engine.with(move |e| {
+        // #811 C2: enable key_shared + join membership on THIS stream's OWN per-stream work-group shard.
+        let shard = crate::actor::shard_of(&stream_name, engine.shard_count());
+        let joined = engine.with_on_shard(shard, move |e| {
             if e.is_configured_key_shared(&sub)
                 && e.set_key_ordering_in_stream(&stream_name, &sub, KeyOrdering::KeyShared)
                     .is_ok()
@@ -5713,7 +5773,9 @@ impl Session {
         if self.default_tier == ConsumeTier::Streaming {
             let stream_name = self.stream.clone();
             let sub = self.subscription.clone();
-            engine.with(move |e| {
+            // #811 C2: mark THIS stream's group streaming on the stream's OWN shard.
+            let shard = crate::actor::shard_of(&stream_name, engine.shard_count());
+            engine.with_on_shard(shard, move |e| {
                 let _ = e.set_streaming_in_stream(&stream_name, &sub, true);
             })?;
         }
@@ -5825,7 +5887,11 @@ impl Session {
         let stream = self.tenant_stream(stream).into_owned();
         let group = group.to_string();
         let pause_ms = decoded.pause_ms;
-        match engine.with(move |e| e.pause_group_in_stream(&stream, &group, pause_ms))? {
+        // #811 C2: pause/resume the group on the target stream's OWN shard (default → shard 0).
+        let shard = crate::actor::shard_of(&stream, engine.shard_count());
+        match engine.with_on_shard(shard, move |e| {
+            e.pause_group_in_stream(&stream, &group, pause_ms)
+        })? {
             Ok(_resumes_at) => reply(out, FrameType::Ok, &[]),
             Err(e) => reply_err_coded(out, e.code().as_str(), &e.to_string()),
         }
@@ -5969,13 +6035,43 @@ impl Session {
             reply_err_coded(out, e.code(), e.message());
             return Ok(());
         }
-        // Move the per-connection resolve cache into the job; the job returns it (and the produce
-        // outcome) so the cache's freshly-cached entry + adopted generation persist across publishes.
-        let cache = std::mem::take(&mut self.subject_cache);
-        let (cache, outcome) = engine.with(move |e| {
-            let mut cache = cache;
-            let level = append.ack_level;
-            let outcome = resolve_then_produce(e, &mut cache, &subject, &append);
+        // #811 C3: resolve the subject to its single bound stream OFF the actor, on THIS connection
+        // thread, through the generation-guarded resolve cache against the engine's SHARED wait-free
+        // routing snapshot (the SAME `ArcSwap` `bind_subject` publishes to). Then route the produce to
+        // the RESOLVED stream's shard — parity with `PubTo`, which hashes the stream name on the
+        // connection thread. The resolve stays single-home FAIL-CLOSED byte-for-byte (`NoStream` /
+        // `Ambiguous` / `Invalid` are typed rejects WITHOUT touching a log — no silent drop, no partial
+        // write, the beat over NATS); only WHERE it runs moved off the actor. At K = 1 the resolved
+        // shard is 0, so the append is byte-for-byte the pre-#811 shard-0 path.
+        let stream = {
+            let snapshot = engine.binding_snapshot();
+            match resolve_subject_cached(&snapshot, &mut self.subject_cache, &subject) {
+                Ok(id) => id,
+                Err(e) => {
+                    // An unbound/ambiguous/malformed subject: a typed, connection-preserving reject,
+                    // never a panic and NEVER a silent drop. A resolve reject is never fatal.
+                    reply_err_coded(out, e.code().as_str(), &e.to_string());
+                    return Ok(());
+                }
+            }
+        };
+        let level = append.ack_level;
+        // Route the append to the resolved stream's shard: the default stream `""` hashes to shard 0
+        // and appends byte-for-byte through the default path; a named stream appends to its own log.
+        let shard = crate::actor::shard_of(stream.name(), engine.shard_count());
+        let outcome = engine.with_on_shard(shard, move |e| {
+            // The literal subject is PERSISTED with the record (#594) so a per-subject filtered consumer
+            // can match it — on the default stream (#594-A) AND the resolved NAMED stream (#594-B); the
+            // subject was validated `Subject::parse_literal` at resolve.
+            let view = Append {
+                timestamp_ms: append.timestamp_ms,
+                flags: RecordFlags::from_bits(append.flags),
+                key: &append.key,
+                headers: &append.headers,
+                payload: &append.payload,
+            };
+            let outcome =
+                e.produce_in_stream_with_subject(stream.name(), &view, subject.as_bytes());
             // Per-ack-level PRODUCE throughput (#571) for the subject-routed produce path (which runs
             // synchronously in this engine job, not through the actor drain that counts the default
             // batched path): count only on a successful append, so the per-level sum matches the
@@ -5983,9 +6079,8 @@ impl Session {
             if outcome.is_ok() {
                 e.record_produce_ack_level(level);
             }
-            (cache, outcome)
+            outcome
         })?;
-        self.subject_cache = cache;
         match outcome {
             Ok(offset) => {
                 let ack = PubAckBody {
@@ -6002,9 +6097,10 @@ impl Session {
                 reply_err(out, "fatal storage error");
                 Err(SessionError::EngineFatal(e))
             }
-            // An unbound (NoStreamForSubject) or ambiguous (AmbiguousSubject) subject, a malformed
-            // subject, or a non-fatal storage shed is a typed, connection-preserving reject — never a
-            // panic and (critically) NEVER a silent drop.
+            // A non-fatal storage shed on the resolved stream (a byte-cap drop, etc.) is a typed,
+            // connection-preserving reject — never a panic and (critically) NEVER a silent drop. The
+            // resolve rejects (NoStreamForSubject / AmbiguousSubject / InvalidSubject) were already
+            // handled off the actor above, BEFORE the produce, so this arm only sees produce errors.
             Err(e) => {
                 reply_err_coded(out, e.code().as_str(), &e.to_string());
                 Ok(())
@@ -6105,10 +6201,19 @@ impl Session {
                     Resolved::Local(name) => (name, self.default_stream(), group.to_string()),
                 };
             let group_bind = group_owned.clone();
+            // #811 C2: this filter-bind resolves its covering stream IN-JOB (see the ROUTE-EXEMPT note
+            // below), so it stays on `with` — atomic resolve+set on shard 0, byte-for-byte at K=1.
             let (resolved_stream, set) = engine.with(move |e| {
                 let stream = e
                     .covering_named_stream_for_filter(&pattern_owned)
                     .map_or(default_stream, |id| id.name().to_string());
+                // ROUTE-EXEMPT(#811): the target `stream` is resolved HERE, IN-JOB, from the binding
+                // ENTRIES (`covering_named_stream_for_filter` reduces `bindings.entries` by pattern-
+                // subset — NOT the wait-free subject snapshot the C3 publish path reads), so it cannot
+                // pick a shard BEFORE dispatch. Keeping the resolve+set atomic in ONE job is byte-for-
+                // byte at K=1 (shard 0); routing this one site needs the binding registry shared
+                // off-actor (owner-gated, C6 territory). This is an explicit, reviewed exemption from
+                // the route-completeness lint — never a missed site.
                 let set =
                     e.set_subject_filter_in_stream(&stream, &group_bind, Some(&pattern_owned));
                 (stream, set)
@@ -6164,13 +6269,14 @@ impl Session {
                 Resolved::Cross { name, .. } => (name, self.scope_group_under_self(group)),
                 Resolved::Local(name) => (name, group.to_string()),
             };
-        let cache = std::mem::take(&mut self.subject_cache);
-        let (cache, resolved) = engine.with(move |e| {
-            let mut cache = cache;
-            let resolved = resolve_subject_cached(e, &mut cache, &subject_owned);
-            (cache, resolved)
-        })?;
-        self.subject_cache = cache;
+        // #811 C3: resolve the subject OFF the actor (parity with `PubSubject`), on this connection
+        // thread, through the generation-guarded cache against the engine's SHARED wait-free snapshot.
+        // Single-home fail-closed is unchanged; a `SubSubject` only binds session state (the subsequent
+        // Flow/Ack route by `self.stream`), so there is no cross-shard hazard — just the off-actor read.
+        let resolved = {
+            let snapshot = engine.binding_snapshot();
+            resolve_subject_cached(&snapshot, &mut self.subject_cache, &subject_owned)
+        };
         let stream = match resolved {
             Ok(id) => id,
             Err(e) => {
@@ -6263,7 +6369,9 @@ impl Session {
             let group = self.subscription.clone();
             let stream = self.stream.clone();
             let member = self.member_id;
-            engine.with(move |e| {
+            // #811 C2: leave the key_shared membership on the bound stream's shard (default → shard 0).
+            let shard = crate::actor::shard_of(&stream, engine.shard_count());
+            engine.with_on_shard(shard, move |e| {
                 // The membership is per-(stream, group) (#64 follow-up): a named-stream subscription
                 // leaves THIS stream's router, the default stream (`""`) the default-group router.
                 if stream.is_empty() {
@@ -6297,7 +6405,9 @@ impl Session {
             let group = self.subscription.clone();
             let stream = self.stream.clone();
             let member = self.member_id;
-            engine.with(move |e| {
+            // #811 C2: deregister the subscription on the bound stream's shard (default → shard 0).
+            let shard = crate::actor::shard_of(&stream, engine.shard_count());
+            engine.with_on_shard(shard, move |e| {
                 // Routed per-stream (#771), like `leave_current_key_shared`: an EPHEMERAL
                 // named-stream subscription registered membership on THAT stream's group (and the
                 // leave is what triggers its reap when this member was the last). Only ephemeral
@@ -6416,18 +6526,22 @@ fn negotiate_credit_bytes(requested: Option<u64>, cap: u64) -> u64 {
 /// This is the cached twin of [`Engine::resolve_subject`]: the engine method walks the trie directly;
 /// this resolves through the connection's cache so a hot subject is O(1). The single-home reduction is
 /// the shared [`single_home`] policy, so the two agree.
-fn resolve_subject_cached<F: Filesystem, C: Clock + Clone>(
-    engine: &Engine<F, C>,
+// #811 C3: resolves against a SHARED wait-free routing snapshot (`&SublistSnapshot`) rather than a
+// borrowed `&Engine`, so a connection thread resolves a subject OFF the actor (then routes the produce
+// to the resolved stream's shard). The snapshot the caller passes is the SAME `ArcSwap` `bind_subject`
+// publishes to, so the resolution is identical to the historical in-actor one — only WHERE it runs moved.
+fn resolve_subject_cached(
+    snapshot: &SublistSnapshot<StreamId>,
     cache: &mut ResolveCache<StreamId>,
     subject: &str,
 ) -> Result<StreamId, EngineError> {
     // Validate as a #567 LITERAL (no wildcards on the publish/subscribe-by-literal side); a wildcard or
     // malformed subject is a typed reject before any routing.
     let subj = Subject::parse_literal(subject).map_err(EngineError::InvalidSubject)?;
-    // Resolve through the cache against the engine's wait-free snapshot, then reduce single-home over the
+    // Resolve through the cache against the shared wait-free snapshot, then reduce single-home over the
     // cached target slice WITHOUT cloning the whole Vec (only the one routed id is cloned on the happy
     // path).
-    match cache.resolve_with(engine.binding_snapshot(), &subj, single_home) {
+    match cache.resolve_with(snapshot, &subj, single_home) {
         Resolution::Routed(id) => Ok(id),
         Resolution::NoStream => Err(EngineError::NoStreamForSubject {
             subject: subject.to_string(),
@@ -6437,35 +6551,6 @@ fn resolve_subject_cached<F: Filesystem, C: Clock + Clone>(
             matched,
         }),
     }
-}
-
-/// Resolves `subject` single-home through `cache` (fail-closed) and, on a single-home hit, routes the
-/// owned `append` to the resolved stream via the id-routed [`Engine::produce_in_stream`] — the publish
-/// half of a `PubSubject` (#585), run in ONE actor job. An unbound/ambiguous/malformed subject is
-/// returned as a typed reject WITHOUT any append (no silent drop, no partial write — the fail-closed
-/// beat over NATS). Returns the assigned [`Offset`] in the resolved stream on success.
-fn resolve_then_produce<F: Filesystem + Clone, C: Clock + Clone>(
-    engine: &mut Engine<F, C>,
-    cache: &mut ResolveCache<StreamId>,
-    subject: &str,
-    append: &OwnedAppend,
-) -> Result<Offset, EngineError> {
-    // Resolve first (fail-closed): a NoStream/Ambiguous/Invalid subject is refused BEFORE any append.
-    let stream = resolve_subject_cached(engine, cache, subject)?;
-    // Route the append to the resolved stream's log via the id-routed produce (the default stream `""`
-    // routes byte-for-byte through `produce`; a named stream appends to its own log + commit tick).
-    // The literal subject is PERSISTED with the record (#594) so a per-subject filtered consumer can
-    // match it — on the default stream (#594-A) AND on the resolved NAMED stream (#594-B); the subject
-    // was validated `Subject::parse_literal` at resolve. `produce_in_stream_with_subject` routes the
-    // subject to whichever log the stream resolved to.
-    let view = Append {
-        timestamp_ms: append.timestamp_ms,
-        flags: RecordFlags::from_bits(append.flags),
-        key: &append.key,
-        headers: &append.headers,
-        payload: &append.payload,
-    };
-    engine.produce_in_stream_with_subject(stream.name(), &view, subject.as_bytes())
 }
 
 /// The #438 compressed-descriptor SHAPE gate, shared by ALL FOUR produce verbs (`handle_pub`,
@@ -7164,6 +7249,103 @@ mod tests {
     use ironbus_storage::fs::InMemoryFs;
     use ironbus_storage::log::{Append, LogConfig};
     use std::sync::Arc;
+
+    /// #811 C2 ROUTE-COMPLETENESS LINT — the safety net for the future K > 1 append-shard flip.
+    ///
+    /// Proves that EVERY per-NAMED-stream engine verb in the PRODUCTION (non-test) part of this file is
+    /// dispatched through `with_on_shard(shard_of(stream), …)`, never plain `with(…)`, so a produce,
+    /// consume, ack, cursor-commit, subscribe, or membership op ALWAYS lands on the shard that OWNS the
+    /// stream. At K = 1 `with_on_shard(0, …) == with(…)`, so this is inert today; it is the tripwire that
+    /// catches a NEW per-stream verb (or a missed conversion) being routed to the WRONG shard once the
+    /// owner-gated flip spawns K actors.
+    ///
+    /// It source-scans THIS file (`include_str!`), cuts the test module out (so this very verb list and
+    /// the test fixtures' direct `&mut Engine` calls are not scanned), then for every enumerated verb
+    /// call locates its ENCLOSING dispatch opener — the NEAREST preceding `.with(` vs `.with_on_shard(`.
+    /// A verb under a plain `.with(` FAILS, UNLESS that closure carries an explicit `ROUTE-EXEMPT(#811)`
+    /// marker (the single site whose target stream is resolved IN-JOB from the binding registry — see its
+    /// documented call site in `handle_sub_subject`). The verbs it enforces (the whole named-stream
+    /// surface): the 16 `*_in_stream` twins (ack / committed-offset / resolve-time / stream-fetch{,-raw,
+    /// -fd} / stream-commit / subscribe-ephemeral / is-ephemeral / set-key-ordering / join-member /
+    /// leave-member / set-streaming / unsubscribe / pause-group / set-subject-filter) plus the member-
+    /// aware `poll_in_stream_member` and the partition/priority twins (`ack_partition` / `poll_partition`
+    /// / `ack_priority` / `poll_priority`).
+    #[test]
+    fn every_named_stream_verb_routes_through_with_on_shard() {
+        const PER_STREAM_VERBS: &[&str] = &[
+            "ack_in_stream",
+            "committed_offset_in_stream",
+            "stream_resolve_time_in_stream",
+            "stream_fetch_in_stream",
+            "stream_fetch_raw_in_stream",
+            "stream_fetch_fd_in_stream",
+            "stream_commit_in_stream",
+            "subscribe_ephemeral_in_stream",
+            "is_ephemeral_in_stream",
+            "set_key_ordering_in_stream",
+            "join_member_in_stream",
+            "leave_member_in_stream",
+            "set_streaming_in_stream",
+            "unsubscribe_in_stream",
+            "pause_group_in_stream",
+            "set_subject_filter_in_stream",
+            "poll_in_stream_member",
+            "ack_partition",
+            "poll_partition",
+            "ack_priority",
+            "poll_priority",
+        ];
+        const SRC: &str = include_str!("session.rs");
+        // Everything from the module declaration on is test-only (this verb list + the fixtures' direct
+        // `&mut Engine` calls), so scan ONLY the production prefix before it.
+        let prod = SRC
+            .split("\nmod tests {")
+            .next()
+            .expect("session.rs always has a production prefix before its test module");
+        let mut violations: Vec<String> = Vec::new();
+        for verb in PER_STREAM_VERBS {
+            let needle = format!(".{verb}(");
+            let mut from = 0usize;
+            while let Some(rel) = prod[from..].find(&needle) {
+                let idx = from + rel;
+                from = idx + needle.len();
+                let before = &prod[..idx];
+                let plain = before.rfind(".with(");
+                let sharded = before.rfind(".with_on_shard(");
+                // The enclosing dispatch is the NEAREST preceding opener. Dispatch closures never nest a
+                // second `with`/`with_on_shard` before the verb in this file, so nearest == enclosing.
+                let enclosed_by_plain_with = match (plain, sharded) {
+                    // Both openers precede the verb: the enclosing one is the NEARER (larger index).
+                    (Some(p), Some(s)) => p > s,
+                    // Only `with_on_shard` precedes it → routed, good.
+                    (None, Some(_)) => false,
+                    // Only plain `with` precedes it, OR — a refactor hazard — NEITHER opener does (a
+                    // per-stream verb called outside any dispatch closure): treat as plain, flag it.
+                    _ => true,
+                };
+                if enclosed_by_plain_with {
+                    // Honor the ONE explicit exemption: its closure body (opener → verb) carries a
+                    // `ROUTE-EXEMPT(#811)` marker whose rationale lives at the call site.
+                    let body = plain.map_or("", |p| &prod[p..idx]);
+                    if !body.contains("ROUTE-EXEMPT") {
+                        let line = before.bytes().filter(|&b| b == b'\n').count() + 1;
+                        violations.push(format!(
+                            "`{verb}` at session.rs:{line} is dispatched through plain `with` — it must \
+                             go through `with_on_shard(shard_of(stream), …)`"
+                        ));
+                    }
+                }
+            }
+        }
+        assert!(
+            violations.is_empty(),
+            "#811 route-completeness: {} per-named-stream verb call(s) still route through plain `with` \
+             instead of `with_on_shard`, so a future K > 1 append-shard flip would land them on the \
+             WRONG shard:\n{}",
+            violations.len(),
+            violations.join("\n"),
+        );
+    }
 
     /// The shared session-test engine config, factored out so the pipelined-window test (#450) can
     /// open the SAME config over a fault-injecting filesystem (to count fsyncs).

--- a/crates/ironbus-server/src/session.rs
+++ b/crates/ironbus-server/src/session.rs
@@ -980,7 +980,11 @@ impl Session {
             }
         }
         let name = default.clone();
-        match engine.with(move |e| e.declare_stream(&name))? {
+        // #811 C2: a named stream's log is materialized on `shard_of(name)`, so declaring the tenant's
+        // own default stream routes to that stream's shard — parity with declare-on-first-produce, which
+        // already routes to `shard_of(stream)`. Byte-for-byte `with` at K = 1 (a named tenant → shard 0).
+        let shard = crate::actor::shard_of(&name, engine.shard_count());
+        match engine.with_on_shard(shard, move |e| e.declare_stream(&name))? {
             Ok(_) => {}
             Err(e) if e.is_fatal() => {
                 reply_err(out, "fatal storage error");
@@ -2226,7 +2230,11 @@ impl Session {
             return Ok(());
         }
         let level = append.ack_level;
-        let outcome = engine.with(move |e| {
+        // #811 C2: a multi-tenant connection's default stream is the NAMED stream `<tenant>`, so this
+        // synchronous id-routed produce must land on `shard_of(stream)` — the same shard the `PubTo`
+        // named-stream produce path routes to. Byte-for-byte `with` at K = 1 (`shard_of` → 0).
+        let shard = crate::actor::shard_of(&stream, engine.shard_count());
+        let outcome = engine.with_on_shard(shard, move |e| {
             let view = Append {
                 timestamp_ms: append.timestamp_ms,
                 flags: RecordFlags::from_bits(append.flags),
@@ -4629,7 +4637,12 @@ impl Session {
         self.subscription = GroupName::from(group);
         self.partition = None;
         let stream_p = stream.to_string();
-        self.priority_bound = engine.with(move |e| e.is_priority_stream(&stream_p))?;
+        // #811 C2: the priority-mode flag is per-stream metadata OWNED by `shard_of(stream)`, so read it
+        // on that stream's shard — parity with the key_shared + streaming sets routed just below.
+        // Byte-for-byte `with` at K = 1 (`shard_of` → 0).
+        let shard = crate::actor::shard_of(stream, engine.shard_count());
+        self.priority_bound =
+            engine.with_on_shard(shard, move |e| e.is_priority_stream(&stream_p))?;
         self.registered_subscription = ephemeral;
         self.ephemeral_subscription = ephemeral;
         self.leased.clear();
@@ -4892,7 +4905,11 @@ impl Session {
         // fails closed with the engine's typed reason. The two partitioned modes are mutually exclusive.
         let partition_count = decoded.partition_count;
         let priority = decoded.priority;
-        let result = engine.with(move |e| {
+        // #811 C2: a declare materializes the named stream's OWN log / partition sub-logs / priority
+        // lanes, so route it to `shard_of(stream)` — parity with declare-on-first-produce, which routes
+        // there too. Byte-for-byte `with` at K = 1 (`shard_of` → 0).
+        let shard = crate::actor::shard_of(&stream, engine.shard_count());
+        let result = engine.with_on_shard(shard, move |e| {
             if priority {
                 e.declare_priority_stream(&stream, partition_count)
             } else {
@@ -4956,8 +4973,13 @@ impl Session {
         // One round-trip reads both the existence bit and the durable head: the head is meaningful only
         // when the stream exists, and `stream_head` reports `0` for an unknown/malformed stream (which
         // the response folds with `exists = false`), so the two reads are consistent.
-        let (exists, head) =
-            engine.with(move |e| (e.stream_exists(&stream), e.stream_head(&stream).get()))?;
+        // #811 C2: `stream_head` reads the named stream's OWN durable log head, state OWNED by
+        // `shard_of(stream)`, so route the probe to that stream's shard (the existence bit is read in the
+        // same job). Byte-for-byte `with` at K = 1 (`shard_of` → 0).
+        let shard = crate::actor::shard_of(&stream, engine.shard_count());
+        let (exists, head) = engine.with_on_shard(shard, move |e| {
+            (e.stream_exists(&stream), e.stream_head(&stream).get())
+        })?;
         let resp = StreamInfoResponseBody { exists, head };
         let mut resp_body = Vec::new();
         encode_stream_info_response(&resp, &mut resp_body);
@@ -5587,7 +5609,10 @@ impl Session {
         // The named stream must already exist: a SubTo binds a consume cursor, and consuming an
         // unknown (never-declared) stream is a typed rejection, never a silent empty subscription.
         let stream_owned = stream.to_string();
-        if !engine.with(move |e| e.stream_exists(&stream_owned))? {
+        // #811 C2: existence keys on the named stream (its own log/subtree), so probe it on
+        // `shard_of(stream)`. Byte-for-byte `with` at K = 1 (`shard_of` → 0).
+        let shard = crate::actor::shard_of(&stream_owned, engine.shard_count());
+        if !engine.with_on_shard(shard, move |e| e.stream_exists(&stream_owned))? {
             reply_err(
                 out,
                 &format!("stream {stream:?} does not exist (declare or publish to it first)"),
@@ -5617,7 +5642,11 @@ impl Session {
             // a priority lane; subscribe to the stream and the broker picks). Checked alongside the range
             // check in one engine query.
             let stream_q = stream.to_string();
-            let (in_range, is_priority) = engine.with(move |e| {
+            // #811 C2: partition count + priority-mode are per-stream metadata OWNED by
+            // `shard_of(stream)`, so read them on that stream's shard. Byte-for-byte `with` at K = 1
+            // (`shard_of` → 0).
+            let shard = crate::actor::shard_of(stream, engine.shard_count());
+            let (in_range, is_priority) = engine.with_on_shard(shard, move |e| {
                 (
                     e.partition_count_of(&stream_q)
                         .is_some_and(|pc| partition < pc.get()),
@@ -5730,7 +5759,12 @@ impl Session {
         // first). A non-priority whole-stream subscribe clears it (byte-for-byte the pre-#553 path). One
         // engine query; a false for every non-priority stream.
         let stream_p = stream.to_string();
-        self.priority_bound = engine.with(move |e| e.is_priority_stream(&stream_p))?;
+        // #811 C2: the priority-mode flag is per-stream metadata OWNED by `shard_of(stream)`, so read it
+        // on that stream's shard — parity with the key_shared + streaming sets routed just below.
+        // Byte-for-byte `with` at K = 1 (`shard_of` → 0).
+        let shard = crate::actor::shard_of(stream, engine.shard_count());
+        self.priority_bound =
+            engine.with_on_shard(shard, move |e| e.is_priority_stream(&stream_p))?;
         // A DURABLE named-stream consume does not register in the default-stream broadcast subscriber
         // set (#676); an EPHEMERAL one registers per-stream membership (#771) that the leave path
         // routes by `self.stream`.
@@ -6207,13 +6241,18 @@ impl Session {
                 let stream = e
                     .covering_named_stream_for_filter(&pattern_owned)
                     .map_or(default_stream, |id| id.name().to_string());
-                // ROUTE-EXEMPT(#811): the target `stream` is resolved HERE, IN-JOB, from the binding
-                // ENTRIES (`covering_named_stream_for_filter` reduces `bindings.entries` by pattern-
-                // subset — NOT the wait-free subject snapshot the C3 publish path reads), so it cannot
-                // pick a shard BEFORE dispatch. Keeping the resolve+set atomic in ONE job is byte-for-
-                // byte at K=1 (shard 0); routing this one site needs the binding registry shared
-                // off-actor (owner-gated, C6 territory). This is an explicit, reviewed exemption from
-                // the route-completeness lint — never a missed site.
+                // ROUTE-EXEMPT(#811): `set_subject_filter_in_stream` DOES write per-stream state (it
+                // mints/updates the resolved stream's OWN per-shard work-group + filter), so on the face
+                // of it this is a routable per-stream verb. The blocker is the SHARD KEY, not the write:
+                // the target `stream` is resolved HERE, IN-JOB, from the binding ENTRIES
+                // (`covering_named_stream_for_filter` reduces `bindings.entries` by pattern-subset — a
+                // GLOBAL registry, NOT the wait-free subject snapshot the C3 publish path reads), so the
+                // caller cannot pick `shard_of(stream)` BEFORE dispatch. The only correct K > 1 route is a
+                // TWO-PHASE resolve-on-shard-0 → set-on-`shard_of(resolved)`, which needs the binding
+                // registry shared off-actor (owner-gated, C6) AND breaks the current ATOMIC resolve+set
+                // (a TOCTOU window opens between the two dispatches) — i.e. it is NOT byte-for-byte at
+                // K = 1. So the resolve+set stays ONE job on shard 0 (byte-for-byte at K = 1). This is an
+                // explicit, reviewed exemption from the route-completeness lint — never a missed site.
                 let set =
                     e.set_subject_filter_in_stream(&stream, &group_bind, Some(&pattern_owned));
                 (stream, set)
@@ -7250,89 +7289,140 @@ mod tests {
     use ironbus_storage::log::{Append, LogConfig};
     use std::sync::Arc;
 
-    /// #811 C2 ROUTE-COMPLETENESS LINT — the safety net for the future K > 1 append-shard flip.
+    /// #811 C2 ROUTE-COMPLETENESS LINT — the safety net for the future owner-gated K > 1 append-shard flip.
     ///
-    /// Proves that EVERY per-NAMED-stream engine verb in the PRODUCTION (non-test) part of this file is
-    /// dispatched through `with_on_shard(shard_of(stream), …)`, never plain `with(…)`, so a produce,
-    /// consume, ack, cursor-commit, subscribe, or membership op ALWAYS lands on the shard that OWNS the
-    /// stream. At K = 1 `with_on_shard(0, …) == with(…)`, so this is inert today; it is the tripwire that
-    /// catches a NEW per-stream verb (or a missed conversion) being routed to the WRONG shard once the
-    /// owner-gated flip spawns K actors.
+    /// Proves that EVERY per-NAMED-stream engine verb dispatched in the PRODUCTION (non-test) code of
+    /// EVERY file that can reach the actor is routed through `with_on_shard(shard_of(stream), …)`, never
+    /// plain `with(…)`, so a produce, consume, ack, cursor-checkpoint, declare, subscribe, or membership
+    /// op ALWAYS lands on the shard that OWNS that stream's log/cursors. At K = 1
+    /// `with_on_shard(0, …) == with(…)`, so this is inert today; it is the tripwire that catches a NEW
+    /// per-stream verb (or a missed conversion) being routed to the WRONG shard once the flip spawns K
+    /// actors — a miss is a SILENT DATA DEFECT (e.g. a cursor checkpoint persisted on the wrong shard →
+    /// nowhere → mass redelivery on restart).
     ///
-    /// It source-scans THIS file (`include_str!`), cuts the test module out (so this very verb list and
-    /// the test fixtures' direct `&mut Engine` calls are not scanned), then for every enumerated verb
-    /// call locates its ENCLOSING dispatch opener — the NEAREST preceding `.with(` vs `.with_on_shard(`.
-    /// A verb under a plain `.with(` FAILS, UNLESS that closure carries an explicit `ROUTE-EXEMPT(#811)`
-    /// marker (the single site whose target stream is resolved IN-JOB from the binding registry — see its
-    /// documented call site in `handle_sub_subject`). The verbs it enforces (the whole named-stream
-    /// surface): the 16 `*_in_stream` twins (ack / committed-offset / resolve-time / stream-fetch{,-raw,
-    /// -fd} / stream-commit / subscribe-ephemeral / is-ephemeral / set-key-ordering / join-member /
-    /// leave-member / set-streaming / unsubscribe / pause-group / set-subject-filter) plus the member-
-    /// aware `poll_in_stream_member` and the partition/priority twins (`ack_partition` / `poll_partition`
-    /// / `ack_priority` / `poll_priority`).
+    /// It source-scans every production file that dispatches engine verbs — `session.rs` (the
+    /// SUB/ACK/FLOW/DECLARE/produce verbs), `server.rs` (the clean-disconnect + per-pass cursor
+    /// checkpoints — the two misses that slipped past the ORIGINAL `session.rs`-only lint, #1177), and
+    /// `health.rs` (its admin/metrics snapshots dispatch engine reads through `with` too; scanned for
+    /// defense-in-depth even though today they read only GLOBAL aggregates) — cuts each file's `mod tests`
+    /// out (so this very verb list and the fixtures' direct `&mut Engine` calls are not scanned), then for
+    /// every enumerated verb call locates its ENCLOSING dispatch opener (the NEAREST preceding `.with(` vs
+    /// `.with_on_shard(`). A verb under a plain `.with(` FAILS, UNLESS that closure carries an explicit
+    /// `ROUTE-EXEMPT(#811)` marker (the single filtered-subscribe site whose target stream is resolved
+    /// IN-JOB from the GLOBAL binding registry — see its documented rationale in `handle_sub_subject`).
+    ///
+    /// `PER_STREAM_VERBS` is the EXHAUSTIVE per-named-stream surface (every `engine.rs` method that
+    /// resolves `StreamId::named(stream)` and touches THAT stream's own log / durable cursors / work-group
+    /// membership+leases / partition sub-logs / priority lanes / per-stream subscription+filter+ordering).
+    /// GLOBAL / cross-shard verbs are deliberately EXCLUDED — routing them to `shard_of(stream)` would be
+    /// WRONG at K > 1 because they do NOT key on one stream's shard: the default-stream `*_in` family
+    /// (`ack_in`/`nack_in`/`term_in`/`progress_in`/`cumulative_ack_in`/…, all pinned to shard 0), the
+    /// GLOBAL subject-binding registry (`bind_subject`, read off-actor via `binding_snapshot`), the GLOBAL
+    /// txn 2PC coordinator (`txn_prepare`/`txn_commit`/`txn_rollback`, keyed by `txn_id` — the stream is
+    /// only the eventual-produce destination metadata), and the broker-global mirror config
+    /// (`is_mirror_read_only`) / key-shared config (`is_configured_key_shared`). Those are owner-gated
+    /// C5/C6 subsystems, out of scope for this inert-at-K=1 phase.
     #[test]
     fn every_named_stream_verb_routes_through_with_on_shard() {
         const PER_STREAM_VERBS: &[&str] = &[
+            // Synchronous id-routed produce into a named stream's OWN log.
+            "produce_in_stream",
+            "produce_in_stream_with_subject",
+            "produce_in_stream_prioritized",
+            // Durable work-group cursor checkpoints (the #1177 blocking miss lived here).
+            "checkpoint_in_stream",
+            "maybe_checkpoint_in_stream",
+            // Stream lifecycle — materializes the stream's own log / partition sub-logs / priority lanes.
+            "declare_stream",
+            "declare_partitioned_stream",
+            "declare_priority_stream",
+            // Whole-stream consume + ack + committed-cursor read on the stream's own work-group.
             "ack_in_stream",
+            "poll_in_stream",
+            "poll_in_stream_member",
             "committed_offset_in_stream",
-            "stream_resolve_time_in_stream",
+            // Durable head / existence / residency reads of the stream's own log.
+            "stream_head",
+            "stream_exists",
+            "is_named_stream_resident",
+            // Partition twins — a partition's records live on its stream's shard.
+            "partition_count_of",
+            "poll_partition",
+            "ack_partition",
+            "committed_offset_in_partition",
+            // Priority twins — a priority stream's lanes live on its stream's shard.
+            "is_priority_stream",
+            "poll_priority",
+            "ack_priority",
+            "committed_offset_in_priority_lane",
+            // Named-stream fetch / resolve-time / stream-commit (Tier-S + replay).
             "stream_fetch_in_stream",
             "stream_fetch_raw_in_stream",
             "stream_fetch_fd_in_stream",
+            "stream_resolve_time_in_stream",
             "stream_commit_in_stream",
+            // Per-stream subscription + membership.
             "subscribe_ephemeral_in_stream",
             "is_ephemeral_in_stream",
-            "set_key_ordering_in_stream",
+            "unsubscribe_in_stream",
             "join_member_in_stream",
             "leave_member_in_stream",
-            "set_streaming_in_stream",
-            "unsubscribe_in_stream",
             "pause_group_in_stream",
+            // Per-stream work-group configuration + routing reads.
+            "set_key_ordering_in_stream",
+            "key_ordering_in_stream",
+            "set_streaming_in_stream",
+            "is_streaming_in_stream",
+            "busy_keys_in_stream",
+            "route_decision_in_stream",
+            "subject_filter_in_stream",
             "set_subject_filter_in_stream",
-            "poll_in_stream_member",
-            "ack_partition",
-            "poll_partition",
-            "ack_priority",
-            "poll_priority",
         ];
-        const SRC: &str = include_str!("session.rs");
-        // Everything from the module declaration on is test-only (this verb list + the fixtures' direct
-        // `&mut Engine` calls), so scan ONLY the production prefix before it.
-        let prod = SRC
-            .split("\nmod tests {")
-            .next()
-            .expect("session.rs always has a production prefix before its test module");
+        // Scan EVERY production file that dispatches engine verbs. The ORIGINAL lint scanned `session.rs`
+        // ALONE, so the two mis-routed `server.rs` checkpoint verbs slipped through green (#1177).
+        const FILES: &[(&str, &str)] = &[
+            ("session.rs", include_str!("session.rs")),
+            ("server.rs", include_str!("server.rs")),
+            ("health.rs", include_str!("health.rs")),
+        ];
         let mut violations: Vec<String> = Vec::new();
-        for verb in PER_STREAM_VERBS {
-            let needle = format!(".{verb}(");
-            let mut from = 0usize;
-            while let Some(rel) = prod[from..].find(&needle) {
-                let idx = from + rel;
-                from = idx + needle.len();
-                let before = &prod[..idx];
-                let plain = before.rfind(".with(");
-                let sharded = before.rfind(".with_on_shard(");
-                // The enclosing dispatch is the NEAREST preceding opener. Dispatch closures never nest a
-                // second `with`/`with_on_shard` before the verb in this file, so nearest == enclosing.
-                let enclosed_by_plain_with = match (plain, sharded) {
-                    // Both openers precede the verb: the enclosing one is the NEARER (larger index).
-                    (Some(p), Some(s)) => p > s,
-                    // Only `with_on_shard` precedes it → routed, good.
-                    (None, Some(_)) => false,
-                    // Only plain `with` precedes it, OR — a refactor hazard — NEITHER opener does (a
-                    // per-stream verb called outside any dispatch closure): treat as plain, flag it.
-                    _ => true,
-                };
-                if enclosed_by_plain_with {
-                    // Honor the ONE explicit exemption: its closure body (opener → verb) carries a
-                    // `ROUTE-EXEMPT(#811)` marker whose rationale lives at the call site.
-                    let body = plain.map_or("", |p| &prod[p..idx]);
-                    if !body.contains("ROUTE-EXEMPT") {
-                        let line = before.bytes().filter(|&b| b == b'\n').count() + 1;
-                        violations.push(format!(
-                            "`{verb}` at session.rs:{line} is dispatched through plain `with` — it must \
-                             go through `with_on_shard(shard_of(stream), …)`"
-                        ));
+        for &(fname, src) in FILES {
+            // Everything from the `mod tests {` declaration on is test-only (a verb list + the fixtures'
+            // direct `&mut Engine` calls), so scan ONLY the production prefix before it.
+            let prod = src
+                .split_once("\nmod tests {")
+                .map_or(src, |(head, _)| head);
+            for verb in PER_STREAM_VERBS {
+                let needle = format!(".{verb}(");
+                let mut from = 0usize;
+                while let Some(rel) = prod[from..].find(&needle) {
+                    let idx = from + rel;
+                    from = idx + needle.len();
+                    let before = &prod[..idx];
+                    let plain = before.rfind(".with(");
+                    let sharded = before.rfind(".with_on_shard(");
+                    // The enclosing dispatch is the NEAREST preceding opener. Dispatch closures never nest
+                    // a second `with`/`with_on_shard` before the verb, so nearest == enclosing.
+                    let enclosed_by_plain_with = match (plain, sharded) {
+                        // Both openers precede the verb: the enclosing one is the NEARER (larger index).
+                        (Some(p), Some(s)) => p > s,
+                        // Only `with_on_shard` precedes it → routed, good.
+                        (None, Some(_)) => false,
+                        // Only plain `with` precedes it, OR — a refactor hazard — NEITHER opener does (a
+                        // per-stream verb called outside any dispatch closure): treat as plain, flag it.
+                        _ => true,
+                    };
+                    if enclosed_by_plain_with {
+                        // Honor the explicit exemption: the closure body (opener → verb) carries a
+                        // `ROUTE-EXEMPT(#811)` marker whose rationale lives at the call site.
+                        let body = plain.map_or("", |p| &prod[p..idx]);
+                        if !body.contains("ROUTE-EXEMPT") {
+                            let line = before.bytes().filter(|&b| b == b'\n').count() + 1;
+                            violations.push(format!(
+                                "`{verb}` at {fname}:{line} is dispatched through plain `with` — it must \
+                                 go through `with_on_shard(shard_of(stream), …)`"
+                            ));
+                        }
                     }
                 }
             }

--- a/crates/ironbus-storage/src/streamset.rs
+++ b/crates/ironbus-storage/src/streamset.rs
@@ -348,7 +348,9 @@ impl<F: Filesystem + Clone, C: Clock + Clone> StreamSet<F, C> {
         clock: C,
         config: LogConfig,
     ) -> Result<OpenedStreamSet<F, C>, StorageError> {
-        Self::open_inner(fs, clock, config, AtRestCrypto::default())
+        // The unfiltered open = every named stream on disk (`|_| true`), which is exactly the
+        // single-shard broker's set. Byte-for-byte the historical single-log/StreamSet open.
+        Self::open_inner(fs, clock, config, AtRestCrypto::default(), |_| true)
     }
 
     /// Opens (recovering, or creating fresh) the whole stream set with LIVE at-rest AEAD encryption
@@ -367,7 +369,13 @@ impl<F: Filesystem + Clone, C: Clock + Clone> StreamSet<F, C> {
         crypto: Option<std::sync::Arc<crate::crypto::SegmentCrypto>>,
         keyring: Option<std::sync::Arc<crate::crypto::KeyRing>>,
     ) -> Result<OpenedStreamSet<F, C>, StorageError> {
-        Self::open_inner(fs, clock, config, AtRestCrypto::new(crypto, keyring))
+        Self::open_inner(
+            fs,
+            clock,
+            config,
+            AtRestCrypto::new(crypto, keyring),
+            |_| true,
+        )
     }
 
     /// Opens the whole stream set with a pre-built [`AtRestCrypto`] context (#780 phase 3, the serve
@@ -386,16 +394,60 @@ impl<F: Filesystem + Clone, C: Clock + Clone> StreamSet<F, C> {
         config: LogConfig,
         at_rest: AtRestCrypto,
     ) -> Result<OpenedStreamSet<F, C>, StorageError> {
-        Self::open_inner(fs, clock, config, at_rest)
+        Self::open_inner(fs, clock, config, at_rest, |_| true)
     }
 
-    /// The shared body behind [`StreamSet::open`] and [`StreamSet::open_encrypted`]: opens every
-    /// stream's log with the SAME at-rest context.
-    fn open_inner(
+    /// Opens ONE APPEND SHARD's slice of the stream set (#811, C7 — the recovery partition): the
+    /// DEFAULT stream `""` root log PLUS only those NAMED streams under `streams/<hex(name)>/` for
+    /// which `should_open(name)` is `true`. A shard passes `|name| shard_of(name, K) == shard_index`,
+    /// so each shard recovers ONLY the named streams it owns, in parallel, with per-stream isolation
+    /// fully preserved — a torn segment in one shard's stream cannot touch a stream a sibling shard
+    /// owns. The union of every shard's `should_open` subset is the whole on-disk named set, so no
+    /// stream is dropped and none is double-opened (`shard_of` is a total function into `0..K`).
+    ///
+    /// This is the storage primitive behind the append-actor sharding recovery plumbing; it is
+    /// deliberately AGNOSTIC to `shard_of` (which lives in the server crate), taking a plain name
+    /// predicate so the storage layer never depends on the routing hash. `shard_of` is recomputed at
+    /// every open and NEVER persisted, so the hash algorithm can change freely between runs — only its
+    /// stability WITHIN one boot matters, which a pure function of the name trivially gives.
+    ///
+    /// ## Inert at K = 1
+    /// With one append shard (the default and, until the owner-gated C8 flip, the only runtime mode)
+    /// the predicate is `|_| true` (shard 0 owns every stream), so this opens the FULL set exactly as
+    /// [`StreamSet::open_with_at_rest`] — byte-for-byte. The filter is applied to the cheap, already
+    /// sorted serial enumeration BEFORE the parallel per-stream open, so at K = 1 the parallel open
+    /// receives the identical stream list and produces the identical recovered map, summaries, and LRU.
+    ///
+    /// ## Coordinator-owned root + globals (scope)
+    /// The DEFAULT `""` root log is opened here unconditionally because at K = 1 the sole shard IS the
+    /// coordinator (shard 0). The K > 1 topology where a LEAN shard (index > 0) skips the root log and
+    /// the global checkpoints (producer-seq / counters / bindings / txn) — leaving those to the
+    /// coordinator so they open ONCE — is the owner-gated C6/C8 flip and is NOT done here.
+    ///
+    /// # Errors
+    /// As [`StreamSet::open_with_at_rest`]: a [`StorageError`] from opening/recovering any stream in
+    /// this shard's subset (including the fail-closed layout-version check on the root) or from
+    /// enumerating `streams/`.
+    pub fn open_with_at_rest_for_shard<P: Fn(&str) -> bool>(
         fs: &F,
         clock: C,
         config: LogConfig,
         at_rest: AtRestCrypto,
+        should_open: P,
+    ) -> Result<OpenedStreamSet<F, C>, StorageError> {
+        Self::open_inner(fs, clock, config, at_rest, should_open)
+    }
+
+    /// The shared body behind [`StreamSet::open`], [`StreamSet::open_encrypted`], and
+    /// [`StreamSet::open_with_at_rest_for_shard`]: opens the root default stream plus every NAMED
+    /// stream for which `should_open(name)` holds, all with the SAME at-rest context. The unsharded
+    /// opens pass `|_| true` (open every named stream), byte-for-byte the historical behavior.
+    fn open_inner<P: Fn(&str) -> bool>(
+        fs: &F,
+        clock: C,
+        config: LogConfig,
+        at_rest: AtRestCrypto,
+        should_open: P,
     ) -> Result<OpenedStreamSet<F, C>, StorageError> {
         let mut streams = BTreeMap::new();
         let mut recoveries = BTreeMap::new();
@@ -419,11 +471,19 @@ impl<F: Filesystem + Clone, C: Clock + Clone> StreamSet<F, C> {
             // any stray/foreign directory (not a canonical hex stream name) exactly as before — it
             // never opens as a stream and never shadows a real one. `list_subdirs` is already sorted,
             // so `named` is in a deterministic order.
+            //
+            // #811 C7 recovery partition: retain ONLY the named streams THIS shard owns
+            // (`should_open(name)`). The filter runs on the cheap serial enumeration, BEFORE the
+            // parallel per-stream open below, so per-stream isolation and the deterministic order are
+            // untouched; a shard opens (and recovers) exactly its `shard_of` subset and no sibling's
+            // stream. At K = 1 `should_open` is `|_| true`, so `named` is the full sorted list and the
+            // parallel open, recovered map, summaries, and LRU are byte-for-byte the historical set.
             let named: Vec<(StreamId, String)> = streams_fs
                 .list_subdirs()
                 .map_err(StorageError::Io)?
                 .into_iter()
                 .filter_map(|dir| parse_stream_subdir_name(&dir).map(|name| (StreamId(name), dir)))
+                .filter(|(id, _)| should_open(id.name()))
                 .collect();
             // Open every named stream's INDEPENDENT log at streams/<dir>/ in PARALLEL across a
             // bounded worker set (#822). Each open recovers over its own durable bytes alone: a torn
@@ -1746,6 +1806,150 @@ mod tests {
             assert_eq!(read.len(), read_b.len());
             assert_eq!(&*read[i].payload, &*read_b[i].payload);
         }
+    }
+
+    // ============= #811 C7: the append-shard RECOVERY PARTITION (inert at K = 1) =============
+    //
+    // `open_with_at_rest_for_shard` opens ONLY the named streams a shard owns. These tests prove the
+    // partition is exact (each shard opens precisely its predicate subset, per-stream isolation
+    // preserved), LOSSLESS (the union of every shard's subset is the whole on-disk set and the total
+    // recovered record count equals the pre-crash total), and byte-for-byte the unsharded open at
+    // K = 1. `shard_of` lives in the server crate; the storage primitive takes a bare name predicate,
+    // so the test mirrors the server's hash locally (same `DefaultHasher`, same `""`/K<=1 pins) to
+    // drive a realistic, TOTAL partition into `0..K`.
+
+    /// The storage twin of the server's `shard_of` (a NAMED stream hashes its name bytes with the same
+    /// `DefaultHasher`, and K <= 1 pins to shard 0), used ONLY to drive a realistic total partition in
+    /// these tests — the storage crate itself never knows the routing hash.
+    fn shard_of_name(name: &str, shards: usize) -> usize {
+        use core::hash::{Hash, Hasher};
+        if shards <= 1 || name.is_empty() {
+            return 0;
+        }
+        let mut h = std::collections::hash_map::DefaultHasher::new();
+        name.as_bytes().hash(&mut h);
+        usize::try_from(h.finish() % shards as u64).unwrap_or(0)
+    }
+
+    /// THE RECOVERY-PARTITION TEST. A data dir holding the default stream plus 12 named streams (each
+    /// with a distinct record count) is recovered SHARD BY SHARD for K in {1, 2, 4}: each shard opens
+    /// exactly its `shard_of` subset, holds each of its streams' OWN records (isolation), and the
+    /// shards together recover every stream exactly once and every record exactly once (the union is
+    /// the whole pre-crash set). At K = 1 the single shard's set is byte-for-byte the unsharded open.
+    #[test]
+    #[allow(clippy::too_many_lines)] // one cohesive K in {1,2,4} partition sweep; splitting hurts clarity
+    fn each_shard_recovers_exactly_its_shard_of_subset_union_is_lossless() {
+        let fs = InMemoryFs::new();
+        let def = StreamId::default_stream();
+        // 12 named streams, stream i carrying i + 1 records tagged with its index, so a mis-partitioned
+        // (wrong-shard) or mis-assembled recovery surfaces as a wrong record count or wrong bytes.
+        let ids: Vec<StreamId> = (0..12)
+            .map(|i| StreamId::named(&format!("s{i:02}")).unwrap())
+            .collect();
+        let expected_records: BTreeMap<StreamId, usize> = ids
+            .iter()
+            .enumerate()
+            .map(|(i, id)| (id.clone(), i + 1))
+            .collect();
+        let total_named_records: usize = expected_records.values().sum();
+        {
+            let (mut set, _) = open(&fs);
+            for id in &ids {
+                set.declare(id).unwrap();
+            }
+            set.append_to(&def, &rec(b"default")).unwrap();
+            for (i, id) in ids.iter().enumerate() {
+                for r in 0..=i {
+                    set.append_to(id, &rec(format!("{}-r{r}", id.name()).as_bytes()))
+                        .unwrap();
+                }
+            }
+            set.sync_all().unwrap();
+        }
+
+        // The unsharded (K = 1) baseline set: the whole named set, default-first, deterministic.
+        let (baseline, _) = open(&fs);
+        let baseline_ids = baseline.stream_ids();
+
+        for k in [1usize, 2, 4] {
+            let mut union_named: BTreeMap<StreamId, usize> = BTreeMap::new();
+            let mut recovered_named_records = 0usize;
+
+            for idx in 0..k {
+                let (shard, recoveries) = StreamSet::open_with_at_rest_for_shard(
+                    &fs,
+                    ManualClock::new(),
+                    cfg(),
+                    AtRestCrypto::default(),
+                    |name| shard_of_name(name, k) == idx,
+                )
+                .unwrap();
+
+                // Every shard opens the default `""` root (coordinator-owned; unconditional).
+                assert!(
+                    shard.is_open(&def),
+                    "K={k} shard {idx} opens the default root"
+                );
+                assert!(recoveries[&def].loss_report.is_empty());
+
+                for id in shard.stream_ids() {
+                    if id.is_default() {
+                        continue;
+                    }
+                    // (a) EXACT partition: a named stream this shard opened MUST hash to this shard.
+                    assert_eq!(
+                        shard_of_name(id.name(), k),
+                        idx,
+                        "K={k} shard {idx} opened {} which is NOT in its shard_of subset",
+                        id.name()
+                    );
+                    // (b) ISOLATION: the stream holds exactly its OWN records, recovered clean.
+                    assert!(
+                        recoveries[&id].loss_report.is_empty(),
+                        "{} clean",
+                        id.name()
+                    );
+                    let read = shard.read_range(&id, Offset::ZERO, 1000, None).unwrap();
+                    let want = expected_records[&id];
+                    assert_eq!(
+                        read.len(),
+                        want,
+                        "{} recovered its own record count",
+                        id.name()
+                    );
+                    assert_eq!(&*read[0].payload, format!("{}-r0", id.name()).as_bytes());
+                    recovered_named_records += read.len();
+                    // (c) No double-open across shards.
+                    assert!(
+                        union_named.insert(id.clone(), read.len()).is_none(),
+                        "K={k}: {} was opened by more than one shard",
+                        id.name()
+                    );
+                }
+            }
+
+            // (d) LOSSLESS union: every named stream recovered exactly once, every record once.
+            assert_eq!(
+                union_named.keys().cloned().collect::<Vec<_>>(),
+                ids,
+                "K={k}: the union of the shard subsets is the whole named set"
+            );
+            assert_eq!(
+                recovered_named_records, total_named_records,
+                "K={k}: total recovered records equals the pre-crash total"
+            );
+        }
+
+        // (e) BYTE-FOR-BYTE at K = 1: the single shard's set equals the unsharded open exactly.
+        let (single_shard, _) = StreamSet::open_with_at_rest_for_shard(
+            &fs,
+            ManualClock::new(),
+            cfg(),
+            AtRestCrypto::default(),
+            |_| true,
+        )
+        .unwrap();
+        assert_eq!(single_shard.stream_ids(), baseline_ids);
     }
 
     // ======================= M2-I4 (#565): the max_open_streams hot-set LRU =======================


### PR DESCRIPTION
## This PR is INERT at K=1 — BYTE-FOR-BYTE, ZERO runtime change

`append_shards` defaults to **1** (and, until the owner-gated C8 flip, K=1 is the **only** runtime mode). At K=1 every seam this PR lands collapses to today's single-actor engine:

- `with_on_shard(0, f)` forwards to today's `engine.with(f)`
- `shard_of("")` and `shard_of(name)` both resolve to shard 0 while `shard_count() == 1`
- the shard-filtered recovery open with the coordinator predicate `|_| true` opens the exact same set as today's `StreamSet::open`

No second actor is spawned. The whole change is byte-for-byte identical at runtime. That is what makes it safe to land now: it completes and de-risks the routing/recovery plumbing so the future K>1 flip is a single small commit.

## What this PR lands

Phase-1 of #811 (shard the single append actor by stream-id — the write-plane multi-core lever). Across the branch:

- **Routing seam (C2):** every per-named-stream verb in `session.rs` is dispatched through `with_on_shard(shard_of(&stream), …)` instead of plain `with`, guarded by a **route-completeness test** (`every_named_stream_verb_routes_through_with_on_shard`) that fails if any enumerated per-stream verb regresses to plain `with`.
- **Subject off-actor resolve (C3):** subject publishes resolve their covering stream off the actor, then route.
- **Shared-WAL shards=1 guard (C4):** a shared-WAL broker cannot shard (all named streams share one physical commit log); `resolve_append_shards` forces 1 and fail-closed rejects an explicit `--append-shards > 1` + shared-WAL, verified by `shared_wal_engine_reports_one_append_shard_and_named_produces_route_to_shard_zero`.
- **Shard-filtered recovery (C7 — this commit):** `StreamSet::open_with_at_rest_for_shard(…, should_open)` recovers only the named streams a shard owns (predicate `|name| shard_of(name, K) == shard_index`), in parallel, per-stream isolation preserved. The storage layer stays agnostic to `shard_of` (a bare name predicate). `Engine::open` drives it with the coordinator (shard-0-of-1) `|_| true` predicate, so the production open path exercises the partition seam at K=1 while opening the full set. `known_named_streams` is seeded per-shard-subset (at K=1 = the full set). `shard_of` is recomputed at open and never persisted (only within-run stability matters). No global offset reconcile.

### C7 tests
- `ironbus-storage::each_shard_recovers_exactly_its_shard_of_subset_union_is_lossless` — recovers a 12-named-stream dir shard-by-shard for K ∈ {1,2,4}: each shard opens exactly its predicate subset (per-stream isolation: each stream holds its own records), the union of the shard subsets is the whole named set, total recovered records == pre-crash, and at K=1 the single shard's set is byte-for-byte the unsharded open.
- `ironbus-server::shard_of_partitions_named_stream_recovery_losslessly` — the same lossless-partition property driven by the **real** `crate::actor::shard_of` hash over a real on-disk named set.

### Portability fix (C1 follow-up)
C1 (`256e049`) added a `to_engine()` / `AppendShards` / `resolve_append_shards` call into the **cross-platform** serve-flags parser while those symbols stayed `#[cfg(unix)]`, breaking `cargo check --target x86_64-pc-windows-gnu`. Those symbols are platform-neutral pure logic (same pattern as `DurabilityLevelArg`/`StorageModeArg`), so this un-gates them; only the actor **spawn** stays Unix-only. cfg-only, zero runtime change on the (Unix) broker.

## Owner-gated follow-ups (NOT in this PR)
- **C8 — the K>1 FLIP:** the actual throughput win (spawn K actors). Gated on sign-off + a **t4g thread-per-core multi-stream throughput bench** as acceptance (a single `""` stream sees no benefit; the win is multi-stream / multi-tenant).
- **C5 — txn cross-shard disposition:** route commit to `shard_of(target)` keeping the A3-fsync-before-B-op-marker commit point, vs restricting txn targets to shard-0. A genuine design decision — left for the owner.
- **C6 — per-shard global-state split + dedup re-key:** the lean-shard split that has index>0 shards skip the root log + the global producer-seq/counters/bindings/txn checkpoints (so the coordinator opens them once), plus the dedup re-key contract. A genuine design decision — left for the owner.

## Gates (all green, run in the Linux container, `--all-features`)
- `cargo test --workspace --all-features --locked` — 0 failed (incl. route-completeness, shared-WAL guard, and both C7 recovery tests)
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- `sh scripts/check-format-registry.sh` — byte-identical digest (no on-disk format change)
- `cargo deny check` — advisories/bans/licenses/sources ok
- `cargo tree --all-features -i ring` — EMPTY (no `ring` in the graph)
- golden-path acceptance gate — PASS
- `cargo check --target x86_64-pc-windows-gnu` — clean

No wire/format/proto/registry change. No new dependency (`Cargo.lock` / `Cargo.toml` / `deny.toml` unchanged).

Refs #811. **DO NOT MERGE** — hold for review.
