### PR TITLE
feat(cli): `ironbus dev` one-command local quickstart (#796)

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,32 @@ cargo build --release --target aarch64-unknown-linux-musl
 scp target/aarch64-unknown-linux-musl/release/ironbus pi@edge-device:/usr/local/bin/ironbus
 ```
 
+### The fastest local loop: `ironbus dev`
+
+Just want to see a message move? After installing, **one command** stands up a throwaway local broker — friendly loopback ports, a pre-declared `demo` stream with a couple of `demo.*` subjects, and a copy-paste produce/consume snippet — all backed by an **ephemeral temp data dir that is removed on exit** (a clean stop *and* `Ctrl-C` / `SIGTERM`). Nothing to configure, nothing to clean up:
+
+```sh
+ironbus dev
+```
+
+It prints exactly what to paste into another terminal, pointed at the address it bound, for example:
+
+```sh
+# consume the default stream (this blocks, waiting for messages):
+ironbus sub --addr 127.0.0.1:7777 --group demo --ack
+
+# produce a message — watch it land in the consumer above:
+ironbus pub --addr 127.0.0.1:7777 --key demo.hello 'hello from ironbus dev'
+```
+
+Want instant activity in `ironbus top` and `/admin`? Seed some synthetic messages into the demo stream on startup:
+
+```sh
+ironbus dev --seed 1000
+```
+
+`dev` is **pure sugar** over the normal `serve` / `top` / `/admin` surfaces — the same single binary, no extra process, no Docker, no config file, no embedded console. If `127.0.0.1:7777` / `:7778` are already in use it picks free ports and tells you. It is for local exploration only; for a real node use `serve` below. (Unix only, like the broker itself.)
+
 ### 2. Start the broker on the edge
 
 The only required flag is `--data-dir` (the durable log, the consumer cursors, and the dead-letter sink all live there). Use the `edge-tiny` profile for a small-RAM, flash-gentle node:

--- a/crates/ironbus-cli/Cargo.toml
+++ b/crates/ironbus-cli/Cargo.toml
@@ -118,6 +118,14 @@ bytes = { version = "1", default-features = false }
 tempfile = "3"
 sha2 = { version = "0.10", default-features = false }
 argon2 = { version = "0.5", default-features = false, features = ["alloc", "password-hash"] }
+# The `ironbus dev` end-to-end test (#796) launches the REAL `ironbus dev` binary as a subprocess and
+# then drives the live broker as a genuine client to prove the acceptance: the demo stream is
+# pre-declared (`stream_info`), `--seed N` lands N messages (a consume count via `subscribe_to`), and a
+# produce->consume roundtrip works. `ironbus-client` is ALREADY a normal (shipped) dependency of this
+# crate and is already in `Cargo.lock`; an integration test of this BIN-only crate cannot see the
+# crate's normal deps, so it is re-declared here DEV-ONLY. It adds NO new crate to the graph, never
+# enters the shipped binary, and leaves the SBOM, `deny.toml`, and the cffi-ban gate byte-identical.
+ironbus-client = { path = "../ironbus-client" }
 
 [lints]
 workspace = true

--- a/crates/ironbus-cli/Cargo.toml
+++ b/crates/ironbus-cli/Cargo.toml
@@ -125,7 +125,7 @@ argon2 = { version = "0.5", default-features = false, features = ["alloc", "pass
 # crate and is already in `Cargo.lock`; an integration test of this BIN-only crate cannot see the
 # crate's normal deps, so it is re-declared here DEV-ONLY. It adds NO new crate to the graph, never
 # enters the shipped binary, and leaves the SBOM, `deny.toml`, and the cffi-ban gate byte-identical.
-ironbus-client = { path = "../ironbus-client" }
+ironbus-client = { path = "../ironbus-client", version = "0.1.0" }
 
 [lints]
 workspace = true

--- a/crates/ironbus-cli/src/completion.rs
+++ b/crates/ironbus-cli/src/completion.rs
@@ -277,6 +277,12 @@ pub(crate) const COMMAND_TREE: &[Cmd] = &[
         ],
     },
     Cmd {
+        name: "dev",
+        about: "One-command local quickstart broker (ephemeral)",
+        flags: &["--seed", "--addr", "--health-addr"],
+        subs: &[],
+    },
+    Cmd {
         name: "completion",
         about: "Generate a shell-completion script",
         flags: &[],
@@ -613,6 +619,7 @@ mod tests {
             "migrate",
             "dict",
             "context",
+            "dev",
             "completion",
             "cheat",
             "version",

--- a/crates/ironbus-cli/src/dev.rs
+++ b/crates/ironbus-cli/src/dev.rs
@@ -1,0 +1,596 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! `ironbus dev`: a one-command local quickstart (#796).
+//!
+//! `ironbus dev` gives a newcomer a first-five-minutes "wow": one command stands up a working
+//! local broker, pre-declares a demo stream + subjects, and prints a copy-paste produce/consume
+//! snippet — nothing to hand-assemble.
+//!
+//! It is PURE SUGAR over capabilities the broker already has: `dev` spawns the SAME `ironbus serve`
+//! as a child process (the broker binary and its data plane are byte-for-byte untouched) and only
+//! layers orchestration on top:
+//!
+//! 1. **serve-with-sane-defaults** — a normal broker bound to loopback on friendly, non-privileged
+//!    default ports, backed by an EPHEMERAL data dir (a temp dir) that is removed on exit: a clean
+//!    exit, a broker that exits on its own, AND Ctrl-C / `SIGINT` / `SIGTERM`.
+//! 2. **pre-declared demo topology** — a [`DEMO_STREAM`] named stream plus a couple of [`DEMO_SUBJECTS`]
+//!    bound to it, declared over the live admin/declare surface right after the broker is up, so
+//!    produce/consume, `top`, and `/admin` have something to show on first launch.
+//! 3. **a copy-paste snippet** — the real `ironbus pub` / `ironbus sub` / `ironbus top` / `ironbus
+//!    admin` commands pointed at THIS broker's bound address, printed on startup.
+//! 4. **optional `--seed N`** — publish N synthetic messages into [`DEMO_STREAM`] so `ironbus top`
+//!    and `/admin` show instant activity.
+//!
+//! Deliberately OUT OF SCOPE (kept an XS quickstart, not a Trojan horse): no embedded console / web
+//! UI, no connector / seed pipeline beyond the trivial synthetic `--seed`, no new broker runtime,
+//! and no KV / object store (the ephemeral dir is just the bus's normal storage at a temp path).
+//!
+//! Unix-only in v1, exactly like `serve` itself (the on-disk broker uses positioned IO the Windows
+//! path does not yet implement); the non-Unix build compiles a stub that errors cleanly. The
+//! argument parser, the help, and the snippet builder are pure and cross-platform so their behavior
+//! and unit tests are identical on every target.
+
+use crate::CliError;
+use std::io::Write;
+
+/// The demo NAMED stream `ironbus dev` pre-declares on startup. Declaring is idempotent
+/// (create-or-ensure), so a re-run never conflicts.
+const DEMO_STREAM: &str = "demo";
+
+/// The demo SUBJECT patterns bound to [`DEMO_STREAM`] (wildcards live on the pattern side). The two
+/// patterns are DISJOINT, so a literal subject resolves unambiguously to the one demo stream; they
+/// exist so the subject router is non-empty out of the box.
+const DEMO_SUBJECTS: &[&str] = &["demo.orders.*", "demo.events.*"];
+
+/// The friendly default client-wire port `dev` binds when `--addr` is not given. Non-privileged
+/// (> 1024, needs no elevation); if it is already in use `dev` falls back to an OS-assigned free
+/// port rather than failing.
+const DEFAULT_DEV_WIRE_PORT: u16 = 7777;
+
+/// The friendly default health/admin port (`/admin`, `top --health-addr`) `dev` binds when
+/// `--health-addr` is not given; same non-privileged + fallback story as [`DEFAULT_DEV_WIRE_PORT`].
+const DEFAULT_DEV_HEALTH_PORT: u16 = 7778;
+
+/// Parsed `ironbus dev` arguments. Cross-platform (the parser and its error text are identical on
+/// every target); the Unix-only orchestration reads them, and the non-Unix stub consumes them.
+struct DevArgs {
+    /// `--seed N`: publish N synthetic messages into [`DEMO_STREAM`]. `0` (the default) seeds
+    /// nothing.
+    seed: u64,
+    /// `--addr <host:port>`: override the client-wire bind (default: the friendly
+    /// [`DEFAULT_DEV_WIRE_PORT`] with fallback). Mostly for tests and for an operator who wants a
+    /// specific port.
+    addr: Option<String>,
+    /// `--health-addr <host:port>`: override the health/admin bind (default:
+    /// [`DEFAULT_DEV_HEALTH_PORT`] with fallback).
+    health_addr: Option<String>,
+}
+
+/// Parses the `dev` flags. Cross-platform pure logic (unit-tested on every target).
+///
+/// # Errors
+/// [`CliError::Usage`] on an unknown flag, a missing flag value, or a non-numeric `--seed`.
+fn parse_dev_args(args: &[String]) -> Result<DevArgs, CliError> {
+    let mut seed = 0u64;
+    let mut addr = None;
+    let mut health_addr = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--seed" => seed = crate::take_number::<u64>("--seed", args, &mut i)?,
+            "--addr" => addr = Some(crate::take_value("--addr", args, &mut i)?),
+            "--health-addr" => {
+                health_addr = Some(crate::take_value("--health-addr", args, &mut i)?);
+            }
+            other => return Err(CliError::Usage(format!("unknown flag `{other}` for dev"))),
+        }
+    }
+    Ok(DevArgs {
+        seed,
+        addr,
+        health_addr,
+    })
+}
+
+/// Prints the `dev` help. It formats the demo + default-port constants so they are "used" on EVERY
+/// target, keeping the non-Unix `-D warnings` build free of `dead_code` (the #288/#99 footgun: a
+/// const read only on the Unix path trips `never used` on the Windows cross-check).
+///
+/// # Errors
+/// Propagates an [`io::Error`](std::io::Error) writing to `out`.
+fn print_dev_help(out: &mut impl Write) -> Result<(), CliError> {
+    let subjects = DEMO_SUBJECTS.join(", ");
+    writeln!(
+        out,
+        "ironbus dev — one-command local quickstart.\n\
+         \n\
+         USAGE:\n    ironbus dev [--seed <n>] [--addr <host:port>] [--health-addr <host:port>]\n\
+         \n\
+         Starts a normal broker on an EPHEMERAL data dir (a temp dir removed on exit — a clean exit\n\
+         AND Ctrl-C/SIGINT/SIGTERM), pre-declares the `{DEMO_STREAM}` stream (subjects: {subjects}),\n\
+         and prints a copy-paste produce/consume snippet pointed at the live broker.\n\
+         \n\
+         --seed <n>          publish <n> synthetic messages into `{DEMO_STREAM}` so `ironbus top`\n\
+                             and `/admin` show instant activity (default: 0).\n\
+         --addr <host:port>  client-wire bind (default: 127.0.0.1:{DEFAULT_DEV_WIRE_PORT}, or an\n\
+                             OS-assigned free port when that is busy).\n\
+         --health-addr <a>   health/admin bind (default: 127.0.0.1:{DEFAULT_DEV_HEALTH_PORT}, same\n\
+                             fallback).\n\
+         \n\
+         The broker binary and data plane are untouched: `dev` spawns the SAME `ironbus serve` and\n\
+         adds only the ephemeral-dir + friendly-defaults + demo-declare + snippet + optional-seed\n\
+         orchestration. Unix only in v1 (the broker is Unix-only)."
+    )?;
+    Ok(())
+}
+
+/// Dispatch entry for `ironbus dev`.
+///
+/// # Errors
+/// [`CliError::Usage`] on a bad flag; on Unix, [`CliError::Unreachable`] if the broker never comes
+/// up and [`CliError::Internal`] on an orchestration failure; on non-Unix, always
+/// [`CliError::Internal`] (the broker is Unix-only in v1).
+pub(crate) fn run_dev(args: &[String], out: &mut impl Write) -> Result<(), CliError> {
+    if args.iter().any(|a| a == "--help" || a == "-h") {
+        return print_dev_help(out);
+    }
+    let parsed = parse_dev_args(args)?;
+    run_dev_impl(parsed, out)
+}
+
+/// Builds the copy-paste produce/consume snippet: the real `ironbus` verbs pointed at THIS broker's
+/// bound `wire` / `health` addresses, referencing the demo `stream`. Pure + cross-platform so the
+/// snippet-correctness unit test exercises exactly what a newcomer would paste.
+#[cfg(unix)]
+fn dev_snippet(wire: &str, health: &str, stream: &str, seed: u64) -> String {
+    // `write!` into a String is infallible; the discarded `fmt::Result` is clippy's endorsed fix for
+    // `format_push_string` (which forbids `push_str(&format!(..))`). Each literal starts with its own
+    // two-space indent, so the rendered snippet is indented exactly as a newcomer sees it.
+    use std::fmt::Write as _;
+    let mut s = String::from("Try it now — in another terminal:\n\n");
+    let _ = write!(
+        s,
+        "  # consume the default stream (this blocks, waiting for messages):\n  \
+         ironbus sub --addr {wire} --group {stream} --ack\n\n"
+    );
+    let _ = write!(
+        s,
+        "  # produce a message — watch it land in the consumer above:\n  \
+         ironbus pub --addr {wire} --key {stream}.hello 'hello from ironbus dev'\n\n"
+    );
+    let _ = write!(
+        s,
+        "  # watch live traffic — the pre-declared `{stream}` stream and any seeded activity are here:\n  \
+         ironbus top --addr {wire}\n\n"
+    );
+    let _ = write!(
+        s,
+        "  # or grab the raw /admin JSON snapshot:\n  \
+         ironbus admin --health-addr {health}\n"
+    );
+    if seed > 0 {
+        let _ = write!(
+            s,
+            "\n  # the {seed} seeded messages already sit in `{stream}` — watch them in `ironbus top`.\n"
+        );
+    }
+    s
+}
+
+/// The running dev session: the child broker + the ephemeral data dir. Its [`Drop`] is the cleanup
+/// backstop — it runs on EVERY exit path (a clean stop, the broker exiting on its own, a Ctrl-C /
+/// SIGTERM that broke the wait loop, an early `?` error, or a panic) and reaps the broker before
+/// removing the temp dir so the dir is never held by the broker's data-dir lock at removal.
+#[cfg(unix)]
+struct DevSession {
+    child: std::process::Child,
+    data_dir: std::path::PathBuf,
+}
+
+#[cfg(unix)]
+impl Drop for DevSession {
+    fn drop(&mut self) {
+        // Reap the broker FIRST (releasing its exclusive data-dir lock), THEN remove the ephemeral
+        // dir. Both are best-effort: cleanup must never itself panic.
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+        let _ = std::fs::remove_dir_all(&self.data_dir);
+    }
+}
+
+/// The Unix orchestration: pick friendly ports, mint the ephemeral dir, spawn the SAME `ironbus
+/// serve`, wait for it, pre-declare the demo topology, optionally seed, print the snippet, then
+/// block until a stop signal or the broker exits — cleanup runs via [`DevSession`]'s `Drop`.
+#[cfg(unix)]
+fn run_dev_impl(args: DevArgs, out: &mut impl Write) -> Result<(), CliError> {
+    use ironbus_client::ClientConfig;
+
+    // 1. Resolve the two loopback binds (friendly default, or the explicit override), each falling
+    //    back to an OS-assigned free port if the default is busy — never a panic.
+    let wire = resolve_dev_addr(args.addr, DEFAULT_DEV_WIRE_PORT, out)?;
+    let health = resolve_dev_addr(args.health_addr, DEFAULT_DEV_HEALTH_PORT, out)?;
+
+    // 2. The ephemeral data dir (a fresh temp dir owned by `dev`, removed on exit).
+    let data_dir = make_ephemeral_dir()?;
+    let data_display = data_dir.display().to_string();
+
+    // 3. Spawn the SAME broker a `serve` would run — this binary re-invoked as `serve`, so the
+    //    broker code path is byte-for-byte unchanged. `dev` owns the temp dir, not the broker.
+    let exe = std::env::current_exe().map_err(|e| {
+        CliError::Internal(format!(
+            "could not locate the ironbus binary to launch the broker: {e}"
+        ))
+    })?;
+    let data_arg = data_dir.to_str().ok_or_else(|| {
+        CliError::Internal("the ephemeral data-dir path is not valid UTF-8".to_string())
+    })?;
+    let child = std::process::Command::new(&exe)
+        .args([
+            "serve",
+            "--data-dir",
+            data_arg,
+            "--addr",
+            &wire,
+            "--health-addr",
+            &health,
+            "--enable-admin",
+        ])
+        .stdin(std::process::Stdio::null())
+        .spawn()
+        .map_err(|e| {
+            CliError::Internal(format!("could not start the dev broker (`serve`): {e}"))
+        })?;
+
+    // From here on, `session`'s Drop is the cleanup backstop on every exit path.
+    let mut session = DevSession { child, data_dir };
+
+    // 4. Advertise stream addressing so declare/bind/publish-to work, and reuse this readiness
+    //    connection to declare the demo topology.
+    let config = ClientConfig {
+        understands_streams: true,
+        ..ClientConfig::default()
+    };
+    let mut client = wait_for_broker(&wire, &config, &mut session.child)?;
+    if !client.streams_enabled() {
+        return Err(CliError::Internal(
+            "the dev broker did not negotiate stream addressing (cannot pre-declare the demo stream)"
+                .to_string(),
+        ));
+    }
+
+    // 5. Pre-declare the demo stream + subjects over the live declare surface (idempotent).
+    client
+        .declare_stream(DEMO_STREAM)
+        .map_err(|e| crate::classify(&wire, "declaring the demo stream on", &e))?;
+    for pattern in DEMO_SUBJECTS {
+        client
+            .bind_subject(DEMO_STREAM, pattern)
+            .map_err(|e| crate::classify(&wire, "binding a demo subject on", &e))?;
+    }
+
+    // 6. Optional synthetic seed into the demo stream.
+    if args.seed > 0 {
+        seed_demo(&mut client, args.seed, &wire)?;
+    }
+    drop(client);
+
+    // 7. Print the banner + the copy-paste snippet.
+    print_ready_banner(out, &wire, &health, &data_display, args.seed)?;
+
+    // 8. Block until Ctrl-C / SIGTERM or the broker exits, then fall through so `session`'s Drop
+    //    reaps the broker and removes the temp dir.
+    block_until_stop(out, &mut session.child)
+    // `session` drops here (and on any early return above): broker reaped, temp dir removed.
+}
+
+/// Prints the "ready" banner and the copy-paste produce/consume snippet, flushing so it is visible
+/// before `dev` blocks.
+#[cfg(unix)]
+fn print_ready_banner(
+    out: &mut impl Write,
+    wire: &str,
+    health: &str,
+    data_display: &str,
+    seed: u64,
+) -> Result<(), CliError> {
+    let subjects = DEMO_SUBJECTS.join(", ");
+    writeln!(out)?;
+    writeln!(out, "ironbus dev: local quickstart broker is ready.")?;
+    writeln!(out, "  wire (produce/consume): {wire}")?;
+    writeln!(out, "  admin  (/admin, top):   {health}")?;
+    writeln!(
+        out,
+        "  ephemeral data dir:     {data_display} (removed on exit)"
+    )?;
+    writeln!(
+        out,
+        "  pre-declared stream:    {DEMO_STREAM} (subjects: {subjects})"
+    )?;
+    if seed > 0 {
+        writeln!(
+            out,
+            "  seeded:                 {seed} messages into `{DEMO_STREAM}`"
+        )?;
+    }
+    writeln!(out)?;
+    write!(out, "{}", dev_snippet(wire, health, DEMO_STREAM, seed))?;
+    writeln!(out)?;
+    writeln!(
+        out,
+        "ironbus dev: press Ctrl-C to stop (the ephemeral data dir is removed on exit)."
+    )?;
+    out.flush()?;
+    Ok(())
+}
+
+/// Blocks until Ctrl-C / SIGTERM (the flag flips) or the broker exits on its own. Registering the
+/// stop signals REPLACES the default terminate-without-cleanup disposition, so the caller's
+/// `DevSession` `Drop` still runs (and removes the temp dir) on a stop signal.
+#[cfg(unix)]
+fn block_until_stop(out: &mut impl Write, child: &mut std::process::Child) -> Result<(), CliError> {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+    use std::time::Duration;
+    let stop = Arc::new(AtomicBool::new(false));
+    for sig in [signal_hook::consts::SIGINT, signal_hook::consts::SIGTERM] {
+        signal_hook::flag::register(sig, Arc::clone(&stop)).map_err(|e| {
+            CliError::Internal(format!(
+                "could not install the dev stop-signal handler: {e}"
+            ))
+        })?;
+    }
+    loop {
+        if stop.load(Ordering::Relaxed) {
+            writeln!(
+                out,
+                "\nironbus dev: stopping; removing the ephemeral data dir."
+            )?;
+            return Ok(());
+        }
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                writeln!(
+                    out,
+                    "\nironbus dev: the broker exited ({status}); cleaning up."
+                )?;
+                return Ok(());
+            }
+            Ok(None) => {}
+            Err(e) => {
+                return Err(CliError::Internal(format!(
+                    "waiting on the dev broker failed: {e}"
+                )))
+            }
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+}
+
+/// Resolves one loopback bind: the explicit `override_addr` verbatim, else `127.0.0.1:preferred_port`
+/// when that is free, else an OS-assigned free loopback port (with a friendly note). Never panics
+/// and never blocks — the probe listener is dropped immediately, so `serve` binds it moments later.
+#[cfg(unix)]
+fn resolve_dev_addr(
+    override_addr: Option<String>,
+    preferred_port: u16,
+    out: &mut impl Write,
+) -> Result<String, CliError> {
+    use std::net::TcpListener;
+    if let Some(addr) = override_addr {
+        return Ok(addr);
+    }
+    let preferred = format!("127.0.0.1:{preferred_port}");
+    if TcpListener::bind(&preferred).is_ok() {
+        return Ok(preferred);
+    }
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .map_err(|e| CliError::Internal(format!("could not find a free loopback port: {e}")))?;
+    let chosen = listener
+        .local_addr()
+        .map_err(|e| CliError::Internal(format!("could not read the chosen port: {e}")))?;
+    drop(listener);
+    writeln!(
+        out,
+        "ironbus dev: 127.0.0.1:{preferred_port} is in use; using {chosen} instead."
+    )?;
+    Ok(chosen.to_string())
+}
+
+/// Creates a fresh, owner-only (0700) ephemeral data dir under the system temp dir, named uniquely
+/// from the pid + a nanosecond clock so parallel `dev` runs never collide. `dev` owns it and removes
+/// it on exit; `serve` opens the existing empty dir.
+#[cfg(unix)]
+fn make_ephemeral_dir() -> Result<std::path::PathBuf, CliError> {
+    use std::os::unix::fs::PermissionsExt;
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let base = std::env::temp_dir();
+    let pid = std::process::id();
+    for attempt in 0u32..1024 {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_or(0, |d| d.as_nanos());
+        let candidate = base.join(format!("ironbus-dev-{pid}-{nanos}-{attempt}"));
+        match std::fs::create_dir(&candidate) {
+            Ok(()) => {
+                // Match serve's created-dir posture (owner-only); best-effort for a throwaway dir.
+                let _ =
+                    std::fs::set_permissions(&candidate, std::fs::Permissions::from_mode(0o700));
+                return Ok(candidate);
+            }
+            // A name collision (same pid + nanos + attempt) just retries the next attempt.
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
+            Err(e) => {
+                return Err(CliError::Internal(format!(
+                    "could not create the ephemeral data dir under {}: {e}",
+                    base.display()
+                )))
+            }
+        }
+    }
+    Err(CliError::Internal(
+        "could not create a unique ephemeral data dir after 1024 attempts".to_string(),
+    ))
+}
+
+/// Polls the broker until it accepts the stream-addressing handshake, returning that connected
+/// client (reused to declare the demo topology). Detects a broker that died during startup (e.g. a
+/// lost port race) and reports it as unreachable rather than spinning to the timeout.
+#[cfg(unix)]
+fn wait_for_broker(
+    wire: &str,
+    config: &ironbus_client::ClientConfig,
+    child: &mut std::process::Child,
+) -> Result<ironbus_client::Client, CliError> {
+    use std::time::{Duration, Instant};
+    let deadline = Instant::now() + Duration::from_secs(20);
+    loop {
+        if let Some(status) = child
+            .try_wait()
+            .map_err(|e| CliError::Internal(format!("waiting on the dev broker failed: {e}")))?
+        {
+            return Err(CliError::Unreachable(format!(
+                "the dev broker exited during startup ({status}); is another broker already bound to {wire}?"
+            )));
+        }
+        if let Ok(client) = ironbus_client::Client::connect_with(wire, config) {
+            return Ok(client);
+        }
+        if Instant::now() >= deadline {
+            return Err(CliError::Unreachable(format!(
+                "the dev broker did not become ready within 20s at {wire}"
+            )));
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+/// Publishes `n` synthetic at-least-once messages into [`DEMO_STREAM`] over the live wire, so `top`
+/// and `/admin` show instant activity.
+#[cfg(unix)]
+fn seed_demo(client: &mut ironbus_client::Client, n: u64, wire: &str) -> Result<(), CliError> {
+    use ironbus_proto::message::PubBody;
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let now_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX));
+    for i in 0..n {
+        let payload = format!("seed message {i}");
+        let key = format!("{DEMO_STREAM}.seed.{i}");
+        client
+            .publish_to(
+                DEMO_STREAM,
+                &PubBody {
+                    flags: 0,
+                    timestamp_ms: now_ms,
+                    key: key.as_bytes(),
+                    headers: b"",
+                    dedup: None,
+                    fire_and_forget: false,
+                    payload: payload.as_bytes(),
+                },
+            )
+            .map_err(|e| crate::classify(wire, "seeding the demo stream on", &e))?;
+    }
+    Ok(())
+}
+
+/// The non-Unix stub: `dev` runs a local broker, which is Unix-only in v1. Consumes every `DevArgs`
+/// field and `out` so the cross-platform struct has no "never read" field and no unused parameter on
+/// the non-Unix `-D warnings` build (the #288/#99 footgun the Windows cross-check catches).
+#[cfg(not(unix))]
+fn run_dev_impl(args: DevArgs, out: &mut impl Write) -> Result<(), CliError> {
+    let DevArgs {
+        seed,
+        addr,
+        health_addr,
+    } = args;
+    let _ = (seed, addr, health_addr);
+    let _ = out;
+    Err(CliError::Internal(
+        "`ironbus dev` runs a local broker, which is supported on Unix only in v1".to_string(),
+    ))
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dev_snippet_references_the_demo_stream_and_the_bound_addresses() {
+        let wire = "127.0.0.1:7777";
+        let health = "127.0.0.1:7778";
+        let snippet = dev_snippet(wire, health, DEMO_STREAM, 5);
+        // Paste-and-run correctness: the real pub/sub verbs pointed at THIS broker's wire address.
+        assert!(
+            snippet.contains(&format!("ironbus sub --addr {wire}")),
+            "snippet missing the sub line:\n{snippet}"
+        );
+        assert!(
+            snippet.contains(&format!("ironbus pub --addr {wire}")),
+            "snippet missing the pub line:\n{snippet}"
+        );
+        // References the demo stream + the health/admin address.
+        assert!(
+            snippet.contains(DEMO_STREAM),
+            "snippet missing the demo stream:\n{snippet}"
+        );
+        assert!(
+            snippet.contains(&format!("ironbus top --addr {wire}")),
+            "snippet missing the top line:\n{snippet}"
+        );
+        assert!(
+            snippet.contains(&format!("ironbus admin --health-addr {health}")),
+            "snippet missing the admin line:\n{snippet}"
+        );
+        // The seed note appears only when seeding.
+        assert!(
+            snippet.contains("5 seeded messages"),
+            "snippet missing the seed note:\n{snippet}"
+        );
+    }
+
+    #[test]
+    fn dev_snippet_omits_the_seed_note_when_nothing_is_seeded() {
+        let snippet = dev_snippet("127.0.0.1:7777", "127.0.0.1:7778", DEMO_STREAM, 0);
+        assert!(
+            !snippet.contains("seeded messages"),
+            "snippet should have no seed note at seed=0:\n{snippet}"
+        );
+        // The paste-and-run verbs are still present.
+        assert!(snippet.contains("ironbus pub --addr 127.0.0.1:7777"));
+        assert!(snippet.contains("ironbus sub --addr 127.0.0.1:7777"));
+    }
+
+    #[test]
+    fn parse_dev_args_reads_seed_and_addr_overrides() {
+        let args = vec![
+            "--seed".to_string(),
+            "7".to_string(),
+            "--addr".to_string(),
+            "127.0.0.1:9001".to_string(),
+        ];
+        let parsed = parse_dev_args(&args).expect("parse");
+        assert_eq!(parsed.seed, 7);
+        assert_eq!(parsed.addr.as_deref(), Some("127.0.0.1:9001"));
+        assert_eq!(parsed.health_addr, None);
+    }
+
+    #[test]
+    fn parse_dev_args_defaults_seed_to_zero() {
+        let parsed = parse_dev_args(&[]).expect("parse empty");
+        assert_eq!(parsed.seed, 0);
+        assert!(parsed.addr.is_none());
+        assert!(parsed.health_addr.is_none());
+    }
+
+    #[test]
+    fn parse_dev_args_rejects_an_unknown_flag() {
+        let args = vec!["--nope".to_string()];
+        assert!(parse_dev_args(&args).is_err());
+    }
+
+    #[test]
+    fn parse_dev_args_rejects_a_non_numeric_seed() {
+        let args = vec!["--seed".to_string(), "lots".to_string()];
+        assert!(parse_dev_args(&args).is_err());
+    }
+}

--- a/crates/ironbus-cli/src/main.rs
+++ b/crates/ironbus-cli/src/main.rs
@@ -85,6 +85,13 @@ mod dict_cmd;
 mod completion;
 /// Named connection profiles (server + auth + TLS + data-dir), `kubectl config`-style (#581).
 mod context;
+/// The `dev` one-command local quickstart (#796): spawn the SAME `ironbus serve` on an ephemeral
+/// temp dir + friendly loopback ports, pre-declare a demo stream + subjects, print a copy-paste
+/// produce/consume snippet, and optionally `--seed` synthetic messages. Pure sugar — the broker
+/// binary and its data plane are untouched. The module compiles on every target (the parser, help,
+/// and snippet builder are cross-platform); the broker orchestration + signal-cleanup is Unix-only,
+/// and the non-Unix stub errors cleanly, exactly like `serve` itself.
+mod dev;
 /// The interactive fuzzy stream/group picker (TTY-only, scriptable-safe) (#583).
 mod fuzzy;
 /// The uniform `--json` envelope + frozen exit-code contract (V2-M6, #579).
@@ -1014,6 +1021,11 @@ USAGE:
                   [--storage-mode <per-stream|shared-wal>] [--append-shards <auto|N>]
                   [--key-shared-group <name>]... [--broadcast-group <name>]...
                   [--visibility-timeout-ms <n>] [--health-addr <host:port>] [--enable-admin]
+    ironbus dev   [--seed <n>] [--addr <host:port>] [--health-addr <host:port>]
+                  (one-command local quickstart: spins up the broker on an ephemeral temp dir with
+                   friendly loopback ports, pre-declares a demo stream + subjects, prints a
+                   copy-paste produce/consume snippet, and optionally seeds N messages; the temp dir
+                   is removed on exit incl. Ctrl-C. Unix only)
     ironbus passwd --auth-config <path> --user <name> [--scopes <publish,subscribe,admin>]
                   [--password-file <path>] [--remove]
                   (sets/updates or removes a username+password identity; the password is read from
@@ -1572,6 +1584,7 @@ fn run(args: &[String], out: &mut impl Write) -> Result<(), CliError> {
         "migrate" => run_migrate(rest, out),
         "dict" => run_dict(rest, out),
         "context" => context::run_context(rest, out),
+        "dev" => dev::run_dev(rest, out),
         "completion" => completion::run_completion(rest, out),
         "cheat" => completion::run_cheat(rest, out),
         "help" | "--help" | "-h" => {

--- a/crates/ironbus-cli/tests/dev.rs
+++ b/crates/ironbus-cli/tests/dev.rs
@@ -1,0 +1,255 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! End-to-end test for `ironbus dev` (#796), the one-command local quickstart.
+//!
+//! It launches the REAL compiled `ironbus dev` as a subprocess (so it exercises the exact
+//! orchestration a newcomer runs: `dev` mints an ephemeral temp dir, spawns the SAME `ironbus serve`,
+//! pre-declares the demo topology, prints the snippet, and seeds), then proves the issue's
+//! acceptance against the live broker:
+//!
+//! * the demo stream is PRE-DECLARED (`stream_info("demo").exists`),
+//! * `--seed N` makes N messages consumable from the demo stream (a CONSUME COUNT),
+//! * a produce->consume ROUNDTRIP works on the wire (`ironbus pub` then `ironbus sub`),
+//! * the printed snippet references the demo stream and the REAL bound wire address, and
+//! * the ephemeral data dir is REMOVED after the process is SIGTERM'd.
+//!
+//! Unix-only: `dev` (like `serve`) is Unix-only in v1, and the test SIGTERMs a child + reads
+//! `/proc`-style process state, so the whole file is gated off the Windows build.
+#![cfg(unix)]
+
+use ironbus_client::{Client, ClientConfig};
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+use std::process::{Child, Command, Stdio};
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+const BIN: &str = env!("CARGO_BIN_EXE_ironbus");
+
+/// A backstop guard: on drop (including a panicking assertion) it SIGTERMs `ironbus dev` so its own
+/// cleanup runs (broker reaped, temp dir removed), then hard-kills if it does not exit promptly, so a
+/// failing test never leaks the broker or the temp dir.
+struct DevGuard(Child);
+
+impl Drop for DevGuard {
+    fn drop(&mut self) {
+        term_and_reap(&mut self.0);
+    }
+}
+
+/// Sends SIGTERM to `child`, waits up to 3s for a graceful exit, then hard-kills and reaps. A no-op
+/// if the child was already reaped (the happy path terminates it explicitly).
+fn term_and_reap(child: &mut Child) {
+    if matches!(child.try_wait(), Ok(Some(_))) {
+        return;
+    }
+    let pid = child.id().to_string();
+    let _ = Command::new("kill").args(["-TERM", &pid]).status();
+    if wait_for_exit(child, Duration::from_secs(3)) {
+        return;
+    }
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+/// Polls `child` until it exits or `budget` elapses; returns `true` if it exited in time.
+fn wait_for_exit(child: &mut Child, budget: Duration) -> bool {
+    let deadline = Instant::now() + budget;
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => return true,
+            Ok(None) => {}
+            Err(_) => return false,
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+/// Runs one `ironbus` subcommand to completion, returning (stdout, exit code).
+fn run(args: &[&str]) -> (String, i32) {
+    let out = Command::new(BIN)
+        .args(args)
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("run an ironbus subcommand");
+    (
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        out.status.code().unwrap_or(-1),
+    )
+}
+
+/// Extracts the value after `marker` on a line that contains it, trimmed; the demo banner prints
+/// `wire (produce/consume): <addr>` and `ephemeral data dir: <path> (removed on exit)`.
+fn field_after<'a>(line: &'a str, marker: &str) -> Option<&'a str> {
+    line.split_once(marker).map(|(_, rest)| rest.trim())
+}
+
+/// Launches the real `ironbus dev --seed <seed>` (no explicit ports: `dev` binds its friendly
+/// default, or an OS-assigned free port if busy, and REPORTS the bound address — so the test is
+/// robust under parallelism without racing on a fixed port), drains its output over a channel, and
+/// returns the kill-guard plus the parsed wire address, the ephemeral data-dir path, and the full
+/// startup transcript (captured through the final "press Ctrl-C" banner line).
+fn start_dev(seed: u32) -> (DevGuard, String, String, String) {
+    let mut child = Command::new(BIN)
+        .args(["dev", "--seed", &seed.to_string()])
+        .env("NO_COLOR", "1")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn ironbus dev");
+
+    // Drain stdout (dev's banner + the inherited broker logs) line-by-line over a channel, and drain
+    // stderr in the background so neither pipe can fill and wedge the child.
+    let stdout = child.stdout.take().expect("piped stdout");
+    let stderr = child.stderr.take().expect("piped stderr");
+    let (tx, rx) = mpsc::channel::<String>();
+    std::thread::spawn(move || {
+        let mut reader = BufReader::new(stdout);
+        loop {
+            let mut line = String::new();
+            match reader.read_line(&mut line) {
+                Ok(0) | Err(_) => break,
+                Ok(_) => {
+                    if tx.send(line).is_err() {
+                        break;
+                    }
+                }
+            }
+        }
+    });
+    std::thread::spawn(move || {
+        let mut reader = BufReader::new(stderr);
+        let mut sink = String::new();
+        while reader.read_line(&mut sink).unwrap_or(0) != 0 {
+            sink.clear();
+        }
+    });
+
+    let guard = DevGuard(child);
+
+    // Collect banner lines until the final "press Ctrl-C" marker, capturing the wire address and the
+    // ephemeral data-dir path along the way.
+    let mut transcript = String::new();
+    let mut wire: Option<String> = None;
+    let mut data_dir: Option<String> = None;
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let mut ready = false;
+    while Instant::now() < deadline {
+        let Ok(line) = rx.recv_timeout(Duration::from_secs(5)) else {
+            break;
+        };
+        transcript.push_str(&line);
+        if let Some(a) = field_after(&line, "wire (produce/consume):") {
+            wire = Some(a.to_string());
+        }
+        if let Some(rest) = field_after(&line, "ephemeral data dir:") {
+            // `<path> (removed on exit)` -> keep just the path.
+            let path = rest.split_once(" (removed").map_or(rest, |(p, _)| p).trim();
+            data_dir = Some(path.to_string());
+        }
+        if line.contains("press Ctrl-C to stop") {
+            ready = true;
+            break;
+        }
+    }
+
+    let wire = wire.unwrap_or_else(|| panic!("dev never reported its wire address:\n{transcript}"));
+    let data_dir =
+        data_dir.unwrap_or_else(|| panic!("dev never reported its data dir:\n{transcript}"));
+    assert!(
+        ready,
+        "dev never finished its startup banner:\n{transcript}"
+    );
+    (guard, wire, data_dir, transcript)
+}
+
+#[test]
+fn dev_quickstart_declares_seeds_roundtrips_and_cleans_up_on_sigterm() {
+    let (mut guard, wire, data_dir, transcript) = start_dev(5);
+
+    // The ephemeral data dir exists while dev runs.
+    assert!(
+        Path::new(&data_dir).exists(),
+        "the ephemeral data dir should exist while dev runs: {data_dir}"
+    );
+
+    // --- Acceptance 1 + 2: the demo stream is pre-declared, and --seed 5 is consumable from it. ---
+    let config = ClientConfig {
+        understands_streams: true,
+        ..ClientConfig::default()
+    };
+    let mut client = Client::connect_with(&wire, &config).expect("connect a streams client to dev");
+    assert!(
+        client.streams_enabled(),
+        "dev broker should negotiate stream addressing"
+    );
+    let (exists, _head) = client.stream_info("demo").expect("stream_info(demo)");
+    assert!(exists, "the `demo` stream should be PRE-DECLARED by dev");
+
+    // Consume the seeded messages from the demo stream: a fresh group starts at the earliest offset.
+    client
+        .subscribe_to("demo", "e2e-seedcheck")
+        .expect("subscribe_to demo");
+    let mut consumed = 0u32;
+    let mut idle = 0u32;
+    while consumed < 5 && idle < 400 {
+        let batch = client.fetch(64).expect("fetch from demo");
+        if batch.messages.is_empty() {
+            idle += 1;
+            std::thread::sleep(Duration::from_millis(10));
+            continue;
+        }
+        for m in &batch.messages {
+            let _ = client.ack(m.offset, m.generation);
+            consumed += 1;
+        }
+    }
+    assert_eq!(
+        consumed, 5,
+        "--seed 5 should make exactly 5 messages consumable from the demo stream"
+    );
+    drop(client);
+
+    // --- Acceptance 3: a produce->consume ROUNDTRIP works on the wire (the default stream). ---
+    let (_p, pcode) = run(&["pub", "--addr", &wire, "--key", "k1", "hello-roundtrip"]);
+    assert_eq!(pcode, 0, "pub should succeed against the dev broker");
+    let (sout, scode) = run(&[
+        "sub", "--addr", &wire, "--group", "rt", "--max", "1", "--ack",
+    ]);
+    assert_eq!(scode, 0, "sub should succeed against the dev broker");
+    assert!(
+        sout.contains("payload=hello-roundtrip"),
+        "the roundtrip message should come back from sub; got:\n{sout}"
+    );
+
+    // --- Acceptance 4: the printed snippet references the demo stream + the real bound wire addr. ---
+    assert!(
+        transcript.contains(&format!("ironbus pub --addr {wire}")),
+        "snippet should show a paste-and-run pub at the bound wire addr:\n{transcript}"
+    );
+    assert!(
+        transcript.contains(&format!("ironbus sub --addr {wire}")),
+        "snippet should show a paste-and-run sub at the bound wire addr:\n{transcript}"
+    );
+    assert!(
+        transcript.contains("demo"),
+        "snippet should reference the demo stream:\n{transcript}"
+    );
+
+    // --- Acceptance 5: SIGTERM removes the ephemeral data dir. ---
+    let pid = guard.0.id().to_string();
+    Command::new("kill")
+        .args(["-TERM", &pid])
+        .status()
+        .expect("kill -TERM dev");
+    assert!(
+        wait_for_exit(&mut guard.0, Duration::from_secs(15)),
+        "dev should exit cleanly after SIGTERM"
+    );
+    assert!(
+        !Path::new(&data_dir).exists(),
+        "the ephemeral data dir MUST be removed after dev exits on SIGTERM: {data_dir}"
+    );
+}


### PR DESCRIPTION
## `ironbus dev` — one-command local quickstart (#796)

`ironbus dev` gives a newcomer a first-five-minutes "wow": one command stands up a working local broker, pre-declares a demo stream + subjects, and prints a copy-paste produce/consume snippet. It is **pure sugar** over capabilities the broker already has — the **broker binary and its data plane are untouched**, the wire format is unchanged, and `deny.toml` is byte-identical.

### What `dev` does

- **serve-with-sane-defaults** — spawns the **same** `ironbus serve` as a **child process** (this binary re-invoked via `current_exe()`, so the broker code path is byte-for-byte a normal serve) bound to loopback on friendly, non-privileged default ports (`7777` wire / `7778` health, each overridable with `--addr` / `--health-addr`). If a default port is in use it picks an OS-assigned free port and prints a friendly note instead of panicking. The data dir is an **ephemeral temp dir that `dev` owns**.
- **ephemeral-dir cleanup on exit — normal *and* signal** — a `DevSession` guard reaps the child broker (releasing its data-dir lock) and `remove_dir_all`s the temp dir on **every** exit path: a clean stop, the broker exiting on its own, an early `?`, or a panic. `SIGINT`/`SIGTERM` are caught with `signal-hook`'s `flag::register` (already a Unix dependency), which **replaces the default terminate-without-cleanup disposition**, so the wait loop returns and the guard's `Drop` removes the dir on Ctrl-C too.
- **pre-declared demo topology** — right after the broker is up, `dev` connects a streams-capable client and declares a `demo` stream plus two disjoint `demo.*` subjects over the **existing** live declare surface (`declare_stream` / `bind_subject`), so produce/consume, `top`, and `/admin` have something to show on first launch.
- **a copy-paste snippet** — prints the real `ironbus pub` / `ironbus sub` / `ironbus top` / `ironbus admin` commands pointed at **this** broker's bound address, so a newcomer pastes them into another terminal and sees a message move immediately.
- **optional `--seed N`** — publishes N synthetic at-least-once messages into the demo stream so `ironbus top` and `/admin` show instant activity.

### Out-of-scope guards honored (kept an XS quickstart, not a Trojan horse)

- **No** embedded console / web UI / bundle.
- **No** connector / seed pipeline beyond the trivial synthetic `--seed`.
- **No** new broker runtime or broker code path — the broker binary stays untouched.
- **No** new KV / object store — the ephemeral dir is just the bus's normal on-disk storage at a temp path.

`dev` composes only the existing serve / top / admin / pub / sub surfaces.

### Cross-platform

The arg parser, help, and snippet builder are pure and cross-platform; the broker orchestration + signal cleanup is `#[cfg(unix)]`, and the non-Unix stub errors cleanly and consumes every field so the Windows `-D warnings` cross-check stays dead-code-free. Verified with `cargo check --target x86_64-pc-windows-gnu`.

### Tests

- **e2e** (`crates/ironbus-cli/tests/dev.rs`): launches the **real** `ironbus dev` as a subprocess, waits for the broker, then proves the acceptance against the live broker — the `demo` stream is pre-declared (`stream_info`), `--seed 5` makes exactly 5 messages consumable from it (a consume count via `subscribe_to`), a produce→consume roundtrip works (`ironbus pub` then `ironbus sub`), the printed snippet references the demo stream + the **real bound wire address**, and the ephemeral data dir is **gone** after the process is SIGTERM'd.
- **unit** (`dev.rs`): snippet references the demo stream + both bound addresses and the pub/sub verbs (paste-and-run correctness), omits the seed note at `--seed 0`; the arg parser reads `--seed`/`--addr` and rejects an unknown flag / a non-numeric seed.

### Dependencies

**No new external crate.** `ironbus-client` is added only as a `[dev-dependencies]` of `ironbus-cli` so the bin-only crate's e2e test can drive the broker as a real client; it is already a normal (shipped) dependency and already in `Cargo.lock`, so it adds nothing to the shipped binary graph and leaves the SBOM, `deny.toml`, and the cffi-ban gate byte-identical.

### Docs

A "fastest local loop: `ironbus dev`" Quickstart section in the README shows `ironbus dev` (+ `--seed`) as the first-five-minutes path.

Closes #796.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C3PZ2vLBhaQCQXSVSdsPD5
