### PR TITLE
fix(iceberg-sink): fsync data/ dir before metadata commit + robustness (#1151)

### DIFF
--- a/tools/iceberg-sink/src/table.rs
+++ b/tools/iceberg-sink/src/table.rs
@@ -19,14 +19,22 @@
 //! ## Atomic commit + resume/dedup
 //!
 //! A batch commit writes, in order: the Parquet data file, the manifest, the manifest list, the new
-//! `v{N}.metadata.json`, and finally an ATOMIC rename of `version-hint.text` to `N`. Everything the
-//! new metadata references exists and is fsynced before the pointer flips, so a crash mid-commit
-//! leaves the table valid at the previous version (orphaned files are harmless). Each snapshot's
-//! summary records `ironbus.next-offset` (the exclusive high offset the table now covers); that is
-//! the sink's authoritative resume point AND dedup watermark — [`IcebergTable::append`] drops any
-//! record at or below it, so an at-least-once redelivery can never duplicate a row.
+//! `v{N}.metadata.json`, and finally an ATOMIC rename of `version-hint.text` to `N`. Crash-safety
+//! rests on the classic "fsync the file, THEN fsync its parent directory, before writing the pointer
+//! that references it" discipline: every file the new metadata transitively references — the Parquet
+//! data file, the manifest, the manifest list, and `v{N}.metadata.json` — has both its CONTENTS and
+//! its parent DIRECTORY ENTRY fsynced to disk BEFORE the `version-hint.text` rename that publishes
+//! them, and the rename itself is then made durable by a final fsync of its directory. So a crash
+//! mid-commit leaves the table valid at the previous version (orphaned files are harmless) and can
+//! never leave the published pointer chain referencing a file whose dirent a power-loss dropped —
+//! the failure that would otherwise cost committed rows the broker cursor has already advanced past.
+//! See [`IcebergTable::append`] (data + manifest fsyncs) and [`IcebergTable::commit_metadata`] (the
+//! metadata/version-hint publish) for the exact ordering. Each snapshot's summary records
+//! `ironbus.next-offset` (the exclusive high offset the table now covers); that is the sink's
+//! authoritative resume point AND dedup watermark — [`IcebergTable::append`] drops any record at or
+//! below it, so an at-least-once redelivery can never duplicate a row.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs::{File, OpenOptions};
 use std::io::Write as _;
 use std::path::Path;
@@ -251,14 +259,23 @@ impl IcebergTable {
             .ok_or_else(|| anyhow!("offset overflow"))?;
 
         let commit_uuid = Uuid::new_v4();
-        let snapshot_id = new_snapshot_id();
+        // Never reuse a snapshot id already in this table (Iceberg requires them unique) and never 0.
+        let existing_ids: HashSet<i64> =
+            self.metadata.snapshots().map(|s| s.snapshot_id()).collect();
+        let snapshot_id = new_snapshot_id(&existing_ids);
         let next_seq = self.metadata.next_sequence_number();
         let schema_ref = self.metadata.current_schema().clone();
         let spec = self.metadata.default_partition_spec().as_ref().clone();
 
-        // 1. Parquet data file.
+        // 1. Parquet data file. `write_parquet` fsyncs the file's CONTENTS; here we additionally make
+        //    its DIRENT durable by fsyncing the data/ directory, BEFORE any pointer (manifest ->
+        //    metadata -> the published version-hint) references it. A file-content fsync alone does
+        //    not guarantee the parent directory's new entry survives a power loss on every FS; without
+        //    this a committed metadata could reference a data file whose dirent was lost, yielding an
+        //    unreadable table and rows lost past the already-advanced broker cursor.
         let data_path = format!("{}/data/{commit_uuid}.parquet", self.location);
         let size = write_parquet(&data_path, &fresh).context("writing the Parquet data file")?;
+        fsync_dir(&format!("{}/data", self.location)).context("fsyncing the data directory")?;
         let data_file = DataFileBuilder::default()
             .content(DataContentType::Data)
             .file_path(data_path)
@@ -285,6 +302,9 @@ impl IcebergTable {
             .rt
             .block_on(mw.write_manifest_file())
             .context("writing the manifest file")?;
+        // The async opendal writer returns a path, not a synced handle: fsync the manifest's contents
+        // now. Its DIRENT is made durable with the rest of metadata/ at the commit point below.
+        fsync_file(&manifest_path).context("fsyncing the manifest file")?;
 
         // 3. Manifest list (Avro): carry forward every manifest from the parent snapshot, then add
         //    the new one, so the snapshot references the FULL set of live data (the append bug that
@@ -317,6 +337,8 @@ impl IcebergTable {
         self.rt
             .block_on(mlw.close())
             .context("writing the manifest list")?;
+        // Fsync the manifest list's contents (same reason as the manifest above).
+        fsync_file(&ml_path).context("fsyncing the manifest list")?;
 
         // 4. Snapshot, recording the durable resume watermark in its summary.
         let mut props = HashMap::new();
@@ -365,21 +387,36 @@ impl IcebergTable {
         Ok(fresh.len())
     }
 
-    /// Writes `v{version}.metadata.json` (fsynced), then atomically renames `version-hint.text` to
-    /// point at it (the commit point). Returns the metadata file path.
+    /// Persists `v{version}.metadata.json` and then atomically publishes it by renaming
+    /// `version-hint.text` over it — the table's commit point. The ordering is crash-safe and
+    /// FAIL-CLOSED:
+    ///
+    /// 1. write + fsync `v{version}.metadata.json`'s contents;
+    /// 2. fsync the `metadata/` directory, so the new metadata.json AND the manifest / manifest-list
+    ///    files [`IcebergTable::append`] already wrote there have durable DIRENTS — everything the
+    ///    pointer is about to reference now survives a crash;
+    /// 3. write + fsync a temp `version-hint.text`, then atomically rename it over the real one;
+    /// 4. fsync the `metadata/` directory again, so the rename (the publish) is itself durable.
+    ///
+    /// A directory fsync that cannot be performed FAILS the commit rather than being silently skipped:
+    /// on a data-integrity path a missing dirent-fsync is exactly the durability hole being closed.
+    /// Returns the metadata file path.
     fn commit_metadata(&self, version: u64, md: &TableMetadata) -> Result<String> {
-        let meta_path = format!("{}/metadata/v{version}.metadata.json", self.location);
+        let meta_dir = format!("{}/metadata", self.location);
+        let meta_path = format!("{meta_dir}/v{version}.metadata.json");
         let json = serde_json::to_vec_pretty(md).context("serializing table metadata")?;
         write_fsync(&meta_path, &json)?;
 
-        let hint = format!("{}/metadata/version-hint.text", self.location);
+        // Make the metadata.json + manifest + manifest-list DIRENTS durable BEFORE publishing the
+        // pointer that references them.
+        fsync_dir(&meta_dir).context("fsyncing the metadata directory before publish")?;
+
+        let hint = format!("{meta_dir}/version-hint.text");
         let tmp = format!("{hint}.tmp.{}", Uuid::new_v4());
         write_fsync(&tmp, version.to_string().as_bytes())?;
         std::fs::rename(&tmp, &hint).context("atomically swapping version-hint.text")?;
-        // fsync the metadata directory so the rename + new files are durable.
-        if let Ok(dir) = File::open(format!("{}/metadata", self.location)) {
-            let _ = dir.sync_all();
-        }
+        // Make the rename itself (the commit point) durable.
+        fsync_dir(&meta_dir).context("fsyncing the metadata directory after publish")?;
         Ok(meta_path)
     }
 }
@@ -455,6 +492,26 @@ fn write_fsync(path: &str, bytes: &[u8]) -> Result<()> {
     Ok(())
 }
 
+/// Fsyncs a directory so a newly created or renamed entry inside it is durable. FAIL-CLOSED: on the
+/// data-integrity commit path a directory-fsync failure must fail the commit, never be skipped — a
+/// lost dirent for a file the committed metadata references is exactly the power-loss hole this
+/// closes. Opening the directory read-only and calling `fsync` on it is the portable POSIX idiom.
+fn fsync_dir(path: &str) -> Result<()> {
+    let dir = File::open(path).with_context(|| format!("opening directory {path} for fsync"))?;
+    dir.sync_all()
+        .with_context(|| format!("fsyncing directory {path}"))?;
+    Ok(())
+}
+
+/// Fsyncs an already-written file's CONTENTS by path. The async manifest / manifest-list writers hand
+/// back only a path (not a synced handle) and may not fsync themselves, so the sink fsyncs them here;
+/// their dirents are then made durable together with the enclosing directory at the commit point.
+fn fsync_file(path: &str) -> Result<()> {
+    let f = File::open(path).with_context(|| format!("opening {path} for fsync"))?;
+    f.sync_all().with_context(|| format!("fsyncing {path}"))?;
+    Ok(())
+}
+
 fn write_parquet(path: &str, records: &[&Record]) -> Result<u64> {
     let schema = arrow_schema();
     let offsets = Int64Array::from(records.iter().map(|r| r.offset).collect::<Vec<_>>());
@@ -498,10 +555,19 @@ fn now_ms() -> i64 {
         .map_or(0, |d| d.as_millis() as i64)
 }
 
-fn new_snapshot_id() -> i64 {
-    let (a, b) = Uuid::new_v4().as_u64_pair();
-    let id = (a ^ b) as i64;
-    id.saturating_abs()
+/// Generates a fresh snapshot id: 128 bits of UUID entropy folded to a positive 63-bit value. A
+/// collision is astronomically unlikely, but the loop turns "unique and non-zero" from a probability
+/// into a guarantee — Iceberg requires snapshot ids unique within a table, and `0` is the
+/// nil/degenerate id some readers treat as "no snapshot". Re-rolls on `0` or a collision with an
+/// existing id.
+fn new_snapshot_id(existing: &HashSet<i64>) -> i64 {
+    loop {
+        let (a, b) = Uuid::new_v4().as_u64_pair();
+        let id = ((a ^ b) as i64).saturating_abs();
+        if id != 0 && !existing.contains(&id) {
+            return id;
+        }
+    }
 }
 
 #[cfg(test)]
@@ -600,5 +666,131 @@ mod tests {
         let mut t = IcebergTable::open_or_create(loc, 0).unwrap();
         let bad = vec![mk(0), mk(2), mk(2)];
         assert!(t.append(&bad).is_err());
+    }
+
+    /// Walks the CURRENT metadata graph (version-hint -> metadata.json -> manifest-list -> manifests)
+    /// and returns every live data-file path it references — the files whose dirents FIX 1 makes
+    /// durable before the metadata that points at them is published.
+    fn referenced_data_files(location: &str) -> Vec<String> {
+        let hint =
+            std::fs::read_to_string(format!("{location}/metadata/version-hint.text")).unwrap();
+        let version: u64 = hint.trim().parse().unwrap();
+        let md: TableMetadata = serde_json::from_slice(
+            &std::fs::read(format!("{location}/metadata/v{version}.metadata.json")).unwrap(),
+        )
+        .unwrap();
+        let snap = md
+            .current_snapshot()
+            .expect("a committed table has a current snapshot");
+        let ml = ManifestList::parse_with_version(
+            &std::fs::read(snap.manifest_list()).unwrap(),
+            FormatVersion::V2,
+        )
+        .unwrap();
+        let mut out = Vec::new();
+        for entry in ml.entries() {
+            let man =
+                iceberg::spec::Manifest::parse_avro(&std::fs::read(&entry.manifest_path).unwrap())
+                    .unwrap();
+            for e in man.entries() {
+                if e.is_alive() {
+                    out.push(e.data_file().file_path().to_string());
+                }
+            }
+        }
+        out
+    }
+
+    /// The commit-ordering durability invariant, verified functionally (FIX 1). After commits return
+    /// and the writer is DROPPED — so only the durable on-disk state remains — the table opened COLD
+    /// through its public Iceberg reference chain reads back EXACTLY the committed rows, and every
+    /// data file the metadata references is present on disk. This is precisely what the "fsync the
+    /// data/ dirent (and each manifest) before publishing the metadata that points at it" ordering
+    /// guarantees: a lost data-file dirent would make the cold scan fail to open the file or drop its
+    /// rows. (A syscall-order recording FS is not available across both std::fs and iceberg's async
+    /// opendal writer, so this cold read-back + reachability check is the invariant's proof; the exact
+    /// fsync ordering is documented on `append`/`commit_metadata`.)
+    #[test]
+    fn committed_table_reads_back_all_rows_and_referenced_files_exist() {
+        let dir = tempfile::tempdir().unwrap();
+        let loc = dir.path().to_str().unwrap();
+        {
+            let mut t = IcebergTable::open_or_create(loc, 0).unwrap();
+            t.append(&(0..5).map(mk).collect::<Vec<_>>()).unwrap();
+            t.append(&(5..11).map(mk).collect::<Vec<_>>()).unwrap();
+        } // writer dropped: nothing in memory, only what was fsynced survives
+
+        let mut got = scan_offsets(loc).unwrap();
+        got.sort_unstable();
+        assert_eq!(
+            got,
+            (0..11).collect::<Vec<_>>(),
+            "cold read through the metadata chain must return exactly the committed rows"
+        );
+
+        let referenced = referenced_data_files(loc);
+        assert_eq!(
+            referenced.len(),
+            2,
+            "two appends -> two data files referenced"
+        );
+        for path in referenced {
+            assert!(
+                Path::new(&path).exists(),
+                "data file {path} referenced by committed metadata must exist on disk"
+            );
+        }
+
+        // The durable resume watermark also survives a cold reopen.
+        let t2 = IcebergTable::open_or_create(loc, 999).unwrap();
+        assert_eq!(t2.next_offset(), 11);
+        assert_eq!(t2.version(), 2);
+    }
+
+    /// FIX 2: `new_snapshot_id` never yields 0 and never collides with an id already in the set.
+    #[test]
+    fn new_snapshot_id_is_nonzero_and_unique() {
+        let mut seen: HashSet<i64> = HashSet::new();
+        for _ in 0..20_000 {
+            let id = new_snapshot_id(&seen);
+            assert!(
+                id > 0,
+                "snapshot id must be positive and non-zero, got {id}"
+            );
+            assert!(
+                seen.insert(id),
+                "new_snapshot_id must not return an id already in the set"
+            );
+        }
+        // The guard must re-roll away from a preloaded id: seed the set with a value and confirm the
+        // generator never hands it (or 0) back.
+        let mut preset: HashSet<i64> = HashSet::new();
+        preset.insert(0);
+        let forced = new_snapshot_id(&preset);
+        preset.insert(forced);
+        for _ in 0..1000 {
+            let id = new_snapshot_id(&preset);
+            assert_ne!(id, 0);
+            assert_ne!(id, forced);
+            preset.insert(id);
+        }
+    }
+
+    /// FIX 2: across many real appends the snapshot ids recorded in metadata stay distinct and
+    /// non-zero (the collision/zero guard holds end-to-end, not just in isolation).
+    #[test]
+    fn snapshot_ids_across_appends_are_distinct_and_nonzero() {
+        let dir = tempfile::tempdir().unwrap();
+        let loc = dir.path().to_str().unwrap();
+        let mut t = IcebergTable::open_or_create(loc, 0).unwrap();
+        for i in 0..8 {
+            let batch: Vec<Record> = (i * 4..i * 4 + 4).map(mk).collect();
+            t.append(&batch).unwrap();
+        }
+        let ids: Vec<i64> = t.metadata.snapshots().map(|s| s.snapshot_id()).collect();
+        assert_eq!(ids.len(), 8, "one snapshot per append");
+        assert!(ids.iter().all(|&id| id != 0), "no snapshot id may be 0");
+        let uniq: HashSet<i64> = ids.iter().copied().collect();
+        assert_eq!(uniq.len(), ids.len(), "all snapshot ids must be distinct");
     }
 }


### PR DESCRIPTION
Durability + robustness hardening for the standalone Iceberg/Parquet sink connector (`tools/iceberg-sink`, an **excluded** workspace with its own lockfile). The broker and its dependency graph are untouched. Addresses the non-blocking items the #1150 review flagged (tracked in #1151); the O(N^2) growth item is split into a focused follow-up (#1179).

## FIX 1 — crash-safety: fsync every dirent before the pointer that references it (the real bug)
The Parquet file's **contents** were fsynced but its `data/` **dirent** was not, while `metadata/` was. On a hard power loss on a filesystem that does not persist a new file's dirent on file-fsync, a committed `version-hint -> metadata` could point at a data file whose dirent was lost → an unreadable table with rows lost past the already-advanced broker consume cursor.

The commit path now enforces the full "fsync the file, then fsync its parent dir, before the referencing pointer" discipline. **Exact final ordering:**

1. write Parquet data file → **fsync file contents** (`write_parquet`)
2. **fsync `data/` dir** (the new data-file dirent is durable before anything references it)
3. write manifest (`.avro`) → **fsync manifest contents**
4. write manifest list (`.avro`) → **fsync manifest-list contents**
5. write `v{N}.metadata.json` → **fsync its contents**
6. **fsync `metadata/` dir** → the metadata.json + manifest + manifest-list **dirents** are durable *before* the pointer is published
7. write `version-hint.text.tmp` → **fsync its contents** → **atomic rename** over `version-hint.text` (the commit point)
8. **fsync `metadata/` dir again** → the rename itself is durable

The async opendal manifest/manifest-list writers return only a path (not a synced handle), so steps 3–4 fsync their contents explicitly; their dirents are made durable with the enclosing directory at step 6.

## FIX 2 — robustness guards (both done)
- **Fail-closed directory fsyncs.** `commit_metadata` previously did `if let Ok(dir) = open { let _ = dir.sync_all() }` — a silent skip on any failure. A new `fsync_dir` helper returns `Result`; every required dir fsync (`data/`, `metadata/` before publish, `metadata/` after publish) now **fails the commit** rather than being skipped.
- **`new_snapshot_id` guard.** It could theoretically return `0` or collide. It now takes the set of existing snapshot ids and re-rolls on `0` or a collision, so "unique and non-zero" is a guarantee, not a probability.

## FIX 3 — O(N^2) manifest/metadata growth: **DEFERRED to #1179**
Each commit rewrites the full manifest set and accumulates snapshots. This is **correctness-safe today** (growth only — a reader always sees a valid, complete table). A correctness-preserving compaction / expire-snapshots pass must itself be crash-safe over *this same durability seam*, so bundling it here would put the fix under review at risk. It is split into a focused follow-up (#1179) with explicit safety requirements (keep the current snapshot + configurable retention, never drop a manifest/file a retained snapshot needs, same fsync discipline).

## Tests (`tools/iceberg-sink/src/table.rs`)
- `committed_table_reads_back_all_rows_and_referenced_files_exist` — after commits the writer is **dropped** (only durable on-disk state remains) and the table is opened **cold** through its real Iceberg reference chain; it reads back exactly the committed rows and every data file the metadata references exists on disk. This is the FIX-1 invariant's functional proof. (A syscall-order recording FS is not available across both `std::fs` and iceberg's async opendal writer, so the exact ordering is documented on `append` / `commit_metadata` and asserted via cold read-back + reachability.)
- `new_snapshot_id_is_nonzero_and_unique` and `snapshot_ids_across_appends_are_distinct_and_nonzero` — the FIX-2 guard in isolation and end-to-end.

## Verification (Linux container, foreground, pipefail)
- `cargo test -p ironbus-iceberg-sink --locked` → **13 passed, 0 failed** (9 unit incl. 3 new + 1 integration skip), and again with `IRONBUS_BIN` set → the **live broker → sink → table → restart/resume** end-to-end passes through the modified commit path.
- `cargo clippy --all-targets --locked -- -D warnings` → clean; `cargo fmt --check` → clean.
- Broker supply-chain unaffected: **no lockfiles changed**, `cargo deny check` on the root workspace → `advisories ok, bans ok, licenses ok, sources ok`, and `cargo tree -p ironbus-cli` has **no arrow/parquet/iceberg/thrift/avro/opendal**.
- **DuckDB external query** of a sink-produced table (independent engine, iceberg extension): **13 rows, offsets 0–12, contiguous=true, no_duplicates=true, across 5 snapshots**.

Do not merge — please adversarially review the fsync-ordering durability seam first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
