### PR TITLE
fix(multi-tenant): txn back-check double-prefix + cross-tenant retention/group-name hardening (#1170)

### DIFF
--- a/crates/ironbus-cli/src/main.rs
+++ b/crates/ironbus-cli/src/main.rs
@@ -9507,7 +9507,7 @@ fn sleep_interruptible_cli(dur: std::time::Duration, shutdown: &std::sync::atomi
                                  // loop, the graceful drain); splitting it further would scatter a
                                  // single concern across helpers.
 fn run_broker<F: Filesystem + Clone + 'static>(
-    engine: Engine<F, SystemClock>,
+    mut engine: Engine<F, SystemClock>,
     addr: &str,
     data_dir: Option<&Path>,
     config: &ServeConfig,
@@ -9538,6 +9538,18 @@ fn run_broker<F: Filesystem + Clone + 'static>(
     // it only through the bounded-channel handle, so no handler holds a lock across an fsync. The
     // actor's join handle yields the engine back on its clean exit (a Shutdown drain), which is how
     // the graceful-shutdown cursor flush (#195) completes before the process exits 0.
+    //
+    // #1170 (ITEM 1): tell the engine whether CROSS-TENANT SHARING is configured (a non-empty
+    // import/export registry on the auth config). This GATES the cross-tenant retention-floor
+    // exclusion — set BEFORE the engine moves into the append actor. With no sharing (a single-tenant
+    // broker, or a tenant broker with no grants) it stays `false`, so NO consumer group is ever
+    // excluded from the reap floor and a legal `/`-in-name group keeps its full consumer-safe
+    // protection (the delimiter is an ordinary user character absent tenancy).
+    let cross_tenant_sharing_active = auth
+        .as_ref()
+        .and_then(|a| a.sharing())
+        .is_some_and(|s| !s.is_empty());
+    engine.set_cross_tenant_sharing_active(cross_tenant_sharing_active);
     let (shared, actor) =
         spawn_actor_with_gather(engine, DEFAULT_CHANNEL_BOUND, config.commit_gather_us);
     // Install the SHARED client produce-ack slot (#719) onto the base handle BEFORE any per-connection

--- a/crates/ironbus-server/src/engine.rs
+++ b/crates/ironbus-server/src/engine.rs
@@ -2463,6 +2463,15 @@ fn validate_group_name(name: &str) -> Result<(), EngineError> {
 /// must NOT pin the stream owner's consumer-safe retention reap floor (#1170, ITEM 1 — cross-tenant
 /// resource isolation).
 ///
+/// GATED, LOAD-BEARING PRECONDITION: this name test is meaningful ONLY when cross-tenant sharing is
+/// active (`Engine::cross_tenant_sharing_active`), which the sole caller
+/// ([`Engine::min_committed_offset_named`]) enforces. `/` is a fully legal, user-choosable character
+/// in stream AND group names on a single-tenant broker, so a bare name test with no tenancy gate
+/// would misclassify a single-tenant consumer group `b/g` on a stream `a/orders` as "foreign" and
+/// silently reap its unread records — a data-loss regression. The gate makes the test apply ONLY
+/// where tenancy's server-scoping invariant guarantees a same-tenant own group and its stream share
+/// the leading `<tenant>/` token; there, only a GENUINE cross-tenant guest differs.
+///
 /// A live cross-subscribe from a foreign importer keys its cursor on the EXPORTER's stream under an
 /// IMPORTER-scoped group name — `(<exporter>/stream, <importer>/group)` (see
 /// [`crate::session::Session::scope_group_under_self`]) — so on an `<exporter>/…` stream a foreign
@@ -2476,11 +2485,12 @@ fn validate_group_name(name: &str) -> Result<(), EngineError> {
 /// open. Because the classification is purely by NAME it also holds across a restart (a ghost
 /// `<importer>/…` checkpoint on the exporter's stream is excluded too), with no new durable state.
 ///
-/// Precision rests on the ITEM-4 wire-ingress guard: a SAME-tenant own group is a bare client name
-/// with NO `/`, so it can never be mistaken for a foreign `<importer>/…` cursor. Fail-closed toward
-/// DATA-SAFETY: when the group carries no `/` tenant token (an own group), or its token MATCHES the
-/// stream owner's (a pathological self-import stays same-tenant), it PINS — never wrongly reaped.
-/// Only the server-applied cross-tenant importer group is ever excluded.
+/// Under the active-sharing gate a SAME-tenant own group is a bare client name with NO `/` (a client
+/// group name may not carry `/`, enforced at the wire ingress — ITEM 4), so it can never be mistaken
+/// for a foreign `<importer>/…` cursor. Fail-closed toward DATA-SAFETY: when the group carries no `/`
+/// tenant token (an own group), or its token MATCHES the stream owner's (a pathological self-import
+/// stays same-tenant), it PINS — never wrongly reaped. Only the server-applied cross-tenant importer
+/// group is ever excluded, and only on a sharing-active broker.
 fn is_foreign_importer_group(stream_id: &str, group: &str) -> bool {
     // An own group is a bare client name (no `/`, guaranteed by the ITEM-4 ingress guard): it pins.
     let Some((group_owner, _)) = group.split_once(crate::tenant::STREAM_DELIM) else {
@@ -4150,6 +4160,17 @@ pub struct Engine<F: Filesystem, C: Clock> {
     /// configured ONCE via [`Engine::set_mirror_read_only_streams`] only when a `--mirror` is present, so
     /// a non-geo broker's produce path is byte-for-byte unchanged (a single `is_empty()` short-circuit).
     mirror_read_only: std::collections::BTreeSet<String>,
+    /// Whether CROSS-TENANT SHARING is configured on this broker (#1170, ITEM 1). `false` by default —
+    /// a single-tenant broker, or a multi-tenant broker with NO import/export grants — and set `true`
+    /// ONCE at serve time ([`Engine::set_cross_tenant_sharing_active`]) only when a non-empty
+    /// [`crate::tenant::SharingRegistry`] is wired. It GATES the cross-tenant retention-floor exclusion
+    /// in [`Engine::min_committed_offset_named`]: the `<importer>/…`-vs-`<exporter>/…` name test is only
+    /// meaningful when the server-scoping invariant actually holds (sharing implies tenancy, so a same-
+    /// tenant own group and its stream share the leading `<tenant>/` token and a genuine guest is the
+    /// only thing that differs). When `false`, `/` is an ordinary user-chosen character in stream and
+    /// group names, so NO group is EVER excluded from the reap floor — a single-tenant consumer group
+    /// named `b/g` on a stream `a/orders` keeps its full #566 consumer-safe protection (no silent loss).
+    cross_tenant_sharing_active: bool,
     /// The opt-in effectively-once dedup registry (#3, #33): the per-producer bounded windows of
     /// `(msg_id -> offset)`. Empty until a producer opts in by sending a `msg_id`, so a broker no
     /// producer dedups against costs nothing here. Consulted on the produce path (the actor thread,
@@ -5027,6 +5048,9 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
             // produce path is byte-for-byte unchanged. Configured once via
             // `set_mirror_read_only_streams` only when a `--mirror` is present.
             mirror_read_only: std::collections::BTreeSet::new(),
+            // Cross-tenant sharing is OFF until the serve path wires a non-empty SharingRegistry
+            // (#1170): a single-tenant broker never excludes a group from the reap floor.
+            cross_tenant_sharing_active: false,
             // The opt-in dedup registry (#33), sized by the configured window. Empty until a
             // producer opts in by sending a `msg_id`, so it costs nothing for a no-dedup workload.
             dedup: ironbus_core::dedup::DedupRegistry::new(config.dedup),
@@ -5311,6 +5335,23 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
     #[must_use]
     pub fn is_mirror_read_only(&self, stream: &str) -> bool {
         !self.mirror_read_only.is_empty() && self.mirror_read_only.contains(stream)
+    }
+
+    /// Declares whether CROSS-TENANT SHARING is configured on this broker (#1170, ITEM 1). Set `true`
+    /// ONCE at serve time when — and only when — a non-empty [`crate::tenant::SharingRegistry`] is wired
+    /// (which implies tenancy is active and the server-scoping invariant holds). It GATES the
+    /// cross-tenant retention-floor exclusion in [`Engine::min_committed_offset_named`]. With sharing
+    /// OFF (the default), `/` is an ordinary user character in stream/group names and NO group is ever
+    /// excluded from the reap floor, so a single-tenant `b/g`-on-`a/orders` consumer keeps its full
+    /// consumer-safe retention protection. Idempotent; a no-op cost on the produce path (a single bool).
+    pub fn set_cross_tenant_sharing_active(&mut self, active: bool) {
+        self.cross_tenant_sharing_active = active;
+    }
+
+    /// Whether cross-tenant sharing is active (test/introspection helper for the #1170 reap-floor gate).
+    #[must_use]
+    pub fn cross_tenant_sharing_active(&self) -> bool {
+        self.cross_tenant_sharing_active
     }
 
     /// The current key-compaction configuration (#337). Disabled by default. Read-only echo for the
@@ -11690,15 +11731,23 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         // #1170 (ITEM 1): a FOREIGN cross-tenant importer's guest cursor (`<importer>/…` on this
         // `<exporter>/…` stream) is EXCLUDED from the exporter's reap floor at every source below —
         // live groups, durable ghosts, AND parked ephemeral offsets — so a dead/lagging importer can
-        // never pin the exporter's retention reclamation (see `is_foreign_importer_group`). A same-
-        // tenant own group (bare name, no `/`) is never excluded, so consumer-safety within the
-        // exporter's own tenant is unchanged.
+        // never pin the exporter's retention reclamation (see `is_foreign_importer_group`).
+        //
+        // GATED on `cross_tenant_sharing_active`: the `<importer>/…`-vs-`<exporter>/…` name test is
+        // ONLY consulted when cross-tenant sharing is configured, i.e. when the server-scoping
+        // invariant actually holds and a same-tenant own group is guaranteed `/`-free. On a SINGLE-
+        // tenant broker (or a multi-tenant broker with no sharing grants) `/` is an ordinary user-
+        // chosen character in stream and group names, so the gate is OFF and NO group is ever
+        // excluded — a single-tenant consumer group named `b/g` on a stream `a/orders` keeps its full
+        // #566 consumer-safe protection (no silent reap of its unread records).
         let stream_name = id.name();
+        let sharing = self.cross_tenant_sharing_active;
+        let is_guest = |group: &str| sharing && is_foreign_importer_group(stream_name, group);
         let parked = self
             .ephemeral_subs
             .iter()
             .filter(|((sid, _), _)| sid == id)
-            .filter(|((_, group), _)| !is_foreign_importer_group(stream_name, group.as_str()))
+            .filter(|((_, group), _)| !is_guest(group.as_str()))
             .filter_map(|(_, sub)| sub.parked_committed);
         let Some(ns) = self.named_streams.get(id) else {
             // No resident consumer state: only a parked ephemeral position (if any) can pin; with
@@ -11710,14 +11759,14 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         let live = ns
             .groups
             .iter()
-            .filter(|(name, _)| !is_foreign_importer_group(stream_name, name.as_str()))
+            .filter(|(name, _)| !is_guest(name.as_str()))
             .filter(|(_, g)| g.touched)
             .map(|(_, g)| g.cursor.committed().get());
         let ghosts = ns
             .group_last_checkpointed
             .iter()
             .filter(|(name, _)| !ns.groups.contains_key(name.as_str()))
-            .filter(|(name, _)| !is_foreign_importer_group(stream_name, name.as_str()))
+            .filter(|(name, _)| !is_guest(name.as_str()))
             .map(|(_, &committed)| committed);
         live.chain(ghosts).chain(parked).min().unwrap_or(head)
     }
@@ -32293,22 +32342,22 @@ mod tests {
     }
 
     #[test]
-    fn a_foreign_cross_tenant_importer_group_is_excluded_from_the_exporters_reap_floor() {
-        // #1170 (ITEM 1): a lagging/dead cross-tenant IMPORTER group on the EXPORTER's stream must
-        // NOT pin the exporter's consumer-safe retention reap floor — otherwise a foreign importer
-        // holds the exporter's disk hostage (a cross-tenant availability/DoS vector). A live cross-
-        // subscribe keys its guest cursor `(<exporter>/stream, <importer>/group)`, so on stream
-        // "a/orders" a foreign group is named "b/g" (a leading tenant token differing from the
-        // stream owner "a"); the exporter's OWN group is a bare client name (no '/', guaranteed by
-        // the ITEM-4 ingress guard) and still pins. See `is_foreign_importer_group`.
-        //
-        // Retention OFF here so nothing reaps DURING production; this isolates the pure reap-FLOOR
-        // computation, the exact fix point.
-        let mut e = open(config(64, 5));
+    fn a_cross_tenant_guest_is_excluded_from_the_reap_floor_only_when_sharing_is_active() {
+        // #1170 (ITEM 1) — the SHARING-GATED reap-floor exclusion, and its INVERSE (the data-loss
+        // regression fix). A genuine cross-tenant importer keys its guest cursor
+        // `(<exporter>/stream, <importer>/group)`, so on exporter "a/orders" a guest is named "b/g".
+        // With CROSS-TENANT SHARING ACTIVE (the server-scoping invariant holds — a same-tenant own
+        // group and its stream share the leading `<tenant>/` token) the guest is EXCLUDED so a
+        // dead/lagging importer can never pin the exporter's disk. But `/` is a FULLY LEGAL user
+        // character in group/stream names on a SINGLE-TENANT broker, so with sharing OFF the SAME
+        // "b/g" group MUST pin — otherwise its unread records are silently reaped (the regression the
+        // review caught). Same group + same cursor; only the sharing gate flips the floor.
+        let mut e = open(config(64, 5)); // retention OFF: isolate the pure reap-FLOOR computation
+        e.set_cross_tenant_sharing_active(true); // a broker with cross-tenant sharing configured
         for _ in 0..24 {
             produce_named(&mut e, "a/orders", &[0xab; 16]);
         }
-        // The exporter's OWN group "g": drain + ack everything, so it is caught up to the head (24).
+        // Exporter a's OWN group "g" (a bare name, no '/') caught up to the head (24).
         drain_and_ack_all(&mut e, "a/orders", "g");
         let head = e
             .streams
@@ -32318,30 +32367,43 @@ mod tests {
             .get();
         assert_eq!(head, 24);
 
-        // A FOREIGN importer group "b/g" lagging at committed 0 (one poll creates + touches it; its
-        // leased offset 0 is never acked) is EXCLUDED: the floor stays at the exporter's own head.
+        // Importer b's guest cursor "b/g" lagging at committed 0 (one poll creates + touches it; the
+        // leased offset 0 is never acked). Creation is ALLOWED because sharing is active.
         let _ = e.poll_in_stream("a/orders", "b/g", 0).unwrap();
         assert_eq!(
             e.min_committed_offset_named(&sid("a/orders")),
             head,
-            "the foreign importer cursor at 0 is EXCLUDED — the floor stays at the exporter's own \
-             caught-up head, not 0 (mutation: dropping the is_foreign_importer_group filter → 0)"
+            "SHARING ACTIVE: the cross-tenant guest cursor at 0 is EXCLUDED — the floor stays at the \
+             exporter's own caught-up head (a dead importer can't pin the exporter's disk)"
         );
 
-        // Contrast: a SAME-tenant own group "g2" (bare name, no '/') lagging at 0 STILL pins — the
-        // exclusion is scoped to a FOREIGN importer only, so within-tenant consumer-safety is intact.
+        // THE REGRESSION FIX: on a SINGLE-TENANT broker the SAME "b/g" is an ordinary user group, so
+        // it MUST pin. Flip sharing OFF and re-read the floor — no group is excluded now.
+        e.set_cross_tenant_sharing_active(false);
+        assert_eq!(
+            e.min_committed_offset_named(&sid("a/orders")),
+            0,
+            "SHARING OFF (single-tenant): the same 'b/g' group PINS at 0 — its unread records are \
+             protected, NOT silently reaped (mutation: an ungated name-only exclusion makes this 24)"
+        );
+
+        // And a SAME-tenant own group "g2" at 0 pins under sharing too (exclusion is guest-only).
+        e.set_cross_tenant_sharing_active(true);
         let _ = e.poll_in_stream("a/orders", "g2", 0).unwrap();
         assert_eq!(
             e.min_committed_offset_named(&sid("a/orders")),
             0,
-            "a same-tenant own group lagging at 0 still pins the floor"
+            "even with sharing active, a same-tenant own group (bare name) at 0 still pins"
         );
     }
 
     #[test]
-    fn a_lagging_foreign_importer_does_not_block_the_exporters_retention_reap() {
-        // #1170 (ITEM 1), the end-to-end reclaim: with retention ON, a dead/lagging foreign importer
-        // at 0 must NOT block the exporter reaping below its OWN (caught-up) group's floor.
+    fn a_single_tenant_slash_group_is_never_reaped_the_data_loss_regression_fix() {
+        // #1170 (ITEM 1) regression, end-to-end with retention ON: a SINGLE-TENANT broker (sharing
+        // OFF, the default) with a legal consumer group "b/g" lagging on stream "a/orders" must keep
+        // its #566 consumer-safe protection — its unread records are NOT reaped. `/` is a long-
+        // supported user character in group/stream names, so nothing here uses tenancy; this is
+        // exactly the deployment the review flagged as silently losing data before the gate.
         let mut probe = open(config_with_retention(0));
         produce_named(&mut probe, "a/orders", &[0xab; 16]);
         let one = probe
@@ -32350,23 +32412,63 @@ mod tests {
             .unwrap()
             .durable_record_bytes();
 
-        // Retain ~4 records. Produce 3 (UNDER the bound: no reap yet), then establish the cursors.
-        let mut e = open(config_with_retention(4 * one));
+        // Sharing is OFF for the whole test (a genuine single-tenant broker never sets the flag).
+        let mut e = open(config_with_retention(4 * one)); // retain ~4 records
+        assert!(!e.cross_tenant_sharing_active());
         for _ in 0..3 {
             produce_named(&mut e, "a/orders", &[0xab; 16]);
         }
-        // The exporter's OWN group "g" caught up to 3; the FOREIGN importer "b/g" lagging at 0.
+        // The single-tenant user's group "b/g" lagging at 0 (one poll leases offset 0, never acked).
+        let _ = e.poll_in_stream("a/orders", "b/g", 0).unwrap();
+        // Grow well past the retention bound; each produce runs the per-stream reap.
+        for _ in 0..24 {
+            produce_named(&mut e, "a/orders", &[0xab; 16]);
+        }
+        assert_eq!(
+            e.min_committed_offset_named(&sid("a/orders")),
+            0,
+            "the lagging single-tenant 'b/g' group PINS the floor at 0 (mutation: an ungated \
+             name-only exclusion would exclude it and let the reap advance)"
+        );
+        assert_eq!(
+            e.streams
+                .get(&sid("a/orders"))
+                .unwrap()
+                .earliest_offset()
+                .get(),
+            0,
+            "NOT ONE record is reaped out from under the lagging single-tenant 'b/g' consumer — its \
+             consumer-safe retention protection is intact (the data-loss regression is fixed)"
+        );
+    }
+
+    #[test]
+    fn a_lagging_cross_tenant_guest_does_not_block_the_exporters_retention_reap() {
+        // #1170 (ITEM 1), the guest side end-to-end with SHARING ACTIVE: a dead/lagging importer
+        // guest at 0 must NOT block the exporter reaping below its OWN (caught-up) group's floor.
+        let mut probe = open(config_with_retention(0));
+        produce_named(&mut probe, "a/orders", &[0xab; 16]);
+        let one = probe
+            .streams
+            .get(&sid("a/orders"))
+            .unwrap()
+            .durable_record_bytes();
+
+        let mut e = open(config_with_retention(4 * one));
+        e.set_cross_tenant_sharing_active(true);
+        for _ in 0..3 {
+            produce_named(&mut e, "a/orders", &[0xab; 16]);
+        }
+        // Exporter a's OWN group "g" caught up to 3; importer b's guest "b/g" lagging at 0.
         assert_eq!(drain_and_ack_all(&mut e, "a/orders", "g"), 3);
         let _ = e.poll_in_stream("a/orders", "b/g", 0).unwrap();
-        // Grow well past the retention bound; each produce runs the per-stream reap, floored at g=3
-        // because the foreign "b/g" at 0 is EXCLUDED (without the fix the floor is 0 → no reap).
         for _ in 0..24 {
             produce_named(&mut e, "a/orders", &[0xab; 16]);
         }
         assert_eq!(
             e.min_committed_offset_named(&sid("a/orders")),
             3,
-            "the floor is the exporter's own group (3), NOT the foreign importer's 0 (mutation → 0)"
+            "the floor is the exporter's own group (3), NOT the guest's 0 (mutation → 0)"
         );
         let earliest = e
             .streams
@@ -32377,7 +32479,7 @@ mod tests {
         assert!(
             earliest > 0 && earliest <= 3,
             "the exporter reaped old sealed segments below its own floor despite the dead/lagging \
-             foreign importer at 0 (earliest = {earliest}; without the exclusion it stays 0)"
+             cross-tenant guest at 0 (earliest = {earliest}; without the exclusion it stays 0)"
         );
     }
 }

--- a/crates/ironbus-server/src/engine.rs
+++ b/crates/ironbus-server/src/engine.rs
@@ -2459,6 +2459,42 @@ fn validate_group_name(name: &str) -> Result<(), EngineError> {
     Ok(())
 }
 
+/// Whether `group` is a FOREIGN cross-tenant IMPORTER's guest cursor on stream `stream_id`, and so
+/// must NOT pin the stream owner's consumer-safe retention reap floor (#1170, ITEM 1 — cross-tenant
+/// resource isolation).
+///
+/// A live cross-subscribe from a foreign importer keys its cursor on the EXPORTER's stream under an
+/// IMPORTER-scoped group name — `(<exporter>/stream, <importer>/group)` (see
+/// [`crate::session::Session::scope_group_under_self`]) — so on an `<exporter>/…` stream a foreign
+/// group is named `<importer>/…`, a leading `/`-token that DIFFERS from the stream's owning-tenant
+/// token. Left in the reap-floor min, a dead/lagging importer would pin the exporter's log from
+/// reaping — a cross-tenant availability/DoS vector (an importer holding the exporter's disk
+/// hostage). Excluding it means the exporter's retention reclaims on ITS OWN policy regardless of a
+/// foreign guest's position; a LIVE, keeping-up importer is unaffected (its cursor sits near the
+/// head, well above any reaped prefix), while a lagging importer is subject to the exporter's
+/// retention window exactly like any consumer that falls outside it — it can never HOLD the window
+/// open. Because the classification is purely by NAME it also holds across a restart (a ghost
+/// `<importer>/…` checkpoint on the exporter's stream is excluded too), with no new durable state.
+///
+/// Precision rests on the ITEM-4 wire-ingress guard: a SAME-tenant own group is a bare client name
+/// with NO `/`, so it can never be mistaken for a foreign `<importer>/…` cursor. Fail-closed toward
+/// DATA-SAFETY: when the group carries no `/` tenant token (an own group), or its token MATCHES the
+/// stream owner's (a pathological self-import stays same-tenant), it PINS — never wrongly reaped.
+/// Only the server-applied cross-tenant importer group is ever excluded.
+fn is_foreign_importer_group(stream_id: &str, group: &str) -> bool {
+    // An own group is a bare client name (no `/`, guaranteed by the ITEM-4 ingress guard): it pins.
+    let Some((group_owner, _)) = group.split_once(crate::tenant::STREAM_DELIM) else {
+        return false;
+    };
+    // The stream's owning-tenant token is the part before its first `/` (`<exporter>/orders`), or the
+    // whole id when it has none (`<exporter>`, a tenant's bare default stream). Foreign iff the
+    // group's leading tenant token differs from the stream owner's.
+    let stream_owner = stream_id
+        .split_once(crate::tenant::STREAM_DELIM)
+        .map_or(stream_id, |(owner, _)| owner);
+    group_owner != stream_owner
+}
+
 /// The filename prefix and suffix of a named work-group's durable cursor checkpoint. The
 /// default group uses `cursor.ckpt` (note `cursor.`, not `cursor-`), so it never matches the
 /// named pattern and the two never collide.
@@ -11651,10 +11687,18 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         // records. The default stream needs no twin: its groups are never dropped while their
         // intent is live (the #277 sweep refuses ephemeral groups and the default stream is never
         // LRU-evicted), so a parked default-stream offset cannot exist.
+        // #1170 (ITEM 1): a FOREIGN cross-tenant importer's guest cursor (`<importer>/…` on this
+        // `<exporter>/…` stream) is EXCLUDED from the exporter's reap floor at every source below —
+        // live groups, durable ghosts, AND parked ephemeral offsets — so a dead/lagging importer can
+        // never pin the exporter's retention reclamation (see `is_foreign_importer_group`). A same-
+        // tenant own group (bare name, no `/`) is never excluded, so consumer-safety within the
+        // exporter's own tenant is unchanged.
+        let stream_name = id.name();
         let parked = self
             .ephemeral_subs
             .iter()
             .filter(|((sid, _), _)| sid == id)
+            .filter(|((_, group), _)| !is_foreign_importer_group(stream_name, group.as_str()))
             .filter_map(|(_, sub)| sub.parked_committed);
         let Some(ns) = self.named_streams.get(id) else {
             // No resident consumer state: only a parked ephemeral position (if any) can pin; with
@@ -11665,13 +11709,15 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         };
         let live = ns
             .groups
-            .values()
-            .filter(|g| g.touched)
-            .map(|g| g.cursor.committed().get());
+            .iter()
+            .filter(|(name, _)| !is_foreign_importer_group(stream_name, name.as_str()))
+            .filter(|(_, g)| g.touched)
+            .map(|(_, g)| g.cursor.committed().get());
         let ghosts = ns
             .group_last_checkpointed
             .iter()
             .filter(|(name, _)| !ns.groups.contains_key(name.as_str()))
+            .filter(|(name, _)| !is_foreign_importer_group(stream_name, name.as_str()))
             .map(|(_, &committed)| committed);
         live.chain(ghosts).chain(parked).min().unwrap_or(head)
     }
@@ -32224,6 +32270,114 @@ mod tests {
             earliest > 3,
             "with the intent gone the floor released and reaping proceeded (earliest = \
              {earliest})"
+        );
+    }
+
+    // Drains + acks EVERY currently-deliverable record of `stream`'s group `group`, so the group's
+    // committed cursor catches up to the durable head. Returns the monotonic `now` it advanced to.
+    fn drain_and_ack_all(
+        e: &mut Engine<InMemoryFs, ManualClock>,
+        stream: &str,
+        group: &str,
+    ) -> u64 {
+        let mut now = 0u64;
+        loop {
+            match e.poll_in_stream(stream, group, now).unwrap() {
+                Poll::Message(d) => {
+                    assert_eq!(e.ack_in_stream(stream, group, &d.token), AckResult::Acked);
+                    now += 1;
+                }
+                _ => break now,
+            }
+        }
+    }
+
+    #[test]
+    fn a_foreign_cross_tenant_importer_group_is_excluded_from_the_exporters_reap_floor() {
+        // #1170 (ITEM 1): a lagging/dead cross-tenant IMPORTER group on the EXPORTER's stream must
+        // NOT pin the exporter's consumer-safe retention reap floor — otherwise a foreign importer
+        // holds the exporter's disk hostage (a cross-tenant availability/DoS vector). A live cross-
+        // subscribe keys its guest cursor `(<exporter>/stream, <importer>/group)`, so on stream
+        // "a/orders" a foreign group is named "b/g" (a leading tenant token differing from the
+        // stream owner "a"); the exporter's OWN group is a bare client name (no '/', guaranteed by
+        // the ITEM-4 ingress guard) and still pins. See `is_foreign_importer_group`.
+        //
+        // Retention OFF here so nothing reaps DURING production; this isolates the pure reap-FLOOR
+        // computation, the exact fix point.
+        let mut e = open(config(64, 5));
+        for _ in 0..24 {
+            produce_named(&mut e, "a/orders", &[0xab; 16]);
+        }
+        // The exporter's OWN group "g": drain + ack everything, so it is caught up to the head (24).
+        drain_and_ack_all(&mut e, "a/orders", "g");
+        let head = e
+            .streams
+            .get(&sid("a/orders"))
+            .unwrap()
+            .flushed_offset()
+            .get();
+        assert_eq!(head, 24);
+
+        // A FOREIGN importer group "b/g" lagging at committed 0 (one poll creates + touches it; its
+        // leased offset 0 is never acked) is EXCLUDED: the floor stays at the exporter's own head.
+        let _ = e.poll_in_stream("a/orders", "b/g", 0).unwrap();
+        assert_eq!(
+            e.min_committed_offset_named(&sid("a/orders")),
+            head,
+            "the foreign importer cursor at 0 is EXCLUDED — the floor stays at the exporter's own \
+             caught-up head, not 0 (mutation: dropping the is_foreign_importer_group filter → 0)"
+        );
+
+        // Contrast: a SAME-tenant own group "g2" (bare name, no '/') lagging at 0 STILL pins — the
+        // exclusion is scoped to a FOREIGN importer only, so within-tenant consumer-safety is intact.
+        let _ = e.poll_in_stream("a/orders", "g2", 0).unwrap();
+        assert_eq!(
+            e.min_committed_offset_named(&sid("a/orders")),
+            0,
+            "a same-tenant own group lagging at 0 still pins the floor"
+        );
+    }
+
+    #[test]
+    fn a_lagging_foreign_importer_does_not_block_the_exporters_retention_reap() {
+        // #1170 (ITEM 1), the end-to-end reclaim: with retention ON, a dead/lagging foreign importer
+        // at 0 must NOT block the exporter reaping below its OWN (caught-up) group's floor.
+        let mut probe = open(config_with_retention(0));
+        produce_named(&mut probe, "a/orders", &[0xab; 16]);
+        let one = probe
+            .streams
+            .get(&sid("a/orders"))
+            .unwrap()
+            .durable_record_bytes();
+
+        // Retain ~4 records. Produce 3 (UNDER the bound: no reap yet), then establish the cursors.
+        let mut e = open(config_with_retention(4 * one));
+        for _ in 0..3 {
+            produce_named(&mut e, "a/orders", &[0xab; 16]);
+        }
+        // The exporter's OWN group "g" caught up to 3; the FOREIGN importer "b/g" lagging at 0.
+        assert_eq!(drain_and_ack_all(&mut e, "a/orders", "g"), 3);
+        let _ = e.poll_in_stream("a/orders", "b/g", 0).unwrap();
+        // Grow well past the retention bound; each produce runs the per-stream reap, floored at g=3
+        // because the foreign "b/g" at 0 is EXCLUDED (without the fix the floor is 0 → no reap).
+        for _ in 0..24 {
+            produce_named(&mut e, "a/orders", &[0xab; 16]);
+        }
+        assert_eq!(
+            e.min_committed_offset_named(&sid("a/orders")),
+            3,
+            "the floor is the exporter's own group (3), NOT the foreign importer's 0 (mutation → 0)"
+        );
+        let earliest = e
+            .streams
+            .get(&sid("a/orders"))
+            .unwrap()
+            .earliest_offset()
+            .get();
+        assert!(
+            earliest > 0 && earliest <= 3,
+            "the exporter reaped old sealed segments below its own floor despite the dead/lagging \
+             foreign importer at 0 (earliest = {earliest}; without the exclusion it stays 0)"
         );
     }
 }

--- a/crates/ironbus-server/src/session.rs
+++ b/crates/ironbus-server/src/session.rs
@@ -1316,7 +1316,7 @@ impl Session {
         // unchanged (no actor round-trip for the scan). The scan itself is a no-op when there are no
         // in-doubt txns, so even a back-checking broker with nothing prepared pays ~nothing.
         if self.registered_txn_listener() {
-            drive_back_check(engine, member_id, out);
+            drive_back_check(engine, member_id, self.tenant.as_ref(), out);
         }
         // Persist the (possibly non-empty) pipelined window back onto the session (#1045), so produces
         // parked but not yet acked survive into the next pass. Empty after a closing exit (the block
@@ -2655,6 +2655,11 @@ impl Session {
             reply_err(out, "cumulative-ack group name must be valid UTF-8");
             return Ok(());
         };
+        // #1170 (ITEM 4): a `/` in a client group name is rejected at every group ingress, so a
+        // cumulative ack can never target (nor lazily mint) a group colliding with a server key.
+        if reject_delimited_group_name(group.as_bytes(), out) {
+            return Ok(());
+        }
         let group = group.to_string();
         let up_to = Offset::new(ack.up_to);
         let up_to_exclusive = ack.up_to;
@@ -4613,6 +4618,10 @@ impl Session {
             reply_err(out, "stream-commit group name must be valid UTF-8");
             return Ok(());
         };
+        // #1170 (ITEM 4): reject a `/` in the client group name at this ingress too, uniformly.
+        if reject_delimited_group_name(group.as_bytes(), out) {
+            return Ok(());
+        }
         let group = group.to_string();
         let up_to = Offset::new(commit.up_to);
         // Route by stream (#681 follow-up): a NAMED-stream streaming consumer commits its OWN per-stream
@@ -4850,6 +4859,11 @@ impl Session {
             reply_err(out, "subscription name must be valid UTF-8");
             return Ok(());
         };
+        // #1170 (ITEM 4): a client group name may not carry the `/` group-namespace delimiter, so it
+        // can never collide with a server-scoped group key (see `reject_delimited_group_name`).
+        if reject_delimited_group_name(group.as_bytes(), out) {
+            return Ok(());
+        }
         // An EPHEMERAL subscribe (#771, routed here by a default-stream `SubTo` carrying the flag;
         // a plain `Sub` body cannot carry it) is gated on the negotiated capability, exactly like
         // the #594 filter gate: a connection that did not advertise it is fail-closed rejected, so
@@ -5590,6 +5604,11 @@ impl Session {
             reply_err(out, "listener group must not be empty");
             return Ok(());
         }
+        // #1170 (ITEM 4): reject a `/` in the RAW client listener-group name BEFORE it is tenant-
+        // scoped, so a client can never name a listener that collides with a server-scoped group key.
+        if reject_delimited_group_name(decoded.group, out) {
+            return Ok(());
+        }
         // #765: SERVER-APPLY the tenant prefix to the back-check listener group — the one group-only
         // routing seam not already isolated by a paired (scoped) stream — so a `TxnCheck` for one
         // tenant's in-doubt half message can NEVER be routed to another tenant that registered the
@@ -5743,6 +5762,11 @@ impl Session {
             reply_err(out, "group name must be valid UTF-8");
             return Ok(());
         };
+        // #1170 (ITEM 4): reject a `/` in the RAW client group name BEFORE it is scoped, so it can
+        // never collide with a server-scoped group key on the resolved stream.
+        if reject_delimited_group_name(group_name.as_bytes(), out) {
+            return Ok(());
+        }
         // #765/#1163: resolve the stream name through the cross-tenant import/export layer (SUBSCRIBE
         // direction). Common case (no import alias): SERVER-APPLY the caller's own tenant prefix so a
         // SubTo can never bind another tenant's stream (an unknown-to-the-tenant name is the standard
@@ -6064,6 +6088,11 @@ impl Session {
             reply_err(out, "group must be valid UTF-8");
             return Ok(());
         };
+        // #1170 (ITEM 4): a `/` in the client group name is rejected here too, so a PauseGroup can
+        // never create (the setter mints an absent group) a group colliding with a server-scoped key.
+        if reject_delimited_group_name(group.as_bytes(), out) {
+            return Ok(());
+        }
         if !stream.is_empty() && !self.streams_enabled {
             reply_err(
                 out,
@@ -6344,6 +6373,11 @@ impl Session {
             reply_err(out, "group name must be valid UTF-8");
             return Ok(());
         };
+        // #1170 (ITEM 4): reject a `/` in the RAW client group name BEFORE it is scoped (own OR
+        // cross-tenant), so it can never collide with a server-scoped group key.
+        if reject_delimited_group_name(group.as_bytes(), out) {
+            return Ok(());
+        }
         // PER-SUBJECT FILTERED consume (#594, filter_mode == 1): fail-closed on the capability, bind the
         // subject PATTERN (wildcards allowed) as the work-group's filter, and consume the covering
         // stream filtered — the DEFAULT stream (#594-A) OR a covering NAMED stream (#594-B). A pre-#594
@@ -6798,6 +6832,36 @@ fn reply_err_coded(out: &mut Vec<u8>, code_token: &str, message: &str) {
     reply(out, FrameType::Err, &body);
 }
 
+/// Rejects a CLIENT-supplied consumer-GROUP name that carries the group-namespace delimiter `/`
+/// (#1170, ITEM 4 — defense-in-depth). A group is server-scoped `<tenant>/<group>` for the txn
+/// back-check listener seam ([`crate::tenant::TenantId::scope_group`]) and `<importer>/<group>` for a
+/// cross-tenant importer's guest cursor ([`Session::scope_group_under_self`]). Permitting a client `/`
+/// would let a tenant NAME a group that COLLIDES with such a server-scoped key on its OWN stream —
+/// e.g. an exporter naming a group `<importer>/orders` that shares the cursor an importer's
+/// `<importer>/orders` guest group keys to. That is un-forgeable BY an importer and only
+/// self-inflicted, but it is a cheap footgun to forbid; forbidding it ALSO keeps the retention-floor
+/// guest classification ([`crate::engine::Engine`]'s `min_committed_offset_named`, ITEM 1) precise,
+/// since a same-tenant own group is then guaranteed to carry NO `/` and can never be mistaken for a
+/// foreign importer's `<importer>/…` cursor. Applied to the RAW client bytes at the wire ingress,
+/// BEFORE any server scoping, so a legitimately server-scoped group (which does contain `/`) is never
+/// rejected. `.` is deliberately NOT restricted: it is the SUBJECT delimiter, never a group prefix
+/// delimiter, so a dotted group name cannot collide with a server-applied group key.
+///
+/// Returns `true` and writes a typed `ERR_INVALID_GROUP_NAME` reply when the name is rejected (the
+/// caller returns early); `false` (no reply) when the name is clean.
+fn reject_delimited_group_name(group: &[u8], out: &mut Vec<u8>) -> bool {
+    if group.contains(&(crate::tenant::STREAM_DELIM as u8)) {
+        reply_err_coded(
+            out,
+            crate::codes::ErrorCode::ERR_INVALID_GROUP_NAME.as_str(),
+            "consumer-group name must not contain '/'",
+        );
+        true
+    } else {
+        false
+    }
+}
+
 /// #1163: the single typed reject for a cross-tenant import that no export authorizes for the
 /// requested direction. Emitted at EVERY resolution seam a [`Resolved::Denied`] can arise, so the
 /// wire signal is uniform: the client named an import alias, but the crossing is not (or no longer)
@@ -6921,15 +6985,57 @@ fn drain_produce_confirms<
     }
 }
 
+/// Strips the server-applied `<tenant>/` prefix off an engine-stored txn id for the OUTBOUND
+/// `TxnCheck` echo (#1170, ITEM 3 — a real multi-tenant bug, pre-existing from #1162). In
+/// multi-tenant mode a producer's client txn id `tx1` is server-scoped to `<tenant>/tx1` before it
+/// reaches the engine ([`Session::tenant_txn_id`]); the back-check scan then drains that ALREADY-
+/// scoped id and, without this strip, would echo `<tenant>/tx1` back to the producer's listener. The
+/// listener answers by ECHOING the id it received, and the inbound
+/// [`Session::handle_txn_check_result`] re-scopes it UNCONDITIONALLY — so a scoped echo became
+/// `<tenant>/<tenant>/tx1`, which matches no stored txn, never resolves, and (after the bounded
+/// attempt cap) wrongly ROLLS BACK a live multi-tenant transaction. Presenting the listener its OWN
+/// (client) id — the exact bytes it sent in `TxnPrepare` — makes the echo re-scope to the SAME
+/// `<tenant>/tx1`, so the txn resolves correctly.
+///
+/// ISOLATION is preserved because ONLY this client-facing OUTBOUND echo is de-scoped: the security-
+/// critical INBOUND scoping in `handle_txn_check_result` stays unconditional, so a forged
+/// `TxnCheckResult` from a DIFFERENT tenant is still scoped under THAT tenant (`<other>/tx1`) and can
+/// never resolve this tenant's txn — cross-tenant txns stay in their own namespace. A no-op for a
+/// single-tenant connection (`tenant` is `None`) or, defensively, for an id that does not carry the
+/// expected `<tenant>/` prefix (a can't-happen the strip leaves untouched rather than truncating).
+fn strip_tenant_txn_id<'a>(tenant: Option<&crate::tenant::TenantId>, txn_id: &'a [u8]) -> &'a [u8] {
+    let Some(t) = tenant else {
+        return txn_id;
+    };
+    let tid = t.as_str().as_bytes();
+    // The scoped id is exactly `<tenant>` + `/` + `<client id>`; strip that and only that.
+    if txn_id.len() > tid.len() && txn_id.starts_with(tid) && txn_id[tid.len()] == b'/' {
+        &txn_id[tid.len() + 1..]
+    } else {
+        txn_id
+    }
+}
+
 /// Writes one `TxnCheck` frame (#640 part 2) asking the producer's listener about an in-doubt
 /// transaction. Reuses the frozen [`encode_txn_resolve`] codec (the same `txn_id`-only body shape as
-/// `TxnCommit`/`TxnRollback`), so the wire body cannot drift from the proto definition.
-fn write_txn_check(txn_id: &[u8], out: &mut Vec<u8>) {
+/// `TxnCommit`/`TxnRollback`), so the wire body cannot drift from the proto definition. The stored id
+/// is DE-SCOPED to the producer's own client id for a multi-tenant connection (#1170, ITEM 3) via
+/// [`strip_tenant_txn_id`], so the listener's echoed answer re-scopes to the same txn (not a double-
+/// prefixed one that never resolves).
+fn write_txn_check(tenant: Option<&crate::tenant::TenantId>, txn_id: &[u8], out: &mut Vec<u8>) {
+    let client_txn_id = strip_tenant_txn_id(tenant, txn_id);
     let mut body = Vec::new();
     // The encode only fails for a txn id over the u16 wire cap, which the lifecycle bounds to 256, so
     // this is infallible in practice; on the unreachable error we simply emit no frame (the txn is
     // re-checked on a later scan).
-    if encode_txn_resolve(&TxnResolveBody { txn_id }, &mut body).is_ok() {
+    if encode_txn_resolve(
+        &TxnResolveBody {
+            txn_id: client_txn_id,
+        },
+        &mut body,
+    )
+    .is_ok()
+    {
         reply(out, FrameType::TxnCheck, &body);
     }
 }
@@ -6949,6 +7055,7 @@ fn drive_back_check<
 >(
     engine: &E,
     member_id: MemberId,
+    tenant: Option<&crate::tenant::TenantId>,
     out: &mut Vec<u8>,
 ) {
     // Run one scan tick (single-writer). A gone actor or a storage error both mean "skip this pass".
@@ -6959,8 +7066,11 @@ fn drive_back_check<
     let Ok(checks) = engine.with(move |e| e.drain_txn_checks(member_id)) else {
         return; // a gone actor: the connection is ending, nothing to deliver
     };
+    // The drained ids are ALREADY tenant-scoped (`handle_txn_prepare` scoped them before the engine
+    // stored them); de-scope each to the producer's own client id for the outbound echo (#1170,
+    // ITEM 3), so the listener's answer re-scopes to the same txn rather than a double-prefixed one.
     for check in checks {
-        write_txn_check(&check.txn_id, out);
+        write_txn_check(tenant, &check.txn_id, out);
     }
 }
 
@@ -18890,6 +19000,213 @@ mod tests {
     // failure). Every test drives real Sessions (tenant derived from the authenticated identity) over a
     // real Engine, so it exercises the actual server-applied prefixing at the session→engine boundary.
     // ================================================================================================
+
+    // ---- #1170 (ITEM 4): the wire-ingress group-name guard ----
+
+    #[test]
+    fn a_client_group_name_with_a_slash_is_rejected_at_the_wire_ingress() {
+        // #1170 (ITEM 4): the `/` group-namespace delimiter is forbidden in a CLIENT group name at
+        // EVERY group ingress, so a client can never name a group that collides with a server-scoped
+        // key (`<tenant>/…` back-check listener / `<importer>/…` cross-tenant cursor) — a typed
+        // ERR_INVALID_GROUP_NAME, never a silent bind. Applies universally (single- or multi-tenant);
+        // exercised here on a plain no-auth session (the guard runs before the tenant branch).
+        use ironbus_proto::err::ServerErrorCode;
+        let e = DirectEngine::new(engine());
+        let mut s = connected_session(&e);
+        let mut out = Vec::new();
+
+        // A plain Sub (the default-stream group) carrying `/` is rejected.
+        s.process(&e, &frame(FrameType::Sub, b"tenant/evil"), &mut out)
+            .unwrap();
+        assert_eq!(
+            err_code(&out),
+            Some(ServerErrorCode::InvalidGroupName),
+            "a Sub group with '/' is rejected"
+        );
+
+        // The TxnListen listener group is guarded too (it is the one seam that is tenant-scoped).
+        out.clear();
+        let mut listen_body = Vec::new();
+        ironbus_proto::message::encode_txn_listen(
+            &ironbus_proto::message::TxnListenBody { group: b"a/b" },
+            &mut listen_body,
+        )
+        .unwrap();
+        s.process(&e, &frame(FrameType::TxnListen, &listen_body), &mut out)
+            .unwrap();
+        assert_eq!(
+            err_code(&out),
+            Some(ServerErrorCode::InvalidGroupName),
+            "a TxnListen group with '/' is rejected"
+        );
+
+        // A clean group name (no '/') still binds — the guard rejects ONLY the delimiter.
+        out.clear();
+        s.process(&e, &frame(FrameType::Sub, b"good-group"), &mut out)
+            .unwrap();
+        assert_eq!(
+            one_response(&out).0,
+            FrameType::Ok,
+            "a delimiter-free group still binds"
+        );
+    }
+
+    // ---- #1170 (ITEM 3): the multi-tenant txn back-check double-prefix fix ----
+
+    #[test]
+    #[allow(clippy::too_many_lines)]
+    fn multi_tenant_txn_back_check_resolves_without_double_prefix_and_stays_isolated() {
+        // #1170 (ITEM 3, a real BUG pre-existing from #1162): the back-check echo must present a
+        // MULTI-TENANT producer its OWN client txn id, not the server-scoped `<tenant>/tx1`. Before
+        // the fix, `write_txn_check` echoed the scoped id and `handle_txn_check_result` re-scoped it
+        // to `<tenant>/<tenant>/tx1`, which matched no stored txn and never resolved — so after the
+        // bounded attempt cap a live multi-tenant transaction was WRONGLY ROLLED BACK. ISOLATION is
+        // preserved: a DIFFERENT tenant's answer scopes into ITS OWN namespace and can never resolve
+        // this tenant's txn.
+        //
+        // Connects three tenant sessions (t1 producer, t1 consumer, t2 attacker).
+        fn mk(
+            e: &DirectEngine<InMemoryFs, Arc<ManualClock>>,
+            auth: &Arc<AuthConfig>,
+            member: u64,
+            token: &[u8],
+        ) -> Session {
+            let mut s =
+                Session::with_member_id_and_auth(MemberId::new(member), Arc::clone(auth), None);
+            let mut o = Vec::new();
+            s.process(e, &mt_connect(token, false), &mut o).unwrap();
+            assert!(s.authenticated, "tenant handshake succeeds");
+            s
+        }
+        let clock = Arc::new(ManualClock::new());
+        let e = DirectEngine::new(engine_with(Arc::clone(&clock), 5));
+        // Immediate back-check eligibility + a generous attempt cap so the test drives the resolve.
+        e.engine_mut()
+            .set_back_check_config(ironbus_core::txn::BackCheckConfig {
+                timeout: 0,
+                retry: 1,
+                max_attempts: 1000,
+                batch: 256,
+            });
+        let auth = mt_auth(
+            &[
+                (
+                    b"tok-t1-000000000000000000000000000",
+                    &[Scope::Publish, Scope::Subscribe],
+                    "t1",
+                ),
+                (
+                    b"tok-t2-000000000000000000000000000",
+                    &[Scope::Publish, Scope::Subscribe],
+                    "t2",
+                ),
+            ],
+            &[],
+        );
+        let mut p1 = mk(&e, &auth, 1, b"tok-t1-000000000000000000000000000"); // producer (t1)
+        let mut c1 = mk(&e, &auth, 2, b"tok-t1-000000000000000000000000000"); // consumer (t1)
+        let mut p2 = mk(&e, &auth, 3, b"tok-t2-000000000000000000000000000"); // attacker (t2)
+
+        let result_body = |txn_id: &[u8], decision: ironbus_proto::message::TxnCheckDecision| {
+            let mut b = Vec::new();
+            ironbus_proto::message::encode_txn_check_result(
+                &ironbus_proto::message::TxnCheckResultBody { txn_id, decision },
+                &mut b,
+            )
+            .unwrap();
+            b
+        };
+
+        // p1 registers a listener group, then prepares an INVISIBLE half message named "tx1".
+        let mut out = Vec::new();
+        let mut listen_body = Vec::new();
+        ironbus_proto::message::encode_txn_listen(
+            &ironbus_proto::message::TxnListenBody { group: b"svc" },
+            &mut listen_body,
+        )
+        .unwrap();
+        p1.process(&e, &frame(FrameType::TxnListen, &listen_body), &mut out)
+            .unwrap();
+        assert_eq!(one_response(&out).0, FrameType::Ok, "listener registered");
+        out.clear();
+        p1.process(&e, &txn_prepare_frame(b"tx1", b"half"), &mut out)
+            .unwrap();
+        assert_eq!(
+            one_response(&out).0,
+            FrameType::Ok,
+            "half prepared (invisible)"
+        );
+
+        // Make the half due, then drive p1's OWN pass (a Ping): the back-check scan routes a TxnCheck
+        // to its listener, drained onto this pass. The echoed id must be the producer's OWN "tx1".
+        clock.advance_monotonic_nanos(2);
+        out.clear();
+        p1.process(&e, &frame(FrameType::Ping, b""), &mut out)
+            .unwrap();
+        let check_id = decode_all(&out)
+            .into_iter()
+            .find(|(ty, _)| *ty == FrameType::TxnCheck)
+            .map(|(_, body)| decode_txn_resolve(&body).unwrap().txn_id.to_vec())
+            .expect("a TxnCheck was routed to the producer's listener");
+        assert_eq!(
+            check_id, b"tx1",
+            "the outbound TxnCheck carries the producer's OWN (unscoped) txn id — not the scoped \
+             b\"t1/tx1\" (mutation: dropping the strip makes this b\"t1/tx1\")"
+        );
+
+        // ISOLATION: attacker t2 echoes the SAME id back. Its inbound scoping sends it to t2/tx1, so
+        // it CANNOT resolve t1's t1/tx1 — the txn stays PREPARED (invisible), unaffected. (No consume
+        // is driven here: a prepared half is invisible by construction, so `txn_prepared_count == 1`
+        // is the clean isolation proof; polling now would only advance c1 past the not-yet-visible
+        // record.)
+        out.clear();
+        p2.process(
+            &e,
+            &frame(
+                FrameType::TxnCheckResult,
+                &result_body(&check_id, ironbus_proto::message::TxnCheckDecision::Commit),
+            ),
+            &mut out,
+        )
+        .unwrap();
+        assert_eq!(
+            e.engine_mut().txn_prepared_count(),
+            1,
+            "a different tenant's answer cannot resolve this tenant's txn (isolation preserved)"
+        );
+
+        // LEGIT: p1 echoes the received (unscoped) id — it re-scopes to t1/tx1, resolves, and commits.
+        out.clear();
+        p1.process(
+            &e,
+            &frame(
+                FrameType::TxnCheckResult,
+                &result_body(&check_id, ironbus_proto::message::TxnCheckDecision::Commit),
+            ),
+            &mut out,
+        )
+        .unwrap();
+        assert_eq!(
+            one_response(&out).0,
+            FrameType::Ok,
+            "the producer's own answer resolves its txn (no double-prefix)"
+        );
+        assert_eq!(
+            e.engine_mut().txn_prepared_count(),
+            0,
+            "the half committed via the back-check — NOT left in doubt to be rolled back"
+        );
+        // t1's consumer subscribes to its tenant default stream + flows: it receives the committed
+        // half (proving the txn COMMITTED, not spuriously rolled back by the double-prefix bug).
+        out.clear();
+        c1.process(&e, &frame(FrameType::Sub, b"g"), &mut out)
+            .unwrap();
+        assert_eq!(
+            delivered_payloads(&flow(&mut c1, &e, 8)),
+            vec![b"half".to_vec()],
+            "t1's committed half is delivered (the multi-tenant txn was not spuriously rolled back)"
+        );
+    }
 
     /// Builds an auth config whose identities each carry a tenant (`token`, `scopes`, `tenant`), plus an
     /// optional per-tenant quota table. The tenant is a property of the credential — the client never

--- a/crates/ironbus-server/src/tenant.rs
+++ b/crates/ironbus-server/src/tenant.rs
@@ -418,8 +418,20 @@ impl Drop for ConnGuard {
 // subject to it exactly like any consumer that lags past the window — it can never HOLD the window
 // open. The exclusion is by NAME (the importer's `<importer>/…` token differs from the exporter's
 // stream-owner token), so it holds for a live guest, a durable ghost, AND across a restart, with no
-// new durable state; a SAME-tenant own group (a bare client name, no `/`, enforced at the wire
-// ingress — see below) is never excluded, so within-tenant consumer-safety is unchanged.
+// new durable state.
+//
+// This name test is GATED on `Engine::cross_tenant_sharing_active` — set true ONLY when a non-empty
+// SharingRegistry is wired at serve time — because `/` is a fully LEGAL, user-choosable character in
+// stream AND group names on a single-tenant broker. Without the gate, a single-tenant consumer group
+// `b/g` on a stream `a/orders` would be misread as a "foreign importer" and its unread records
+// silently reaped (a #566 consumer-safety violation). With the gate, the exclusion applies ONLY where
+// tenancy's server-scoping invariant actually holds (sharing implies tenancy), so a SAME-tenant own
+// group — a bare client name with no `/`, enforced at the CLIENT wire ingress (ITEM 4) — is never
+// excluded, and on a NON-sharing broker no group is EVER excluded (every group keeps its full
+// consumer-safe protection). NOTE the engine deliberately still ACCEPTS `/` in a group name: a
+// server-applied cross-tenant guest group is legitimately `<importer>/<group>`, and `/` is a
+// long-supported path-unsafe group-name character (hex-encoded in checkpoint filenames); only the
+// client-facing wire ingress forbids it.
 //
 // REVOKE SEMANTICS (effective on the next resolution; live cross-subs are NOT torn down). A grant is
 // AUTHORIZED at resolution time (SubTo / PubTo / StreamInfo / SubSubject / PubSubject); the whole

--- a/crates/ironbus-server/src/tenant.rs
+++ b/crates/ironbus-server/src/tenant.rs
@@ -402,6 +402,45 @@ impl Drop for ConnGuard {
 // The whole authorization decision is this one pure, side-effect-free module — [`SharingRegistry`]
 // plus the token matchers below — so the security argument is auditable in one place and unit-tested
 // exhaustively. The session layer merely applies the [`Resolution`] it returns.
+//
+// ------------------------------------------------------------------------------------------------
+// #1170 — cross-tenant sharing SECURITY / CORRECTNESS policy (the #1169-review follow-ups).
+//
+// RETENTION ISOLATION (a foreign importer never holds the exporter's disk hostage). A live importer
+// cross-subscribe keeps a cursor on the EXPORTER's stream, keyed `(<exporter>/stream,
+// <importer>/group)` (the importer's group is scoped under ITSELF, never the exporter). That guest
+// cursor is DELIBERATELY EXCLUDED from the exporter's consumer-safe retention reap floor
+// (`Engine::min_committed_offset_named` via `Engine::is_foreign_importer_group`): a dead or lagging
+// importer must NOT be able to pin the exporter's log from reaping (a cross-tenant availability/DoS
+// vector). The exporter therefore reclaims disk strictly on ITS OWN retention policy regardless of a
+// foreign guest's position. A LIVE, keeping-up importer is unaffected (its cursor sits near the head,
+// well above any reaped prefix); an importer that falls outside the exporter's retention window is
+// subject to it exactly like any consumer that lags past the window — it can never HOLD the window
+// open. The exclusion is by NAME (the importer's `<importer>/…` token differs from the exporter's
+// stream-owner token), so it holds for a live guest, a durable ghost, AND across a restart, with no
+// new durable state; a SAME-tenant own group (a bare client name, no `/`, enforced at the wire
+// ingress — see below) is never excluded, so within-tenant consumer-safety is unchanged.
+//
+// REVOKE SEMANTICS (effective on the next resolution; live cross-subs are NOT torn down). A grant is
+// AUTHORIZED at resolution time (SubTo / PubTo / StreamInfo / SubSubject / PubSubject); the whole
+// sharing config is loaded at broker start into the immutable [`crate::auth::AuthConfig`] and pinned
+// per-connection at `Connect`. Removing an export/import (a revoke) is therefore effective for every
+// resolution that happens AFTER the new config is in force — a new connection, or a re-subscribe on a
+// connection that re-reads the registry — but an ALREADY-BOUND live cross-subscription keeps
+// delivering off its established binding until it re-resolves (a reconnect/rebind). IronBus does NOT
+// proactively tear down live cross-subscriptions on revoke: the broker is thread-per-connection with
+// no central live-session registry and no cross-thread teardown channel, so enumerating and dropping
+// exactly the cross-subs bound under a now-revoked grant — WITHOUT risking a same-tenant session — is
+// not a contained change. The STRONGER "revoke is immediately effective (tear down live cross-subs)"
+// behavior is an intentional, separately-tracked owner decision, NOT a silent default here.
+//
+// GROUP-NAME INGRESS GUARD (defense-in-depth). A consumer-group is server-scoped `<tenant>/<group>`
+// for the txn back-check listener seam and `<importer>/<group>` for a cross-tenant importer cursor,
+// both using the `/` [`STREAM_DELIM`]. A CLIENT-supplied group name may therefore NOT contain `/`
+// (rejected at every group ingress with `ERR_INVALID_GROUP_NAME`): it stops a tenant self-colliding
+// by naming a group `<importer>/…` on its own stream, and it keeps the retention-floor guest
+// classification above precise (an own group is then guaranteed `/`-free). `.` is NOT a group prefix
+// delimiter, so a dotted group name is unaffected.
 // ================================================================================================
 
 /// The direction of a single resource access at a resolution seam. An export grants a subset of


### PR DESCRIPTION
Non-blocking follow-ups from the #1169 cross-tenant sharing security review (the multi-tenant path from #1162/#1163/#1169). **DO NOT MERGE** until adversarially reviewed for any cross-tenant leak. Every change preserves tenant isolation absolutely and fails closed on ambiguity.

## ITEM 3 — a real BUG (highest value): txn back-check double-prefix
Pre-existing from #1162. In multi-tenant mode the txn-listener back-check DOUBLE-PREFIXED the txn id: `write_txn_check` echoed the already-`<tenant>/`-scoped stored id to the producer's listener; the listener answers by echoing the id it received, and `handle_txn_check_result` re-scopes **unconditionally**, so a scoped echo became `<tenant>/<tenant>/tx1` — which matched no stored txn, never resolved, and (after the bounded attempt cap) **wrongly ROLLED BACK a live multi-tenant transaction**.

**Fix:** strip the `<tenant>/` prefix on the **outbound** echo only (`strip_tenant_txn_id`), so the listener sees its OWN client id and its answer re-scopes to the *same* txn.

**Isolation preserved:** the security-critical **inbound** scoping stays unconditional, so a *different* tenant's forged `TxnCheckResult` still scopes into ITS OWN namespace (`<other>/tx1`) and can never resolve this tenant's `t1/tx1` — cross-tenant txns stay own-namespace. The test proves both (own tenant resolves; other tenant cannot).

## ITEM 1 — cross-tenant retention isolation
A dead/lagging cross-tenant IMPORTER group holds a cursor on the EXPORTER's stream (`(<exporter>/stream, <importer>/group)`); left in the reap-floor min it could pin the exporter's log from reaping — a cross-tenant availability/DoS (an importer holds the exporter's disk hostage).

**Fix:** a foreign importer's guest cursor is **excluded** from `Engine::min_committed_offset_named` (`is_foreign_importer_group`), at every source (live groups, durable ghosts, parked ephemeral) and **by name**, so it holds for a live guest, a ghost, and **across a restart** with no new durable state. A live keeping-up importer is unaffected (its cursor sits near the head); a lagging importer is subject to the exporter's retention window like any late consumer but can never hold it open. A same-tenant own group still pins (within-tenant consumer-safety unchanged). Policy documented in the tenant.rs `#1170` sharing block.

## ITEM 4 — defense-in-depth group-name guard
A CLIENT-supplied consumer-group name may no longer contain the `/` group-namespace delimiter (rejected at **every** group ingress — Sub / SubTo / SubSubject / TxnListen / CumulativeAck / StreamCommit / PauseGroup — with `ERR_INVALID_GROUP_NAME`). Stops a tenant self-colliding with a server-scoped group key, and keeps the ITEM-1 guest classification precise (an own group is guaranteed `/`-free). `.` is not a group delimiter and is unaffected. (The empty-token-subject note stays within-grant; no code needed.)

## ITEM 2 — revoke vs in-flight: DEFERRED (owner decision)
The stronger "tear down live cross-subscriptions on revoke (immediately effective)" behavior is **not a contained change**: the broker is thread-per-connection with no central live-session registry and no cross-thread teardown channel, and the sharing registry is pinned per-connection at `Connect`; enumerating and dropping exactly the cross-subs under a now-revoked grant without risking a same-tenant session is semantically involved. Per the issue's guidance, **not implemented** — the current "revoke is effective on the next resolution (new connection / reconnect)" behavior is documented in the tenant.rs sharing policy block and raised here for the owner to decide.

## Tests (all mutation-verified — each fails with its fix neutered)
- `multi_tenant_txn_back_check_resolves_without_double_prefix_and_stays_isolated` (ITEM 3)
- `a_foreign_cross_tenant_importer_group_is_excluded_from_the_exporters_reap_floor` (ITEM 1)
- `a_lagging_foreign_importer_does_not_block_the_exporters_retention_reap` (ITEM 1)
- `a_client_group_name_with_a_slash_is_rejected_at_the_wire_ingress` (ITEM 4)

## Constraints
No new dependencies; `Cargo.lock` / `Cargo.toml` / `deny.toml` byte-identical. Wire format unchanged (the group-name reject is validation, not a format change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01McmNfYNWPmohVS8umY9Lkp
