### PR TITLE
perf(consume): fix sendfile fd-run assembly — bulk header walk, no re-walk, min-splice threshold (#1198)

### DIFF
--- a/crates/ironbus-bench/src/inproc.rs
+++ b/crates/ironbus-bench/src/inproc.rs
@@ -66,6 +66,7 @@ fn engine_config() -> EngineConfig {
 /// subject), not the per-group window, is the binding constraint the bench measures.
 fn engine_config_with_credit(consumer_credit: u32, max_in_flight: u32) -> EngineConfig {
     EngineConfig {
+        min_splice_bytes: 0,
         consume_longpoll_ms: 0,
         storage_mode: ironbus_storage::shared_wal::StorageMode::PerStreamLogs,
         log: LogConfig::default(),

--- a/crates/ironbus-cli/src/admin.rs
+++ b/crates/ironbus-cli/src/admin.rs
@@ -672,6 +672,7 @@ mod tests {
             SystemClock::new(),
             EngineConfig {
                 consume_longpoll_ms: 0,
+                min_splice_bytes: 0,
                 storage_mode: ironbus_storage::shared_wal::StorageMode::PerStreamLogs,
                 log: LogConfig::default(),
                 lease: LeaseConfig::default(),

--- a/crates/ironbus-cli/src/main.rs
+++ b/crates/ironbus-cli/src/main.rs
@@ -2578,6 +2578,10 @@ struct ServeFlags {
     /// AUTO-ON where sound (a plaintext, disk-backed, unencrypted window on a Linux build). Setting it
     /// forces the userspace copy path on every connection, with no behavioral or wire change.
     disable_zero_copy_sendfile: bool,
+    /// The `sendfile(2)` MIN-SPLICE threshold in BYTES (#1198): `--min-splice-bytes <n>`. A spliceable
+    /// run below this is served through the byte-identical copy path (the splice's fixed per-run costs
+    /// only pay above it). `None` falls back to the 64 KiB default; `0` splices every non-empty run.
+    min_splice_bytes: Option<u64>,
     /// The OTLP collector endpoint (#352): `--otlp-endpoint <url>`, e.g. `http://127.0.0.1:4317`
     /// (plaintext gRPC). `None` falls back to the default endpoint when export is on. Read only when
     /// export is on AND the `otlp` feature is built in.
@@ -3004,6 +3008,11 @@ fn collect_serve_flags(args: &[String]) -> Result<ServeFlags, CliError> {
             "--no-zero-copy-sendfile" => {
                 f.disable_zero_copy_sendfile = true;
                 i += 1;
+            }
+            // The `sendfile(2)` min-splice threshold in bytes (#1198): runs below it copy, at or
+            // above it splice. `0` splices every non-empty run.
+            "--min-splice-bytes" => {
+                f.min_splice_bytes = Some(take_number("--min-splice-bytes", args, &mut i)?);
             }
             "--key-shared-group" => {
                 f.key_shared_groups
@@ -3847,6 +3856,15 @@ fn parse_serve_flags_with_env_and_reader(
                 "--no-zero-copy-sendfile",
                 f.disable_zero_copy_sendfile,
                 env,
+            )?,
+            // The `sendfile(2)` min-splice threshold (#1198), flag > env > the 64 KiB default: a
+            // spliceable run below it takes the byte-identical copy path (the splice's fixed per-run
+            // costs only pay above it); `0` splices every non-empty run.
+            min_splice_bytes: resolve_number(
+                "--min-splice-bytes",
+                f.min_splice_bytes,
+                env,
+                ironbus_server::engine::DEFAULT_MIN_SPLICE_BYTES,
             )?,
             // V2-M4 routing richness (#549/#551), the #710 serve surface. Each defaults to its
             // disabling value (no TTL, no exchange, expired-routing off), so a zero-config broker
@@ -5748,6 +5766,13 @@ struct ServeConfig {
     /// `#[cfg(unix)]` `run_broker`, so on a non-unix build (which never serves) the field is inert.
     #[cfg_attr(not(unix), allow(dead_code))]
     zero_copy_sendfile: bool,
+    /// The `sendfile(2)` MIN-SPLICE threshold in BYTES (#1198, `--min-splice-bytes`, default 64 KiB):
+    /// a spliceable run below this many on-disk bytes is served through the byte-identical copy path
+    /// (the splice's fixed per-run costs — syscall + directive bookkeeping + interleaved socket writes
+    /// — only pay once the avoided body copy is large enough). `0` splices every non-empty run.
+    /// Threaded into [`EngineConfig::min_splice_bytes`]; `--no-zero-copy-sendfile` remains the full
+    /// kill-switch. See `ironbus_server::engine::DEFAULT_MIN_SPLICE_BYTES` for the measured basis.
+    min_splice_bytes: u64,
     /// The per-stream DEFAULT message TTL in MILLISECONDS (V2-M4 #549, wired by #710): a record
     /// older than this (its durable producer `timestamp_ms + ttl` against the wall-clock seam) is
     /// EXPIRED — skipped on read, never delivered, reclaimed by the segment reap. `0` = OFF (the
@@ -5832,6 +5857,8 @@ impl ServeConfig {
             // Zero-copy `sendfile(2)` delivery (#1034) AUTO-ON, the shipped default (the in-process bench
             // broker is a memory backend, where the fd path fail-closes to the copy path anyway).
             zero_copy_sendfile: true,
+            // The `sendfile(2)` min-splice threshold (#1198) at its shipped 64 KiB default.
+            min_splice_bytes: ironbus_server::engine::DEFAULT_MIN_SPLICE_BYTES,
             // V2-M4 routing richness (#549/#551) at its shipped defaults: no TTL, no dead-letter
             // exchange (the fixed `dlq/`), expired-routing off — the historical broker.
             default_message_ttl_ms: 0,
@@ -11064,6 +11091,11 @@ fn open_engine_with<F: Filesystem + Clone>(
         // `--consume-longpoll-ms` (default `0` = OFF). Server-only: an idle consumer wakes on a
         // commit instead of returning empty; no wire/client/format change.
         consume_longpoll_ms: config.consume_longpoll_ms,
+        // The `sendfile(2)` min-splice threshold (#1198), wired from `--min-splice-bytes`
+        // (default 64 KiB): a spliceable run below this many bytes is served through the
+        // byte-identical copy path, because the splice's fixed per-run costs only pay above it.
+        // `0` splices every non-empty run; `--no-zero-copy-sendfile` remains the full kill-switch.
+        min_splice_bytes: config.min_splice_bytes,
         // The fsync-headroom admission window (#378), wired from `--wal-fsync-headroom-bytes`.
         // Default `0` = OFF (the un-fsynced frontier is bounded only by the group-commit
         // drain under `sync` / the interval window under a relaxed level), so a zero-config
@@ -14716,6 +14748,7 @@ mod tests {
         ServeConfig {
             consume_longpoll_ms: 0,
             zero_copy_sendfile: true,
+            min_splice_bytes: ironbus_server::engine::DEFAULT_MIN_SPLICE_BYTES,
             // V2-M4 routing (#549/#551) at its inert defaults: no TTL, no exchange, no
             // expired-routing — the historical fixed-`dlq/` broker.
             default_message_ttl_ms: 0,
@@ -17056,6 +17089,7 @@ mod tests {
             StdFs::new(dir.clone()),
             Arc::clone(&clock),
             EngineConfig {
+                min_splice_bytes: 0,
                 storage_mode: ironbus_storage::shared_wal::StorageMode::PerStreamLogs,
                 consume_longpoll_ms: 0,
                 compression: ironbus_core::compress::Codec::None,
@@ -18094,6 +18128,7 @@ mod tests {
             InMemoryFs::new(),
             SystemClock::new(),
             EngineConfig {
+                min_splice_bytes: 0,
                 storage_mode: ironbus_storage::shared_wal::StorageMode::PerStreamLogs,
                 consume_longpoll_ms: 0,
                 compression: ironbus_core::compress::Codec::None,
@@ -18186,6 +18221,7 @@ mod tests {
             InMemoryFs::new(),
             SystemClock::new(),
             EngineConfig {
+                min_splice_bytes: 0,
                 storage_mode: ironbus_storage::shared_wal::StorageMode::PerStreamLogs,
                 consume_longpoll_ms: 0,
                 compression: ironbus_core::compress::Codec::None,
@@ -18670,6 +18706,7 @@ mod tests {
         ServeConfig {
             consume_longpoll_ms: 0,
             zero_copy_sendfile: true,
+            min_splice_bytes: ironbus_server::engine::DEFAULT_MIN_SPLICE_BYTES,
             // V2-M4 routing (#549/#551) at its inert defaults, mirroring production.
             default_message_ttl_ms: 0,
             max_delay_ms: DEFAULT_MAX_DELAY_MS,
@@ -22516,6 +22553,7 @@ eImsLe+T6lqrpgIgENKsK8qL9U5HkY7evGZM+CZNPHezUtmVVeASiOLgQO8=
             InMemoryFs::new(),
             SystemClock::new(),
             EngineConfig {
+                min_splice_bytes: 0,
                 storage_mode: ironbus_storage::shared_wal::StorageMode::PerStreamLogs,
                 consume_longpoll_ms: 0,
                 compression: ironbus_core::compress::Codec::None,
@@ -22607,6 +22645,7 @@ eImsLe+T6lqrpgIgENKsK8qL9U5HkY7evGZM+CZNPHezUtmVVeASiOLgQO8=
             InMemoryFs::new(),
             SystemClock::new(),
             EngineConfig {
+                min_splice_bytes: 0,
                 storage_mode: ironbus_storage::shared_wal::StorageMode::PerStreamLogs,
                 consume_longpoll_ms: 0,
                 compression: ironbus_core::compress::Codec::None,

--- a/crates/ironbus-cli/src/main.rs
+++ b/crates/ironbus-cli/src/main.rs
@@ -5772,6 +5772,9 @@ struct ServeConfig {
     /// — only pay once the avoided body copy is large enough). `0` splices every non-empty run.
     /// Threaded into [`EngineConfig::min_splice_bytes`]; `--no-zero-copy-sendfile` remains the full
     /// kill-switch. See `ironbus_server::engine::DEFAULT_MIN_SPLICE_BYTES` for the measured basis.
+    /// Server-only — read ONLY by the `#[cfg(unix)]` serve path (`open_engine_with`), so on a
+    /// non-unix build (which never serves) the field is inert, same as `zero_copy_sendfile` above.
+    #[cfg_attr(not(unix), allow(dead_code))]
     min_splice_bytes: u64,
     /// The per-stream DEFAULT message TTL in MILLISECONDS (V2-M4 #549, wired by #710): a record
     /// older than this (its durable producer `timestamp_ms + ttl` against the wall-clock seam) is

--- a/crates/ironbus-client-async/tests/roundtrip.rs
+++ b/crates/ironbus-client-async/tests/roundtrip.rs
@@ -32,6 +32,7 @@ fn open_engine() -> Engine<InMemoryFs, SystemClock> {
         InMemoryFs::new(),
         SystemClock::new(),
         EngineConfig {
+            min_splice_bytes: 0,
             consume_longpoll_ms: 0,
             storage_mode: ironbus_storage::shared_wal::StorageMode::PerStreamLogs,
             log: LogConfig::default(),

--- a/crates/ironbus-client/src/lib.rs
+++ b/crates/ironbus-client/src/lib.rs
@@ -4917,6 +4917,7 @@ mod tests {
             InMemoryFs::new(),
             SystemClock::new(),
             EngineConfig {
+                min_splice_bytes: 0,
                 consume_longpoll_ms: 0,
                 storage_mode: ironbus_storage::shared_wal::StorageMode::PerStreamLogs,
                 log: LogConfig::default(),
@@ -4985,6 +4986,7 @@ mod tests {
             InMemoryFs::new(),
             SystemClock::new(),
             EngineConfig {
+                min_splice_bytes: 0,
                 consume_longpoll_ms: 0,
                 storage_mode: ironbus_storage::shared_wal::StorageMode::PerStreamLogs,
                 log: LogConfig::default(),
@@ -5082,6 +5084,7 @@ mod tests {
             SystemClock::new(),
             EngineConfig {
                 consume_longpoll_ms: 0,
+                min_splice_bytes: 0,
                 storage_mode: ironbus_storage::shared_wal::StorageMode::PerStreamLogs,
                 log: LogConfig::default(),
                 lease: LeaseConfig::default(),
@@ -8896,6 +8899,7 @@ toYtkjmdU2eQ2pK/3gM=
             InMemoryFs::new(),
             SystemClock::new(),
             EngineConfig {
+                min_splice_bytes: 0,
                 consume_longpoll_ms: 0,
                 storage_mode: ironbus_storage::shared_wal::StorageMode::PerStreamLogs,
                 log: LogConfig::default(),
@@ -9223,6 +9227,7 @@ toYtkjmdU2eQ2pK/3gM=
     #[cfg(unix)]
     fn cluster_test_engine_config() -> EngineConfig {
         EngineConfig {
+            min_splice_bytes: 0,
             consume_longpoll_ms: 0,
             storage_mode: ironbus_storage::shared_wal::StorageMode::PerStreamLogs,
             log: LogConfig::default(),

--- a/crates/ironbus-server/src/actor.rs
+++ b/crates/ironbus-server/src/actor.rs
@@ -4037,6 +4037,7 @@ mod tests {
 
     fn config() -> EngineConfig {
         EngineConfig {
+            min_splice_bytes: 0,
             consume_longpoll_ms: 0,
             storage_mode: ironbus_storage::shared_wal::StorageMode::PerStreamLogs,
             log: LogConfig::default(),

--- a/crates/ironbus-server/src/engine.rs
+++ b/crates/ironbus-server/src/engine.rs
@@ -656,6 +656,20 @@ pub struct EngineConfig {
     /// against a long-poll-enabled broker simply gets its empty batches later (once a commit or the
     /// budget wakes it) instead of instantly.
     pub consume_longpoll_ms: u64,
+    /// The MINIMUM spliceable-run size in BYTES for the Linux `sendfile(2)` zero-copy consume path
+    /// (#1198, the tunability principle): a spliceable run whose on-disk byte length is BELOW this
+    /// is served through the ordinary copy path instead of being spliced, because the splice's
+    /// per-run fixed costs (the extra syscall + directive bookkeeping + interleaved socket writes)
+    /// only pay for themselves once the avoided userspace body copy is large enough. Enforced at
+    /// the ONE engine chokepoint both the Tier-S ([`Engine::stream_fetch_fd_in`] /
+    /// [`Engine::stream_fetch_fd_in_stream`]) and Tier-W ([`Engine::work_batch_fd_in`]) splice
+    /// decisions share, so every splice site honors it. Routing through the copy path is always
+    /// byte-identical on the wire (the differential oracles pin this), so this knob is pure
+    /// performance policy — never a correctness switch. `0` splices every non-empty spliceable run.
+    /// The default is [`DEFAULT_MIN_SPLICE_BYTES`] (64 KiB — see its doc for the measured #1191
+    /// basis); the `--no-zero-copy-sendfile` kill-switch remains the operator OFF-switch that forces
+    /// the copy path regardless of run size.
+    pub min_splice_bytes: u64,
     /// How named streams are STORED — the storage-mode selector (#597, M2-I13). The SAFE default is
     /// [`StorageMode::PerStreamLogs`] (today's per-stream [`ironbus_storage::streamset::StreamSet`]
     /// logs, byte-for-byte), so the shared-WAL fallback is strictly OPT-IN and an existing deployment
@@ -2341,6 +2355,25 @@ pub const DEFAULT_CONSUMER_CREDIT: u32 = ironbus_core::backpressure::DEFAULT_CRE
 /// in-flight RAM, which is why a no-byte-budget config is charged the full count ceiling by the RAM
 /// guard). See [`EngineConfig::consumer_credit_bytes`].
 pub const DEFAULT_CONSUMER_CREDIT_BYTES: u64 = 8 * 1024 * 1024;
+
+/// The default MINIMUM spliceable-run size in BYTES below which the Linux `sendfile(2)` zero-copy
+/// consume path routes a batch to the ordinary copy path instead of splicing (#1198, the tunability
+/// principle): 64 KiB.
+///
+/// MEASURED BASIS (#1191 refresh, `docs/benchmarks/matched-vm-harness/refresh-2026-07/`): the
+/// splice's advantage over the copy path is avoiding the userspace body copy, which SCALES WITH RUN
+/// BYTES, while its costs are FIXED per run (the extra `sendfile(2)` syscall, the directive
+/// bookkeeping, and the interleaved socket writes around each splice point). The refresh measured
+/// small-batch/loopback C1 shapes losing up to 3.4x on the splice path — the dominant mechanism was
+/// the per-record assembly walk (fixed by the #1198 bulk-read assembly), but it also showed the copy
+/// path serving a sub-socket-buffer run with ONE buffered write that a splice turns into at least
+/// three syscalls. Below one typical socket send buffer (~64 KiB) a memcpy into the already-flushing
+/// outbound buffer is reliably cheaper than that fixed splice overhead, and both measured C1 batch
+/// shapes (~360 KiB @128 B and ~2.2 MiB @1 KiB per run) sit well ABOVE this default, so the shipped
+/// default keeps them on the (now fixed) splice path — the post-fix VM re-measure is the acceptance
+/// gate that validates exactly that routing. `0` splices every non-empty run (the pre-#1198
+/// behavior); the `--no-zero-copy-sendfile` kill-switch still forces the copy path everywhere.
+pub const DEFAULT_MIN_SPLICE_BYTES: u64 = 64 * 1024;
 
 /// The default pipelined-sync-tier dirty-byte admission bound (#1040): the most UNSYNCED record
 /// bytes the append actor's pipelined branch lets accumulate behind an in-flight `fdatasync`
@@ -4147,6 +4180,12 @@ pub struct Engine<F: Filesystem, C: Clock> {
     /// to this budget on the commit-notify seam instead of returning empty immediately. Fixed for the
     /// engine's life (a `serve` flag sets it once), like the per-consumer credit caps.
     consume_longpoll_ms: u64,
+    /// The minimum spliceable-run size in BYTES for the `sendfile(2)` zero-copy consume path (#1198),
+    /// from [`EngineConfig::min_splice_bytes`] at open: a spliceable run below this is served through
+    /// the copy path (byte-identical on the wire), because the splice's fixed per-run costs only pay
+    /// above it. `0` splices every non-empty run. Set at open (a `serve` flag), re-settable server-side
+    /// via [`Engine::set_min_splice_bytes`] (like [`Engine::set_confirm_group`], NOT on the wire).
+    min_splice_bytes: u64,
     /// The set of group names CONFIGURED to use `key_shared` ordering (#64), declared server-side
     /// (NOT on the wire). Empty by default, so every group is plain competing
     /// ([`KeyOrdering::None`]) unless an operator opts it in. A session consults
@@ -5110,6 +5149,10 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
             dead_letter_exchange: config.dead_letter_exchange,
             dead_letter_expired: config.dead_letter_expired,
             consume_longpoll_ms: config.consume_longpoll_ms,
+            // The `sendfile(2)` min-splice threshold (#1198): a spliceable run below this many bytes
+            // routes to the copy path (byte-identical wire), because the splice's fixed per-run costs
+            // only pay above it. `0` = splice every non-empty run.
+            min_splice_bytes: config.min_splice_bytes,
         };
         engine.seed_registry_from_recovered_state(flushed);
         // RESTORE the durable idempotent-producer SEQUENCE high-waters (V2-M8) into the registry, so a
@@ -13703,7 +13746,10 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
     /// window — at-rest encryption, a compacted (v2 sparse) or offloaded (remote) slot, a no-fd backend
     /// (memory / `O_DIRECT`), or a not-yet-indexed active tail — reusing the exact fail-closed reroutes
     /// [`ironbus_storage::log::Log::read_range_fd_range`] already applies (byte-for-byte the
-    /// `read_range_raw` the copy path falls back to). On the fd path the returned [`StreamFdBatch::Fd`]
+    /// `read_range_raw` the copy path falls back to). A spliceable run BELOW
+    /// [`EngineConfig::min_splice_bytes`] is likewise served as `Copy` (#1198, the shared
+    /// [`Engine::splice_meets_min`] gate): too small for the splice's fixed per-run costs, identical on
+    /// the wire. On the fd path the returned [`StreamFdBatch::Fd`]
     /// holds the segment reader ALIVE (via its `Box<dyn SpliceSource>` holder) so a concurrent compaction
     /// retire cannot close the fd mid-splice.
     ///
@@ -13725,22 +13771,26 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         // None` mirrors `work_batch_raw_in` — the run is already bounded to `count` records.
         let (fd_run, _tail_from) = self.log.read_range_fd_range(first, count, None)?;
         if let Some(fd_run) = fd_run {
-            let file_offset = fd_run.file_offset();
-            let len = fd_run.len();
-            let first_offset = fd_run.first_offset();
-            let record_count = fd_run.record_count();
-            let next_offset = fd_run.next_offset();
-            return Ok(StreamFdBatch::Fd {
-                holder: Box::new(fd_run),
-                file_offset,
-                len,
-                first_offset,
-                record_count,
-                // The Tier-W drain ships the ACTIVE-tail remainder per-record from its OWN decoded
-                // records (`run.records[sealed..]`), so the engine returns no tail here.
-                tail: Vec::new(),
-                next_offset,
-            });
+            // The min-splice size gate (#1198): a run below the threshold falls through to the
+            // byte-identical copy fallback below — the splice's fixed per-run costs only pay above it.
+            if self.splice_meets_min(fd_run.len()) {
+                let file_offset = fd_run.file_offset();
+                let len = fd_run.len();
+                let first_offset = fd_run.first_offset();
+                let record_count = fd_run.record_count();
+                let next_offset = fd_run.next_offset();
+                return Ok(StreamFdBatch::Fd {
+                    holder: Box::new(fd_run),
+                    file_offset,
+                    len,
+                    first_offset,
+                    record_count,
+                    // The Tier-W drain ships the ACTIVE-tail remainder per-record from its OWN decoded
+                    // records (`run.records[sealed..]`), so the engine returns no tail here.
+                    tail: Vec::new(),
+                    next_offset,
+                });
+            }
         }
         // Copy fallback: byte-for-byte `work_batch_raw_in` (the same single-segment `read_range_raw`).
         let (raw, _tail_from) = self.log.read_range_raw(first, count, None)?;
@@ -13750,6 +13800,32 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
             tail: Vec::new(),
             next_offset,
         }))
+    }
+
+    /// The MINIMUM spliceable-run size in BYTES for the `sendfile(2)` zero-copy consume path (#1198);
+    /// see [`EngineConfig::min_splice_bytes`]. A spliceable run below this is served through the
+    /// byte-identical copy path; `0` splices every non-empty run.
+    #[must_use]
+    pub fn min_splice_bytes(&self) -> u64 {
+        self.min_splice_bytes
+    }
+
+    /// Retunes the `sendfile(2)` min-splice threshold (#1198) server-side (NOT on the wire), like
+    /// [`Engine::set_confirm_group`]: a spliceable run below `bytes` routes to the copy path from the
+    /// next fetch on. Pure performance policy — both routes are byte-identical on the wire — so it is
+    /// safe to change at any time. `0` splices every non-empty run.
+    pub fn set_min_splice_bytes(&mut self, bytes: u64) {
+        self.min_splice_bytes = bytes;
+    }
+
+    /// The ONE splice-vs-copy SIZE gate (#1198) every `sendfile(2)` decision consults — the Tier-S
+    /// [`Engine::stream_fetch_fd_in`] / [`Engine::stream_fetch_fd_in_stream`] and the Tier-W
+    /// [`Engine::work_batch_fd_in`] all route a spliceable run through this single predicate, so the
+    /// min-splice policy cannot drift between tiers: `true` iff a run of `len` on-disk bytes is at or
+    /// above [`Engine::min_splice_bytes`] (a below-threshold run takes the byte-identical copy path).
+    #[cfg(target_os = "linux")]
+    fn splice_meets_min(&self, len: usize) -> bool {
+        u64::try_from(len).unwrap_or(u64::MAX) >= self.min_splice_bytes
     }
 
     /// The name of the ONE designated group whose ack confirms a Level-2 produce (#497). Defaults to
@@ -15168,7 +15244,10 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
     /// FAIL-CLOSES to the copy path (a materialized [`StreamRawBatch`] in [`StreamFdBatch::Copy`]) whenever
     /// the fd path is not available for the window — at-rest encryption, a compacted (v2 sparse) or remote
     /// (offloaded) slot, a no-fd backend (memory / `O_DIRECT`), or a not-yet-indexed active tail — reusing
-    /// the exact fail-closed reroutes [`ironbus_storage::log::Log::read_range_fd_range`] already applies. On
+    /// the exact fail-closed reroutes [`ironbus_storage::log::Log::read_range_fd_range`] already applies.
+    /// A spliceable run BELOW [`EngineConfig::min_splice_bytes`] is likewise served through the copy path
+    /// (#1198, the shared [`Engine::splice_meets_min`] gate): too small for the splice's fixed per-run
+    /// costs, identical on the wire. On
     /// the fd path the returned [`StreamFdBatch::Fd`] holds the segment reader ALIVE (via its
     /// `Box<dyn SpliceSource>` holder) so a concurrent compaction retire cannot close the fd mid-splice.
     ///
@@ -15214,34 +15293,38 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
             self.log
                 .read_range_fd_range(start_offset, max_records, max_bytes)?;
         if let Some(fd_run) = fd_run {
-            // ACTIVE-tail remainder, bounded exactly as `stream_fetch_raw_in` bounds it.
-            let fd_count = usize::try_from(fd_run.record_count()).unwrap_or(usize::MAX);
-            let tail = match tail_from {
-                Some(from) if fd_count < max_records => {
-                    self.log
-                        .read_range(from, max_records - fd_count, max_bytes)?
-                }
-                _ => Vec::new(),
-            };
-            let next_offset = tail.last().map_or(fd_run.next_offset(), |r| {
-                r.offset.checked_next().unwrap_or(r.offset)
-            });
-            let total = fd_run.record_count().saturating_add(tail.len() as u64);
-            let file_offset = fd_run.file_offset();
-            let len = fd_run.len();
-            let first_offset = fd_run.first_offset();
-            let record_count = fd_run.record_count();
-            // `self.log` borrow ended above (the tail read was its last use); bump the counter now.
-            self.counters.delivered = self.counters.delivered.saturating_add(total);
-            return Ok(StreamFdBatch::Fd {
-                holder: Box::new(fd_run),
-                file_offset,
-                len,
-                first_offset,
-                record_count,
-                tail,
-                next_offset,
-            });
+            // The min-splice size gate (#1198): a run below the threshold falls through to the
+            // byte-identical copy fallback below — the splice's fixed per-run costs only pay above it.
+            if self.splice_meets_min(fd_run.len()) {
+                // ACTIVE-tail remainder, bounded exactly as `stream_fetch_raw_in` bounds it.
+                let fd_count = usize::try_from(fd_run.record_count()).unwrap_or(usize::MAX);
+                let tail = match tail_from {
+                    Some(from) if fd_count < max_records => {
+                        self.log
+                            .read_range(from, max_records - fd_count, max_bytes)?
+                    }
+                    _ => Vec::new(),
+                };
+                let next_offset = tail.last().map_or(fd_run.next_offset(), |r| {
+                    r.offset.checked_next().unwrap_or(r.offset)
+                });
+                let total = fd_run.record_count().saturating_add(tail.len() as u64);
+                let file_offset = fd_run.file_offset();
+                let len = fd_run.len();
+                let first_offset = fd_run.first_offset();
+                let record_count = fd_run.record_count();
+                // `self.log` borrow ended above (the tail read was its last use); bump the counter now.
+                self.counters.delivered = self.counters.delivered.saturating_add(total);
+                return Ok(StreamFdBatch::Fd {
+                    holder: Box::new(fd_run),
+                    file_offset,
+                    len,
+                    first_offset,
+                    record_count,
+                    tail,
+                    next_offset,
+                });
+            }
         }
         // Copy fallback: byte-for-byte the body of `stream_fetch_raw_in` post-guard.
         let (raw, tail_from) = self
@@ -15333,32 +15416,36 @@ impl<F: Filesystem, C: Clock + Clone> Engine<F, C> {
         };
         let (fd_run, tail_from) = log.read_range_fd_range(start_offset, max_records, max_bytes)?;
         if let Some(fd_run) = fd_run {
-            let fd_count = usize::try_from(fd_run.record_count()).unwrap_or(usize::MAX);
-            let tail = match tail_from {
-                Some(from) if fd_count < max_records => {
-                    log.read_range(from, max_records - fd_count, max_bytes)?
-                }
-                _ => Vec::new(),
-            };
-            let next_offset = tail.last().map_or(fd_run.next_offset(), |r| {
-                r.offset.checked_next().unwrap_or(r.offset)
-            });
-            let total = fd_run.record_count().saturating_add(tail.len() as u64);
-            let file_offset = fd_run.file_offset();
-            let len = fd_run.len();
-            let first_offset = fd_run.first_offset();
-            let record_count = fd_run.record_count();
-            // `log` borrow (of `self.streams`) ended above; bump the counter now.
-            self.counters.delivered = self.counters.delivered.saturating_add(total);
-            return Ok(StreamFdBatch::Fd {
-                holder: Box::new(fd_run),
-                file_offset,
-                len,
-                first_offset,
-                record_count,
-                tail,
-                next_offset,
-            });
+            // The min-splice size gate (#1198): a run below the threshold falls through to the
+            // byte-identical copy fallback below — the splice's fixed per-run costs only pay above it.
+            if self.splice_meets_min(fd_run.len()) {
+                let fd_count = usize::try_from(fd_run.record_count()).unwrap_or(usize::MAX);
+                let tail = match tail_from {
+                    Some(from) if fd_count < max_records => {
+                        log.read_range(from, max_records - fd_count, max_bytes)?
+                    }
+                    _ => Vec::new(),
+                };
+                let next_offset = tail.last().map_or(fd_run.next_offset(), |r| {
+                    r.offset.checked_next().unwrap_or(r.offset)
+                });
+                let total = fd_run.record_count().saturating_add(tail.len() as u64);
+                let file_offset = fd_run.file_offset();
+                let len = fd_run.len();
+                let first_offset = fd_run.first_offset();
+                let record_count = fd_run.record_count();
+                // `log` borrow (of `self.streams`) ended above; bump the counter now.
+                self.counters.delivered = self.counters.delivered.saturating_add(total);
+                return Ok(StreamFdBatch::Fd {
+                    holder: Box::new(fd_run),
+                    file_offset,
+                    len,
+                    first_offset,
+                    record_count,
+                    tail,
+                    next_offset,
+                });
+            }
         }
         let (raw, tail_from) = log.read_range_raw(start_offset, max_records, max_bytes)?;
         let raw_count = usize::try_from(raw.record_count).unwrap_or(usize::MAX);
@@ -16190,6 +16277,7 @@ mod tests {
 
     fn config(max_in_flight: u32, max_deliver: u32) -> EngineConfig {
         EngineConfig {
+            min_splice_bytes: 0,
             consume_longpoll_ms: 0,
             storage_mode: ironbus_storage::shared_wal::StorageMode::PerStreamLogs,
             log: LogConfig::default(),

--- a/crates/ironbus-server/src/health.rs
+++ b/crates/ironbus-server/src/health.rs
@@ -2765,6 +2765,7 @@ mod tests {
     /// extracted so the connz/disk-free integration test reuses the SAME config as `start()`.
     fn test_eng_cfg() -> EngineConfig {
         EngineConfig {
+            min_splice_bytes: 0,
             consume_longpoll_ms: 0,
             storage_mode: ironbus_storage::shared_wal::StorageMode::PerStreamLogs,
             compression: ironbus_core::compress::Codec::None,
@@ -3208,6 +3209,7 @@ mod tests {
             InMemoryFs::new(),
             Arc::clone(&clock),
             EngineConfig {
+                min_splice_bytes: 0,
                 consume_longpoll_ms: 0,
                 storage_mode: ironbus_storage::shared_wal::StorageMode::PerStreamLogs,
                 compression: ironbus_core::compress::Codec::None,
@@ -4102,6 +4104,7 @@ mod tests {
             InMemoryFs::new(),
             SystemClock::new(),
             EngineConfig {
+                min_splice_bytes: 0,
                 consume_longpoll_ms: 0,
                 storage_mode: ironbus_storage::shared_wal::StorageMode::PerStreamLogs,
                 compression: ironbus_core::compress::Codec::None,
@@ -4255,6 +4258,7 @@ mod tests {
             InMemoryFs::new(),
             SystemClock::new(),
             EngineConfig {
+                min_splice_bytes: 0,
                 consume_longpoll_ms: 0,
                 storage_mode: ironbus_storage::shared_wal::StorageMode::PerStreamLogs,
                 compression: ironbus_core::compress::Codec::None,
@@ -4341,6 +4345,7 @@ mod tests {
             InMemoryFs::new(),
             SystemClock::new(),
             EngineConfig {
+                min_splice_bytes: 0,
                 consume_longpoll_ms: 0,
                 storage_mode: ironbus_storage::shared_wal::StorageMode::PerStreamLogs,
                 compression: ironbus_core::compress::Codec::None,
@@ -4624,6 +4629,7 @@ mod tests {
                 InMemoryFs::new(),
                 SystemClock::new(),
                 EngineConfig {
+                    min_splice_bytes: 0,
                     consume_longpoll_ms: 0,
                     storage_mode: ironbus_storage::shared_wal::StorageMode::PerStreamLogs,
                     compression: ironbus_core::compress::Codec::None,
@@ -4688,6 +4694,7 @@ mod tests {
             InMemoryFs::new(),
             SystemClock::new(),
             EngineConfig {
+                min_splice_bytes: 0,
                 consume_longpoll_ms: 0,
                 storage_mode: ironbus_storage::shared_wal::StorageMode::PerStreamLogs,
                 compression: ironbus_core::compress::Codec::None,
@@ -4851,6 +4858,7 @@ mod tests {
             InMemoryFs::new(),
             Arc::clone(&clock),
             EngineConfig {
+                min_splice_bytes: 0,
                 consume_longpoll_ms: 0,
                 storage_mode: ironbus_storage::shared_wal::StorageMode::PerStreamLogs,
                 compression: ironbus_core::compress::Codec::None,
@@ -4998,6 +5006,7 @@ mod tests {
             InMemoryFs::new(),
             SystemClock::new(),
             EngineConfig {
+                min_splice_bytes: 0,
                 consume_longpoll_ms: 0,
                 storage_mode: ironbus_storage::shared_wal::StorageMode::PerStreamLogs,
                 compression: ironbus_core::compress::Codec::None,
@@ -5224,6 +5233,7 @@ mod tests {
             InMemoryFs::new(),
             SystemClock::new(),
             EngineConfig {
+                min_splice_bytes: 0,
                 consume_longpoll_ms: 0,
                 storage_mode: ironbus_storage::shared_wal::StorageMode::PerStreamLogs,
                 compression: ironbus_core::compress::Codec::None,
@@ -6360,6 +6370,7 @@ mod tests {
             InMemoryFs::new(),
             SystemClock::new(),
             EngineConfig {
+                min_splice_bytes: 0,
                 consume_longpoll_ms: 0,
                 storage_mode: ironbus_storage::shared_wal::StorageMode::PerStreamLogs,
                 compression: ironbus_core::compress::Codec::None,
@@ -6579,6 +6590,7 @@ mod tests {
             InMemoryFs::new(),
             Arc::clone(&clock),
             EngineConfig {
+                min_splice_bytes: 0,
                 consume_longpoll_ms: 0,
                 storage_mode: ironbus_storage::shared_wal::StorageMode::PerStreamLogs,
                 compression: ironbus_core::compress::Codec::None,
@@ -6808,6 +6820,7 @@ mod tests {
             fs,
             ManualClock::new(),
             EngineConfig {
+                min_splice_bytes: 0,
                 consume_longpoll_ms: 0,
                 storage_mode: ironbus_storage::shared_wal::StorageMode::PerStreamLogs,
                 compression: ironbus_core::compress::Codec::None,
@@ -7126,6 +7139,7 @@ mod tests {
             InMemoryFs::new(),
             SystemClock::new(),
             EngineConfig {
+                min_splice_bytes: 0,
                 consume_longpoll_ms: 0,
                 storage_mode: ironbus_storage::shared_wal::StorageMode::PerStreamLogs,
                 compression: ironbus_core::compress::Codec::None,

--- a/crates/ironbus-server/src/server.rs
+++ b/crates/ironbus-server/src/server.rs
@@ -1098,6 +1098,7 @@ mod tests {
 
     fn config() -> EngineConfig {
         EngineConfig {
+            min_splice_bytes: 0,
             consume_longpoll_ms: 0,
             storage_mode: ironbus_storage::shared_wal::StorageMode::PerStreamLogs,
             log: LogConfig::default(),

--- a/crates/ironbus-server/src/session.rs
+++ b/crates/ironbus-server/src/session.rs
@@ -7765,6 +7765,10 @@ mod tests {
     /// open the SAME config over a fault-injecting filesystem (to count fsyncs).
     fn test_config() -> EngineConfig {
         EngineConfig {
+            // Min-splice threshold OFF (`0` = splice every non-empty run) in the shared test config
+            // (#1198), so the sendfile differential tests keep exercising the splice path over their
+            // deliberately tiny runs; the threshold-routing tests set a non-zero value explicitly.
+            min_splice_bytes: 0,
             consume_longpoll_ms: 0,
             storage_mode: ironbus_storage::shared_wal::StorageMode::PerStreamLogs,
             compression: ironbus_core::compress::Codec::None,
@@ -7875,6 +7879,7 @@ mod tests {
             InMemoryFs::new(),
             clock,
             EngineConfig {
+                min_splice_bytes: 0,
                 consume_longpoll_ms: 0,
                 storage_mode: ironbus_storage::shared_wal::StorageMode::PerStreamLogs,
                 compression: ironbus_core::compress::Codec::None,
@@ -7937,6 +7942,7 @@ mod tests {
             InMemoryFs::new(),
             clock,
             EngineConfig {
+                min_splice_bytes: 0,
                 consume_longpoll_ms: 0,
                 storage_mode: ironbus_storage::shared_wal::StorageMode::PerStreamLogs,
                 compression: ironbus_core::compress::Codec::None,
@@ -8264,6 +8270,7 @@ mod tests {
             InMemoryFs::new(),
             ManualClock::new(),
             EngineConfig {
+                min_splice_bytes: 0,
                 consume_longpoll_ms: 0,
                 storage_mode: ironbus_storage::shared_wal::StorageMode::PerStreamLogs,
                 compression: ironbus_core::compress::Codec::None,
@@ -10595,8 +10602,18 @@ mod tests {
 
         /// A disk-backed engine with a SMALL segment cap so a run SEALS several segments (the raw fd path
         /// serves only the SEALED/indexed prefix) plus an active tail. `StdFs` gives each sealed segment a
-        /// real spliceable fd (unlike `InMemoryFs`, whose `splice_fd` is `None`).
+        /// real spliceable fd (unlike `InMemoryFs`, whose `splice_fd` is `None`). Min-splice threshold OFF
+        /// (`test_config`'s `0`), so the tiny runs these tests build still exercise the splice.
         fn disk_engine(dir: &std::path::Path) -> Engine<StdFs, ManualClock> {
+            disk_engine_with_min_splice(dir, 0)
+        }
+
+        /// [`disk_engine`] with an EXPLICIT `sendfile(2)` min-splice threshold (#1198), for the
+        /// threshold-routing tests.
+        fn disk_engine_with_min_splice(
+            dir: &std::path::Path,
+            min_splice_bytes: u64,
+        ) -> Engine<StdFs, ManualClock> {
             Engine::open(
                 StdFs::new(dir.to_path_buf()),
                 ManualClock::new(),
@@ -10605,6 +10622,7 @@ mod tests {
                         max_segment_bytes: 160,
                         ..LogConfig::default()
                     },
+                    min_splice_bytes,
                     ..test_config()
                 },
             )
@@ -11184,6 +11202,142 @@ mod tests {
                 "the spliced fd survives the engine drop + segment retire (holder keeps it open)"
             );
         }
+
+        // ===== Min-splice auto-on threshold (#1198) ==============================================
+        // A spliceable run BELOW `min_splice_bytes` routes to the byte-identical copy path (the
+        // splice's fixed per-run costs only pay above it); at or above, it splices. The operator
+        // kill-switch (splice_enabled = false) forcing the copy path regardless is pinned by
+        // `kill_switch_forces_the_full_frame_copy_path` / `tier_w_kill_switch_forces_the_full_frame_
+        // copy_path` above, unchanged.
+
+        #[test]
+        fn min_splice_threshold_routes_a_small_run_to_the_copy_path() {
+            // Tier-S: a splice-ENABLED session over an engine whose threshold exceeds every run in the
+            // window emits NO directives — and the wire is byte-for-byte the copy engine's (the
+            // threshold is pure routing policy, never a wire change).
+            let dir_t = tempfile::tempdir().unwrap();
+            let dir_c = tempfile::tempdir().unwrap();
+            let et = DirectEngine::new(disk_engine_with_min_splice(dir_t.path(), 1 << 20));
+            let ec = DirectEngine::new(disk_engine(dir_c.path()));
+            for i in 0..16u8 {
+                produce_disk(&et, &[i], &[i, 1], &[i; 6]);
+                produce_disk(&ec, &[i], &[i, 1], &[i; 6]);
+            }
+            let mut st = disk_batch_session(&et, b"s", true);
+            let mut sc = disk_batch_session(&ec, b"s", false);
+            let mut out_thresh = Vec::new();
+            st.process(
+                &et,
+                &frame(FrameType::StreamFetch, &stream_fetch_req()),
+                &mut out_thresh,
+            )
+            .unwrap();
+            assert!(
+                st.take_splices().is_empty(),
+                "every run in this window is below the 1 MiB threshold: no splice directive"
+            );
+            let mut out_copy = Vec::new();
+            sc.process(
+                &ec,
+                &frame(FrameType::StreamFetch, &stream_fetch_req()),
+                &mut out_copy,
+            )
+            .unwrap();
+            assert_eq!(
+                out_thresh, out_copy,
+                "the threshold-rerouted wire == the copy-path wire, byte for byte"
+            );
+        }
+
+        #[test]
+        fn min_splice_threshold_engages_at_and_only_at_the_boundary() {
+            // The `>=` boundary, engine-level for exactness: with the threshold set EXACTLY to a run's
+            // on-disk byte length the run still splices (`Fd`); one byte higher routes it to the copy
+            // path (`Copy`). Uses the Tier-S engine chokepoint directly so the boundary is exact.
+            use crate::engine::StreamFdBatch;
+            let dir = tempfile::tempdir().unwrap();
+            let e = DirectEngine::new(disk_engine(dir.path()));
+            for i in 0..16u8 {
+                produce_disk(&e, &[i], &[i, 1], &[i; 6]);
+            }
+            e.with(|eng| eng.set_streaming_in("s", true).unwrap())
+                .unwrap();
+            // Threshold 0 (`disk_engine`): the first sealed run splices; capture its byte length.
+            let len = e
+                .with(|eng| {
+                    match eng
+                        .stream_fetch_fd_in("s", MemberId::default(), Offset::new(0), 100, None)
+                        .unwrap()
+                    {
+                        StreamFdBatch::Fd { len, .. } => len,
+                        StreamFdBatch::Copy(_) => panic!("threshold 0 must splice a sealed run"),
+                    }
+                })
+                .unwrap();
+            assert!(len > 0);
+            // Exactly AT the threshold: still spliced (the gate is `>=`).
+            e.with(move |eng| eng.set_min_splice_bytes(len as u64))
+                .unwrap();
+            let at = e
+                .with(|eng| {
+                    eng.stream_fetch_fd_in("s", MemberId::default(), Offset::new(0), 100, None)
+                        .unwrap()
+                })
+                .unwrap();
+            assert!(
+                matches!(at, StreamFdBatch::Fd { .. }),
+                "a run exactly at the threshold splices"
+            );
+            // One byte ABOVE: routed to the byte-identical copy path.
+            e.with(move |eng| eng.set_min_splice_bytes(len as u64 + 1))
+                .unwrap();
+            let above = e
+                .with(|eng| {
+                    eng.stream_fetch_fd_in("s", MemberId::default(), Offset::new(0), 100, None)
+                        .unwrap()
+                })
+                .unwrap();
+            match above {
+                StreamFdBatch::Copy(batch) => assert_eq!(
+                    batch.raw.bytes.len(),
+                    len,
+                    "the copy route serves the same run bytes"
+                ),
+                StreamFdBatch::Fd { .. } => panic!("a run below the threshold must not splice"),
+            }
+        }
+
+        #[test]
+        fn tier_w_min_splice_threshold_routes_a_small_run_to_the_copy_path() {
+            // Tier-W twin: the lease/reseal `flush_run` batch path honors the SAME engine chokepoint —
+            // a splice-enabled work-queue session over a high-threshold engine emits NO directives and
+            // its wire is byte-for-byte the copy engine's (incl. the reseal generation).
+            let dir_t = tempfile::tempdir().unwrap();
+            let dir_c = tempfile::tempdir().unwrap();
+            let et = DirectEngine::new(disk_engine_with_min_splice(dir_t.path(), 1 << 20));
+            let ec = DirectEngine::new(disk_engine(dir_c.path()));
+            for i in 0..16u8 {
+                produce_disk(&et, &[i], &[i, 1], &[i; 6]);
+                produce_disk(&ec, &[i], &[i, 1], &[i; 6]);
+            }
+            let mut st = disk_work_batch_session(&et, b"w", true);
+            let mut sc = disk_work_batch_session(&ec, b"w", false);
+            let mut out_thresh = Vec::new();
+            st.process(&et, &fetch_frame(100, 0, 0, true), &mut out_thresh)
+                .unwrap();
+            assert!(
+                st.take_splices().is_empty(),
+                "every Tier-W run in this window is below the 1 MiB threshold: no splice directive"
+            );
+            let mut out_copy = Vec::new();
+            sc.process(&ec, &fetch_frame(100, 0, 0, true), &mut out_copy)
+                .unwrap();
+            assert!(!out_copy.is_empty(), "the copy path produced a response");
+            assert_eq!(
+                out_thresh, out_copy,
+                "the Tier-W threshold-rerouted wire == the copy-path wire, byte for byte"
+            );
+        }
     }
 
     #[test]
@@ -11638,6 +11792,7 @@ mod tests {
             InMemoryFs::new(),
             clock,
             EngineConfig {
+                min_splice_bytes: 0,
                 consume_longpoll_ms: 0,
                 storage_mode: ironbus_storage::shared_wal::StorageMode::PerStreamLogs,
                 compression: ironbus_core::compress::Codec::None,
@@ -12991,6 +13146,7 @@ mod tests {
                 InMemoryFs::new(),
                 ManualClock::new(),
                 EngineConfig {
+                    min_splice_bytes: 0,
                     consume_longpoll_ms: 0,
                     storage_mode: ironbus_storage::shared_wal::StorageMode::PerStreamLogs,
                     compression: ironbus_core::compress::Codec::None,
@@ -13620,6 +13776,7 @@ mod tests {
             InMemoryFs::new(),
             clock,
             EngineConfig {
+                min_splice_bytes: 0,
                 consume_longpoll_ms: 0,
                 storage_mode: ironbus_storage::shared_wal::StorageMode::PerStreamLogs,
                 compression: ironbus_core::compress::Codec::None,
@@ -13687,6 +13844,7 @@ mod tests {
             InMemoryFs::new(),
             clock,
             EngineConfig {
+                min_splice_bytes: 0,
                 consume_longpoll_ms: 0,
                 storage_mode: ironbus_storage::shared_wal::StorageMode::PerStreamLogs,
                 compression: ironbus_core::compress::Codec::None,
@@ -13905,6 +14063,7 @@ mod tests {
             InMemoryFs::new(),
             ManualClock::new(),
             EngineConfig {
+                min_splice_bytes: 0,
                 consume_longpoll_ms: 0,
                 storage_mode: ironbus_storage::shared_wal::StorageMode::PerStreamLogs,
                 compression: ironbus_core::compress::Codec::Lz4,
@@ -14957,6 +15116,7 @@ mod tests {
             InMemoryFs::new(),
             clock,
             EngineConfig {
+                min_splice_bytes: 0,
                 consume_longpoll_ms: 0,
                 storage_mode: ironbus_storage::shared_wal::StorageMode::PerStreamLogs,
                 compression: ironbus_core::compress::Codec::None,

--- a/crates/ironbus-server/tests/conformance_vectors.rs
+++ b/crates/ironbus-server/tests/conformance_vectors.rs
@@ -634,6 +634,7 @@ fn build_config(setup: &Setup) -> EngineConfig {
         _ => DiskFullPolicy::DropNew,
     };
     EngineConfig {
+        min_splice_bytes: 0,
         consume_longpoll_ms: 0,
         storage_mode: ironbus_storage::shared_wal::StorageMode::PerStreamLogs,
         log: LogConfig {

--- a/crates/ironbus-server/tests/determinism.rs
+++ b/crates/ironbus-server/tests/determinism.rs
@@ -18,6 +18,7 @@ use ironbus_storage::log::{Append, LogConfig};
 
 fn config() -> EngineConfig {
     EngineConfig {
+        min_splice_bytes: 0,
         consume_longpoll_ms: 0,
         storage_mode: ironbus_storage::shared_wal::StorageMode::PerStreamLogs,
         log: LogConfig::default(),

--- a/crates/ironbus-storage/src/log.rs
+++ b/crates/ironbus-storage/src/log.rs
@@ -4429,9 +4429,12 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
     /// byte-for-byte the [`RawByteRun::bytes`] the copy path returns for the same window (the
     /// differential test pins this) — the wire body is unchanged and the client is oblivious.
     ///
-    /// The boundary walk touches only frame HEADERS: no record body is ever read into userspace, which
-    /// is the whole point of the zero-copy path (the kernel splices the bodies straight from the page
-    /// cache to the socket).
+    /// The boundary walk is ONE bulk read of the seek window into a transient scratch buffer plus an
+    /// in-memory walk (#1198 — the old per-header `pread64` walk was ~2 syscalls per record, a
+    /// 2.3-3.4x C1 consume regression; see `SegmentReader::raw_fd_range_with_plan` for the honest
+    /// memory accounting). The scratch is the same order the copy path already allocates and is
+    /// dropped before the splice; the bodies still reach the socket kernel-side via `sendfile(2)`,
+    /// never through the outbound frame buffer.
     ///
     /// Returns `(Some(fd_run), tail_from)` when a spliceable run was found, or `(None, tail_from)` when
     /// there is nothing to splice here and the caller must serve the window through the COPY path
@@ -4500,9 +4503,10 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
         let want = max_records.saturating_add(gap).min(below_flushed);
         let reader = SegmentReader::open(self.fs.open(&segment_file_name(slot.id))?)?;
         let raw_max_bytes = if gap == 0 { max_bytes } else { None };
-        // The anchor run over this single segment, header-only. `None` = no splice fd for this segment
+        // The anchor run over this single segment: ONE bulk window read + an in-memory walk that also
+        // records the admitted frames' LENGTH PLAN (#1198). `None` = no splice fd for this segment
         // (an `O_DIRECT` sealed segment): the caller serves the whole window through the copy path.
-        let Some(anchor) = reader.raw_fd_range(
+        let Some((anchor, plan)) = reader.raw_fd_range_with_plan(
             byte_pos,
             Offset::new(anchor_offset),
             read_end,
@@ -4516,18 +4520,18 @@ impl<F: Filesystem, C: Clock> Log<F, C> {
         // has to be dropped so `reader` can move into `FdRun`. `RawFdRun` is `Copy`, so its last field
         // read below ends the borrow (NLL) — no explicit `drop` (which clippy would reject on a Copy).
         let anchor_start = anchor.file_offset;
-        let anchor_len = anchor.len;
         let anchor_first = anchor.first_offset.get();
         // Trim the leading `gap` frames and re-bound to `max_records` / `max_bytes` — the fd twin of
-        // `trim_and_bound_raw_run`, header-only, producing byte-identical boundaries.
-        let (file_offset, len, first_offset, record_count, next) = reader.trim_fd_run(
+        // `trim_and_bound_raw_run`, pure arithmetic over the anchor walk's frame plan (#1198): it
+        // never re-reads a header, producing byte-identical boundaries with zero additional syscalls.
+        let (file_offset, len, first_offset, record_count, next) = crate::segment::trim_fd_run(
             anchor_start,
-            anchor_len,
             anchor_first,
+            &plan,
             seg_start,
             max_records,
             max_bytes,
-        )?;
+        );
         // Resume reporting: byte-for-byte the same computation `read_range_raw` performs.
         let tail_from = if next < flushed && record_count >= max_records as u64 {
             None

--- a/crates/ironbus-storage/src/segment.rs
+++ b/crates/ironbus-storage/src/segment.rs
@@ -582,8 +582,10 @@ pub struct RawByteRun {
 /// (#1034 / #658): instead of the run's bytes IN userspace, it names the exact on-disk BYTE RANGE
 /// `[file_offset, file_offset + len)` — a contiguous run of `record_count` whole, header-validated
 /// frames in one segment file — plus a BORROWED descriptor to splice that range straight from the
-/// page cache to the socket. The bodies are never read into userspace: the boundary walk that
-/// produced this touched only the frame HEADERS (see [`SegmentReader::raw_fd_range`]).
+/// page cache to the socket. The bodies never enter the OUTBOUND path in userspace: the boundary
+/// walk that produced this bulk-read the window into a transient, immediately-dropped scratch (see
+/// [`SegmentReader::raw_fd_range_with_plan`] for the #1198 syscall/memory accounting), and the splice
+/// itself moves the bodies kernel-side.
 ///
 /// Byte-for-byte, `[file_offset, file_offset + len)` equals the [`RawByteRun::bytes`] the copy path
 /// returns for the SAME window (the differential test in `log.rs` pins this), so the wire body a
@@ -611,6 +613,113 @@ pub struct RawFdRun<'a> {
     /// The next offset AFTER the run (the first offset NOT included): where a follow-on read resumes.
     /// Equals `first_offset` when the run is empty.
     pub next_offset: Offset,
+}
+
+/// The ONE in-memory frame-boundary walk shared by the copy path ([`SegmentReader::raw_byte_range`])
+/// and the fd path ([`SegmentReader::raw_fd_range`]) (#1198): steps whole, HEADER-CRC-validated
+/// frames through `body` under the identical bounds — at most `max` frames, the `max_bytes` cap with
+/// the first-frame-always rule, a torn/corrupt header or a frame running past `body` ends the run —
+/// invoking `on_frame(frame_len)` for each ADMITTED frame, and returns `(count, byte_total)`.
+///
+/// Both read paths walking the SAME window bytes through this ONE loop is what makes the fd run's
+/// `[file_offset, file_offset + len)` byte-identical to the copy run's `bytes` by CONSTRUCTION (the
+/// differential tests then pin it), instead of by maintaining two parallel walks. It is also the
+/// #1198 syscall fix: the walk touches only memory, so the per-frame `pread64`s the old
+/// `frame_len_at` header walk issued (~2 per record with the trim re-walk — the measured 2.3-3.4x C1
+/// consume regression) are gone; the callers pay ONE bulk window read instead.
+fn walk_frame_run(
+    body: &[u8],
+    max: usize,
+    max_bytes: Option<usize>,
+    mut on_frame: impl FnMut(usize),
+) -> (usize, usize) {
+    let mut cursor = 0usize;
+    let mut byte_total = 0usize;
+    let mut count = 0usize;
+    while cursor < body.len() && count < max {
+        // HEADER-ONLY boundary check: `decoded_len` validates the frame's HEADER CRC and returns the
+        // full frame length WITHOUT touching the body — the cheap half of `codec::decode`. A torn or
+        // corrupt header ends the run, exactly as `scan_range`'s `decode` does, so the admitted bytes
+        // are always whole, header-validated frames.
+        let Ok(consumed) = codec::decoded_len(&body[cursor..]) else {
+            break;
+        };
+        // The frame must lie WHOLLY within the read region; a frame that would run off the end of
+        // the buffer is a torn tail and ends the run (matching `scan_range`, whose `decode` of a
+        // short tail returns `Truncated` and breaks).
+        if cursor.saturating_add(consumed) > body.len() {
+            break;
+        }
+        // Byte cap: stop BEFORE a frame that would push the accumulated bytes past `max_bytes`,
+        // but ALWAYS admit the first frame so a single frame larger than the cap never stalls —
+        // the identical rule `scan_range` applies against `OwnedRecord::encoded_len`.
+        if let Some(cap) = max_bytes {
+            if count != 0 && byte_total.saturating_add(consumed) > cap {
+                break;
+            }
+        }
+        byte_total = byte_total.saturating_add(consumed);
+        count += 1;
+        cursor += consumed;
+        on_frame(consumed);
+    }
+    (count, byte_total)
+}
+
+/// The fd sibling of `trim_and_bound_raw_run` (in `log.rs`): given an anchor fd run starting at file
+/// byte `anchor_start` whose admitted frames' lengths are `plan` (in order, as
+/// [`SegmentReader::raw_fd_range_with_plan`] recorded them), drops the leading frames below
+/// `seg_start` and re-bounds the remainder to `max_records` / `max_bytes` (first-frame-always),
+/// returning the trimmed `(file_offset, len, first_offset, record_count, next_offset)`.
+/// `anchor_first_offset` is the log offset of the anchor run's first frame.
+///
+/// PURE ARITHMETIC over the anchor walk's frame plan (#1198): the old implementation RE-WALKED the
+/// same on-disk headers with one positioned `pread64` each — half of the measured ~2-preads-PER-RECORD
+/// fd-assembly regression — but the anchor walk already validated and measured every admitted frame,
+/// so carrying its lengths here reproduces byte-identical boundaries with ZERO file access.
+#[cfg(unix)]
+pub(crate) fn trim_fd_run(
+    anchor_start: u64,
+    anchor_first_offset: u64,
+    plan: &[usize],
+    seg_start: u64,
+    max_records: usize,
+    max_bytes: Option<usize>,
+) -> (u64, usize, u64, u64, u64) {
+    let mut idx = 0usize;
+    let mut rel = 0usize;
+    let mut offset = anchor_first_offset;
+    // Drop the leading frames below `seg_start` by stepping their recorded lengths (mirrors the
+    // first loop of `trim_and_bound_raw_run`, bounded by the plan == the anchor run's frames).
+    while offset < seg_start && idx < plan.len() {
+        rel = rel.saturating_add(plan[idx]);
+        idx += 1;
+        offset = offset.saturating_add(1);
+    }
+    let run_start_rel = rel;
+    let first_offset = offset;
+    // Admit up to `max_records` / `max_bytes` frames from `seg_start`, "at least one" honored.
+    let mut count = 0usize;
+    let mut byte_total = 0usize;
+    while idx < plan.len() && count < max_records {
+        let consumed = plan[idx];
+        if let Some(cap) = max_bytes {
+            if count != 0 && byte_total.saturating_add(consumed) > cap {
+                break;
+            }
+        }
+        byte_total = byte_total.saturating_add(consumed);
+        count += 1;
+        offset = offset.saturating_add(1);
+        idx += 1;
+    }
+    (
+        anchor_start + run_start_rel as u64,
+        byte_total,
+        first_offset,
+        count as u64,
+        offset,
+    )
 }
 
 impl OwnedRecord {
@@ -2678,44 +2787,16 @@ impl<F: RandomAccessFile> SegmentReader<F> {
         // one syscall + one allocation + zero per-record allocations and zero body decodes.
         // Read straight into fresh (unzeroed) capacity: the read fully overwrites it (#813 / #815).
         let body = self.read_into_fresh(len, start_byte)?;
-        let mut cursor = 0usize;
-        let mut byte_total = 0usize;
-        let mut count = 0usize;
-        let mut next_offset = start_offset.get();
-        while cursor < body.len() && count < max {
-            // HEADER-ONLY boundary walk: `decoded_len` validates the frame's HEADER CRC and returns
-            // the full frame length WITHOUT touching the body — the cheap half of `codec::decode`. A
-            // torn or corrupt header ends the run, exactly as `scan_range`'s `decode` does, so the
-            // admitted bytes are always whole, header-validated frames.
-            let Ok(consumed) = codec::decoded_len(&body[cursor..]) else {
-                break;
-            };
-            // The frame must lie WHOLLY within the read region; a frame that would run off the end of
-            // the buffer is a torn tail and ends the run (matching `scan_range`, whose `decode` of a
-            // short tail returns `Truncated` and breaks).
-            if cursor.saturating_add(consumed) > body.len() {
-                break;
-            }
-            // Byte cap: stop BEFORE a frame that would push the accumulated bytes past `max_bytes`,
-            // but ALWAYS admit the first frame so a single frame larger than the cap never stalls —
-            // the identical rule `scan_range` applies against `OwnedRecord::encoded_len`.
-            if let Some(cap) = max_bytes {
-                if count != 0 && byte_total.saturating_add(consumed) > cap {
-                    break;
-                }
-            }
-            byte_total = byte_total.saturating_add(consumed);
-            count += 1;
-            next_offset = next_offset.saturating_add(1);
-            cursor += consumed;
-        }
+        // The boundary walk is the ONE shared in-memory walker (`walk_frame_run`, #1198) — the same
+        // loop the fd path runs over the same window bytes, so the two paths cannot drift.
+        let (count, byte_total) = walk_frame_run(&body, max, max_bytes, |_| {});
         Ok(RawByteRun {
             // The admitted prefix: the first `byte_total` bytes are exactly `count` whole frames. A
             // refcount slice of the shared buffer, never a copy.
             bytes: body.slice(0..byte_total),
             first_offset: start_offset,
             record_count: count as u64,
-            next_offset: Offset::new(next_offset),
+            next_offset: Offset::new(start_offset.get().saturating_add(count as u64)),
         })
     }
 
@@ -2728,38 +2809,10 @@ impl<F: RandomAccessFile> SegmentReader<F> {
         self.file.splice_fd()
     }
 
-    /// Reads ONLY the frame header at absolute file offset `abs` (never the body) and returns the whole
-    /// frame's on-disk length via [`codec::decoded_len`], or `None` when the header is torn, corrupt,
-    /// or too short — which ENDS a run exactly as [`SegmentReader::raw_byte_range`]'s in-buffer walk
-    /// does when `decoded_len` errors. `region_end` bounds the read so it never reads past the admitted
-    /// region; at most `RECORD_HEADER_LEN` + the fixed post-header `u16` prefix (the width the subject
-    /// (#594) and stream-tag (#597) fields share) enter userspace — never a record body. This is the
-    /// header-only atom that keeps the fd walk zero-copy.
-    #[cfg(unix)]
-    fn frame_len_at(&self, abs: u64, region_end: u64) -> Result<Option<usize>, StorageError> {
-        const HDR_MAX: usize = RECORD_HEADER_LEN + RECORD_SUBJECT_LEN_PREFIX;
-        let want = usize::try_from(region_end.saturating_sub(abs))
-            .unwrap_or(HDR_MAX)
-            .min(HDR_MAX);
-        if want < RECORD_HEADER_LEN {
-            // Fewer bytes than a header remain: a torn tail. `decoded_len` would report `Truncated`, so
-            // end the run — mirroring `raw_byte_range` where `decoded_len(&body[cursor..])` breaks.
-            return Ok(None);
-        }
-        let mut hdr = [0u8; HDR_MAX];
-        self.file.read_exact_at(&mut hdr[..want], abs)?;
-        // `decoded_len` reads only the header fields (and, for a tagged/subject frame, the `u16` at the
-        // fixed post-header offset), so `want` bytes always suffice: it returns the SAME length the
-        // in-buffer walk computes for the identical on-disk header. A header-CRC/magic/version failure
-        // (or a short tagged frame) errors, which we map to `None` = end of run.
-        Ok(codec::decoded_len(&hdr[..want]).ok())
-    }
-
     /// The fd sibling of [`SegmentReader::raw_byte_range`]: walks the SAME contiguous run of whole,
     /// header-validated frames from `start_byte`, under the IDENTICAL bounds (`max`, `read_end`,
-    /// `max_bytes` with the first-frame-always rule), but reads ONLY the frame headers — never a body —
-    /// and returns the run's on-disk BYTE RANGE plus a borrowed splice fd as a [`RawFdRun`], for the
-    /// Linux `sendfile(2)` zero-copy path (#1034 / #658).
+    /// `max_bytes` with the first-frame-always rule), and returns the run's on-disk BYTE RANGE plus a
+    /// borrowed splice fd as a [`RawFdRun`], for the Linux `sendfile(2)` zero-copy path (#1034 / #658).
     ///
     /// Returns `Ok(None)` when this backend has no spliceable descriptor (memory / ephemeral /
     /// `O_DIRECT`): the caller then takes the copy path via [`SegmentReader::raw_byte_range`]. Otherwise
@@ -2768,9 +2821,13 @@ impl<F: RandomAccessFile> SegmentReader<F> {
     /// same `first_offset` / `record_count` / `next_offset`. `start_byte` MUST be a real frame boundary;
     /// a header that fails its CRC ENDS the run, so the range is always a clean whole-frame prefix.
     ///
+    /// SYSCALL SHAPE (#1198): ONE bulk positioned read of the window into a TRANSIENT scratch buffer,
+    /// then the boundary walk runs in memory — see [`SegmentReader::raw_fd_range_with_plan`] for the
+    /// memory-vs-throughput accounting (the scratch is the same order the copy path already allocates).
+    ///
     /// # Errors
-    /// Returns an IO error from reading a header, or [`StorageError::SegmentFull`] if the region length
-    /// does not fit `usize`. A torn or corrupt header is NOT an error: it ends the run.
+    /// Returns an IO error from reading the window, or [`StorageError::SegmentFull`] if the region
+    /// length does not fit `usize`. A torn or corrupt header is NOT an error: it ends the run.
     #[cfg(unix)]
     pub fn raw_fd_range(
         &self,
@@ -2780,6 +2837,43 @@ impl<F: RandomAccessFile> SegmentReader<F> {
         max: usize,
         max_bytes: Option<usize>,
     ) -> Result<Option<RawFdRun<'_>>, StorageError> {
+        Ok(self
+            .raw_fd_range_with_plan(start_byte, start_offset, read_end, max, max_bytes)?
+            .map(|(run, _plan)| run))
+    }
+
+    /// [`SegmentReader::raw_fd_range`] plus the admitted frames' LENGTH PLAN (#1198): the per-frame
+    /// on-disk lengths of the run's frames, in order, so [`trim_fd_run`] can trim and re-bound the run
+    /// with pure arithmetic instead of re-walking the same headers off disk.
+    ///
+    /// This is where the #1198 fd-assembly regression is fixed. The old walk read each frame HEADER
+    /// with its own positioned `pread64` (`frame_len_at`), and the trim re-walked them: ~2 syscalls PER
+    /// RECORD (strace: 2,010,730 preads for 1M records vs 1,134 on the copy path), a 2.3-3.4x C1
+    /// consume regression. Now the walk does ONE bulk read of the SAME `[start_byte, read_end)` window
+    /// the copy path reads and steps frames in memory via the shared [`walk_frame_run`].
+    ///
+    /// MEMORY vs THROUGHPUT, honestly: the bulk read materializes the window (bodies included) in a
+    /// transient scratch buffer, so the strict "only headers ever enter userspace" property of the old
+    /// walk is deliberately traded for O(1) syscalls per batch. The scratch is bounded by the SAME
+    /// window every `read_range` copy-path call already reads into userspace (the #664 seek window,
+    /// `O(want + stride)` bytes, further bounded by `max_bytes`) and is DROPPED before the splice, so
+    /// peak per-fetch memory is the same order as the copy path's — the fd path does not regress the
+    /// broker's memory story, it stops regressing its throughput. What stays zero-copy is the part
+    /// that matters on the wire: the bodies are still spliced kernel-side by `sendfile(2)`, never
+    /// copied into the outbound frame buffer.
+    ///
+    /// # Errors
+    /// Returns an IO error from reading the window, or [`StorageError::SegmentFull`] if the region
+    /// length does not fit `usize`. A torn or corrupt header is NOT an error: it ends the run.
+    #[cfg(unix)]
+    pub(crate) fn raw_fd_range_with_plan(
+        &self,
+        start_byte: u64,
+        start_offset: Offset,
+        read_end: u64,
+        max: usize,
+        max_bytes: Option<usize>,
+    ) -> Result<Option<(RawFdRun<'_>, Vec<usize>)>, StorageError> {
         // Only a backend with a spliceable descriptor can serve the zero-copy path; otherwise the
         // caller copies. Take the fd first so `None` short-circuits before any IO.
         let Some(fd) = self.file.splice_fd() else {
@@ -2794,108 +2888,20 @@ impl<F: RandomAccessFile> SegmentReader<F> {
             next_offset: start_offset,
         };
         if max == 0 || start_byte >= read_end {
-            return Ok(Some(run));
+            return Ok(Some((run, Vec::new())));
         }
-        // The region is `[start_byte, read_end)` — the exact window `raw_byte_range` reads into `body`,
-        // so `region_len` plays the role of `body.len()` and every bound below matches it one-for-one.
+        // The region is `[start_byte, read_end)` — the exact window `raw_byte_range` reads into `body`.
         let region_len = usize::try_from(read_end.saturating_sub(start_byte))
             .map_err(|_| StorageError::SegmentFull)?;
-        let mut rel = 0usize;
-        let mut byte_total = 0usize;
-        let mut count = 0usize;
-        let mut next_offset = start_offset.get();
-        while rel < region_len && count < max {
-            // HEADER-ONLY boundary walk (`decoded_len`, header-CRC-validated); a torn/corrupt header
-            // ends the run exactly as `raw_byte_range`'s `decoded_len(&body[cursor..])` does.
-            let Some(consumed) = self.frame_len_at(start_byte + rel as u64, read_end)? else {
-                break;
-            };
-            // A frame that would run past the region is a torn tail: end the run (mirrors
-            // `cursor + consumed > body.len()`).
-            if rel.saturating_add(consumed) > region_len {
-                break;
-            }
-            // Byte cap: stop before a frame that would exceed `max_bytes`, but ALWAYS admit the first
-            // (the "at least one" rule) — the identical check `raw_byte_range` applies.
-            if let Some(cap) = max_bytes {
-                if count != 0 && byte_total.saturating_add(consumed) > cap {
-                    break;
-                }
-            }
-            byte_total = byte_total.saturating_add(consumed);
-            count += 1;
-            next_offset = next_offset.saturating_add(1);
-            rel += consumed;
-        }
+        // ONE bulk read + the ONE shared in-memory walker (`walk_frame_run`): the identical read shape
+        // and loop `raw_byte_range` runs, so the admitted boundaries are byte-identical by construction.
+        let window = self.read_into_fresh(region_len, start_byte)?;
+        let mut plan = Vec::new();
+        let (count, byte_total) = walk_frame_run(&window, max, max_bytes, |len| plan.push(len));
         run.len = byte_total;
         run.record_count = count as u64;
-        run.next_offset = Offset::new(next_offset);
-        Ok(Some(run))
-    }
-
-    /// The fd sibling of `trim_and_bound_raw_run` (in `log.rs`): given an anchor run's byte range
-    /// `[anchor_start, anchor_start + anchor_len)`, drops the leading frames below `seg_start` and
-    /// re-bounds the remainder to `max_records` / `max_bytes` (first-frame-always), returning the
-    /// trimmed `(file_offset, len, first_offset, record_count, next_offset)`. A header-only re-walk of
-    /// the SAME frames the anchor run admitted, so it produces byte-identical boundaries without ever
-    /// reading a body. `anchor_first_offset` is the log offset of the anchor run's first frame.
-    ///
-    /// # Errors
-    /// Propagates an IO error from reading a header.
-    #[cfg(unix)]
-    pub(crate) fn trim_fd_run(
-        &self,
-        anchor_start: u64,
-        anchor_len: usize,
-        anchor_first_offset: u64,
-        seg_start: u64,
-        max_records: usize,
-        max_bytes: Option<usize>,
-    ) -> Result<(u64, usize, u64, u64, u64), StorageError> {
-        let region_end = anchor_start + anchor_len as u64;
-        let mut rel = 0usize;
-        let mut offset = anchor_first_offset;
-        // Drop the leading frames below `seg_start` by walking their header lengths (mirrors the first
-        // loop of `trim_and_bound_raw_run`, bounded by `anchor_len` == the run's `bytes.len()`).
-        while offset < seg_start && rel < anchor_len {
-            let Some(consumed) = self.frame_len_at(anchor_start + rel as u64, region_end)? else {
-                break;
-            };
-            if rel.saturating_add(consumed) > anchor_len {
-                break;
-            }
-            rel += consumed;
-            offset = offset.saturating_add(1);
-        }
-        let run_start_rel = rel;
-        let first_offset = offset;
-        // Admit up to `max_records` / `max_bytes` frames from `seg_start`, "at least one" honored.
-        let mut count = 0usize;
-        let mut byte_total = 0usize;
-        while rel < anchor_len && count < max_records {
-            let Some(consumed) = self.frame_len_at(anchor_start + rel as u64, region_end)? else {
-                break;
-            };
-            if rel.saturating_add(consumed) > anchor_len {
-                break;
-            }
-            if let Some(cap) = max_bytes {
-                if count != 0 && byte_total.saturating_add(consumed) > cap {
-                    break;
-                }
-            }
-            byte_total = byte_total.saturating_add(consumed);
-            count += 1;
-            offset = offset.saturating_add(1);
-            rel += consumed;
-        }
-        Ok((
-            anchor_start + run_start_rel as u64,
-            byte_total,
-            first_offset,
-            count as u64,
-            offset,
-        ))
+        run.next_offset = Offset::new(start_offset.get().saturating_add(count as u64));
+        Ok(Some((run, plan)))
     }
 
     /// Materializes the bytes of `[file_offset, file_offset + len)` into an owned [`Bytes`] — the
@@ -4379,6 +4385,94 @@ mod tests {
             &fd_torn_bytes[..],
             &raw_torn.bytes[..],
             "torn byte range matches copy path"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn fd_run_assembly_reads_o_few_not_o_records() {
+        // #1198 MECHANISM PIN: assembling an N-record fd run (`raw_fd_range_with_plan` + the
+        // `trim_fd_run` re-bound) must cost O(few) positioned reads — ONE bulk window read — NOT the
+        // O(2 per record) header walk + trim re-walk that strace measured as 2,010,730 preads per 1M
+        // records (the 2.3-3.4x C1 consume regression vs the copy path). Counted through the
+        // `RandomAccessFile` seam with a delegating wrapper over the REAL `StdFile` (the only backend
+        // with a splice fd), so any future re-introduction of a per-frame file read fails this test.
+        use crate::io::StdFile;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        struct CountingFile {
+            inner: StdFile,
+            reads: AtomicUsize,
+        }
+        impl RandomAccessFile for CountingFile {
+            fn read_at(&self, buf: &mut [u8], offset: u64) -> std::io::Result<usize> {
+                self.reads.fetch_add(1, Ordering::Relaxed);
+                self.inner.read_at(buf, offset)
+            }
+            fn write_all_at(&self, buf: &[u8], offset: u64) -> std::io::Result<()> {
+                self.inner.write_all_at(buf, offset)
+            }
+            fn sync_data(&self) -> std::io::Result<()> {
+                self.inner.sync_data()
+            }
+            fn sync_all(&self) -> std::io::Result<()> {
+                self.inner.sync_all()
+            }
+            fn len(&self) -> std::io::Result<u64> {
+                self.inner.len()
+            }
+            fn set_len(&self, len: u64) -> std::io::Result<()> {
+                self.inner.set_len(len)
+            }
+            fn splice_fd(&self) -> Option<std::os::fd::BorrowedFd<'_>> {
+                self.inner.splice_fd()
+            }
+        }
+
+        const N: u64 = 200;
+        let dir = tempfile::tempdir().unwrap();
+        let file = Arc::new(CountingFile {
+            inner: StdFile::create(&dir.path().join("seg.log")).unwrap(),
+            reads: AtomicUsize::new(0),
+        });
+        let mut w = SegmentWriter::create(Arc::clone(&file), header()).unwrap();
+        for i in 0..N {
+            w.append(&rec(i, &[u8::try_from(i % 251).unwrap(); 24]))
+                .unwrap();
+        }
+        w.sync().unwrap();
+        let reader = SegmentReader::open(Arc::clone(&file)).unwrap();
+        let (positions, valid_end) = reader.record_byte_positions().unwrap();
+
+        // Count ONLY the assembly: the anchor walk over the whole N-record window plus the trim
+        // re-bound (leading-gap drop + re-cap), the exact pair `Log::read_range_fd_range` runs.
+        let before = file.reads.load(Ordering::Relaxed);
+        let (anchor, plan) = reader
+            .raw_fd_range_with_plan(positions[0], Offset::new(0), valid_end, usize::MAX, None)
+            .unwrap()
+            .expect("a StdFile-backed reader has a splice fd");
+        assert_eq!(anchor.record_count, N, "the walk admitted every record");
+        assert_eq!(
+            plan.len() as u64,
+            N,
+            "the plan carries one length per frame"
+        );
+        let anchor_start = anchor.file_offset;
+        let (_, _, first_offset, record_count, _) = trim_fd_run(
+            anchor_start,
+            0,
+            &plan,
+            3, // drop a leading gap, exercising the first trim loop
+            usize::MAX,
+            None,
+        );
+        let reads = file.reads.load(Ordering::Relaxed) - before;
+        assert_eq!(first_offset, 3);
+        assert_eq!(record_count, N - 3);
+        assert!(
+            reads <= 3,
+            "fd-run assembly of {N} records must cost O(few) positioned reads (one bulk window \
+             read), got {reads} — a per-record file walk has been re-introduced (#1198)"
         );
     }
 


### PR DESCRIPTION
Fixes #1198 (epic #1196 phase-2 lever 1). Refs #1191 #1174 #1178 #1041.

## The measured mechanism (why)

The #1191 matched-matrix refresh attributed a **2.3–3.4× C1 durable-consume regression** on the shipped splice default to the fd-run **assembly**, not the sendfile syscall:

| C1 (VM, matched durability, medians of 3) | splice AUTO-ON (shipped) | `--no-zero-copy-sendfile` | OFF/ON |
|---|---:|---:|:--|
| 128 B | 1,324,592 msg/s | 4,563,071 msg/s | **3.44×** |
| 1 KiB | 846,280 msg/s | 1,961,457 msg/s | **2.32×** |

strace (1M msgs @128 B): **2,010,730 `pread64`s** on the splice path vs **1,134** on the copy path, with only **504 sendfiles** (~1 per 2048-record batch). `frame_len_at` issued one positioned `pread64` per FRAME header during `raw_fd_range`'s boundary walk, and `trim_fd_run` **re-walked the same headers** — ~2 preads **per record**. The copy path is fast because ONE pread reads the window and the walk is in memory.

## Design chosen (part 1: assembly without per-record syscalls)

**Bulk window read + ONE shared in-memory walker + carry-the-plan into the trim:**

- `raw_fd_range` now bulk-reads the SAME `[start_byte, read_end)` window the copy path reads (ONE pread over the #664-bounded seek window) into a transient scratch and walks the boundaries in memory.
- The walk is the ONE shared `walk_frame_run` that `raw_byte_range` (the copy path) now also uses — the fd run's `[file_offset, len)` is byte-identical to the copy run's bytes **by construction**, not by maintaining two parallel loops.
- The walk records the admitted frames' length plan; `trim_fd_run` becomes **pure arithmetic over the plan** (no `&self`, no IO) — the trim re-walk, half the measured syscalls, is simply gone.

**Memory vs throughput, honestly** (noted in the code): the scratch trades the strict "only headers ever enter userspace" property for O(1) syscalls per batch. It is bounded by the same window every copy-path `read_range` already reads into userspace (`O(want + stride)` bytes, further bounded by `max_bytes`) and is dropped before the splice — so peak per-fetch memory is the same order as the copy path's, and the bodies still reach the socket kernel-side via `sendfile(2)`.

## Part 2: min-splice auto-on threshold (tunability principle)

The splice engages only when the run's spliceable bytes ≥ `min_splice_bytes` (`EngineConfig` field, `--min-splice-bytes` flag/env, live-retunable via `Engine::set_min_splice_bytes`), enforced at the ONE engine chokepoint all three fd methods share (`splice_meets_min`: Tier-S `stream_fetch_fd_in` / `stream_fetch_fd_in_stream`, Tier-W `work_batch_fd_in`). Below-threshold runs take the byte-identical copy path. `--no-zero-copy-sendfile` remains the full kill-switch.

**Default: 64 KiB (`DEFAULT_MIN_SPLICE_BYTES`).** Rationale from the measured data:

- The splice's win (avoided userspace body copy) scales with run bytes; its costs are fixed per run (extra syscall + directive bookkeeping + interleaved socket writes around each splice point). Below one typical socket send buffer (~64 KiB) a memcpy into the already-flushing outbound buffer reliably beats that fixed overhead — the refresh's small-batch/loopback shapes are exactly where the splice lost hardest.
- Both measured C1 batch shapes (~360 KiB @128 B and ~2.2 MiB @1 KiB per run) sit well ABOVE the default, so the shipped default keeps them ON the (now fixed) splice path — the acceptance re-measure validates that routing rather than being made vacuous by the threshold.
- `0` restores splice-every-run; the threshold is pure routing policy (both routes byte-identical on the wire), never a correctness switch.

## Tests

- **Byte-identity oracles green UNCHANGED**: `read_range_fd_range_byte_range_is_identical_to_read_range_raw`, `fd_range_byte_range_is_identical_for_compressed_subject_and_stream_tag_frames`, `raw_fd_range_names_the_same_bytes_as_raw_byte_range`, wire-level `socket_bytes_are_byte_identical_to_the_copy_path` + the Tier-W twin.
- **Syscall-count proxy** (new, pins the mechanism forever): `fd_run_assembly_reads_o_few_not_o_records` counts positioned reads through the `RandomAccessFile` seam (delegating counter over the real `StdFile`) across a 200-record `raw_fd_range` + `trim_fd_run` and asserts ≤ 3 reads — O(few), not O(N).
- **Threshold** (new): below-threshold reroute emits no directives and is wire-identical to the copy engine (Tier-S + Tier-W twins); `min_splice_threshold_engages_at_and_only_at_the_boundary` pins the exact `>=` boundary at the engine chokepoint; the existing kill-switch tests (`kill_switch_forces_the_full_frame_copy_path` + Tier-W twin) pass unchanged.
- Existing sendfile fallback/CRC/fd-lifetime tests unchanged (16/16 sendfile suite green in the Linux container).
- Shared test configs set `min_splice_bytes: 0` so the existing tiny-run splice differentials keep exercising the splice path.

## Gates run (Linux container)

- `cargo test -p ironbus-storage --all-features --locked` — 603 passed
- `cargo test -p ironbus-server sendfile` — 16 passed (incl. the 3 new threshold tests)
- `cargo fmt --all --check` + `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — clean

CI is the authoritative full gate.

## Acceptance gate (deliberately NOT claimed here)

The post-fix C1 re-measure on the #1191 VM (`c1diag.sh`) is the acceptance gate: the shipped default must be ≥ the copy path on both payloads, and strace preads/record must be ~O(1/batch). No throughput number is claimed in this PR — the VM re-measure decides, per #1198's acceptance section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
