### PR TITLE
fix(consume): gate Tier-W batch reseal on the run's staged generations (#1168)

### DIFF
--- a/crates/ironbus-core/src/lease.rs
+++ b/crates/ironbus-core/src/lease.rs
@@ -351,27 +351,38 @@ impl LeaseTable {
         }
     }
 
-    /// Overwrites the fencing generation of the live lease at `offset` to `generation`, returning
-    /// whether a live lease was present to reseal (#546, batched Tier-W delivery). Every record in one
-    /// zero-copy `DeliverBatch` shares ONE generation so the reused batch frame (a single `generation`
-    /// field, positional offsets) can carry them all: each record is first [`claim`]ed under its own
-    /// distinct generation, then the whole contiguous run is resealed to the run's first generation.
+    /// Overwrites the fencing generation of the live lease at `offset` to `generation` — GATED on the
+    /// lease still carrying the caller's own claim generation `from` — returning whether the reseal was
+    /// applied (#546 batched Tier-W delivery, gated per #1168). Every record in one zero-copy
+    /// `DeliverBatch` shares ONE generation so the reused batch frame (a single `generation` field,
+    /// positional offsets) can carry them all: each record is first [`claim`]ed under its own distinct
+    /// generation, then the whole contiguous run is resealed to the run's first generation.
     ///
-    /// This is SOUND because fencing is PER-OFFSET — the lease map is keyed by offset and an ack's
-    /// token is `(offset, generation)`, so a generation shared across DISTINCT offsets never collides
-    /// (the offset disambiguates). Distinctness is only required ACROSS REDELIVERIES OF THE SAME OFFSET,
-    /// and that still holds: `next_generation` already sits strictly ABOVE every value in the resealed
-    /// run (each was drawn by [`claim`] below it), so any future redelivery of a resealed offset draws a
-    /// strictly-greater generation and FENCES the stale shared-generation ack. At-least-once and
-    /// no-double-ack are therefore preserved per record exactly as with distinct generations. A no-op
-    /// (returns `false`) if `offset` holds no live lease — e.g. it was concurrently acked or freed; the
-    /// batch caller reseals offsets it JUST claimed under the same lock, so the live case is the norm.
-    pub fn reseal_to(&mut self, offset: Offset, generation: u64) -> bool {
-        if let Some(lease) = self.leases.get_mut(&offset.get()) {
-            lease.generation = generation;
-            true
-        } else {
-            false
+    /// The SHARED generation is SOUND because fencing is PER-OFFSET — the lease map is keyed by offset
+    /// and an ack's token is `(offset, generation)`, so a generation shared across DISTINCT offsets
+    /// never collides (the offset disambiguates). Distinctness is only required ACROSS REDELIVERIES OF
+    /// THE SAME OFFSET, and that still holds: `next_generation` already sits strictly ABOVE every value
+    /// in the resealed run (each was drawn by [`claim`] below it), so any future redelivery of a
+    /// resealed offset draws a strictly-greater generation and FENCES the stale shared-generation ack.
+    /// At-least-once and no-double-ack are therefore preserved per record exactly as with distinct
+    /// generations.
+    ///
+    /// The `from` GATE (#1168) makes the reseal safe against a mid-drain reclaim: between the caller
+    /// STAGING a run (claiming each record) and FLUSHING it (resealing here), a COMPETING consumer may
+    /// reclaim an already-expired staged offset, drawing a strictly-greater generation (reachable only
+    /// under a pathological near-zero visibility window — a drain pass is sub-millisecond, visibility
+    /// is normally seconds). An ungated overwrite would clobber that competitor's generation back down,
+    /// FENCING its legitimate ack and forcing a spurious extra redelivery. Generations are never
+    /// reused, so a current generation equal to `from` PROVES the caller's own claim is still the live
+    /// lease; anything else (a competitor's newer claim, or no live lease at all — concurrently acked
+    /// or freed) is a no-op returning `false`, leaving the current owner's fence intact.
+    pub fn reseal_from_to(&mut self, offset: Offset, from: u64, generation: u64) -> bool {
+        match self.leases.get_mut(&offset.get()) {
+            Some(lease) if lease.generation == from => {
+                lease.generation = generation;
+                true
+            }
+            _ => false,
         }
     }
 
@@ -605,7 +616,7 @@ mod tests {
     }
 
     #[test]
-    fn reseal_to_shares_one_generation_yet_keeps_per_offset_fencing() {
+    fn reseal_from_to_shares_one_generation_yet_keeps_per_offset_fencing() {
         // #546 batched Tier-W: a contiguous run is claimed under DISTINCT generations, then resealed to
         // ONE shared generation so the reused `DeliverBatch` frame (a single generation, positional
         // offsets) can carry them. This must stay SOUND: (a) an ack of ANY offset under the shared
@@ -619,11 +630,12 @@ mod tests {
             a.generation != b.generation && b.generation != c.generation,
             "distinct at claim"
         );
-        // Reseal the whole run to the FIRST claim's generation.
+        // Reseal the whole run to the FIRST claim's generation, each gated on its own claim generation
+        // (#1168): the caller still holds every staged lease, so every reseal applies.
         let shared = a.generation;
-        assert!(t.reseal_to(off(0), shared));
-        assert!(t.reseal_to(off(1), shared));
-        assert!(t.reseal_to(off(2), shared));
+        assert!(t.reseal_from_to(off(0), a.generation, shared));
+        assert!(t.reseal_from_to(off(1), b.generation, shared));
+        assert!(t.reseal_from_to(off(2), c.generation, shared));
         // Every offset now acks under the shared generation (a batch is N independent leases).
         let shared_tok = |o| LeaseToken {
             offset: off(o),
@@ -662,7 +674,42 @@ mod tests {
             "only the fresh token commits the redelivery"
         );
         // Reseal is a no-op for an offset with no live lease (returns false).
-        assert!(!t.reseal_to(off(99), shared));
+        assert!(!t.reseal_from_to(off(99), shared, shared));
+    }
+
+    #[test]
+    fn reseal_from_to_refuses_to_clobber_a_competitors_reclaim() {
+        // THE #1168 GATE: a staged lease expires and a COMPETITOR reclaims the offset (drawing a
+        // strictly-greater generation) BEFORE the staging session's flush reseals the run. The gated
+        // reseal must be REFUSED — the competitor's generation survives, so ITS ack still lands and the
+        // stale stager's shared-generation ack is the one fenced. An ungated overwrite would invert
+        // that: it would fence the competitor's legitimate ack and force a spurious extra redelivery.
+        let mut t = LeaseTable::new(cfg());
+        let staged = token(t.claim(off(0), 0));
+        // The pathological near-zero visibility window: the staged lease expires mid-drain and a
+        // competitor reclaims it.
+        assert_eq!(t.expired(30), vec![off(0)]);
+        let competitor = token(t.claim(off(0), 30));
+        assert!(
+            competitor.generation > staged.generation,
+            "a reclaim draws a strictly-greater generation"
+        );
+        // The stager's flush-time reseal (gated on ITS OWN staged generation) is refused.
+        assert!(
+            !t.reseal_from_to(off(0), staged.generation, staged.generation),
+            "the gate refuses an offset whose lease the caller no longer holds"
+        );
+        // The competitor's fence is intact: its ack commits, the stale staged token is fenced.
+        assert_eq!(
+            t.ack(&staged),
+            AckOutcome::Fenced,
+            "the stale staged-generation ack is fenced"
+        );
+        assert_eq!(
+            t.ack(&competitor),
+            AckOutcome::Acked,
+            "the competitor's legitimate ack is NOT fenced"
+        );
     }
 
     #[test]

--- a/crates/ironbus-server/src/engine.rs
+++ b/crates/ironbus-server/src/engine.rs
@@ -13619,27 +13619,41 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         self.poll_in_member(group, member, now)
     }
 
-    /// Reseals the fencing generation of the live leases at the contiguous range `[first, first+count)`
-    /// in `group` to ONE shared `generation` (#546, batched + zero-copy Tier-W delivery). Every record
-    /// in one `DeliverBatch` frame shares a single generation so the reused batch frame — which carries
-    /// exactly one `generation` field and reconstructs each offset POSITIONALLY (`first + i`) — can
-    /// deliver them: the session claims a contiguous run through the ordinary per-record
-    /// [`poll_now_in_member`](Engine::poll_now_in_member) drain (so EVERY per-message semantic — TTL,
-    /// delayed delivery, per-subject filter, `key_shared` routing, retry-throttle, `MaxDeliver`/DLQ — is
-    /// preserved verbatim), each record leased under its own distinct generation, then reseals the run
-    /// to the run's FIRST generation here before framing.
+    /// Reseals the fencing generation of the live leases at the contiguous range
+    /// `[first, first + staged.len())` in `group` to ONE shared `generation` (#546, batched + zero-copy
+    /// Tier-W delivery). Every record in one `DeliverBatch` frame shares a single generation so the
+    /// reused batch frame — which carries exactly one `generation` field and reconstructs each offset
+    /// POSITIONALLY (`first + i`) — can deliver them: the session claims a contiguous run through the
+    /// ordinary per-record [`poll_now_in_member`](Engine::poll_now_in_member) drain (so EVERY
+    /// per-message semantic — TTL, delayed delivery, per-subject filter, `key_shared` routing,
+    /// retry-throttle, `MaxDeliver`/DLQ — is preserved verbatim), each record leased under its own
+    /// distinct generation, then reseals the run to the run's FIRST generation here before framing.
     ///
-    /// SOUND because fencing is per-offset: see [`LeaseTable::reseal_to`]. `next_generation` already
-    /// sits above the resealed value, so a later redelivery of any offset in the run fences the stale
-    /// shared-generation ack; ack/nack/visibility-timeout/redelivery therefore act on each record
-    /// INDIVIDUALLY exactly as with distinct generations. DEFAULT-group only (the batched Tier-W path is
-    /// scoped to the root stream); a never-created group is a silent no-op (nothing to reseal).
-    pub fn reseal_batch_in(&mut self, group: &str, first: Offset, count: u32, generation: u64) {
+    /// Each offset's reseal is GATED on the run's STAGED generations (#1168): `staged[i]` is the
+    /// generation the calling session was granted when it staged the record at `first + i`, and the
+    /// offset is resealed ONLY while its current lease generation is still exactly that value (see
+    /// [`LeaseTable::reseal_from_to`]). If a COMPETING consumer reclaimed the offset between staging
+    /// and this flush (drawing a strictly-greater generation — reachable only under a pathological
+    /// near-zero visibility window), the reseal SKIPS it: the competitor's fence survives, its ack
+    /// still lands, and the staging session's stale shared-generation ack is the one fenced — the
+    /// correct at-least-once outcome instead of a clobbered fence and a spurious extra redelivery.
+    ///
+    /// SOUND because fencing is per-offset: see [`LeaseTable::reseal_from_to`]. `next_generation`
+    /// already sits above the resealed value, so a later redelivery of any offset in the run fences the
+    /// stale shared-generation ack; ack/nack/visibility-timeout/redelivery therefore act on each record
+    /// INDIVIDUALLY exactly as with distinct generations. Scoped to the DEFAULT (root) stream's group
+    /// tables — the batched Tier-W path only engages there — but within them it reseals whatever group
+    /// the session is subscribed to (`self.subscription`), not only the default group; a never-created
+    /// group is a silent no-op (nothing to reseal).
+    pub fn reseal_batch_in(&mut self, group: &str, first: Offset, staged: &[u64], generation: u64) {
         if let Some(g) = self.groups.get_mut(group) {
             let base = first.get();
-            for i in 0..u64::from(count) {
-                g.leases
-                    .reseal_to(Offset::new(base.saturating_add(i)), generation);
+            for (i, &from) in staged.iter().enumerate() {
+                g.leases.reseal_from_to(
+                    Offset::new(base.saturating_add(i as u64)),
+                    from,
+                    generation,
+                );
             }
         }
     }

--- a/crates/ironbus-server/src/session.rs
+++ b/crates/ironbus-server/src/session.rs
@@ -212,6 +212,14 @@ struct StagedRun {
     /// The decoded records in offset order, held for the per-record tail / length-1 emit (the sealed
     /// prefix ships zero-copy from `read_range_raw`, so those decoded copies are simply dropped).
     records: Vec<OwnedRecord>,
+    /// The run's STAGED generation set (#1168), parallel to `records`: `generations[i]` is the claim
+    /// generation THIS session was granted when it staged the record at `first_offset + i`. The
+    /// flush-time engine reseal is GATED on it — an offset is resealed to `shared_generation` ONLY
+    /// while its current lease generation is still exactly the one staged here — so the reseal can
+    /// never clobber a competing consumer's newer mid-drain reclaim (see [`Engine::reseal_batch_in`]).
+    ///
+    /// [`Engine::reseal_batch_in`]: crate::engine::Engine::reseal_batch_in
+    generations: Vec<u64>,
 }
 
 impl StagedRun {
@@ -220,6 +228,7 @@ impl StagedRun {
             first_offset: 0,
             shared_generation: 0,
             records: Vec::new(),
+            generations: Vec::new(),
         }
     }
 
@@ -233,11 +242,26 @@ impl StagedRun {
     }
 
     /// Begins a fresh run anchored at `offset` under `generation` (the caller flushed any prior run
-    /// first). Reuses the record `Vec`'s capacity (it was cleared on the prior flush).
+    /// first). Reuses the vecs' capacity (they were cleared on the prior flush).
     fn begin(&mut self, offset: u64, generation: u64) {
         self.first_offset = offset;
         self.shared_generation = generation;
+        self.clear();
+    }
+
+    /// Stages `record` (claimed under `generation`) at the run's tail. The staged generation set
+    /// extends in LOCKSTEP with the records, so `generations[i]` always names the claim generation of
+    /// the record at `first_offset + i` (#1168).
+    fn push(&mut self, record: OwnedRecord, generation: u64) {
+        self.records.push(record);
+        self.generations.push(generation);
+    }
+
+    /// Empties the run after a flush. The records AND the staged generation set clear in lockstep, so
+    /// a stale staged generation can never leak into a later run's reseal gate (#1168).
+    fn clear(&mut self) {
         self.records.clear();
+        self.generations.clear();
     }
 }
 
@@ -2980,6 +3004,17 @@ impl Session {
     /// (fail-closed, never ciphertext), so the WHOLE batch ships as the decrypted per-record tail. On a
     /// raw-read error the run degrades to all-per-record from the decoded records, so no record is lost.
     ///
+    /// The engine reseal is GATED on the run's STAGED generations (#1168): each offset is resealed ONLY
+    /// while its current lease generation is exactly the one THIS session drew when it staged the record
+    /// (`run.generations`), so the reseal can never clobber a COMPETING consumer's newer mid-drain
+    /// reclaim (reachable only under a pathological near-zero visibility window). A gate-SKIPPED offset
+    /// is still DELIVERED in place under the (now stale) shared generation rather than dropped from the
+    /// run: the batch frame is POSITIONAL (one `first_offset`, one `generation`), so excising an
+    /// interior record would split the frame for zero correctness gain, and the stale token is harmless
+    /// — the competitor's lease stands, its ack lands, and THIS session's ack of that offset is fenced
+    /// by the engine, the correct at-least-once outcome (the extra delivery became inevitable the moment
+    /// the competitor reclaimed the offset).
+    ///
     /// The batch body ships the stored bytes VERBATIM (including any stored-COMPRESSED record) WITHOUT a
     /// compressed-delivery gate, sound because a `DeliverBatch`-capable consumer decodes the on-disk
     /// record layout and is therefore compression-capable by construction (the SAME contract the Tier-S
@@ -2995,20 +3030,31 @@ impl Session {
         if count == 0 {
             return Ok(0);
         }
+        debug_assert_eq!(
+            run.generations.len(),
+            count,
+            "the staged generation set tracks the staged records in lockstep (#1168)"
+        );
         let first = run.first_offset;
         let generation = run.shared_generation;
         if count == 1 {
             Self::emit_staged_record(&run.records[0], first, generation, capable, out);
-            run.records.clear();
+            run.clear();
             return Ok(1);
         }
         // Reseal every lease in [first, first+count) to the ONE shared generation, in the engine AND in
         // this session's `leased` map, so the batch's single-generation wire frame, the engine fence, and
-        // the in-flight accounting all name the same generation for every offset.
+        // the in-flight accounting all name the same generation for every offset. The engine reseal is
+        // GATED per offset on the generation THIS session staged (#1168, see the doc above): an offset a
+        // competitor reclaimed mid-drain is skipped, leaving the competitor's fence intact.
         let group = self.subscription.clone();
-        let count_u32 = u32::try_from(count).unwrap_or(u32::MAX);
-        engine
-            .with(move |e| e.reseal_batch_in(&group, Offset::new(first), count_u32, generation))?;
+        let staged = std::mem::take(&mut run.generations);
+        engine.with(move |e| e.reseal_batch_in(&group, Offset::new(first), &staged, generation))?;
+        // The session-side map takes the shared generation for EVERY run offset, including a gate-skipped
+        // one: the wire carries the shared generation for it regardless (positional batch frame), so this
+        // keeps `leased` agreeing with what the client will echo — its ack then passes the session fence,
+        // reaches the engine, is fenced THERE by the competitor's newer generation (status 0), and clears
+        // this session's in-flight entry rather than stranding it until the stale-lease sweep.
         for i in 0..count as u64 {
             if let Some(lease) = self.leased.get_mut(&first.saturating_add(i)) {
                 lease.generation = generation;
@@ -3037,7 +3083,7 @@ impl Session {
         });
         let delivered =
             Self::emit_work_batch_copy(sealed, body, &run.records, first, generation, capable, out);
-        run.records.clear();
+        run.clear();
         Ok(delivered)
     }
 
@@ -3204,7 +3250,7 @@ impl Session {
                 Self::emit_work_batch_copy(0, &[], &run.records, first, generation, capable, out)
             }
         };
-        run.records.clear();
+        run.clear();
         delivered
     }
 
@@ -3412,7 +3458,9 @@ impl Session {
                         }
                         // Lease ownership + byte size (#175/#275), recorded now under this record's OWN
                         // claim generation; a multi-record run reseals it to the shared generation at
-                        // flush. The byte budget therefore binds correctly WHILE staging.
+                        // flush. The byte budget therefore binds correctly WHILE staging. The claim
+                        // generation is ALSO staged into the run's generation set (#1168), the flush-time
+                        // reseal gate.
                         let bytes = lease_bytes(&d.record);
                         self.leased.insert(
                             d.offset.get(),
@@ -3421,7 +3469,8 @@ impl Session {
                                 bytes,
                             },
                         );
-                        run.records.push(d.record);
+                        let staged_generation = d.token.generation;
+                        run.push(d.record, staged_generation);
                     }
                     Ok(Poll::Message(d)) => {
                         // Gate the delivery encoding on the negotiated compressed-delivery capability
@@ -3810,7 +3859,8 @@ impl Session {
                                 bytes,
                             },
                         );
-                        run.records.push(d.record);
+                        let staged_generation = d.token.generation;
+                        run.push(d.record, staged_generation);
                     }
                     Ok(Poll::Message(d)) => {
                         // Compressed-delivery gate (#1066), IDENTICAL to `handle_flow`: a non-capable
@@ -20223,7 +20273,9 @@ mod tests {
     // drains through the SAME per-record `poll_now_in_member` the unbatched path uses and only defers the
     // WIRE framing. The crux is the SHARED lease generation: the reused batch frame carries one
     // `generation`, so the run's leases are resealed to ONE generation, which is sound because fencing is
-    // per-OFFSET (see `LeaseTable::reseal_to`). These tests pin: the batched wire shape, per-record ack
+    // per-OFFSET (see `LeaseTable::reseal_from_to`), and the reseal is GATED on the run's staged
+    // generations (#1168) so it can never clobber a competitor's mid-drain reclaim. These tests pin: the
+    // batched wire shape, the staged-generation reseal gate, per-record ack
     // (by offset) with generation fencing, per-record nack redelivery, visibility-timeout redelivery of
     // the un-acked, per-record MaxDeliver -> DLQ, key_shared per-key routing, the encrypted / active-tail
     // per-record fallback (never zero-copy ciphertext), the credit bound, order, and single-record parity.
@@ -20371,6 +20423,190 @@ mod tests {
             e.engine_mut().committed_offset_in("g").get(),
             3,
             "0,1,2 committed contiguously; the fenced offset 3 is NOT committed"
+        );
+    }
+
+    #[test]
+    fn tierw_batch_reseal_skips_an_offset_a_competitor_reclaimed_mid_drain() {
+        // THE #1168 RACE: under a pathological near-zero visibility window, a COMPETING consumer can
+        // reclaim a staged offset between the staging drain and the flush's reseal, drawing a
+        // strictly-greater generation. The gated reseal must SKIP that offset — the competitor's
+        // generation survives, so ITS ack is NOT fenced — while the rest of the run reseals to the
+        // shared generation exactly as before. The skipped offset is still delivered in place under the
+        // (stale) shared generation (positional batch frame), and THIS session's ack of it is the one
+        // the engine fences: the correct at-least-once outcome. An UNGATED reseal inverts this — it
+        // clobbers the competitor's generation, this session's stale ack lands, and the competitor's
+        // legitimate ack is fenced into a spurious extra redelivery.
+        //
+        // The interleave cannot occur inside one synchronous `process` call, so the test drives the
+        // REAL machinery at its seams: it stages the run exactly as the drain arm does (per-record
+        // `poll_now_in_member` claims), interposes the competitor's reclaim, then calls the REAL
+        // `flush_run`.
+        let clock = Arc::new(ManualClock::new());
+        let e = DirectEngine::new(engine_with(Arc::clone(&clock), 5));
+        for i in 0..3u8 {
+            produce_kh(&e, &[i], b"", &[i]);
+        }
+        let mut s = tierw_batch_session(&e, MemberId::new(1), b"g");
+        // STAGE offsets 0..3 exactly as the batched drain arm does: claim each through the ordinary
+        // per-record poll, record the lease in `leased`, and stage record + claim generation in the run.
+        let mut run = StagedRun::new();
+        for _ in 0..3 {
+            let d = match e
+                .engine_mut()
+                .poll_now_in_member("g", MemberId::new(1))
+                .unwrap()
+            {
+                Poll::Message(d) => d,
+                other => panic!("expected a message to stage, got {other:?}"),
+            };
+            if run.is_empty() {
+                run.begin(d.offset.get(), d.token.generation);
+            }
+            let staged_generation = d.token.generation;
+            let bytes = lease_bytes(&d.record);
+            s.leased.insert(
+                d.offset.get(),
+                Lease {
+                    generation: staged_generation,
+                    bytes,
+                },
+            );
+            run.push(d.record, staged_generation);
+        }
+        let shared = run.shared_generation;
+        // MID-DRAIN RECLAIM (the pathological near-zero visibility window): every staged lease expires
+        // and a competitor reclaims offset 0, drawing a generation strictly above every staged one.
+        clock.advance_monotonic_nanos(31);
+        let competitor = match e
+            .engine_mut()
+            .poll_now_in_member("g", MemberId::new(2))
+            .unwrap()
+        {
+            Poll::Message(d) => d,
+            other => panic!("expected the competitor to reclaim a message, got {other:?}"),
+        };
+        assert_eq!(
+            competitor.offset.get(),
+            0,
+            "the competitor reclaimed the staged offset 0"
+        );
+        assert!(
+            competitor.token.generation > shared,
+            "the reclaim generation sits strictly above the staged shared generation"
+        );
+        // FLUSH the staged run through the real reseal path.
+        let mut out = Vec::new();
+        let delivered = s.flush_run(&e, &mut run, true, &mut out).unwrap();
+        // The skipped offset is still DELIVERED in place under the (stale) shared generation: the batch
+        // frame is positional, and the stale token is harmless (its ack fences below).
+        assert_eq!(delivered, 3, "the whole run is delivered, skip included");
+        let got = tierw_deliveries(&out);
+        assert_eq!(
+            got.iter().map(|r| r.0).collect::<Vec<_>>(),
+            vec![0, 1, 2],
+            "offsets 0..3 delivered in order"
+        );
+        assert!(
+            got.iter().all(|r| r.1 == shared),
+            "the wire carries the shared generation for every record, the skipped one included"
+        );
+        // THIS session's ack of the reclaimed offset is the one FENCED (by the ENGINE — the session
+        // fence passes because the wire really did deliver the shared generation). Asserted BEFORE the
+        // competitor acks: had the ungated reseal clobbered the competitor's generation, this ack would
+        // have SUCCEEDED.
+        assert_eq!(
+            ack_reply(&mut s, &e, AckOp::Ack, 0, shared),
+            vec![0u8],
+            "the staging session's stale ack of the reclaimed offset is fenced"
+        );
+        // THE HEADLINE: the competitor's generation survived the flush, so its ack is NOT fenced.
+        assert_eq!(
+            e.engine_mut().ack_in("g", &competitor.token),
+            AckResult::Acked,
+            "the competitor's legitimate ack lands — its reclaim was not clobbered"
+        );
+        // The rest of the run resealed exactly as before: offsets 1 and 2 ack under the shared
+        // generation.
+        assert_eq!(ack_reply(&mut s, &e, AckOp::Ack, 1, shared), vec![1u8]);
+        assert_eq!(ack_reply(&mut s, &e, AckOp::Ack, 2, shared), vec![1u8]);
+        assert_eq!(
+            e.engine_mut().committed_offset_in("g").get(),
+            3,
+            "every record committed exactly once: 0 by the competitor, 1 and 2 by this session"
+        );
+    }
+
+    #[test]
+    fn tierw_batch_staged_generations_track_each_run_exactly_across_a_multi_run_pass() {
+        // #1168: ONE drain pass that flushes MULTIPLE runs must gate each run's reseal on THAT run's
+        // OWN staged generations — the staged set has to clear and re-fill in lockstep from run to run.
+        // Setup: a per-record peer leases offsets 0,1,2, then requeues 0 and 1 (keeping 2 in-flight),
+        // so the batch consumer's single Flow drains the redelivered [0,1], skips the in-flight 2, and
+        // drains [3,4,5]: two multi-record flush_run calls in one pass. If the first run's staged set
+        // leaked into (or misaligned) the second run's gate, the second reseal would be skipped and its
+        // shared-generation acks would fence.
+        let e = DirectEngine::new(engine());
+        for i in 0..6u8 {
+            produce_kh(&e, &[i], b"", &[i]);
+        }
+        // The batch-INCAPABLE per-record peer: lease 0,1,2, requeue 0 and 1 immediately (delay 0).
+        let mut peer = Session::with_member_id(MemberId::new(9));
+        let mut pout = Vec::new();
+        peer.process(
+            &e,
+            &frame(FrameType::Connect, &batch_connect_body(true, false)),
+            &mut pout,
+        )
+        .unwrap();
+        pout.clear();
+        peer.process(&e, &frame(FrameType::Sub, b"g"), &mut pout)
+            .unwrap();
+        assert_eq!(one_response(&pout).0, FrameType::Ok, "peer SUB acked");
+        let held = tierw_deliveries(&flow(&mut peer, &e, 3));
+        assert_eq!(
+            held.iter().map(|r| r.0).collect::<Vec<_>>(),
+            vec![0, 1, 2],
+            "the peer leased 0,1,2 per-record"
+        );
+        assert_eq!(ack_reply(&mut peer, &e, AckOp::Nack, 0, held[0].1), vec![1]);
+        assert_eq!(ack_reply(&mut peer, &e, AckOp::Nack, 1, held[1].1), vec![1]);
+        // The batch consumer's ONE Flow: redelivered [0,1] + fresh [3,4,5], with 2 held by the peer.
+        let mut s = tierw_batch_session(&e, MemberId::new(1), b"g");
+        let got = tierw_deliveries(&flow(&mut s, &e, 64));
+        let mut offsets = got.iter().map(|r| r.0).collect::<Vec<_>>();
+        offsets.sort_unstable();
+        assert_eq!(
+            offsets,
+            vec![0, 1, 3, 4, 5],
+            "the pass delivered the two non-contiguous runs and skipped the peer-held 2"
+        );
+        let gen_of = |o: u64| got.iter().find(|r| r.0 == o).unwrap().1;
+        // Two runs, each under its OWN shared generation (two separate reseals in one pass).
+        assert_eq!(gen_of(0), gen_of(1), "run [0,1] shares one generation");
+        assert_eq!(gen_of(3), gen_of(4), "run [3,4,5] shares one generation");
+        assert_eq!(gen_of(4), gen_of(5), "run [3,4,5] shares one generation");
+        assert_ne!(
+            gen_of(0),
+            gen_of(3),
+            "the two runs resealed independently, each to its own shared generation"
+        );
+        // THE EXACTNESS PIN: every record acks cleanly under its run's wire generation. Each run's
+        // engine reseal must therefore have run with THAT run's exact staged set — a leaked or
+        // misaligned set would have skipped a reseal and fenced these acks.
+        for (offset, generation, _) in &got {
+            assert_eq!(
+                ack_reply(&mut s, &e, AckOp::Ack, *offset, *generation),
+                vec![1u8],
+                "offset {offset} acks under its run's shared generation"
+            );
+        }
+        // The peer settles its held record; the whole log commits.
+        assert_eq!(ack_reply(&mut peer, &e, AckOp::Ack, 2, held[2].1), vec![1]);
+        assert_eq!(
+            e.engine_mut().committed_offset_in("g").get(),
+            6,
+            "all six records committed exactly once"
         );
     }
 


### PR DESCRIPTION
Closes #1168 (the non-blocking hazard from the #1167 review).

## The hazard

`flush_run`'s Tier-W batch reseal (`Engine::reseal_batch_in` + the session's `self.leased` loop) resealed ANY live lease in `[first, first+count)` to the run's shared generation `g0` without checking that the current generation was one THIS session staged. Under a pathological near-zero `visibility_nanos` (the documented degenerate continuous-redelivery config), a competing consumer can reclaim a staged offset mid-drain — drawing `g' > g0` between staging and flush — and the ungated reseal clobbered `g'` back to `g0`, FENCING the competitor's legitimate ack into a spurious extra redelivery. At-least-once-safe (never loss, never double-commit), but avoidable.

## The staged-set mechanism

- `StagedRun` gains `generations: Vec<u64>`, parallel to `records`: `generations[i]` is the claim generation this session drew for `first_offset + i`. It fills in `StagedRun::push` and clears in `begin`/`clear` in lockstep with the records, so the set is exact per run across a multi-run pass.
- `Engine::reseal_batch_in(group, first, staged, generation)` now reseals `first + i` ONLY while its current lease generation equals `staged[i]`, via the new `LeaseTable::reseal_from_to(offset, from, to)` (replacing the ungated `reseal_to`; the per-offset-fencing soundness argument carries over into its doc).
- Generations are never reused, so an exact per-offset match PROVES the caller's own claim is still the live lease; a competitor's newer reclaim (or a freed lease) is skipped, leaving the current owner's fence intact.

## Skip behavior: deliver in place with the stale token (and why)

A gate-skipped offset is still DELIVERED in place under the (now stale) shared generation, NOT dropped from the run:

- The `DeliverBatch` frame is positional (one `first_offset`, one `generation`); excising an interior record would split the frame into multiple frames for zero correctness gain.
- The stale token is harmless: the competitor's lease stands, its ack lands, and THIS session's ack of that offset is fenced by the engine — the correct at-least-once outcome. That extra delivery became inevitable the moment the competitor reclaimed the offset; the gate merely ensures the redelivery lands on the stale side instead of the legitimate one.
- The session's `leased` map still takes the shared generation for every run offset (skipped included): that is the token the wire carries, so the client's ack passes the session fence, reaches the engine, is fenced THERE (status 0), and clears the in-flight entry rather than stranding it until the stale-lease sweep.

## Doc fix

`reseal_batch_in`'s doc claimed "DEFAULT-group only"; it correctly reseals whatever group the session is subscribed to (`self.subscription`) — the scoping is to the DEFAULT (root) stream's group tables, where the batched Tier-W path engages.

## Tests

1. **THE RACE** — `tierw_batch_reseal_skips_an_offset_a_competitor_reclaimed_mid_drain`: stages a 3-record run through real `poll_now_in_member` claims, expires the leases (ManualClock), lets a competitor reclaim offset 0 (`g'` above every staged generation), then calls the REAL `flush_run`. Asserts: the reseal SKIPS offset 0; this session's shared-generation ack of it is the one FENCED (asserted BEFORE the competitor acks — exactly where an ungated reseal would have let it succeed); the competitor's ack is NOT fenced; offsets 1-2 reseal and ack exactly as before; the skipped offset still ships in place under the shared token; every record commits exactly once.
2. **NO REGRESSION**: the whole existing Tier-W suite — including the Linux `tier_w_*` sendfile parity tests — passes unchanged; the normal all-generations-intact path reseals exactly as before (`reseal_from_to_shares_one_generation_yet_keeps_per_offset_fencing` pins the granted case).
3. **EXACTNESS across a multi-run pass** — `tierw_batch_staged_generations_track_each_run_exactly_across_a_multi_run_pass`: a per-record peer requeues 0,1 while holding 2, so ONE Flow flushes runs `[0,1]` and `[3,4,5]` — two distinct shared generations, and every record acks cleanly under its run's wire generation (a leaked or misaligned staged set would skip a reseal and fence them).
4. **LeaseTable unit** — `reseal_from_to_refuses_to_clobber_a_competitors_reclaim`.

## Constraints

- Wire format unchanged (the gate is entirely server-internal; the batch frame is byte-identical).
- No new dependency; `deny.toml` byte-identical; `cargo tree --all-features -i ring` empty.
- Default + windows-gnu builds compile clean under `-D warnings`.
- Gates run in the Linux container: workspace tests (all features, locked), clippy `-D warnings` (after fmt), `cargo fmt --check`, format-registry, cargo-deny, golden-path acceptance, windows-gnu check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01McmNfYNWPmohVS8umY9Lkp
