### PR TITLE
perf(produce): Level-0 batch path leanness + server-side batch tests (#775)

### DIFF
--- a/crates/ironbus-server/src/actor.rs
+++ b/crates/ironbus-server/src/actor.rs
@@ -145,6 +145,48 @@ fn pool_return(pool: &ReplyPool, channel: ReplyChannel) {
         .push(channel);
 }
 
+/// A per-CONNECTION free-list of drained Level-0 batch buffers (#775), so the QoS-0 batch path reuses
+/// ONE `Vec<OwnedAppend>` allocation across flush passes instead of regrowing from zero every pass
+/// (`Session::flush_level0` `mem::take`s the batch by value into the command, leaving a zero-capacity
+/// `Vec` behind). It mirrors [`ReplyPool`] (#475): each cloned [`EngineHandle`] (one per connection,
+/// see `server.rs`) gets its OWN fresh pool, and the pool rides WITH the `Command::ProduceNoReplyBatch`
+/// so the SHARED actor returns the drained buffer to the ORIGINATING connection's pool (a buffer never
+/// crosses connections).
+///
+/// Correctness — the two seams the buffer's lifecycle is kept provably clean on:
+///  * NO STALE APPENDS: [`l0_buf_return`] `clear()`s the `Vec` BEFORE it re-enters the pool, so the pool
+///    only ever holds empty buffers and a reuse can never replay a prior batch's appends.
+///  * NO ALIASING: the buffer is owned by exactly one party at a time — the session `mem::take`s it
+///    (relinquishing its reference) into the command, the channel move hands the actor SOLE ownership,
+///    and the actor returns it to the pool only AFTER its drain loop finished reading it. A `take_l0_buf`
+///    hands out a DIFFERENT buffer (or a fresh one), never the one currently in flight.
+///
+/// Unlike [`ReplyPool`] (locked only by the connection thread), BOTH threads touch this `Mutex` (the
+/// connection thread pops on flush, the actor pushes on drain), but the critical section is a single
+/// `Vec` push/pop — far cheaper than the per-pass regrow it removes.
+pub type L0BufPool = std::sync::Arc<std::sync::Mutex<Vec<Vec<OwnedAppend>>>>;
+
+/// Pops a reusable (already-cleared) Level-0 batch buffer from the pool, or makes a fresh empty one if
+/// the pool is cold (#775). Warms to the connection's steady batch depth once, then recycles; the lock
+/// is a single `Vec::pop`.
+fn l0_buf_take(pool: &L0BufPool) -> Vec<OwnedAppend> {
+    pool.lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .pop()
+        .unwrap_or_default()
+}
+
+/// Returns a DRAINED Level-0 batch buffer to the pool for the next flush pass to reuse (#775). Called by
+/// the actor only AFTER the drain loop finished reading `buf` (no aliasing), and `clear()`s it here so
+/// the pool's INVARIANT — empty buffers only — holds by construction and a reuse can never replay a
+/// stale append. A poisoned lock is recovered (the pool is plain data), so recycling never panics.
+fn l0_buf_return(pool: &L0BufPool, mut buf: Vec<OwnedAppend>) {
+    buf.clear();
+    pool.lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .push(buf);
+}
+
 /// A produce request's payload, OWNED so it can cross the channel to the actor (the wire [`Append`]
 /// borrows the connection's input buffer, which the actor cannot hold). The actor borrows it back as
 /// an [`Append`] to append it. Fields mirror [`Append`], plus the opt-in dedup identity (#33).
@@ -619,6 +661,12 @@ enum Command<F: Filesystem, C: Clock> {
     ProduceNoReplyBatch {
         /// The owned Level-0 produce payloads, in connection order.
         appends: Vec<OwnedAppend>,
+        /// The ORIGINATING connection's Level-0 batch-buffer pool (#775). After the actor drains
+        /// `appends`, it returns the (cleared) `Vec` here so the session reuses the allocation next
+        /// flush pass instead of regrowing from zero. The pool rides WITH the command because the actor
+        /// is SHARED across connections — this routes the drained buffer back to exactly the connection
+        /// that sent it (each cloned handle has its own fresh pool, like [`ReplyPool`]).
+        buf_pool: L0BufPool,
     },
     /// Run an engine job (an ack, a flow/poll batch, a subscribe, a checkpoint), then it replies itself.
     Run(Job<F, C>),
@@ -657,6 +705,14 @@ pub struct EngineHandle<F: Filesystem, C: Clock> {
     /// pool is only ever locked by the owning connection thread (uncontended). It carries no produce
     /// state: it is purely an allocation cache, so it never affects reply ORDER or I2.
     reply_pool: ReplyPool,
+    /// The per-CONNECTION free-list of drained Level-0 batch buffers (#775), the QoS-0 twin of
+    /// `reply_pool`: `produce_no_reply_batch` attaches it to the `Command::ProduceNoReplyBatch` so the
+    /// actor returns the drained `Vec<OwnedAppend>` here (cleared) after appending it, and
+    /// [`EngineHandle::take_l0_buf`] pops it back so the session reuses ONE allocation across flush passes
+    /// instead of regrowing from zero. [`Clone`] gives each new connection a FRESH empty pool (a buffer
+    /// never crosses connections). Pure allocation cache: it never affects the batch's contents, order, or
+    /// the single total order (the actor only ever recycles an already-cleared, no-longer-referenced Vec).
+    l0_buf_pool: L0BufPool,
     /// The connection-thread byte-cap fast-reject gate (#476, fixes #465): a relaxed-atomic snapshot
     /// of the durable-log byte-cap shed state the connection thread reads BEFORE the blocking
     /// `tx.send`, so an at-or-over-cap produce is replied `AtCapacity` immediately WITHOUT enqueuing
@@ -755,6 +811,9 @@ impl<F: Filesystem, C: Clock + Clone> Clone for EngineHandle<F, C> {
             // recycled reply channels stay strictly per-connection and never cross-deliver. The pool
             // warms lazily on that connection's first produces.
             reply_pool: Arc::new(Mutex::new(Vec::new())),
+            // A FRESH Level-0 batch-buffer pool per clone (#775), like `reply_pool`: recycled batch
+            // buffers stay strictly per-connection (a buffer never crosses connections). Warms lazily.
+            l0_buf_pool: Arc::new(Mutex::new(Vec::new())),
             // The SAME shared gate (#476): every connection reads the one byte-cap snapshot the actor
             // publishes, so the `Arc` is shared on clone (NOT freshened like `reply_pool`).
             cap_gate: Arc::clone(&self.cap_gate),
@@ -1022,7 +1081,10 @@ impl<F: Filesystem + 'static, C: Clock + 'static> EngineHandle<F, C> {
         if self.cap_gate.cap() == 0 {
             return self
                 .tx
-                .send(Command::ProduceNoReplyBatch { appends })
+                .send(Command::ProduceNoReplyBatch {
+                    appends,
+                    buf_pool: self.l0_buf_pool.clone(),
+                })
                 .map_err(|_| ActorGone);
         }
         // CAPPED PATH: per-append fast-reject, SAME as `produce_no_reply`. The byte-cap snapshot can
@@ -1046,8 +1108,22 @@ impl<F: Filesystem + 'static, C: Clock + 'static> EngineHandle<F, C> {
             return Ok(());
         }
         self.tx
-            .send(Command::ProduceNoReplyBatch { appends })
+            .send(Command::ProduceNoReplyBatch {
+                appends,
+                buf_pool: self.l0_buf_pool.clone(),
+            })
             .map_err(|_| ActorGone)
+    }
+
+    /// Takes a REUSABLE Level-0 batch buffer for the session to accumulate the next pass's no-ack
+    /// produces into (#775): pops one the actor drained and returned (its capacity retained, always
+    /// cleared, see [`l0_buf_return`]), or a fresh empty `Vec` when the pool is cold. The session's
+    /// [`Session::flush_level0`] calls this right after it `mem::take`s the batch into the command, so the
+    /// buffer it accumulates into next never regrows from zero. The buffer handed back is NEVER the one
+    /// currently in flight (that one is owned by the actor until it drains + returns it), so there is no
+    /// aliasing.
+    pub fn take_l0_buf(&self) -> Vec<OwnedAppend> {
+        l0_buf_take(&self.l0_buf_pool)
     }
 
     /// Runs `job` on the owned engine and AWAITS its result. Used for every engine operation that is
@@ -1287,6 +1363,16 @@ pub trait EngineAccess<F: Filesystem, C: Clock> {
             self.produce_no_reply(append)?;
         }
         Ok(())
+    }
+
+    /// Takes a REUSABLE Level-0 batch buffer for the session to accumulate the next pass's no-ack
+    /// produces into (#775). [`EngineHandle`] overrides this to pop a buffer the actor drained and
+    /// returned (capacity retained, always cleared) so the QoS-0 batch path reuses one allocation across
+    /// passes. The DEFAULT (the direct/test engines) has no actor to recycle through, so it returns a
+    /// fresh empty `Vec` — correct, just unpooled (those engines produce synchronously, so there is
+    /// nothing in flight to recycle).
+    fn take_l0_buf(&self) -> Vec<OwnedAppend> {
+        Vec::new()
     }
 
     /// Runs `job` on the engine and returns its result.
@@ -1547,6 +1633,12 @@ impl<F: Filesystem + Clone + 'static, C: Clock + Clone + 'static> EngineAccess<F
         EngineHandle::produce_no_reply_batch(self, appends)
     }
 
+    fn take_l0_buf(&self) -> Vec<OwnedAppend> {
+        // The REAL pooled take (#775): pop a buffer the actor drained + cleared + returned, so the
+        // session's next Level-0 batch reuses the allocation instead of regrowing from zero.
+        EngineHandle::take_l0_buf(self)
+    }
+
     fn with<R, J>(&self, job: J) -> Result<R, ActorGone>
     where
         R: Send + 'static,
@@ -1763,6 +1855,12 @@ impl<F: Filesystem + Clone + 'static, C: Clock + Clone + 'static> EngineAccess<F
 
     fn produce_no_reply_batch(&self, appends: Vec<OwnedAppend>) -> Result<(), ActorGone> {
         EngineAccess::produce_no_reply_batch(self.primary(), appends)
+    }
+
+    fn take_l0_buf(&self) -> Vec<OwnedAppend> {
+        // Route through the primary handle's pool (#775): at K = 1 this is byte-for-byte the single
+        // handle, and the primary is the connection's real L0-batch target.
+        EngineAccess::take_l0_buf(self.primary())
     }
 
     fn with<R, J>(&self, job: J) -> Result<R, ActorGone>
@@ -2258,6 +2356,9 @@ where
             // The base handle's pool (#475); each per-connection `clone` gets its own fresh pool, so
             // this one is only used if the base handle itself produces (e.g. in tests).
             reply_pool: Arc::new(Mutex::new(Vec::new())),
+            // The base handle's Level-0 batch-buffer pool (#775); each per-connection `clone` gets its
+            // own fresh pool. Only the base handle's is used if the base handle itself batches (tests).
+            l0_buf_pool: Arc::new(Mutex::new(Vec::new())),
             // The shared fast-reject gate (#476); every connection `clone` shares this same `Arc`.
             cap_gate,
             // The spin discriminant snapshotted above (#1032); copied into every connection clone.
@@ -2602,10 +2703,14 @@ where
                 // CHANNEL-SEND coalescing — the per-append append/admission work is byte-identical to the
                 // per-message arm; only the session->actor handoff was batched, so the single total order
                 // and I2 for other records are untouched.
-                Command::ProduceNoReplyBatch { appends } => {
+                Command::ProduceNoReplyBatch { appends, buf_pool } => {
                     for append in &appends {
                         process_produce(&mut engine, &mut pending, append, None);
                     }
+                    // Return the DRAINED buffer to the originating connection's pool (#775): the loop
+                    // above finished reading `appends` (no aliasing), so `l0_buf_return` clears it and
+                    // recycles the allocation for the session's next flush pass.
+                    l0_buf_return(&buf_pool, appends);
                 }
                 // A non-produce job must observe a consistent durable head and keep the total durable
                 // order, so flush the parked produces (one fsync) BEFORE it runs.
@@ -2819,10 +2924,13 @@ where
                 Command::ProduceNoReply { append } => {
                     process_produce(&mut engine, &mut pipeline, &append, None);
                 }
-                Command::ProduceNoReplyBatch { appends } => {
+                Command::ProduceNoReplyBatch { appends, buf_pool } => {
                     for append in &appends {
                         process_produce(&mut engine, &mut pipeline, append, None);
                     }
+                    // Recycle the drained buffer to the connection's pool (#775), same as the legacy
+                    // loop: read the whole batch first, then clear + return the allocation.
+                    l0_buf_return(&buf_pool, appends);
                 }
                 // E5: a Run job does NOT quiesce the pipeline (L9). The job observes a consistent,
                 // MONOTONE durable head that may trail the appended head by the in-flight window;
@@ -3227,10 +3335,14 @@ where
                         Ok(Command::ProduceNoReply { append }) => {
                             process_produce(engine, self, &append, None);
                         }
-                        Ok(Command::ProduceNoReplyBatch { appends }) => {
+                        Ok(Command::ProduceNoReplyBatch { appends, buf_pool }) => {
                             for append in &appends {
                                 process_produce(engine, self, append, None);
                             }
+                            // Recycle the drained buffer to the connection's pool (#775): the linger
+                            // loop reads the batch, then clears + returns the allocation like the
+                            // main loops.
+                            l0_buf_return(&buf_pool, appends);
                         }
                         // A non-produce command ends the linger: dispatch the window now and
                         // handle the command in the normal loop (as the next pass's head).

--- a/crates/ironbus-server/src/session.rs
+++ b/crates/ironbus-server/src/session.rs
@@ -2287,7 +2287,15 @@ impl Session {
         if self.level0_pending.is_empty() {
             return Ok(());
         }
-        engine.produce_no_reply_batch(std::mem::take(&mut self.level0_pending))?;
+        // Reuse ONE batch allocation across passes (#775): `mem::take` hands the drained batch to the
+        // actor by value (the actor returns it to this connection's buffer pool once appended), then
+        // REFILL `level0_pending` with a recycled buffer (its capacity retained, always cleared — see
+        // `l0_buf_return`) so the next pass's appends never regrow from a zero-capacity `Vec`. The buffer
+        // taken here is NEVER the one just sent (that one is owned by the actor until it drains it), so
+        // there is no aliasing; a cold pool simply hands back a fresh empty `Vec` (today's behavior).
+        let batch = std::mem::take(&mut self.level0_pending);
+        self.level0_pending = engine.take_l0_buf();
+        engine.produce_no_reply_batch(batch)?;
         Ok(())
     }
 
@@ -15051,6 +15059,28 @@ mod tests {
         frame(FrameType::Pub, &pub_body)
     }
 
+    /// Encodes one LEVEL-0 (QoS-0, fire-and-forget) PUB frame carrying `payload`, for the server-side
+    /// batch-path tests (#775). The only difference from [`pub_frame`] is the fire-and-forget bit
+    /// ([`PUB_FLAG_FIRE_AND_FORGET`], which `pub_ack_level` reads as [`AckLevel::NoAck`]), so the session
+    /// routes it into the pass-scoped Level-0 batch instead of the parked at-least-once window.
+    fn l0_pub_frame(payload: &[u8]) -> Vec<u8> {
+        let mut pub_body = Vec::new();
+        encode_pub(
+            &PubBody {
+                flags: 0,
+                timestamp_ms: 0,
+                key: b"",
+                headers: b"",
+                dedup: None,
+                fire_and_forget: true,
+                payload,
+            },
+            &mut pub_body,
+        )
+        .unwrap();
+        frame(FrameType::Pub, &pub_body)
+    }
+
     #[test]
     fn pipelined_pubs_in_one_pass_reply_fifo_acks_in_frame_order() {
         // The pipelined window's WIRE contract (#450): N PUB frames in ONE input buffer get N
@@ -15428,6 +15458,272 @@ mod tests {
             1,
             "the second produce takes the next offset — FIFO, no reorder"
         );
+
+        let _ = handle.shutdown();
+        drop(handle);
+        let _ = actor.join().unwrap();
+    }
+
+    // -- #775: server-side Level-0 (QoS-0) batch-path ordering + buffer-pool tests ------------------
+    //
+    // The #755 tests were client-side only; these guard the SERVER side of the Level-0 batch path: the
+    // session's flush-ordering discipline (the batch reaches the actor before any Level-1 produce or
+    // non-produce op, and the MAX_PARKED cap-flush splits in order) and the #775 batch-buffer pool's
+    // clear-on-reuse. The three ordering tests use a recording `EngineAccess` double so the session's
+    // exact flush SEQUENCE is observed directly; the pool test uses a real actor (the pool lives on the
+    // real handle).
+
+    /// One recorded flush-path event the session drove on the [`L0OrderRecorder`] (#775), in call order.
+    #[derive(Debug, PartialEq, Eq)]
+    enum L0FlushEvent {
+        /// A `produce_no_reply_batch` (a Level-0 batch flush), carrying the batched appends' payloads in
+        /// order — so a test can assert both the split boundaries and the in-order, no-drop contents.
+        Batch(Vec<Vec<u8>>),
+        /// A `produce_submit` (an at-least-once produce), carrying its payload.
+        Submit(Vec<u8>),
+    }
+
+    /// A recording [`EngineAccess`] double (#775) that captures the SEQUENCE of produce operations the
+    /// session drives — every Level-0 `produce_no_reply_batch` and every at-least-once `produce_submit`,
+    /// in call order — so a test can assert the session's flush-before-produce / flush-before-dispatch
+    /// ordering and the `MAX_PARKED_PRODUCES` cap-flush split DIRECTLY, with no actor or fsync. It uses
+    /// the DEFAULT (unpooled) `take_l0_buf`, so it exercises the session's flush logic independently of
+    /// the buffer pool (which the real-actor pool test covers separately). `produce_submit` hands back a
+    /// `Ready` outcome at the next monotonically-assigned offset, so a batched L0 run advances the offset
+    /// the same as the actor would and a trailing L1 observes the offset AFTER every batched L0.
+    struct L0OrderRecorder {
+        events: std::cell::RefCell<Vec<L0FlushEvent>>,
+        next_offset: std::cell::Cell<u64>,
+    }
+
+    impl L0OrderRecorder {
+        fn new() -> Self {
+            Self {
+                events: std::cell::RefCell::new(Vec::new()),
+                next_offset: std::cell::Cell::new(0),
+            }
+        }
+
+        fn events(&self) -> Vec<L0FlushEvent> {
+            self.events.borrow_mut().drain(..).collect()
+        }
+    }
+
+    impl EngineAccess<InMemoryFs, ManualClock> for L0OrderRecorder {
+        fn produce(&self, _append: OwnedAppend) -> Result<ProduceOutcome, ActorGone> {
+            // Never reached: `handle_pub` routes an at-least-once produce through `produce_submit` and a
+            // Level-0 produce through `produce_no_reply_batch`.
+            Ok(ProduceOutcome::Appended(Offset::new(0)))
+        }
+        fn produce_submit(&self, append: OwnedAppend) -> Result<ProduceSubmission, ActorGone> {
+            self.events
+                .borrow_mut()
+                .push(L0FlushEvent::Submit(append.payload.to_vec()));
+            let offset = self.next_offset.get();
+            self.next_offset.set(offset + 1);
+            Ok(ProduceSubmission::Ready(ProduceOutcome::Appended(
+                Offset::new(offset),
+            )))
+        }
+        fn produce_no_reply_batch(&self, appends: Vec<OwnedAppend>) -> Result<(), ActorGone> {
+            // Record the batch as ONE event (do NOT fall through to the default's per-append fan-out):
+            // this IS the coalesced Level-0 batch the session handed over.
+            self.events.borrow_mut().push(L0FlushEvent::Batch(
+                appends.iter().map(|a| a.payload.to_vec()).collect(),
+            ));
+            self.next_offset
+                .set(self.next_offset.get() + appends.len() as u64);
+            Ok(())
+        }
+        fn with<R, J>(&self, _job: J) -> Result<R, ActorGone>
+        where
+            R: Send + 'static,
+            J: FnOnce(&mut Engine<InMemoryFs, ManualClock>) -> R + Send + 'static,
+        {
+            // Unreached by the ordering tests (they use PING as the non-produce frame, which never
+            // touches the engine); a call here would be a test-scenario bug, so fail loudly.
+            Err(ActorGone)
+        }
+        fn now_monotonic_nanos(&self) -> u64 {
+            0
+        }
+        fn consumer_credit_caps(&self) -> (u32, u64) {
+            (64, 0)
+        }
+    }
+
+    #[test]
+    fn a_level0_batch_flushes_before_a_level1_produce_in_the_same_pass_775() {
+        // FLUSH-ORDERING (the `flush_level0`-before-`produce_submit` seam, session.rs handle_pub): a
+        // Level-0 batch accumulated BEFORE an at-least-once produce in the SAME pass must reach the actor
+        // FIRST, so the single total order holds (the earlier-decoded L0s are appended before the L1).
+        // Observed directly: the recorder saw the whole L0 batch, THEN the L1 submit, and the L1 took the
+        // offset AFTER every batched L0.
+        let engine = L0OrderRecorder::new();
+        let mut s = Session::new();
+        let mut out = Vec::new();
+        s.process(&engine, &frame(FrameType::Connect, b""), &mut out)
+            .unwrap();
+        out.clear();
+
+        let mut input = Vec::new();
+        input.extend_from_slice(&l0_pub_frame(b"a0"));
+        input.extend_from_slice(&l0_pub_frame(b"a1"));
+        input.extend_from_slice(&l0_pub_frame(b"a2"));
+        input.extend_from_slice(&pub_frame(b"z")); // the at-least-once produce
+        s.process(&engine, &input, &mut out).unwrap();
+        s.flush_all_parked_blocking(&engine, &mut out).unwrap();
+
+        assert_eq!(
+            engine.events(),
+            vec![
+                L0FlushEvent::Batch(vec![b"a0".to_vec(), b"a1".to_vec(), b"a2".to_vec()]),
+                L0FlushEvent::Submit(b"z".to_vec()),
+            ],
+            "the L0 batch is flushed to the actor BEFORE the L1 is submitted (single total order)"
+        );
+        // The L1's PubAck carries the offset AFTER the three batched L0s (offsets 0,1,2 → L1 = 3).
+        let acks = decode_all(&out);
+        assert_eq!(acks.len(), 1, "exactly the L1 acks (the L0s are no-ack)");
+        assert_eq!(acks[0].0, FrameType::PubAck);
+        assert_eq!(
+            decode_pub_ack(&acks[0].1).unwrap().offset,
+            3,
+            "the L1 lands AFTER every batched L0"
+        );
+    }
+
+    #[test]
+    fn a_level0_batch_over_the_max_parked_cap_splits_into_in_order_batches_775() {
+        // THE `MAX_PARKED_PRODUCES` CAP-FLUSH (session.rs, the `level0_pending.len() >= cap` flush): more
+        // than one cap's worth of Level-0 produces in ONE pass cannot accumulate unbounded — the session
+        // flushes at the cap and starts a fresh batch. Proven: the run splits into a first batch at
+        // EXACTLY the cap and the remainder at end-of-pass, with the payloads still 0..N IN ORDER across
+        // the split (no reorder, no drop).
+        let engine = L0OrderRecorder::new();
+        let mut s = Session::new();
+        let mut out = Vec::new();
+        s.process(&engine, &frame(FrameType::Connect, b""), &mut out)
+            .unwrap();
+        out.clear();
+
+        let total = MAX_PARKED_PRODUCES + 5;
+        let mut input = Vec::new();
+        for i in 0..total {
+            let tag = u32::try_from(i).expect("index fits in u32");
+            input.extend_from_slice(&l0_pub_frame(&tag.to_le_bytes()));
+        }
+        s.process(&engine, &input, &mut out).unwrap();
+
+        let events = engine.events();
+        assert_eq!(
+            events.len(),
+            2,
+            "the pass split into two in-order batches at the MAX_PARKED cap"
+        );
+        let (b0, b1) = match (&events[0], &events[1]) {
+            (L0FlushEvent::Batch(b0), L0FlushEvent::Batch(b1)) => (b0, b1),
+            other => panic!("expected two Batch events, got {other:?}"),
+        };
+        assert_eq!(
+            b0.len(),
+            MAX_PARKED_PRODUCES,
+            "the first batch flushed at exactly the cap"
+        );
+        assert_eq!(b1.len(), 5, "the remainder flushed at end-of-pass");
+        let seen: Vec<u32> = b0
+            .iter()
+            .chain(b1.iter())
+            .map(|p| u32::from_le_bytes(p.as_slice().try_into().unwrap()))
+            .collect();
+        let expected: Vec<u32> = (0..u32::try_from(total).expect("total fits in u32")).collect();
+        assert_eq!(
+            seen, expected,
+            "concatenated the two batches are the appends 0..N IN ORDER — no reorder, none dropped"
+        );
+    }
+
+    #[test]
+    fn a_non_produce_frame_flushes_the_level0_batch_before_it_dispatches_775() {
+        // FLUSH-BEFORE-DISPATCH (session.rs, the `flush_level0` before `drain_parked` + `dispatch` for a
+        // non-produce frame): a Level-0 batch accumulated BEFORE a non-produce frame (ack/flow/sub/ping)
+        // must reach the actor FIRST, so the actor observes the earlier L0s before the non-produce op
+        // (single total order). Proven with a PING mid-pass: the batch splits at the PING — the earlier
+        // L0s flush as one batch BEFORE the dispatch, the trailing L0 flushes at end-of-pass. A missing
+        // flush-before-dispatch would coalesce all three into ONE end-of-pass batch.
+        let engine = L0OrderRecorder::new();
+        let mut s = Session::new();
+        let mut out = Vec::new();
+        s.process(&engine, &frame(FrameType::Connect, b""), &mut out)
+            .unwrap();
+        out.clear();
+
+        let mut input = Vec::new();
+        input.extend_from_slice(&l0_pub_frame(b"a0"));
+        input.extend_from_slice(&l0_pub_frame(b"a1"));
+        input.extend_from_slice(&frame(FrameType::Ping, b"")); // the non-produce frame
+        input.extend_from_slice(&l0_pub_frame(b"a2"));
+        s.process(&engine, &input, &mut out).unwrap();
+
+        assert_eq!(
+            engine.events(),
+            vec![
+                L0FlushEvent::Batch(vec![b"a0".to_vec(), b"a1".to_vec()]),
+                L0FlushEvent::Batch(vec![b"a2".to_vec()]),
+            ],
+            "the pending L0 batch flushes BEFORE the non-produce frame dispatches (split at the PING)"
+        );
+        // The PING dispatched (its Pong is the only wire reply) — between the two batch flushes.
+        let frames = decode_all(&out);
+        assert_eq!(
+            frames.iter().map(|(t, _)| *t).collect::<Vec<_>>(),
+            vec![FrameType::Pong],
+            "the non-produce frame ran after the earlier L0s were flushed"
+        );
+    }
+
+    #[test]
+    fn the_level0_batch_buffer_is_cleared_before_reuse_across_flush_passes_775() {
+        // THE #775 BATCH-BUFFER POOL's clear-on-reuse, over a REAL actor (the pool lives on the real
+        // handle). Several flush passes, each a batch of Level-0 PUBs with pass-distinct payloads. A
+        // `with` job between passes BARRIERS the actor: because it drains commands FIFO, by the time
+        // `with` returns the actor has appended the pass's batch AND returned the drained buffer (cleared)
+        // to the connection's pool — so the NEXT pass's `flush_level0` DETERMINISTICALLY reuses that
+        // recycled buffer. If a reused buffer were NOT cleared, the next batch would replay the prior
+        // pass's appends and the durable head would jump by more than that pass's count. Asserting
+        // head == cumulative count after every pass proves the clear-on-reuse (no stale appends leak).
+        use crate::actor::{spawn_actor, DEFAULT_CHANNEL_BOUND};
+
+        let engine = Engine::open(InMemoryFs::new(), ManualClock::new(), test_config()).unwrap();
+        let (handle, actor) = spawn_actor(engine, DEFAULT_CHANNEL_BOUND);
+        let mut s = Session::new();
+        let mut out = Vec::new();
+        s.process(&handle, &frame(FrameType::Connect, b""), &mut out)
+            .unwrap();
+        out.clear();
+
+        let pass_sizes = [3usize, 2, 4, 1];
+        let mut cumulative = 0u64;
+        for (p, &k) in pass_sizes.iter().enumerate() {
+            let mut input = Vec::new();
+            for i in 0..k {
+                input.extend_from_slice(&l0_pub_frame(format!("p{p}-{i}").as_bytes()));
+            }
+            s.process(&handle, &input, &mut out).unwrap();
+            cumulative += k as u64;
+            // Barrier + observe: the `with` job runs AFTER the pass's batch command (FIFO), so the
+            // actor has appended the batch and returned the drained buffer to the pool before it runs.
+            // `append_head` is the visible appended head (a no-ack L0 is not fsync'd, so read the
+            // appended head, not the durable one). Exactly `cumulative` records were appended — a
+            // recycled-but-uncleared buffer would have replayed a prior pass's appends and bumped the
+            // head past `cumulative`.
+            let head = handle.with(|e| e.append_head().get()).unwrap();
+            assert_eq!(
+                head, cumulative,
+                "after pass {p} exactly {cumulative} records were appended — a reused batch buffer never \
+                 replays a prior pass's appends (clear-on-reuse)"
+            );
+        }
 
         let _ = handle.shutdown();
         drop(handle);


### PR DESCRIPTION
Closes the remaining #755-review Level-0 (QoS-0) batch follow-ups tracked in #775. Cleanups + tests only — the wire format and Level-1 (QoS-1) durability semantics are UNCHANGED (same appends, same order, same one covering group commit).

## Scope note (what #782 already did)
The prior #782 landed leanness items **2** (`Vec::retain` on the capped `produce_no_reply_batch` arm) and **3** (`gather_commands` counts `appends.len()`), plus the batched cap-shed test `an_over_cap_level0_batch_sheds_every_append_into_fire_and_forget_shed`. This PR does not re-touch them. It lands the one remaining leanness item (the buffer pool, which #782 had declined) and the three remaining ordering tests + the pool test #775 kept open.

## Leanness

1. **Pool the batch buffer — free-list (NOT capacity-retain).** `Session::flush_level0` `mem::take`s `level0_pending` by value into the command, leaving a zero-capacity `Vec` behind, so each pass regrew from zero. This PR adds a **per-connection free-list mirroring the existing `reply_pool` (#475)**: the batch rides with `Command::ProduceNoReplyBatch { appends, buf_pool }`, the shared actor returns the drained `Vec<OwnedAppend>` to the originating connection's pool after appending it, and `flush_level0` refills `level0_pending` from the pool via a new `EngineAccess::take_l0_buf`. One allocation is reused across passes instead of regrowing.

   Capacity-retain-in-the-session was rejected because it does not actually save the allocation (the command must still own a `Vec` to cross the actor channel, so it only relocates the alloc); the free-list is the only true reuse, and its lifecycle is provably clean (below), so per #775 it is the free-list.

   **Clear-on-reuse proof (the one correctness seam):**
   - *No stale appends:* `l0_buf_return` `clear()`s the buffer **before** it re-enters the pool, so the pool's invariant is empty-buffers-only and a reuse can never replay a prior batch's appends.
   - *No aliasing:* the buffer is owned by exactly one party at a time — session `mem::take` (relinquishes) → command move → actor **sole** ownership → returned to the pool only **after** the drain loop finished reading it. `take_l0_buf` hands back a different (or fresh) buffer, never the in-flight one.
   - *No cross-connection contamination:* the pool is per-connection (fresh on each handle clone, like `reply_pool`) and rides with the command, so the shared actor routes each buffer back to the connection that sent it.

2. **`Vec::retain` on the capped path** — already merged in #782 (unchanged here).
3. **Count `appends.len()` in `gather_commands`** — already merged in #782 (unchanged here).

## Server-side batch tests (the #755 tests were client-side only)
Four new server tests (the fifth, batched cap-shed accounting, already exists from #782):
- `a_level0_batch_flushes_before_a_level1_produce_in_the_same_pass_775` — the L1 lands after every batched L0 (the `flush_level0`-before-`produce_submit` seam): the recorder sees `Batch` then `Submit`, and the L1's PubAck offset is after all L0s.
- `a_non_produce_frame_flushes_the_level0_batch_before_it_dispatches_775` — a PING mid-batch splits the run in two, so the actor observes the earlier L0s before the non-produce op (the flush before `drain_parked` + `dispatch`).
- `a_level0_batch_over_the_max_parked_cap_splits_into_in_order_batches_775` — 1024+ L0 in one pass splits into a batch at exactly `MAX_PARKED_PRODUCES` and the remainder, payloads `0..N` in order (no reorder, no drop).
- `the_level0_batch_buffer_is_cleared_before_reuse_across_flush_passes_775` — real actor; `with`-job barriers force deterministic buffer reuse; asserts the appended head == cumulative count per pass. Disabling the `clear()` makes it fail (head 12 vs 9), so it genuinely guards clear-on-reuse.

The three ordering tests use a recording `EngineAccess` double (observes the session's exact flush sequence, no actor/fsync); the pool test needs the real handle (the pool lives there).

## Gates (all green, container: Linux, `--all-features --locked`, `pipefail`)
- `cargo test --workspace --all-features --locked` — 0 failed (incl. the 4 new tests; CLI 127.0.0.1:1 validation via `--sysctl net.ipv4.ip_unprivileged_port_start=1024 --cap-drop NET_BIND_SERVICE`)
- `cargo clippy --workspace --all-features --all-targets -- -D warnings` — clean (after fmt)
- `cargo fmt --check` — clean
- `sh scripts/check-format-registry.sh` — format + FrameType tag map digests match (wire unchanged)
- `cargo deny check` — advisories/bans/licenses/sources ok
- `cargo tree --all-features -i ring` — empty (no ring)
- golden-path acceptance (#133) — PASS (all 10 steps)
- `cargo check --workspace --target x86_64-pc-windows-gnu` — ok

## Constraints
Wire format unchanged; no new dependency; `deny.toml` byte-identical; L1 (QoS-1) durability semantics untouched.
