### PR TITLE
Make ironbus-client's dev-dependencies path-only so it can publish

### DIFF
--- a/crates/ironbus-client/Cargo.toml
+++ b/crates/ironbus-client/Cargo.toml
@@ -33,8 +33,14 @@ rustls = { version = "0.23", optional = true, default-features = false, features
 rustls-pki-types = { version = "1", optional = true, features = ["std"] }
 
 [dev-dependencies]
-ironbus-server = { path = "../ironbus-server", version = "0.1.0" }
-ironbus-storage = { path = "../ironbus-storage", version = "0.1.0" }
+# PATH-ONLY, deliberately: a dev-dependency carrying a `version` must resolve from the
+# registry at publish time, so these would force `ironbus-server` and `ironbus-storage`
+# (the broker and its storage engine) onto crates.io purely to let the client publish.
+# Cargo omits path-only dev-dependencies from the published manifest, and dev-deps are
+# never part of a consumer's build, so dropping the version costs downstream nothing and
+# keeps the in-repo integration tests building exactly as before.
+ironbus-server = { path = "../ironbus-server" }
+ironbus-storage = { path = "../ironbus-storage" }
 
 [lints]
 workspace = true


### PR DESCRIPTION
`cargo publish -p ironbus-client --dry-run` refused:

```
no matching package named `ironbus-server` found
location searched: crates.io index
required by package `ironbus-client v0.1.0`
```

A dev-dependency carrying a `version` must resolve from the registry at publish time, so `ironbus-server` and `ironbus-storage` (the broker and its storage engine) would have had to go to crates.io purely to let the client publish.

Cargo omits path-only dev-dependencies from the published manifest, and dev-dependencies are never part of a consumer's build, so dropping the version costs downstream nothing and the in-repo integration tests build exactly as before. `--dry-run` passes with the change, compiling against the already-published `ironbus-core` and `ironbus-proto` 0.1.0.

**`ironbus-client v0.1.0` is now published**, which unblocks four IronAuth M11 issues (#104, #106, #112, #113) that depend on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X3FaPPJBUHKa1dXeQ7n6zW